### PR TITLE
Rhewett/fix leaky restart

### DIFF
--- a/src/nvidia_resiliency_ext/inprocess/rank_assignment.py
+++ b/src/nvidia_resiliency_ext/inprocess/rank_assignment.py
@@ -701,6 +701,8 @@ class Tree(RankAssignment):
         self.recompute_rank()
 
         ctx.state = self.get_state_from_tree(state, terminated_ranks)
+        for leaf in self.tree.iter_leaves():
+            leaf.state.fn_exception = None
         ctx.terminated_ranks = set()
 
         return ctx

--- a/src/nvidia_resiliency_ext/inprocess/wrap.py
+++ b/src/nvidia_resiliency_ext/inprocess/wrap.py
@@ -549,11 +549,11 @@ class CallWrapper:
                     state.set_distributed_vars()
                 else:
                     break
-                finally:
-                    while gc.collect():
-                        pass
 
                 state.advance()
+
+                while gc.collect():
+                    pass
 
         except BaseException as exit_ex:
 


### PR DESCRIPTION
Two patches to fix workload leaks across the restart boundary.

First, re-ordering the explicit GC call after state advancement allows the previous state's resources to be GCed.  Second, Tree-mode rank-assignment was caching the previous restart's exception, which preserves workload state, preventing it from being GCed.