### PR TITLE
use spawn for improved stability

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -61,7 +61,7 @@ _results_queue = None
 def _get_write_results_queue():
     global _results_queue
     if _results_queue is None:
-        ctx = mp.get_context('fork')
+        ctx = mp.get_context('spawn')
         with _disable_gc():
             _results_queue = ctx.Manager().Queue()
     return _results_queue


### PR DESCRIPTION
As observed in recent experiments, using spawn improves stability.
Co-authored-by: [sbak@nvidia.com](mailto:sbak@nvidia.com)