### PR TITLE
Improve fault injector tool

### DIFF
--- a/src/nvidia_resiliency_ext/inprocess/tools/inject_fault.py
+++ b/src/nvidia_resiliency_ext/inprocess/tools/inject_fault.py
@@ -25,7 +25,7 @@ import signal
 import sys
 import threading
 import time
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 import torch
 
@@ -49,6 +49,47 @@ class InjectedException(Exception):
     pass
 
 
+# Define the multiprocessing context at module level
+ctx = multiprocessing.get_context('fork')
+_registered_faults = {}
+
+
+def register_fault(fault_name_or_enum: Union[str, Fault], handler: Callable):
+    """
+    Register a fault type and its handler.
+
+    Args:
+        fault_name_or_enum: Either a string name for a new fault or an existing Fault enum
+        handler: Lambda function that implements the fault injection
+
+    Returns:
+        The Fault enum (either existing or newly created)
+    """
+    if isinstance(fault_name_or_enum, Fault):
+        # Using an existing enum
+        fault_enum = fault_name_or_enum
+    else:
+        # Add the new fault to the Fault enum
+        new_fault = enum.auto()
+        Fault._value2member_map_[new_fault] = fault_enum = type(Fault)(
+            fault_name_or_enum, new_fault
+        )
+        Fault._member_names_.append(fault_name_or_enum)
+        Fault._member_map_[fault_name_or_enum] = fault_enum
+
+    # Register the handler
+    _registered_faults[fault_enum] = handler
+
+    return fault_enum
+
+
+def dispatch_fault_injection(fault, delay, callback):
+    if fault in _registered_faults:
+        _registered_faults[fault](delay, callback)
+    else:
+        raise RuntimeError(f"Unknown fault type: {fault}")
+
+
 def async_raise(tid, exc_type):
     set_async_exc = ctypes.pythonapi.PyThreadState_SetAsyncExc
     set_async_exc.argtypes = (ctypes.c_ulong, ctypes.py_object)
@@ -70,7 +111,6 @@ def termination_signal_handler(signum, frame):
     if not sys.is_finalizing():
         raise InjectedException
 
-workload_raise_event = threading.Event()
 
 def workload_exception(delay, callback):
     time.sleep(delay)
@@ -79,6 +119,17 @@ def workload_exception(delay, callback):
     if callback is not None:
         callback()
     workload_raise_event.set()
+
+
+# Register the workload exception fault
+workload_raise_event = threading.Event()
+register_fault(
+    Fault.WORKLOAD_EXC,
+    lambda delay, callback: threading.Thread(
+        target=workload_exception, args=(delay, callback), daemon=True
+    ).start(),
+)
+
 
 def maybe_raise_workload_exception():
     """
@@ -92,6 +143,7 @@ def maybe_raise_workload_exception():
         workload_raise_event.clear()
         raise InjectedException
 
+
 def async_raise_exception(tid, delay, callback):
     time.sleep(delay)
     log = logging.getLogger(__name__)
@@ -99,6 +151,17 @@ def async_raise_exception(tid, delay, callback):
     if callback is not None:
         callback()
     async_raise(tid, InjectedException)
+
+
+# Register the async exception fault
+register_fault(
+    Fault.ASYNC_EXC,
+    lambda delay, callback: threading.Thread(
+        target=async_raise_exception,
+        args=(threading.main_thread().ident, delay, callback),
+        daemon=True,
+    ).start(),
+)
 
 
 def raise_gpu_error(delay, callback):
@@ -113,6 +176,17 @@ def raise_gpu_error(delay, callback):
     a[b] = 0
 
 
+# Register GPU error fault
+register_fault(
+    Fault.GPU_ERROR,
+    lambda delay, callback: threading.Thread(
+        target=raise_gpu_error,
+        args=(delay, callback),
+        daemon=True,
+    ).start(),
+)
+
+
 def gpu_sleep(delay, device, callback):
     time.sleep(delay)
     log = logging.getLogger(__name__)
@@ -121,6 +195,15 @@ def gpu_sleep(delay, device, callback):
         callback()
     torch.cuda.set_device(device)
     torch.cuda._sleep(1 << 62)
+
+
+# Register GPU sleep fault
+register_fault(
+    Fault.GPU_SLEEP,
+    lambda delay, callback: threading.Thread(
+        target=gpu_sleep, args=(delay, torch.cuda.current_device(), callback), daemon=True
+    ).start(),
+)
 
 
 def lock_gil(delay, callback):
@@ -132,6 +215,15 @@ def lock_gil(delay, callback):
     re.match(r'(a?){40}a{40}', 'a' * 40)
 
 
+# Register lock GIL fault
+register_fault(
+    Fault.LOCK_GIL,
+    lambda delay, callback: threading.Thread(
+        target=lock_gil, args=(delay, callback), daemon=True
+    ).start(),
+)
+
+
 def segfault(delay, callback):
     time.sleep(delay)
     log = logging.getLogger(__name__)
@@ -139,6 +231,15 @@ def segfault(delay, callback):
     if callback is not None:
         callback()
     ctypes.string_at(1)
+
+
+# Register segfault fault
+register_fault(
+    Fault.SEGFAULT,
+    lambda delay, callback: threading.Thread(
+        target=segfault, args=(delay, callback), daemon=True
+    ).start(),
+)
 
 
 def send_signal(pid, signal, delay, callback):
@@ -150,6 +251,56 @@ def send_signal(pid, signal, delay, callback):
     os.kill(pid, signal)
 
 
+# Register signal faults
+register_fault(
+    Fault.SIGNAL_EXC,
+    lambda delay, callback: (
+        signal.signal(signal.SIGUSR1, termination_signal_handler),
+        ctx.Process(
+            target=send_signal,
+            args=(os.getpid(), signal.SIGUSR1, delay, callback),
+            daemon=True,
+        ).start(),
+    )[1],
+)  # Return the result of .start()
+
+register_fault(
+    Fault.SIGKILL,
+    lambda delay, callback: ctx.Process(
+        target=send_signal,
+        args=(os.getpid(), signal.SIGKILL, delay, callback),
+        daemon=True,
+    ).start(),
+)
+
+register_fault(
+    Fault.SIGTERM,
+    lambda delay, callback: ctx.Process(
+        target=send_signal,
+        args=(os.getpid(), signal.SIGTERM, delay, callback),
+        daemon=True,
+    ).start(),
+)
+
+register_fault(
+    Fault.SIGINT,
+    lambda delay, callback: ctx.Process(
+        target=send_signal,
+        args=(os.getpid(), signal.SIGINT, delay, callback),
+        daemon=True,
+    ).start(),
+)
+
+register_fault(
+    Fault.SIGSTOP,
+    lambda delay, callback: ctx.Process(
+        target=send_signal,
+        args=(os.getpid(), signal.SIGSTOP, delay, callback),
+        daemon=True,
+    ).start(),
+)
+
+
 def abort(delay, callback):
     time.sleep(delay)
     log = logging.getLogger(__name__)
@@ -159,76 +310,13 @@ def abort(delay, callback):
     os.abort()
 
 
-def dispatch_fault_injection(fault, delay, callback):
-
-    if fault == Fault.ASYNC_EXC:
-        thread = threading.Thread(
-            target=async_raise_exception,
-            args=(threading.main_thread().ident, delay, callback),
-            daemon=True,
-        )
-        thread.start()
-    elif fault == Fault.WORKLOAD_EXC:
-        thread = threading.Thread(target=workload_exception, args=(delay, callback), daemon=True)
-        thread.start()
-    elif fault == Fault.SIGNAL_EXC:
-        signal.signal(signal.SIGUSR1, termination_signal_handler)
-        p = ctx.Process(
-            target=send_signal,
-            args=(os.getpid(), signal.SIGUSR1, delay, callback),
-            daemon=True,
-        )
-        p.start()
-    elif fault == Fault.GPU_ERROR:
-        thread = threading.Thread(
-            target=raise_gpu_error,
-            args=(delay, callback),
-            daemon=True,
-        )
-        thread.start()
-    elif fault == Fault.LOCK_GIL:
-        thread = threading.Thread(target=lock_gil, args=(delay, callback), daemon=True)
-        thread.start()
-    elif fault == Fault.GPU_SLEEP:
-        device = torch.cuda.current_device()
-        thread = threading.Thread(target=gpu_sleep, args=(delay, device, callback), daemon=True)
-        thread.start()
-    elif fault == Fault.SEGFAULT:
-        thread = threading.Thread(target=segfault, args=(delay, callback), daemon=True)
-        thread.start()
-    elif fault == Fault.OS_ABORT:
-        thread = threading.Thread(target=abort, args=(delay, callback), daemon=True)
-        thread.start()
-    elif fault == Fault.SIGKILL:
-        p = ctx.Process(
-            target=send_signal,
-            args=(os.getpid(), signal.SIGKILL, delay, callback),
-            daemon=True,
-        )
-        p.start()
-    elif fault == Fault.SIGTERM:
-        p = ctx.Process(
-            target=send_signal,
-            args=(os.getpid(), signal.SIGTERM, delay, callback),
-            daemon=True,
-        )
-        p.start()
-    elif fault == Fault.SIGINT:
-        p = ctx.Process(
-            target=send_signal,
-            args=(os.getpid(), signal.SIGINT, delay, callback),
-            daemon=True,
-        )
-        p.start()
-    elif fault == Fault.SIGSTOP:
-        p = ctx.Process(
-            target=send_signal,
-            args=(os.getpid(), signal.SIGSTOP, delay, callback),
-            daemon=True,
-        )
-        p.start()
-    else:
-        raise RuntimeError
+# Register abort fault
+register_fault(
+    Fault.OS_ABORT,
+    lambda delay, callback: threading.Thread(
+        target=abort, args=(delay, callback), daemon=True
+    ).start(),
+)
 
 
 def inject_fault(
@@ -247,8 +335,6 @@ def inject_fault(
     generator = random.Random()
     generator.seed(seed)
 
-    ctx = multiprocessing.get_context('fork')
-
     if isinstance(num_faults, int):
         min_faults, max_faults = num_faults, num_faults
     else:
@@ -265,5 +351,3 @@ def inject_fault(
         log.info(f'{seed=} {num_ranks_to_inject=} {ranks_to_inject=} ' f'{fault=} {delay=:.3f}')
 
         dispatch_fault_injection(fault, delay, callback)
-
-


### PR DESCRIPTION
This PR greatly improves usability if the inprocess fault injection testing tool.

* Adds a workload exception, which can be raised directly by the workload, without the violence of an async exception.  This is useful for testing specific scenarios, as the async exception will randomly interrupt and can hit unrecoverable operations.  Using this requires a slight modification to the workload.
* Separates the actual injection call logic from the setup logic.  With this, workloads can have their own setup logic but still invoke the provided call logic.
* Improved registration of possible injected faults.  External workloads can now register their own faults and use the same logic to inject it.