### PR TITLE
Used fork to create RankMonitorServer subprocess.

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -448,7 +448,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         return f"{tempfile.gettempdir()}/_ft_launcher{os.getpid()}_rmon{local_rank}.socket"
 
     def setup_rank_monitors(self, envs: Dict[int, Dict[str, str]]) -> None:
-        spawn_mp_ctx = torch.multiprocessing.get_context("spawn")
+        fork_mp_ctx = torch.multiprocessing.get_context("fork")
         for worker_env in envs.values():
             # Start rank monitors if not already started
             # Each rank (re)connects to its rank monitor when it starts
@@ -461,7 +461,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                     cfg=self._ft_cfg,
                     ipc_socket_path=rmon_ipc_socket,
                     is_restarter_logger=is_restarter_logger,
-                    mp_ctx=spawn_mp_ctx,
+                    mp_ctx=fork_mp_ctx,
                 )
 
     def shutdown_rank_monitors(self):


### PR DESCRIPTION
You should observe approximately a 10-second improvement in the following test before and after the change:

 echo "print('hello world\n')" > /tmp/echo.py
 time ft_launcher \
   --nproc_per_node=8 \
   --max-restarts=1 \
   --ft-param-initial_rank_heartbeat_timeout=30 \
   --ft-param-rank_heartbeat_timeout=15 \
   --ft-param-log_level=debug /tmp/echo.py > /dev/null 2>&1