### PR TITLE
Make MSC changes in FileSystemWriterAsync compatible with PyT 2.3

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -481,7 +481,10 @@ class FileSystemWriterAsync(FileSystemWriter):
                 storage_md.update({wr.index: wr.storage_data for wr in wr_list})
 
             metadata.storage_data = storage_md
-            metadata.storage_meta = self.storage_meta()
+
+            # storage_meta was introduced since PyTorch 2.4
+            if hasattr(self, "storage_meta"):
+                metadata.storage_meta = self.storage_meta()
 
             path = os.path.join(self.checkpoint_dir, ".metadata")
 

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -483,8 +483,8 @@ class FileSystemWriterAsync(FileSystemWriter):
             metadata.storage_data = storage_md
 
             # storage_meta was introduced since PyTorch 2.4
-            if hasattr(self, "storage_meta"):
-                metadata.storage_meta = self.storage_meta()
+            if "storage_meta" in inspect.signature(Metadata).parameters:
+                metadata.stoage_meta = self.storage_meta()
 
             path = os.path.join(self.checkpoint_dir, ".metadata")
 


### PR DESCRIPTION
The `storage_meta` was only introduced in PyTorch 2.4. For PyTorch 2.3, we can ignore this attribute.