### PR TITLE
Use iteration count and NVRX_FR_TRACE_PATH env for fr trace path

### DIFF
--- a/src/nvidia_resiliency_ext/inprocess/abort.py
+++ b/src/nvidia_resiliency_ext/inprocess/abort.py
@@ -88,9 +88,7 @@ class AbortTorchDistributed(Abort):
         Args:
             torch_fr_trace_path: Path to collect PyTorch Flight Recorder traces.
         '''
-        if torch_fr_trace_path is None:
-            torch_fr_trace_path = os.environ.get('NVRX_FR_TRACE_PATH', None)
-        self.torch_fr_trace_path = torch_fr_trace_path
+        self.torch_fr_trace_path = torch_fr_trace_path or os.environ.get('NVRX_FR_TRACE_PATH', None)
 
     @staticmethod
     def shutdown_all_process_group_backends():
@@ -150,8 +148,7 @@ class AbortTorchDistributed(Abort):
             if self.torch_fr_trace_path is None:
                 return
             trace_path = os.path.join(self.torch_fr_trace_path, f'iter_{state.iteration}')
-            if not os.path.exists(trace_path):
-                os.makedirs(trace_path, exist_ok=True)
+            os.makedirs(trace_path, exist_ok=True)
             trace_analyzer = TorchFRTraceCollector(trace_path)
             trace_analyzer.collect()
 

--- a/src/nvidia_resiliency_ext/inprocess/abort.py
+++ b/src/nvidia_resiliency_ext/inprocess/abort.py
@@ -138,12 +138,13 @@ class AbortTorchDistributed(Abort):
                 except ValueError:
                     env_value_int = 0
 
-                if env_value_int <= 0 and rank == 0 and not AbortTorchDistributed._logging_printed:
-                    log = logging.getLogger(__name__)
-                    log.info(
-                        f"Environment variable {env_var} is set to {env_value}"
-                        f", FR trace collection is disabled"
-                    )
+                if env_value_int <= 0 and not AbortTorchDistributed._logging_printed:
+                    if rank == 0:
+                        log = logging.getLogger(__name__)
+                        log.info(
+                            f"Environment variable {env_var} is set to {env_value}"
+                            f", FR trace collection is disabled"
+                        )
                     AbortTorchDistributed._logging_printed = True
                     return False
             return True

--- a/src/nvidia_resiliency_ext/inprocess/abort.py
+++ b/src/nvidia_resiliency_ext/inprocess/abort.py
@@ -132,7 +132,9 @@ class AbortTorchDistributed(Abort):
                 try:
                     env_value_int = int(env_value)
                 except ValueError:
-                    env_value_int = 0
+                    raise ValueError(
+                        f"Environment variable {env_var} is set to {env_value}, which is not an integer"
+                    )
 
                 if env_value_int <= 0:
                     if rank == 0:

--- a/src/nvidia_resiliency_ext/inprocess/abort.py
+++ b/src/nvidia_resiliency_ext/inprocess/abort.py
@@ -68,8 +68,6 @@ class AbortTorchDistributed(Abort):
     thread for each distributed group that has been created.
     '''
 
-    _logging_printed: bool = False
-
     def __init__(self, torch_fr_trace_path: str = None):
         r'''
         This class is used to abort PyTorch distributed collectives, and destroy all PyTorch
@@ -138,14 +136,13 @@ class AbortTorchDistributed(Abort):
                 except ValueError:
                     env_value_int = 0
 
-                if env_value_int <= 0 and not AbortTorchDistributed._logging_printed:
+                if env_value_int <= 0:
                     if rank == 0:
                         log = logging.getLogger(__name__)
                         log.info(
                             f"Environment variable {env_var} is set to {env_value}"
                             f", FR trace collection is disabled"
                         )
-                    AbortTorchDistributed._logging_printed = True
                     return False
             return True
 


### PR DESCRIPTION
Use iteration count for FR trace path not to override existing traces across restarts
Also, use `NVRX_FR_TRACE_PATH` when trace path is not passed to `AbortTorchDistributed`