### PR TITLE
make persistentAsynWorker default. Ensure preload_fn invoked in the sync CP save.

### DIFF
--- a/examples/checkpointing/async_ckpt.py
+++ b/examples/checkpointing/async_ckpt.py
@@ -23,9 +23,14 @@ def parse_args():
         help="Checkpoint directory for async checkpoints",
     )
     parser.add_argument(
-        '--persistent_queue',
-        action='store_true',
-        help="Enables a persistent version of AsyncCallsQueue.",
+        '--no_persistent_queue',
+        action='store_false',
+        default=True,
+        dest='persistent_queue'
+        help=(
+            "Disables a persistent version of AsyncCallsQueue. "
+            "Effective only when --async_save is set."
+        ),
     )
     return parser.parse_args()
 

--- a/examples/checkpointing/async_writer.py
+++ b/examples/checkpointing/async_writer.py
@@ -50,9 +50,14 @@ def parse_args():
         help="Threads to use during saving. Affects the number of files in the checkpoint (saving ranks * num_threads).",
     )
     parser.add_argument(
-        '--persistent_queue',
-        action='store_true',
-        help="Enables a persistent version of AsyncCallsQueue.",
+        '--no_persistent_queue',
+        action='store_false',
+        default=True,
+        dest='persistent_queue',
+        help=(
+            "Disables a persistent version of AsyncCallsQueue. "
+            "Effective only when --async_save is set."
+        ),
     )
 
     return parser.parse_args()

--- a/examples/checkpointing/local_ckpt.py
+++ b/examples/checkpointing/local_ckpt.py
@@ -42,10 +42,12 @@ def parse_args():
         "Needs to be enabled on all ranks.",
     )
     parser.add_argument(
-        '--persistent_queue',
-        action='store_true',
+        '--no_persistent_queue',
+        action='store_false',
+        default=True,
+        dest='persistent_queue',
         help=(
-            "Enables a persistent version of AsyncCallsQueue. "
+            "Disables a persistent version of AsyncCallsQueue. "
             "Effective only when --async_save is set."
         ),
     )

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/torch_ckpt.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/torch_ckpt.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class TorchAsyncCheckpoint(object):
     async_fn = None
 
-    def __init__(self, persistent_queue=False):
+    def __init__(self, persistent_queue=True):
         self.save = torch.save
         self._async_calls_queue = AsyncCallsQueue(persistent=persistent_queue)
         # Use direct torch.save for persistent queue, avoid unnecessary wrapping


### PR DESCRIPTION
1. The TemporalAsyncWorker for Checkpoints is disabled due to instabilities from `fork`
2. This change makes the `PersistentAsyncWorker` the default async mechanism which is safe due to the use of `spawn`.
3. In this MR, we also fix the `sync_cp` mechanism where preload_fn() was originally not being called.