### PR TITLE
Update import 'pytorch_lightning' -> 'lightning.pytorch'

### DIFF
--- a/src/nvidia_resiliency_ext/ptl_resiliency/fault_tolerance_callback.py
+++ b/src/nvidia_resiliency_ext/ptl_resiliency/fault_tolerance_callback.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 import torch
-from pytorch_lightning.callbacks import Callback
+from lightning.pytorch.callbacks import Callback
 
 import nvidia_resiliency_ext.fault_tolerance as ft
 

--- a/src/nvidia_resiliency_ext/ptl_resiliency/straggler_det_callback.py
+++ b/src/nvidia_resiliency_ext/ptl_resiliency/straggler_det_callback.py
@@ -19,7 +19,7 @@ import time
 from typing import Optional
 
 import torch
-from pytorch_lightning.callbacks import Callback
+from lightning.pytorch.callbacks import Callback
 
 import nvidia_resiliency_ext.straggler as straggler
 

--- a/tests/ptl_resiliency/unit/test_ft_callback.py
+++ b/tests/ptl_resiliency/unit/test_ft_callback.py
@@ -25,10 +25,10 @@ import sys
 import tempfile
 
 import pytest
-import pytorch_lightning as pl
+import lightning.pytorch as pl
 import torch
-from pytorch_lightning.callbacks import Callback
-from pytorch_lightning.utilities.exceptions import _TunerExitException
+from lightning.pytorch.callbacks import Callback
+from lightning.pytorch.utilities.exceptions import _TunerExitException
 from torch import nn
 
 import nvidia_resiliency_ext.fault_tolerance as fault_tolerance

--- a/tests/ptl_resiliency/unit/test_ft_callback.py
+++ b/tests/ptl_resiliency/unit/test_ft_callback.py
@@ -24,8 +24,8 @@ import signal
 import sys
 import tempfile
 
-import pytest
 import lightning.pytorch as pl
+import pytest
 import torch
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.utilities.exceptions import _TunerExitException

--- a/tests/ptl_resiliency/unit/test_straggler_det_callback.py
+++ b/tests/ptl_resiliency/unit/test_straggler_det_callback.py
@@ -19,8 +19,8 @@ import pathlib
 import shutil
 import tempfile
 
-import pytest
 import lightning.pytorch as pl
+import pytest
 import torch
 from torch import nn
 

--- a/tests/ptl_resiliency/unit/test_straggler_det_callback.py
+++ b/tests/ptl_resiliency/unit/test_straggler_det_callback.py
@@ -20,7 +20,7 @@ import shutil
 import tempfile
 
 import pytest
-import pytorch_lightning as pl
+import lightning.pytorch as pl
 import torch
 from torch import nn
 


### PR DESCRIPTION
NeMo PR [#11252](https://github.com/NVIDIA/NeMo/pull/11252) broke compatibility with `nvidia-resiliency-ext`. This PR should fix that.