### PR TITLE
Changed default worker monitor interval to 0.1 second.

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -1509,7 +1509,7 @@ def get_args_parser() -> ArgumentParser:
         "--monitor_interval",
         action=env,
         type=float,
-        default=5,
+        default=0.1,
         help="Interval, in seconds, to monitor the state of workers.",
     )
     parser.add_argument(


### PR DESCRIPTION
You should observe improvement on time measurement for InJob restart.