### PR TITLE
Make ft-launcher usage consistent everywhere

### DIFF
--- a/docs/source/fault_tolerance/README-pci-topo-file.md
+++ b/docs/source/fault_tolerance/README-pci-topo-file.md
@@ -6,7 +6,7 @@ In certain environments, such as virtual machines (VMs) provided by cloud servic
 To work around this limitation, users can specify a pre-defined PCI topology file using the following option:  
 
 ```
-–ft-param-pci-topo-file=<pci_topo_file>
+–ft-pci-topo-file=<pci_topo_file>
 ```
 where `<pci_topo_file>` is an XML file describing the PCI topology.
 

--- a/docs/source/fault_tolerance/integration/heartbeats.rst
+++ b/docs/source/fault_tolerance/integration/heartbeats.rst
@@ -24,10 +24,10 @@ Fixed timeout values can be used throughout the training runs, or timeouts can b
 `null` timeout values are interpreted as infinite timeouts. In such cases, values need to be calculated to make the FT usable.
 
 .. note::
-    When --ft-param-initial_rank_heartbeat_timeout and --ft-param-rank_heartbeat_timeout are not
+    When --ft-initial-rank-heartbeat-timeout and --ft-rank-heartbeat-timeout are not
     provided in the command-line arguments, the launcher defaults to FT's predefined values. These are
-    not null/None; currently, the defaults are 60 minutes for --ft-param-initial_rank_heartbeat_timeout
-    and 45 minutes for --ft-param-rank_heartbeat_timeout.
+    not null/None; currently, the defaults are 60 minutes for --ft-initial-rank-heartbeat-timeout
+    and 45 minutes for --ft-rank-heartbeat-timeout.
 
 Configuration file example:
 

--- a/docs/source/fault_tolerance/integration/inprocess.rst
+++ b/docs/source/fault_tolerance/integration/inprocess.rst
@@ -9,7 +9,7 @@ FT Launcher & Inprocess integration
 
 2. Worker Monitoring & Restart Policy
 ====================
-A new ``--restart-policy`` argument in ``ft_launcher`` modifies the default worker monitor logic for better compatibility with :doc:`../inprocess/index`.
+A new ``--ft-restart-policy`` argument in ``ft_launcher`` modifies the default worker monitor logic for better compatibility with :doc:`../inprocess/index`.
 
 **Policy Options**
 

--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -47,13 +47,13 @@ Usage Overview
 FT launcher
 -----------
 
-Fault tolerance includes a launcher tool called ``ft_launcher``, which is based on ``torchrun`` 
-and supports most ``torchrun`` command-line parameters. FT configuration can be specified either 
-via a YAML file using ``--fault-tol-cfg-path`` or through command-line parameters 
-using ``--ft-param-<parameter-name>``.  
+Fault tolerance includes a launcher tool called ``ft_launcher``, which is based on ``torchrun``
+and supports most ``torchrun`` command-line parameters. FT configuration can be specified either
+via a YAML file using ``--ft-cfg-path`` or through command-line parameters
+using ``--ft-<parameter-name>``.
 
-If ``--max-restarts`` is specified, the launcher restarts failed workers. 
-The restart behavior depends on the ``--restart-policy`` parameter, which supports two modes:  
+If ``--max-restarts`` is specified, the launcher restarts failed workers.
+The restart behavior depends on the ``--ft-restart-policy`` parameter, which supports two modes:
 
 * ``any-failed`` (default)  
   All workers are restarted if any worker fails.  
@@ -98,3 +98,18 @@ API, which can be used to control the workload restarting logic implemented in t
    Please note that only the ft_launcher behavior is affected by this call. 
    The fault tolerance package is job scheduler-agnostic, 
    i.e., it does not control underlying SLURM job allocations.
+
+Deprecated arguments
+--------------------
+
+The following arguments are deprecated and will be removed in a future version:
+
+* ``--ft-param-*`` arguments (replaced by ``--ft-*``)
+* ``--fault-tol-cfg-path`` (replaced by ``--ft-cfg-path``)
+* ``--ignore-missing-fault-tol-cfg`` (replaced by ``--ft-ignore-missing-cfg``)
+* ``--restart-policy`` (replaced by ``--ft-restart-policy``)
+* ``--restart_policy`` (replaced by ``--ft-restart-policy``)
+* ``--ft_param_link_down_path_template`` (replaced by ``--ft-link-down-path-template``)
+* ``--ft_param_enable_nic_monitor`` (replaced by ``--ft-enable-nic-monitor``)
+* ``--ft_param_pci_topo_file`` (replaced by ``--ft-pci-topo-file``)
+

--- a/examples/fault_tolerance/basic_ft_example.py
+++ b/examples/fault_tolerance/basic_ft_example.py
@@ -30,7 +30,7 @@ import nvidia_resiliency_ext.fault_tolerance as ft
 # After each epoch, FT timeouts are calculated and saved to the file "./ft_state.json".
 #
 # You can run it using:
-# `ft_launcher --nproc_per_node=4 --max-restarts=3 --ft-param-initial_rank_heartbeat_timeout=30 --ft-param-rank_heartbeat_timeout=15 examples/fault_tolerance/basic_ft_example.py`
+# `ft_launcher --nproc-per-node=4 --max-restarts=3 --ft-initial-rank-heartbeat-timeout=30 --ft-rank-heartbeat-timeout=15 examples/fault_tolerance/basic_ft_example.py`
 # In this example configuration, at most 3 training restarts are allowed.
 #
 # To find rank PIDs, use:

--- a/examples/fault_tolerance/run_inprocess_injob_example.sh
+++ b/examples/fault_tolerance/run_inprocess_injob_example.sh
@@ -22,8 +22,8 @@
 # NOTE: The in-process package has monitoring capabilities that can also be used. 
 # Please refer to the in-process package documentation for details.
 #
-# When using `ft_launcher --restart-policy=min-healthy --nnodes=2:3`, fault tolerance 
-# restarts the training when the number of healthy agents (agents with all ranks alive) 
+# When using `ft_launcher --ft-restart-policy=min-healthy --nnodes=2:3`, fault tolerance
+# restarts the training when the number of healthy agents (agents with all ranks alive)
 # falls below 2.
 #
 # Simulated sequence:
@@ -47,11 +47,11 @@
 THIS_SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 WORKER_SCRIPT="${THIS_SCRIPT_DIR}/in_job_and_in_process_example.py"
 
-COMMON_LAUNCHER_ARGS="--nnodes=2:3 --max-restarts=2 --nproc_per_node=2 --rdzv_backend=c10d --rdzv_endpoint=127.0.0.1:29500"
-COMMON_FT_ARGS="--ft-param-log_level=DEBUG --ft-param-rank_heartbeat_timeout=12 --ft-param-initial_rank_heartbeat_timeout=12 --restart-policy=min-healthy"
+COMMON_LAUNCHER_ARGS="--nnodes=2:3 --max-restarts=2 --nproc-per-node=2 --rdzv-backend=c10d --rdzv-endpoint=127.0.0.1:29500"
+COMMON_FT_ARGS="--ft-log-level=DEBUG --ft-rank-heartbeat-timeout=12 --ft-initial-rank-heartbeat-timeout=12 --ft-restart-policy=min-healthy"
 
 # WAR: this example currently does not work with the NIC monitor
-COMMON_FT_ARGS="${COMMON_FT_ARGS} --ft_param_enable_nic_monitor=False"
+COMMON_FT_ARGS="${COMMON_FT_ARGS} --ft-enable-nic-monitor=False"
 
 # Avoid c10d log clutter with "(...) TCPStore.cpp:122] [c10d] sendBytes failed (...)" 
 # when terminating a hung workload and the TCP Store hosting rank is killed.

--- a/examples/fault_tolerance/train_ddp_heartbeats_api.py
+++ b/examples/fault_tolerance/train_ddp_heartbeats_api.py
@@ -15,6 +15,17 @@
 
 """
 Demo of fault tolerance with DDP training, using FT package heartbeats API
+
+This script demonstrates how to use the FT heartbeats API for hang detection in
+distributed training. It should be run with the ft_launcher command. E.g.:
+
+`ft_launcher --nproc-per-node=2 --ft-cfg-path=./examples/fault_tolerance/fault_tol_cfg_heartbeats.yaml examples/fault_tolerance/train_ddp_heartbeats_api.py --device=cpu`
+
+Fault tolerance features demonstrated:
+1. Heartbeat sending during training
+2. Timeout calculation and setting
+3. State persistence through checkpoints
+4. Simulated fault injection
 """
 
 import argparse

--- a/examples/fault_tolerance/train_ddp_sections_api.py
+++ b/examples/fault_tolerance/train_ddp_sections_api.py
@@ -17,7 +17,7 @@
 Demo of DDP training with fault tolerance, using FT package sections API
 
 It should be run with `ft_launcher`. E.g.
-`ft_launcher --nproc-per-node=2 --fault-tol-cfg-path=./examples/fault_tolerance/fault_tol_cfg_sections.yaml examples/fault_tolerance/train_ddp_sections_api.py --device=cpu`
+`ft_launcher --nproc-per-node=2 --ft-cfg-path=./examples/fault_tolerance/fault_tol_cfg_sections.yaml examples/fault_tolerance/train_ddp_sections_api.py --device=cpu`
 
 This example uses following custom FT sections
 - 'init' - covers workload initialization

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -18,7 +18,12 @@ import dataclasses
 import inspect
 import logging
 import os
-import pickle
+
+# Issue: [B403:blacklist] Consider possible security implications associated with pickle module.
+# Severity: Low   Confidence: High
+# CWE: CWE-502 (https://cwe.mitre.org/data/definitions/502.html)
+# More Info: https://bandit.readthedocs.io/en/1.8.3/blacklists/blacklist_imports.html#b403-import-pickle
+import pickle  # nosec
 import queue
 from functools import partial
 from heapq import heappop, heappush
@@ -481,7 +486,11 @@ class FileSystemWriterAsync(FileSystemWriter):
             path = os.path.join(self.checkpoint_dir, ".metadata")
 
             with msc.open(path, "wb") as metadata_file:
-                pickle.dump(metadata, metadata_file)
+                # Issue: [B301:blacklist] Pickle and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue.
+                # Severity: Medium   Confidence: High
+                # CWE: CWE-502 (https://cwe.mitre.org/data/definitions/502.html)
+                # More Info: https://bandit.readthedocs.io/en/1.8.3/blacklists/blacklist_calls.html#b301-pickle
+                pickle.dump(metadata, metadata_file)  # nosec
         else:
             super().finish(metadata, results)
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 import time
 import uuid
+import warnings
 from argparse import REMAINDER, ArgumentParser
 from dataclasses import dataclass, field
 from string import Template
@@ -1061,6 +1062,34 @@ def launch_agent(
             os.unlink(FT_LAUNCHER_IPC_SOCKET)
 
 
+def check_for_deprecated_args():
+    deprecated_args = [
+        "--fault-tol-cfg-path",
+        "--ignore-missing-fault-tol-cfg",
+        "--ft-param-workload_check_interval",
+        "--ft-param-initial_rank_heartbeat_timeout",
+        "--ft-param-rank_heartbeat_timeout",
+        "--ft-param-node_health_check_interval",
+        "--ft-param-safety_factor",
+        "--ft-param-rank_termination_signal",
+        "--ft-param-log_level",
+        "--ft-param-rank_out_of_section_timeout",
+        "--ft-param-rank_section_timeouts",
+        "--ft-param-restart_check_interval",
+        "--restart-policy",
+        "--restart_policy",
+        "--ft-param-enable-nic-monitor",
+        "--ft_param_enable_nic_monitor",
+        "--ft-param-pci-topo-file",
+        "--ft_param_pci_topo_file",
+        "--ft-param-link-down-path-template",
+        "--ft_param_link_down_path_template",
+    ]
+
+    for arg in deprecated_args:
+        if arg in sys.argv:
+            warnings.warn(f"Argument {arg} is deprecated and will be removed in NVRx v0.5")
+
 # Source
 # https://github.com/pytorch/pytorch/blob/release/2.3/torch/distributed/run.py
 
@@ -1670,136 +1699,166 @@ def get_args_parser() -> ArgumentParser:
     #
     # Fault tolerance related items
     #
+
+    check_for_deprecated_args()
+
     parser.add_argument(
-        "--fault-tol-cfg-path",
-        "--fault-tol-cfg-path",
+        "--ft-cfg-path",
+        "--ft-cfg_path",
+        "--fault-tol-cfg-path",  # Deprecated, to be removed in v0.5
         default=None,
         type=str,
         action=env,
+        dest="ft_cfg_path",
         help="Path to a YAML file that contains Fault Tolerance pkg config (`fault_tolerance` section)."
         " NOTE: config items from the file can be overwritten by `--ft-param-*` args.",
     )
 
     parser.add_argument(
-        "--ignore-missing-fault-tol-cfg",
-        "--ignore-missing-fault-tol-cfg",
-        action='store_true',
-        help="Do not raise an error if there is no Fault Tolerance pkg config provided, just use default settings.",
-    )
-
-    parser.add_argument(
-        "--ft-param-workload_check_interval",
-        "--ft-param-workload_check_interval",
+        "--ft-workload-check-interval",
+        "--ft-workload_check_interval",
+        "--ft-param-workload_check_interval",  # Deprecated, to be removed in v0.5
         type=float,
         default=None,
+        dest="ft_workload_check_interval",
         help="Part of Fault Tolerance pkg config (workload_check_interval).",
     )
 
     parser.add_argument(
-        "--ft-param-initial_rank_heartbeat_timeout",
-        "--ft-param-initial_rank_heartbeat_timeout",
+        "--ft-initial-rank-heartbeat-timeout",
+        "--ft-initial_rank_heartbeat_timeout",
+        "--ft-param-initial_rank_heartbeat_timeout",  # Deprecated, to be removed in v0.5
         type=float,
         default=None,
+        dest="ft_initial_rank_heartbeat_timeout",
         help="Part of Fault Tolerance pkg config (initial_rank_heartbeat_timeout).",
     )
 
     parser.add_argument(
-        "--ft-param-rank_heartbeat_timeout",
-        "--ft-param-rank_heartbeat_timeout",
+        "--ft-rank-heartbeat-timeout",
+        "--ft-rank_heartbeat_timeout",
+        "--ft-param-rank_heartbeat_timeout",  # Deprecated, to be removed in v0.5
         type=float,
         default=None,
+        dest="ft_rank_heartbeat_timeout",
         help="Part of Fault Tolerance pkg config (rank_heartbeat_timeout).",
     )
 
     parser.add_argument(
-        "--ft-param-node_health_check_interval",
-        "--ft-param-node_health_check_interval",
+        "--ft-node-health-check-interval",
+        "--ft-node_health_check_interval",
+        "--ft-param-node_health_check_interval",  # Deprecated, to be removed in v0.5
         type=float,
         default=None,
+        dest="ft_node_health_check_interval",
         help="Part of Fault Tolerance pkg config (node_health_check_interval).",
     )
 
     parser.add_argument(
-        "--ft-param-safety_factor",
-        "--ft-param-safety_factor",
+        "--ft-safety-factor",
+        "--ft-safety_factor",
+        "--ft-param-safety_factor",  # Deprecated, to be removed in v0.5
         type=float,
         default=None,
+        dest="ft_safety_factor",
         help="Part of Fault Tolerance pkg config (safety_factor).",
     )
 
     parser.add_argument(
-        "--ft-param-rank_termination_signal",
-        "--ft-param-rank_termination_signal",
+        "--ft-rank-termination-signal",
+        "--ft-rank_termination_signal",
+        "--ft-param-rank_termination_signal",  # Deprecated, to be removed in v0.5
         type=str,
         default=None,
+        dest="ft_rank_termination_signal",
         help="Part of Fault Tolerance pkg config (rank_termination_signal).",
     )
 
     parser.add_argument(
-        "--ft-param-log_level",
-        "--ft-param-log_level",
+        "--ft-log-level",
+        "--ft-log_level",
+        "--ft-param-log_level",  # Deprecated, to be removed in v0.5
         type=str,
         default=None,
+        dest="ft_log_level",
         help="Part of Fault Tolerance pkg config (log_level).",
     )
 
     parser.add_argument(
-        "--ft-param-rank_out_of_section_timeout",
-        "--ft-param-rank_out_of_section_timeout",
+        "--ft-rank-out-of-section-timeout",
+        "--ft-rank_out_of_section_timeout",
+        "--ft-param-rank_out_of_section_timeout",  # Deprecated, to be removed in v0.5
         type=float,
         default=None,
+        dest="ft_rank_out_of_section_timeout",
         help="Part of Fault Tolerance pkg config (rank_out_of_section_timeout).",
     )
 
     parser.add_argument(
-        "--ft-param-rank_section_timeouts",
-        "--ft-param-rank_section_timeouts",
+        "--ft-rank-section-timeouts",
+        "--ft-rank_section_timeouts",
+        "--ft-param-rank_section_timeouts",  # Deprecated, to be removed in v0.5
         type=str,
         default=None,
+        dest="ft_rank_section_timeouts",
         help="Part of Fault Tolerance pkg config (rank_section_timeouts). "
         "Expected format: name1:value1,name2:value2,... Use 'null'|'none'|'' for None",
     )
 
     parser.add_argument(
-        "--ft-param-restart_check_interval",
-        "--ft-param-restart_check_interval",
+        "--ft-restart-check-interval",
+        "--ft-restart_check_interval",
+        "--ft-param-restart_check_interval",  # Deprecated, to be removed in v0.5
         type=float,
         default=None,
+        dest="ft_restart_check_interval",
         help="Part of Fault Tolerance pkg config (restart_check_interval).",
     )
 
     parser.add_argument(
-        "--restart-policy",
-        "--restart_policy",
+        "--ft-restart-policy",
+        "--ft-restart_policy",
+        "--restart-policy",  # Deprecated, to be removed in v0.5
+        "--restart_policy",  # Deprecated, to be removed in v0.5
         type=str,
         choices=['any-failed', 'min-healthy'],
         default='any-failed',
+        dest="ft_restart_policy",
         help="Worker groups restarting policy. Options: "
         "'any-failed' restart if any worker group fails (torchrun's default); "
         "'min-healthy' restart if number of healthy worker groups falls below <minimum_nodes>",
     )
 
     parser.add_argument(
-        "--ft_param_enable_nic_monitor",
-        "--ft-param-enable-nic-monitor",
+        "--ft-enable-nic-monitor",
+        "--ft-enable_nic_monitor",
+        "--ft-param-enable-nic-monitor",  # Deprecated, to be removed in v0.5
+        "--ft_param_enable_nic_monitor",  # Deprecated, to be removed in v0.5
         type=lambda x: str(x).lower() in ["true", "1", "yes"],
         default=True,
+        dest="ft_enable_nic_monitor",
         help="Enable or Disable NIC health monitoring in training.",
     )
 
     parser.add_argument(
-        "--ft_param_pci_topo_file",
-        "--ft-param-pci-topo-file",
+        "--ft-pci-topo-file",
+        "--ft-pci_topo_file",
+        "--ft-param-pci-topo-file",  # Deprecated, to be removed in v0.5
+        "--ft_param_pci_topo_file",  # Deprecated, to be removed in v0.5
         type=str,
         default=None,
+        dest="ft_pci_topo_file",
         help="PCI topology file that describes GPU and NIC topology.",
     )
 
     parser.add_argument(
-        "--ft_param_link_down_path_template",
-        "--ft-param-link-down-path-template",
+        "--ft-link-down-path-template",
+        "--ft-link_down_path_template",
+        "--ft-param-link-down-path-template",  # Deprecated, to be removed in v0.5
+        "--ft_param_link_down_path_template",  # Deprecated, to be removed in v0.5
         type=str,
         default=None,
+        dest="ft_link_down_path_template",
         help="Part of Fault Tolerance pkg config (link_down_path_template). "
         "Template path to check if a NIC link is down.",
     )
@@ -1958,20 +2017,8 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
             f"Current ft_launcher version supports only rdzv_backend=c10d. Got {args.rdzv_backend}"
         )
 
-    try:
-        fault_tol_cfg = FaultToleranceConfig.from_args(
-            args,
-            cfg_file_arg="fault_tol_cfg_path",
-            ft_args_prefix="ft_param_",
-        )
-    except ValueError:
-        if args.ignore_missing_fault_tol_cfg:
-            logger.warning(
-                f"Could not load FT config from '{args.fault_tol_cfg_path}' or read from CLI args. Will use default FT settings."
-            )
-            fault_tol_cfg = FaultToleranceConfig()
-        else:
-            raise ValueError("Fault Tolerance configuration not provided.")
+
+    fault_tol_cfg = FaultToleranceConfig.from_args(args)
 
     ranks: Optional[Set[int]] = None
     if args.local_ranks_filter:
@@ -2001,7 +2048,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
         rdzv_backend=args.rdzv_backend,
         rdzv_configs=rdzv_configs,
         max_restarts=args.max_restarts,
-        restart_policy=args.restart_policy,
+        restart_policy=args.ft_restart_policy,
         term_timeout=args.term_timeout,
         workers_stop_timeout=args.workers_stop_timeout,
         monitor_interval=args.monitor_interval,

--- a/tests/fault_tolerance/func/run_launcher_any_failed_mode_test.sh
+++ b/tests/fault_tolerance/func/run_launcher_any_failed_mode_test.sh
@@ -100,8 +100,8 @@ log_title() {
 ( kill -s SIGKILL $(pgrep -f ft_launcher) > /dev/null 2>&1 || true ) 
 
 export LOGLEVEL='DEBUG'
-COMMON_FT_ARGS="--ft-param-log_level=DEBUG"
-COMMON_LAUNCHER_ARGS="--nproc-per-node=2 --nnodes=2:3 --rdzv-backend=c10d --rdzv_endpoint=localhost:12345 --max-restarts=5 --restart-policy=any-failed"
+COMMON_FT_ARGS="--ft-log-level=DEBUG"
+COMMON_LAUNCHER_ARGS="--nproc-per-node=2 --nnodes=2:3 --rdzv-backend=c10d --rdzv_endpoint=localhost:12345 --max-restarts=5 --ft-restart-policy=any-failed"
 COMMON_TEST_SCRIPT_ARGS="--max-time=60 --run-cnt-file=${RUNS_COUNT_FILE} --world-size-file=${WORLD_SIZE_FILE}"
 rm -f "${RUNS_COUNT_FILE}"
 rm -f "${WORLD_SIZE_FILE}"

--- a/tests/fault_tolerance/func/run_launcher_min_healthy_mode_test.sh
+++ b/tests/fault_tolerance/func/run_launcher_min_healthy_mode_test.sh
@@ -99,8 +99,8 @@ log_title() {
 ( kill -s SIGKILL $(pgrep -f ft_launcher) > /dev/null 2>&1 || true ) 
 
 export LOGLEVEL='DEBUG'
-COMMON_FT_ARGS="--ft-param-log_level=DEBUG"
-COMMON_LAUNCHER_ARGS="--nproc-per-node=2 --nnodes=2:3 --rdzv-backend=c10d --rdzv_endpoint=localhost:12345 --max-restarts=1 --restart-policy=min-healthy"
+COMMON_FT_ARGS="--ft-log-level=DEBUG"
+COMMON_LAUNCHER_ARGS="--nproc-per-node=2 --nnodes=2:3 --rdzv-backend=c10d --rdzv_endpoint=localhost:12345 --max-restarts=1 --ft-restart-policy=min-healthy"
 COMMON_TEST_SCRIPT_ARGS="--max-time=60 --run-cnt-file=${RUNS_COUNT_FILE} --world-size-file=${WORLD_SIZE_FILE}"
 rm -f "${RUNS_COUNT_FILE}"
 rm -f "${WORLD_SIZE_FILE}"

--- a/tests/fault_tolerance/func/run_local_ddp_test_heartbeats.sh
+++ b/tests/fault_tolerance/func/run_local_ddp_test_heartbeats.sh
@@ -107,8 +107,8 @@ do
    echo "Launching ${WORLD_SIZE} x \"${TRAIN_CMD}\" with ft launcher..."
 
    ft_launcher --nproc-per-node=${WORLD_SIZE} --max-restarts=${MAX_RESTARTS} \
-      --rdzv-backend=c10d --rdzv-endpoint=localhost:0 --ft-param-restart_check_interval=0.5 \
-      --fault-tol-cfg-path="examples/fault_tolerance/fault_tol_cfg_heartbeats.yaml" --term-timeout=15 \
+      --rdzv-backend=c10d --rdzv-endpoint=localhost:0 --ft-restart-check-interval=0.5 \
+      --ft-cfg-path="examples/fault_tolerance/fault_tol_cfg_heartbeats.yaml" --term-timeout=15 \
       ${TRAIN_CMD} 2>&1 | tee -a ${RES_DIR}/output_$i/log.log
 
    if [ $? -ne 0 ]

--- a/tests/fault_tolerance/func/run_local_ddp_test_sections.sh
+++ b/tests/fault_tolerance/func/run_local_ddp_test_sections.sh
@@ -107,8 +107,8 @@ do
    echo "Launching ${WORLD_SIZE} x \"${TRAIN_CMD}\" with ft launcher..."
 
    ft_launcher --nproc-per-node=${WORLD_SIZE} --max-restarts=${MAX_RESTARTS} \
-      --rdzv-backend=c10d --rdzv-endpoint=localhost:0 --ft-param-restart_check_interval=0.5 \
-      --fault-tol-cfg-path="examples/fault_tolerance/fault_tol_cfg_sections.yaml" --term-timeout=15 \
+      --rdzv-backend=c10d --rdzv-endpoint=localhost:0 --ft-restart-check-interval=0.5 \
+      --ft-cfg-path="examples/fault_tolerance/fault_tol_cfg_sections.yaml" --term-timeout=15 \
       ${TRAIN_CMD} 2>&1 | tee -a ${RES_DIR}/output_$i/log.log
 
    if [ $? -ne 0 ]

--- a/tests/fault_tolerance/func/run_workload_ctrl_test_excl_node.sh
+++ b/tests/fault_tolerance/func/run_workload_ctrl_test_excl_node.sh
@@ -101,7 +101,7 @@ function get_still_alive {
 ( kill -s SIGKILL $(pgrep -f ft_launcher) > /dev/null 2>&1 || true ) 
 
 export LOGLEVEL='DEBUG'
-COMMON_FT_ARGS="--ft-param-log_level=DEBUG --ft-param-rank_heartbeat_timeout=5 --ft-param-initial_rank_heartbeat_timeout=5"
+COMMON_FT_ARGS="--ft-log-level=DEBUG --ft-rank-heartbeat-timeout=5 --ft-initial-rank-heartbeat-timeout=5"
 COMMON_LAUNCHER_ARGS="--nproc-per-node=1 --nnodes=2 --rdzv-backend=c10d --rdzv_endpoint=localhost:12345 --max-restarts=10"
 
 rm -f "${RANK_CONTROL_FILE}"

--- a/tests/fault_tolerance/func/run_workload_ctrl_test_shutdown.sh
+++ b/tests/fault_tolerance/func/run_workload_ctrl_test_shutdown.sh
@@ -105,7 +105,7 @@ THIS_SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 WORKER_SCRIPT="${THIS_SCRIPT_DIR}/_workload_ctrl_test_worker.py"
 
 export LOGLEVEL='DEBUG'
-COMMON_FT_ARGS="--ft-param-log_level=DEBUG --ft-param-rank_heartbeat_timeout=5 --ft-param-initial_rank_heartbeat_timeout=5"
+COMMON_FT_ARGS="--ft-log-level=DEBUG --ft-rank-heartbeat-timeout=5 --ft-initial-rank-heartbeat-timeout=5"
 COMMON_LAUNCHER_ARGS="--nproc-per-node=1 --nnodes=${NODES} --rdzv-backend=c10d --rdzv_endpoint=localhost:12345 --max-restarts=100"
 
 rm -f "${RANK_CONTROL_FILE}"

--- a/tests/fault_tolerance/unit/test_config.py
+++ b/tests/fault_tolerance/unit/test_config.py
@@ -17,7 +17,6 @@ import logging
 import os
 import signal
 import tempfile
-from argparse import ArgumentParser
 from contextlib import contextmanager
 
 import pytest
@@ -51,53 +50,28 @@ def test_from_kwargs():
 
 
 def test_from_args():
-    parser = ArgumentParser(description="Test parser")
-    parser.add_argument(
-        "--ft-param-safety_factor",
-        "--ft-param-safety_factor",
-        type=float,
-        default=None,
-    )
-    parser.add_argument(
-        "--ft-param-rank_termination_signal",
-        "--ft-param-rank_termination_signal",
-        type=str,
-        default=None,
-    )
-    parser.add_argument(
-        "--ft-param-log_level",
-        "--ft-param-log_level",
-        type=str,
-        default=None,
-    )
-    parser.add_argument(
-        "--ft-param-rank_out_of_section_timeout",
-        "--ft-param-rank_out_of_section_timeout",
-        type=float,
-        default=None,
-    )
-    parser.add_argument(
-        "--ft-param-rank_section_timeouts",
-        "--ft-param-rank_section_timeouts",
-        type=str,
-        default=None,
-    )
+    from nvidia_resiliency_ext.fault_tolerance.launcher import get_args_parser
+
+    parser = get_args_parser()
     inp = [
-        "--ft-param-safety_factor",
+        "--ft-safety-factor",
         "0.567",
-        "--ft-param-rank_termination_signal",
+        "--ft-rank-termination-signal",
         "SIGUSR2",
-        "--ft-param-log_level",
+        "--ft-log-level",
         "DEBUG",
-        "--ft-param-rank_out_of_section_timeout",
+        "--ft-rank-out-of-section-timeout",
         "123.0",
-        "--ft-param-rank_section_timeouts",
+        "--ft-rank-section-timeouts",
         "custom1:111.1,custom2:222.2",
     ]
+
+    # Add a the dummy training script required by the torchrun argparser
+    inp.append("dummy.py")
+
     args = parser.parse_args(inp)
-    ft = fault_tolerance.FaultToleranceConfig.from_args(
-        args=args, cfg_file_arg=None, ft_args_prefix='ft_param_'
-    )
+    ft = fault_tolerance.FaultToleranceConfig.from_args(args)
+
     assert ft.safety_factor == 0.567
     assert ft.rank_termination_signal == signal.SIGUSR2
     assert ft.log_level == logging.DEBUG


### PR DESCRIPTION
This PR addresses consistency in the arguments to `ft_launcher`.

Some arguments are marked as deprecated and replaced with consistent use of underscore and hyphen.