### PR TITLE
Use MSC in the checkpointing

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -17,6 +17,7 @@
 import dataclasses
 import logging
 import os
+import pickle
 import queue
 from functools import partial
 from heapq import heappop, heappush
@@ -31,6 +32,7 @@ import torch
 from torch import multiprocessing as mp
 from torch.distributed.checkpoint import FileSystemWriter
 from torch.distributed.checkpoint.filesystem import DEFAULT_SUFFIX, _StoragePrefix, _write_item
+from torch.distributed.checkpoint.metadata import Metadata
 
 try:
     from torch.distributed.checkpoint.filesystem import _StorageWriterTransforms
@@ -77,8 +79,13 @@ class FileSystemWriterAsync(FileSystemWriter):
     (intermediate state is stored as writer attributes).
     """
 
-    def __init__(self, *args, separation_hint: Optional[str] = None, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, path: Union[str, os.PathLike], *args, separation_hint: Optional[str] = None, **kwargs
+    ):
+        self.checkpoint_dir = path
+        self.use_msc = kwargs.pop("use_msc", False)
+
+        super().__init__(path, *args, **kwargs)
         if not self.single_file_per_rank:
             raise NotImplementedError(
                 'single_file_per_rank flag not supported for FileSystemWriterAsync'
@@ -159,7 +166,11 @@ class FileSystemWriterAsync(FileSystemWriter):
                 if len(bytes_data) > 0 or len(tensor_data) > 0:
                     file_name = gen_file(prefix=group_name)
                     self.write_buckets.append(
-                        (self.path / file_name, file_name, (bytes_data, tensor_data))
+                        (
+                            os.path.join(self.checkpoint_dir, file_name),
+                            file_name,
+                            (bytes_data, tensor_data),
+                        )
                     )
 
         # Check if there is anything to write on this rank
@@ -189,7 +200,7 @@ class FileSystemWriterAsync(FileSystemWriter):
             return None, None, ()
         transform_list = [self.transforms] if hasattr(self, 'transforms') else []
         return (
-            partial(self.write_preloaded_data_multiproc, transform_list),
+            partial(self.write_preloaded_data_multiproc, transform_list, self.use_msc),
             partial(self.preload_tensors, self.write_buckets, True),
             [torch.distributed.get_rank(), self.write_buckets, self.results_queue],
         )
@@ -219,6 +230,7 @@ class FileSystemWriterAsync(FileSystemWriter):
     @_disable_gc()
     def write_preloaded_data_multiproc(
         transform_list: List[_StorageWriterTransforms],
+        use_msc: bool,
         rank: int,
         write_buckets: List[WriteBucket],
         global_results_queue: mp.Queue,
@@ -254,10 +266,22 @@ class FileSystemWriterAsync(FileSystemWriter):
         for i, write_bucket in enumerate(write_buckets):
             try:
                 count_queue.put(i)
+
+                kwargs = {
+                    'local_proc_idx': i,
+                    'write_bucket': write_bucket,
+                    'results_queue': local_results_queue,
+                    'count_queue': count_queue,
+                    'use_fsync': True,
+                }
+
+                if use_msc:
+                    kwargs['use_msc'] = use_msc
+
                 p_list.append(
                     ctx.Process(
                         target=partial(FileSystemWriterAsync.write_preloaded_data, transform_list),
-                        args=(i, write_bucket, local_results_queue, count_queue, True),
+                        kwargs=kwargs,
                     )
                 )
             except Exception as e:
@@ -313,6 +337,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         results_queue: mp.SimpleQueue,
         count_queue: mp.JoinableQueue,
         use_fsync: bool,
+        **kwargs,
     ) -> None:
         """
         Performs actual data saving to storage.
@@ -330,11 +355,18 @@ class FileSystemWriterAsync(FileSystemWriter):
         logger = logging.getLogger(__name__)
         logger.debug(f'{local_proc_idx} started')
         mem_before = _process_memory()
+        use_msc = kwargs.get('use_msc', False)
 
         local_results = []
         try:
             file_name, storage_key, (bytes_data, tensor_data) = write_bucket
-            with open(file_name, "wb") as stream:
+            if use_msc:
+                import multistorageclient as msc
+
+                open_file = msc.open
+            else:
+                open_file = open
+            with open_file(file_name, "wb") as stream:
                 for write_item, data in bytes_data:
                     local_results.append(
                         _write_item(*transform_list, stream, data, write_item, storage_key)
@@ -347,7 +379,10 @@ class FileSystemWriterAsync(FileSystemWriter):
                     )
 
                 if use_fsync:
-                    os.fsync(stream.fileno())
+                    if use_msc:
+                        stream.fsync()
+                    else:
+                        os.fsync(stream.fileno())
             local_output = (local_proc_idx, local_results)
         except Exception as e:
             logger.debug(f'{local_proc_idx} failed')
@@ -411,6 +446,55 @@ class FileSystemWriterAsync(FileSystemWriter):
         return dataclasses.replace(
             local_plan, storage_data=_StoragePrefix(f"__{torch.distributed.get_rank()}_")
         )
+
+    def finish(self, metadata: Metadata, results: List[List[WriteResult]]) -> None:
+        """
+        Finish the checkpointing process.
+
+        Args:
+            metadata (Metadata): metadata to save
+            results (List[List[WriteResult]]): results to save
+        """
+        if self.use_msc:
+            import multistorageclient as msc
+
+            storage_md = dict()
+            for wr_list in results:
+                storage_md.update({wr.index: wr.storage_data for wr in wr_list})
+
+            metadata.storage_data = storage_md
+            metadata.storage_meta = self.storage_meta()
+
+            path = os.path.join(self.checkpoint_dir, ".metadata")
+
+            with msc.open(path, "wb") as metadata_file:
+                pickle.dump(metadata, metadata_file)
+        else:
+            super().finish(metadata, results)
+
+    def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
+        """
+        Prepare the local plan for the checkpointing process.
+        """
+        if self.use_msc:
+            import multistorageclient as msc
+
+            msc.os.makedirs(str(self.checkpoint_dir), exist_ok=True)
+        else:
+            super().prepare_local_plan(plan)
+
+        return plan
+
+    @property
+    def checkpoint_id(self) -> Union[str, os.PathLike]:
+        """
+        return the checkpoint_id that will be used to save the checkpoint.
+        """
+        return str(self.checkpoint_dir)
+
+    @classmethod
+    def validate_checkpoint_id(cls, checkpoint_id: Union[str, os.PathLike]) -> bool:
+        return True
 
 
 def _split_by_size_and_type(bins: int, items: List[WriteItem]) -> List[List[WriteItem]]:

--- a/tests/checkpointing/unit/test_async_writer_msc.py
+++ b/tests/checkpointing/unit/test_async_writer_msc.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import filecmp
+
+import torch
+from torch.distributed.checkpoint import (
+    DefaultLoadPlanner,
+    DefaultSavePlanner,
+    FileSystemReader,
+    FileSystemWriter,
+    load,
+    state_dict_saver,
+)
+
+from nvidia_resiliency_ext.checkpointing.async_ckpt.core import AsyncCallsQueue, AsyncRequest
+from nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async import FileSystemWriterAsync
+from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
+    save_state_dict_async_finalize,
+    save_state_dict_async_plan,
+)
+
+from . import TempNamedDir
+from .test_utilities import TestModel, Utils
+
+
+class TestAsyncSaveWithMSC:
+
+    def get_async_save_request(self, writer, save_state_dict_ret) -> AsyncRequest:
+        """Creates an async save request with a finalization step."""
+        save_fn, preload_fn, save_args = writer.get_save_function_and_args()
+
+        def finalize_fn():
+            """Finalizes async checkpointing and synchronizes processes."""
+            save_state_dict_async_finalize(*save_state_dict_ret)
+            torch.distributed.barrier()
+
+        return AsyncRequest(save_fn, save_args, [finalize_fn], preload_fn=preload_fn)
+
+    def async_save_checkpoint(
+        self, checkpoint_dir, state_dict, planner, async_queue, thread_count=1
+    ):
+        """Performs an asynchronous model checkpoint save."""
+        writer = FileSystemWriterAsync(checkpoint_dir, thread_count=thread_count, use_msc=True)
+        coordinator_rank = 0
+
+        save_state_dict_ret, *_ = save_state_dict_async_plan(
+            state_dict, writer, None, coordinator_rank, planner=planner
+        )
+        async_request = self.get_async_save_request(writer, save_state_dict_ret)
+        async_queue.schedule_async_request(async_request)
+
+    def sync_save_checkpoint(self, checkpoint_dir, state_dict, planner):
+        """Performs a synchronous model checkpoint save using FileSystemWriter."""
+        state_dict_saver.save(
+            state_dict=state_dict,
+            storage_writer=FileSystemWriter(checkpoint_dir),
+            planner=planner,
+        )
+
+    def load_checkpoint(self, checkpoint_dir, state_dict):
+        """Loads a checkpoint into the given state_dict."""
+        load(
+            state_dict=state_dict,
+            storage_reader=FileSystemReader(checkpoint_dir),
+            planner=DefaultLoadPlanner(),
+        )
+        return state_dict
+
+    def test_async_is_equivalent_to_sync(self, tmp_path_dist_ckpt):
+        """Verifies that async checkpointing produces the same results as sync checkpointing."""
+        Utils.initialize_distributed()
+        model = TestModel((1024, 1024), 10)
+        async_queue = AsyncCallsQueue()
+
+        with (
+            TempNamedDir(tmp_path_dist_ckpt / 'async_checkpoint', sync=True) as async_ckpt_dir,
+            TempNamedDir(tmp_path_dist_ckpt / 'sync_checkpoint', sync=True) as sync_ckpt_dir,
+        ):
+            state_dict = model.state_dict()
+            planner = DefaultSavePlanner()
+
+            # Perform async and sync saves
+            self.async_save_checkpoint(async_ckpt_dir, state_dict, planner, async_queue)
+            self.sync_save_checkpoint(sync_ckpt_dir, state_dict, planner)
+
+            # Finalize async saves
+            async_queue.maybe_finalize_async_calls(blocking=True, no_dist=False)
+
+            # Compare saved files
+            comparison = filecmp.dircmp(async_ckpt_dir, sync_ckpt_dir)
+            assert (
+                not comparison.left_only
+            ), f"Extra files in async checkpoint: {comparison.left_only}"
+            assert (
+                not comparison.right_only
+            ), f"Extra files in sync checkpoint: {comparison.right_only}"
+            assert not comparison.diff_files or comparison.diff_files == [
+                '.metadata'
+            ], f"Differences found in saved files: {comparison.diff_files}"
+
+            # Load and compare state dicts
+            loaded_async_state_dict = self.load_checkpoint(async_ckpt_dir, state_dict.copy())
+            loaded_sync_state_dict = self.load_checkpoint(sync_ckpt_dir, state_dict.copy())
+
+            for key in loaded_sync_state_dict.keys():
+                assert key in loaded_async_state_dict, f"Missing key in async checkpoint: {key}"
+                assert torch.equal(
+                    loaded_async_state_dict[key], loaded_sync_state_dict[key]
+                ), f"Mismatch for key '{key}' between async and sync checkpoints."
+                assert torch.equal(
+                    loaded_async_state_dict[key], state_dict[key]
+                ), f"Mismatch for key '{key}' between async checkpoint and original state_dict."


### PR DESCRIPTION
Integrate the [multi-storage-client](https://github.com/NVIDIA/multi-storage-client) into the checkpoint module to support reading and writing checkpoints on object storage.

```
FileSystemWriterAsync(path="msc://test-bucket-s3/checkpoints/", use_msc=True)
```