### PR TITLE
Update ForkingPickler import

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/utils.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/utils.py
@@ -23,9 +23,9 @@ import time
 
 import psutil
 import torch
-import torch.multiprocessing as mp
+import multiprocessing as mp
 
-_IPC_PICKLER = mp.reductions.ForkingPickler(open(os.devnull, mode='wb'))
+_IPC_PICKLER = mp.reduction.ForkingPickler(open(os.devnull, mode='wb'))
 
 
 def is_process_alive(pid):


### PR DESCRIPTION
Update import of `ForkingPickler` to obtain from `multiprocessing` instead of `torch.multiprocessing` after this [change](https://github.com/pytorch/pytorch/commit/abd16a8c642733bd88e0bb1634b04972a8cfd688)