### PR TITLE
Inprocess logging improvement

### DIFF
--- a/src/nvidia_resiliency_ext/inprocess/attribution.py
+++ b/src/nvidia_resiliency_ext/inprocess/attribution.py
@@ -18,6 +18,7 @@ import dataclasses
 import enum
 import itertools
 import re
+from collections import defaultdict
 
 
 class Interruption(enum.Enum):
@@ -51,11 +52,13 @@ class InterruptionRecord:
 
 
 def format_interruption_records(records):
+    # Group records by interruption type
+    grouped = defaultdict(set)
+    for record in records:
+        grouped[record.interruption].add(record.rank)
+
+    # Format the message with counts instead of individual ranks
     msg = ', '.join(
-        (
-            f'{interruption} on {ranks=}'
-            for interruption, group in itertools.groupby(records, key=lambda r: r.interruption)
-            for ranks in [set([elem.rank for elem in group])]
-        )
+        f'{interruption} affecting {len(ranks)} rank(s)' for interruption, ranks in grouped.items()
     )
     return msg

--- a/src/nvidia_resiliency_ext/inprocess/wrap.py
+++ b/src/nvidia_resiliency_ext/inprocess/wrap.py
@@ -575,7 +575,8 @@ class CallWrapper:
                 log.error(log_exc(state, terminate_ex, 'terminate_ex'))
                 raise terminate_ex from exit_ex
 
-            raise exit_ex
+            # Re-raise the final exception without preserving the chain
+            raise exit_ex.__class__(str(exit_ex))
 
         try:
             if wrapper.completion is not None:

--- a/src/nvidia_resiliency_ext/inprocess/wrap.py
+++ b/src/nvidia_resiliency_ext/inprocess/wrap.py
@@ -576,7 +576,7 @@ class CallWrapper:
                 raise terminate_ex from exit_ex
 
             # Re-raise the final exception without preserving the chain
-            raise exit_ex.__class__(str(exit_ex))
+            raise exit_ex.__class__(str(exit_ex)) from None
 
         try:
             if wrapper.completion is not None:


### PR DESCRIPTION
1. Remove the extra exception chain logging
2. Remove termination stack trace for ranks terminated intentionally by NVRx.
3. Fix the interruption record aggregation (sorting). Logs them in a manageable way for scale setup.