### PR TITLE
Change the health check result logging at FR dump to `debug`

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/trace_analyzer/trace_collector.py
+++ b/src/nvidia_resiliency_ext/attribution/trace_analyzer/trace_collector.py
@@ -121,8 +121,8 @@ class TorchFRTraceCollector(TraceCollector):
             nic_health_check.set_nic_device(local_rank)
             nic_health = nic_health_check._perform_health_check()
 
-        logger.info(f"GPU Health Check: {stderr_gpu.getvalue()}")
-        logger.info(f"NIC Health Check: {stderr_nic.getvalue()}")
+        logger.debug(f"GPU Health Check: {stderr_gpu.getvalue()}")
+        logger.debug(f"NIC Health Check: {stderr_nic.getvalue()}")
         health_check_results['gpu_health_check'] = {
             'status': 'Healthy' if gpu_health else 'Failed',
             'output': stderr_gpu.getvalue(),


### PR DESCRIPTION
the health check logging in the FR dump is optional for debugging. 
The purpose of calling the routine is to covey health check results in FR dump trace for further analysis. 