### PR TITLE
[Build] Improvements to CUDA path detection during source installation

### DIFF
--- a/cupti_build.py
+++ b/cupti_build.py
@@ -83,9 +83,7 @@ def get_cuda_path():
                 return match.group(1)
             else:
                 # fallback: get directory where nvcc is located
-                cuda_dir = os.path.dirname(os.path.dirname(nvcc_path))
-                if os.path.isdir(cuda_dir):
-                    return cuda_dir
+                return os.path.dirname(os.path.dirname(nvcc_path))
         except Exception:
             pass
 

--- a/cupti_build.py
+++ b/cupti_build.py
@@ -15,7 +15,9 @@
 
 import glob
 import os
-
+import re
+import shutil
+import subprocess
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 
@@ -43,6 +45,56 @@ def _skip_ext_build():
     return ans.lower() in ['1', 'on', 'yes', 'true']
 
 
+def get_cuda_path():
+    """
+    Determines the path to the CUDA installation.
+
+    Find the CUDA root directory under stanadard paths or using nvcc
+    as it's typically done in build systems like CMake.
+
+    1. Check if $CUDA_PATH is set or /usr/local/cuda exists; return it if so.
+    2. If not, check if nvcc is in PATH. If yes, run "nvcc -v test.cu" and parse output for CUDA root.
+    3. If neither method works, raise FileNotFoundError.
+
+    Returns:
+        str: The path to the CUDA installation directory.
+
+    Raises:
+        FileNotFoundError: If the CUDA installation cannot be found.
+    """
+    cuda_path = os.environ.get("CUDA_PATH", "/usr/local/cuda")
+    if os.path.isdir(cuda_path):
+        return cuda_path
+
+    nvcc_path = shutil.which("nvcc")
+    if nvcc_path:
+        try:
+            # try to extract CUDA root from nvcc output
+            result = subprocess.run(
+                [nvcc_path, "-v", "test.cu"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+                universal_newlines=True,
+            )
+            # match "#$ TOP=..." in output
+            match = re.search(r'#\$ TOP=([^\r\n]*)', result.stdout)
+            if match and os.path.isdir(match.group(1)):
+                return match.group(1)
+            else:
+                # fallback: get directory where nvcc is located
+                cuda_dir = os.path.dirname(os.path.dirname(nvcc_path))
+                if os.path.isdir(cuda_dir):
+                    return cuda_dir
+        except Exception:
+            pass
+
+    raise FileNotFoundError(
+        "CUDA installation not found in /usr/local/cuda or $CUDA_PATH, "
+        "and could not determine CUDA path from nvcc"
+    )
+
+
 def build(setup_kwargs):
 
     if _skip_ext_build():
@@ -54,9 +106,7 @@ def build(setup_kwargs):
     include_dirs = None
     library_dirs = None
 
-    cuda_path = os.environ.get("CUDA_PATH", "/usr/local/cuda")
-    if not os.path.isdir(cuda_path):
-        raise FileNotFoundError("cuda installation not found in /usr/local/cuda or $CUDA_PATH")
+    cuda_path = get_cuda_path()
 
     cupti_h = "cupti.h"
     libcupti_so = "libcupti.so"


### PR DESCRIPTION
This is a minor thing but thought helpful to improve user experience.

### Summary

- If CUDA is installed and available in `$PATH`, it would be nice if build system could find it rather than throwing an error.
- Currently we just check for `/usr/local/cuda` and `CUDA_PATH` and then throw an error.
- In this PR, we try to check if `nvcc` present in the $PATH and try to determine the path of CUDA as it's typically done in build system like CMake: https://github.com/Kitware/CMake/blob/master/Modules/FindCUDA.cmake#L862

### As an example,

On DLCluster with CUDA setup in Conda environment:

```console
$ which nvcc
/home/scratch.prkumbhar_wwfo/software/x86_64/nvrx-july-2025/conda_envs/nvrx202507/bin/nvcc

$ pip install .
...
      File "/home/prkumbhar/workspace/repos/nvidia/nvidia-resiliency-ext/cupti_build.py", line 59, in build
          raise FileNotFoundError("cuda installation not found in /usr/local/cuda or $CUDA_PATH")
      FileNotFoundError: cuda installation not found in /usr/local/cuda or $CUDA_PATH
```

With this PR, it finds correct CUDA dir:

```console
  ...
  A setup.py file already exists. Using it.
  CUDA root found: /home/scratch.prkumbhar_wwfo/software/x86_64/nvrx-july-2025/conda_envs/nvrx202507/bin/../targets/x86_64-linux
```
