### PR TITLE
checkpoint test utils: fix rank/world size

### DIFF
--- a/tests/checkpointing/unit/test_utilities.py
+++ b/tests/checkpointing/unit/test_utilities.py
@@ -26,8 +26,8 @@ from nvidia_resiliency_ext.checkpointing.local.base_state_dict import TensorAwar
 
 class Utils:
 
-    world_size = torch.cuda.device_count()
-    rank = int(os.environ['LOCAL_RANK'])
+    world_size = int(os.environ['WORLD_SIZE'])
+    rank = int(os.environ['RANK'])
     inited = False
     store = None
 


### PR DESCRIPTION
`WORLD_SIZE` is set to the correct value via torchrun. Using the cuda device count is not correct.

Additionally, `LOCAL_RANK` is only equal to `RANK` on a single node. The `rank` variable is used as a global rank, so correctly set it using `RANK`.

This is required to run the tests on CI on different shaped machines, such as ARM.