### PR TITLE
[Docs] Fix absolute URL links and add documentation building instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,19 @@ git push -u origin <local-branch>:<remote-branch>
 
 4. With CI/CD process in place, the PR will be accepted and the corresponding issue closed only after adequate testing has been completed, manually, by the developer and NVRx engineer reviewing the code.
 
+#### Documentation Building
+
+When contributing documentation changes, ensure the documentation builds correctly. See the [docs CI workflow](https://github.com/NVIDIA/nvidia-resiliency-ext/blob/main/.github/workflows/build_docs.yml) for up-to-date instructions:
+
+   ```bash
+   pip install -U sphinx sphinx-rtd-theme sphinxcontrib-napoleon sphinx_copybutton lightning psutil defusedxml
+   sphinx-build -b html docs/source public/
+
+   # alternatively,
+   cd docs
+   make html
+   ```
+   You can then view the locally built documentation under `public` directory or `docs/build/html` (e.g., `open public/index.html`). Ensure that all documentation changes are properly formatted and that the build completes without warnings or errors.
 
 #### Signing Your Work
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,11 +10,11 @@ nvidia-resiliency-ext v0.4.0
 Features
 --------
 
-* `Hang detection and automatic in-job restarting <https://github.com/NVIDIA/nvidia-resiliency-ext/blob/main/docs/source/fault_tolerance/index.rst>`_
-* `In-process restarting <https://github.com/NVIDIA/nvidia-resiliency-ext/blob/main/docs/source/inprocess/index.rst>`_
-* `Async checkpointing <https://github.com/NVIDIA/nvidia-resiliency-ext/blob/main/docs/source/checkpointing/async/index.rst>`_
-* `Local checkpointing <https://github.com/NVIDIA/nvidia-resiliency-ext/blob/main/docs/source/checkpointing/local/index.rst>`_
-* `Straggler (slower ranks) detection <https://github.com/NVIDIA/nvidia-resiliency-ext/blob/main/docs/source/straggler_det/index.rst>`_
+* `Hang detection and automatic in-job restarting <fault_tolerance/index.html>`_
+* `In-process restarting <inprocess/index.html>`_
+* `Async checkpointing <checkpointing/async/index.html>`_
+* `Local checkpointing <checkpointing/local/index.html>`_
+* `Straggler (slower ranks) detection <straggler_det/index.html>`_
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION

- Replace absolute GitHub URLs with relative internal links in index.rst
  - This is to make sure the docs is referring to the version when it's build/released
- Add documentation building section to CONTRIBUTING.md
