### PR TITLE
feat: Add NIC health monitoring and GB200 platform support

### DIFF
--- a/docs/source/inprocess/api/health_check.rst
+++ b/docs/source/inprocess/api/health_check.rst
@@ -7,3 +7,21 @@ Health Check
 .. automodule:: nvidia_resiliency_ext.inprocess.health_check
     :members:
     :exclude-members: HealthCheck
+
+Enhanced Health Check Features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The InProcess wrapper automatically includes three types of health checks when ``LOCAL_RANK`` is available:
+
+**ChainedGPUHealthCheck**: Monitors GPU device health and recovery actions.
+**ChainedNVLHealthCheck**: Monitors NVLink connectivity and link health.
+**ChainedNicHealthCheck**: Monitors network interface card connectivity and link down events.
+
+All chained health checks automatically use the ``device_index`` from ``LOCAL_RANK`` and are ready to use
+immediately after construction. The underlying health check classes handle device assignment and baseline
+initialization automatically.
+
+.. note::
+   The ``NicHealthCheck`` constructor now accepts an optional ``device_index`` parameter that automatically
+   sets the NIC device and initializes the baseline link down counter during construction. This eliminates
+   the need for manual setup and ensures accurate health monitoring from the first check.

--- a/docs/source/inprocess/usage_guide.rst
+++ b/docs/source/inprocess/usage_guide.rst
@@ -515,6 +515,27 @@ main Python interpreter process on the local rank.
 
 Multiple health checks could be composed with :py:class:`nvidia_resiliency_ext.inprocess.Compose`.
 
+Automatic Health Checks
+~~~~~~~~~~~~~~~~~~~~~~~
+The :py:class:`Wrapper` automatically includes comprehensive health monitoring when the ``LOCAL_RANK``
+environment variable is available. These health checks are executed in sequence during restart to ensure
+the system is in a healthy state before attempting to restart the workload.
+
+**GPU Health Check**: Validates GPU device health and recovery actions using :py:class:`ChainedGPUHealthCheck`.
+
+**NVL Health Check**: Monitors NVLink connectivity and link health using :py:class:`ChainedNVLHealthCheck`.
+
+**NIC Health Check**: Monitors network interface card connectivity and link down events using :py:class:`ChainedNicHealthCheck`.
+This is particularly important for distributed workloads where network connectivity is critical.
+
+The automatic health checks are configured with the same ``device_index`` as the current GPU rank (from ``LOCAL_RANK``),
+ensuring that each GPU monitors its associated network interfaces. No additional configuration is required
+for basic health monitoring - the wrapper automatically handles health check composition and execution.
+
+.. note::
+   The NIC health check automatically establishes baseline link down counter values during initialization,
+   ensuring accurate delta detection from the first health check execution.
+
 Monitoring capabilities
 ~~~~~~~~~~~~~~~~~~~~~~~
 The :py:class:`Wrapper` provides several monitoring mechanisms to track the

--- a/src/nvidia_resiliency_ext/inprocess/wrap.py
+++ b/src/nvidia_resiliency_ext/inprocess/wrap.py
@@ -36,7 +36,12 @@ from .completion import Completion
 from .compose import Compose
 from .exception import HealthCheckError, InternalError
 from .finalize import Finalize
-from .health_check import ChainedGPUHealthCheck, ChainedNVLHealthCheck, HealthCheck
+from .health_check import (
+    ChainedGPUHealthCheck,
+    ChainedNicHealthCheck,
+    ChainedNVLHealthCheck,
+    HealthCheck,
+)
 from .initialize import Initialize
 from .monitor_process import MonitorProcess
 from .monitor_thread import MonitorThread, RankShouldRestart, reraise_if_unraisable
@@ -256,15 +261,16 @@ class Wrapper:
                 # If it's a single health check, add it directly
                 health_checks.append(self.health_check)
 
-        # Add GPU and NVL health checks if LOCAL_RANK is available
+        # Add GPU, NVL, and NIC health checks if LOCAL_RANK is available
         if 'LOCAL_RANK' in os.environ:
             try:
                 local_rank = int(os.environ['LOCAL_RANK'])
                 gpu_check = ChainedGPUHealthCheck(device_index=local_rank)
                 nvl_check = ChainedNVLHealthCheck(device_index=local_rank)
-                health_checks.extend([gpu_check, nvl_check])
+                nic_check = ChainedNicHealthCheck(device_index=local_rank)
+                health_checks.extend([gpu_check, nvl_check, nic_check])
             except (ValueError, TypeError):
-                # If LOCAL_RANK is not a valid integer, skip GPU/NVL checks
+                # If LOCAL_RANK is not a valid integer, skip GPU/NVL/NIC checks
                 pass
 
         # Compose all health checks (or set to None if no health checks)


### PR DESCRIPTION
- Implement ChainedNicHealthCheck extending HealthCheck base class
- Add automatic NIC health checks to InProcess wrapper when LOCAL_RANK present
- Introduce GB200 platform detection via pynvml device count and naming
- Provide static GPU-NIC mapping for GB200: {0: "mlx5_0", 1: "mlx5_1", 2: "mlx5_3", 3: "mlx5_4"}
- Enhance NicHealthCheck with device_index parameter for automatic setup
- Update health check composition to include GPU, NVL, and NIC checks