### PR TITLE
checkpointing: fix error propagation and add test

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -299,7 +299,7 @@ class TemporalAsyncCaller(AsyncCaller):
         return is_done
 
     def close(self, abort=False):
-        """For TemporalAsyncCaller, this method is called explictly in `is_current_async_calls_done`
+        """For TemporalAsyncCaller, this method is called explictly in `is_current_async_call_done`
 
         This method make sure the TemporalAsyncCaller terminated
         with all its assigned async request completed
@@ -621,6 +621,9 @@ class AsyncCallsQueue(metaclass=Singleton):
         Returns:
             List[int]: list of indices (as returned by `schedule_async_request`)
                 of async calls that have been successfully finalized.
+        Raises:
+            CheckpointException: if any rank(s) raised an exception during checkpoint
+                writing, the exceptions are wrapped and raised on all ranks.
         """
         call_idx_finalized = []
         while self.async_calls:

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -37,6 +37,7 @@ import psutil
 import torch
 from torch import multiprocessing as mp
 from torch.distributed.checkpoint import FileSystemWriter
+from torch.distributed.checkpoint.api import WRAPPED_EXCEPTION, _wrap_exception
 from torch.distributed.checkpoint.filesystem import DEFAULT_SUFFIX, _StoragePrefix, _write_item
 from torch.distributed.checkpoint.metadata import Metadata
 
@@ -91,6 +92,7 @@ class FileSystemWriterAsync(FileSystemWriter):
     ):
         self.checkpoint_dir = path
         self.use_msc = kwargs.pop("use_msc", False)
+        self.open_file = kwargs.pop("open_file", open)  # for overriding in tests
 
         super().__init__(path, *args, **kwargs)
         if not self.single_file_per_rank:
@@ -204,10 +206,16 @@ class FileSystemWriterAsync(FileSystemWriter):
             3) arguments to that function in 1).
         """
         if not self.write_buckets:
-            return None, None, ()
+            return None, None, []
+        if self.use_msc:
+            import multistorageclient as msc
+
+            open_file = msc.open
+        else:
+            open_file = self.open_file
         transform_list = [self.transforms] if hasattr(self, 'transforms') else []
         return (
-            partial(self.write_preloaded_data_multiproc, transform_list, self.use_msc),
+            partial(self.write_preloaded_data_multiproc, transform_list, self.use_msc, open_file),
             partial(self.preload_tensors, self.write_buckets, True),
             [torch.distributed.get_rank(), self.write_buckets, self.results_queue],
         )
@@ -238,6 +246,7 @@ class FileSystemWriterAsync(FileSystemWriter):
     def write_preloaded_data_multiproc(
         transform_list: List[_StorageWriterTransforms],
         use_msc: bool,
+        open_file: Callable,
         rank: int,
         write_buckets: List[WriteBucket],
         global_results_queue: mp.Queue,
@@ -287,7 +296,9 @@ class FileSystemWriterAsync(FileSystemWriter):
 
                 p_list.append(
                     ctx.Process(
-                        target=partial(FileSystemWriterAsync.write_preloaded_data, transform_list),
+                        target=partial(
+                            FileSystemWriterAsync.write_preloaded_data, transform_list, open_file
+                        ),
                         kwargs=kwargs,
                     )
                 )
@@ -339,6 +350,7 @@ class FileSystemWriterAsync(FileSystemWriter):
     @_disable_gc()
     def write_preloaded_data(
         transform_list: List[_StorageWriterTransforms],
+        open_file: Callable,
         local_proc_idx: int,
         write_bucket: WriteBucket,
         results_queue: mp.SimpleQueue,
@@ -378,12 +390,6 @@ class FileSystemWriterAsync(FileSystemWriter):
                 assert len(transform_list) <= 1
                 write_fn = partial(_write_item, *transform_list)
 
-            if use_msc:
-                import multistorageclient as msc
-
-                open_file = msc.open
-            else:
-                open_file = open
             with open_file(file_name, "wb") as stream:
                 for write_item, data in bytes_data:
                     local_results.append(
@@ -421,14 +427,14 @@ class FileSystemWriterAsync(FileSystemWriter):
         """Write all items from ``plan``."""
         raise NotImplementedError('write_data not implemented for FileSystemWriterAsync')
 
-    def retrieve_write_results(self) -> List[WriteResult]:
+    def retrieve_write_results(self) -> Union[List[WriteResult], WRAPPED_EXCEPTION]:
         """
         Turn the latest dict including write results from `self.results_queue`
             into a single results lists. Includes error check.
 
-        Returns (List[WriteResult]): the list of write results
-            from all local processes performing the save.
-
+        Returns (Union(List[WriteResult], WRAPPED_EXCEPTION): the list of write results
+            from all local processes performing the save, or a WRAPPED_EXCEPTION if
+            an exception was raised during the writing process.
         """
         assert self.write_buckets is not None
 
@@ -438,15 +444,22 @@ class FileSystemWriterAsync(FileSystemWriter):
             try:
                 write_results_or_exc = self.results_queue.get_nowait()
             except queue.Empty:
-                raise RuntimeError('results_queue should not be empty')
+                return _wrap_exception(RuntimeError('results_queue should not be empty'))
 
         if isinstance(write_results_or_exc, Exception):
-            raise RuntimeError(f'Worker failure: {write_results_or_exc}') from write_results_or_exc
+            try:
+                raise RuntimeError(
+                    f'Worker failure: {write_results_or_exc}'
+                ) from write_results_or_exc
+            except Exception as e:
+                return _wrap_exception(e)
         write_results: dict = write_results_or_exc
         if len(write_results) != len(self.write_buckets):
-            raise RuntimeError(
-                f'Incomplete worker results (expected {len(self.write_buckets)},'
-                f' got {len(write_results)}. This probably indicates a worker failure.'
+            return _wrap_exception(
+                RuntimeError(
+                    f'Incomplete worker results (expected {len(self.write_buckets)},'
+                    f' got {len(write_results)}. This probably indicates a worker failure.'
+                )
             )
         return list(chain.from_iterable(write_results.values()))
 
@@ -484,7 +497,7 @@ class FileSystemWriterAsync(FileSystemWriter):
 
             # storage_meta was introduced since PyTorch 2.4
             if "storage_meta" in inspect.signature(Metadata).parameters:
-                metadata.stoage_meta = self.storage_meta()
+                metadata.storage_meta = self.storage_meta()
 
             path = os.path.join(self.checkpoint_dir, ".metadata")
 

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/state_dict_saver.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/state_dict_saver.py
@@ -447,5 +447,18 @@ def save_state_dict_async_finalize(
             storage_writer.finish(global_metadata, all_results)
             write_end = time()
             logger.debug(f"{write_end}, metadata_write: {write_end - write_start}")
-        else:
-            raise CheckpointException("write", node_failures)
+    else:
+        node_failures = {}
+
+    # Broadcast failure status to all ranks to raise exceptions everywhere if needed.
+    # The failure details are only raised on the coordinator.
+    failures_occurred = torch.tensor(
+        [int(len(node_failures) > 0)],
+        dtype=torch.int,
+        device=torch.cuda.current_device(),
+    )
+    torch.distributed.broadcast(
+        failures_occurred, src=dist_wrapper.coordinator_rank, group=dist_wrapper.group
+    )
+    if failures_occurred:
+        raise CheckpointException("write", node_failures)

--- a/tests/checkpointing/unit/__init__.py
+++ b/tests/checkpointing/unit/__init__.py
@@ -68,13 +68,19 @@ class TempNamedDir(TemporaryDirectory):
         if Utils.rank == 0:
             super().cleanup()
 
-    def __enter__(self):
+    def path(self):
         path = Path(super().__enter__())
         if self.sync:
             import torch
 
             torch.distributed.barrier()
         return path
+
+    def __enter__(self):
+        return self.path()
+
+    def __fspath__(self):
+        return self.path().__fspath__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         raised = exc_type is not None

--- a/tests/checkpointing/unit/conftest.py
+++ b/tests/checkpointing/unit/conftest.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import pytest
 
+from nvidia_resiliency_ext.checkpointing.async_ckpt.core import AsyncCallsQueue
+
 from . import TempNamedDir
 from .test_utilities import Utils
 
@@ -37,3 +39,10 @@ def tmp_path_dist_ckpt(tmp_path_factory) -> Path:
 
     else:
         yield tmp_dir
+
+
+@pytest.fixture
+def async_queue():
+    async_queue = AsyncCallsQueue()
+    yield async_queue
+    async_queue.close()

--- a/tests/checkpointing/unit/test_async_save.py
+++ b/tests/checkpointing/unit/test_async_save.py
@@ -18,19 +18,14 @@ from nvidia_resiliency_ext.checkpointing.async_ckpt.core import abort_nvrx_check
 from nvidia_resiliency_ext.checkpointing.async_ckpt.torch_ckpt import TorchAsyncCheckpoint
 
 from . import TempNamedDir
-from .test_utilities import TestModel, Utils
+from .test_utilities import Model, Utils
 
 
 class TestAsyncSave:
-    def setup_method(self, method):
-        Utils.set_world_size(1)
-
-    def teardown_method(self, method):
-        Utils.set_world_size()
 
     def test_async_is_equivalent_to_sync(self, tmp_path_dist_ckpt):
         Utils.initialize_distributed()
-        model = TestModel((1024, 1024), 10)
+        model = Model((1024, 1024), 10)
         ckpt_impl = TorchAsyncCheckpoint()
         state_dict = model.state_dict()
         with (
@@ -62,7 +57,7 @@ class TestAsyncSave:
 
     def test_persistent_async_cp_abort(self, tmp_path_dist_ckpt):
         Utils.initialize_distributed()
-        model = TestModel((1024, 1024), 10)
+        model = Model((1024, 1024), 10)
         ckpt_impl = TorchAsyncCheckpoint(persistent_queue=True)
         state_dict = model.state_dict()
 
@@ -127,7 +122,7 @@ class TestAsyncSave:
 
     def test_persistent_async_cp_abort_during_cp_ops(self, tmp_path_dist_ckpt):
         Utils.initialize_distributed()
-        model = TestModel((1024, 1024), 10)
+        model = Model((1024, 1024), 10)
         ckpt_impl = TorchAsyncCheckpoint(persistent_queue=True)
         state_dict = model.state_dict()
 

--- a/tests/checkpointing/unit/test_async_writer.py
+++ b/tests/checkpointing/unit/test_async_writer.py
@@ -16,9 +16,12 @@ import filecmp
 import pickle
 from copy import deepcopy
 from dataclasses import fields
+from typing import IO, Any
 
+import pytest
 import torch
 from torch.distributed.checkpoint import (
+    CheckpointException,
     DefaultLoadPlanner,
     DefaultSavePlanner,
     FileSystemReader,
@@ -36,7 +39,16 @@ from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
 )
 from nvidia_resiliency_ext.checkpointing.utils import diff
 from tests.checkpointing.unit import TempNamedDir
-from tests.checkpointing.unit.test_utilities import TestModel, Utils
+from tests.checkpointing.unit.test_utilities import Model, Utils
+
+
+def mock_open(
+    self,
+    path: str,
+    mode: str = "rb",
+) -> IO[Any]:
+    """Function matching the system open() signature that always raises an error."""
+    raise OSError('worker critical failure during open()')
 
 
 class TestAsyncSave:
@@ -47,15 +59,23 @@ class TestAsyncSave:
         def finalize_fn():
             """Finalizes async checkpointing and synchronizes processes."""
             save_state_dict_async_finalize(*save_state_dict_ret)
-            torch.distributed.barrier()
 
         return AsyncRequest(save_fn, save_args, [finalize_fn], preload_fn=preload_fn)
 
     def async_save_checkpoint(
-        self, checkpoint_dir, state_dict, planner, async_queue, thread_count=1, caching=False
+        self,
+        checkpoint_dir,
+        state_dict,
+        planner,
+        async_queue: AsyncCallsQueue,
+        thread_count=1,
+        caching=False,
+        open_file=open,
     ):
         """Performs an asynchronous model checkpoint save."""
-        writer = FileSystemWriterAsync(checkpoint_dir, thread_count=thread_count)
+        writer = FileSystemWriterAsync(
+            checkpoint_dir, thread_count=thread_count, open_file=open_file
+        )
         coordinator_rank = 0
 
         save_state_dict_ret = save_state_dict_async_plan(
@@ -81,11 +101,10 @@ class TestAsyncSave:
         )
         return state_dict
 
-    def test_async_is_equivalent_to_sync(self, tmp_path_dist_ckpt):
+    def test_async_is_equivalent_to_sync(self, tmp_path_dist_ckpt, async_queue):
         """Verifies that async checkpointing produces the same results as sync checkpointing."""
         Utils.initialize_distributed()
-        model = FSDP(TestModel((1024, 1024), 8))
-        async_queue = AsyncCallsQueue()
+        model = FSDP(Model((1024, 1024), 8))
         with (
             TempNamedDir(tmp_path_dist_ckpt / 'async_checkpoint', sync=True) as async_ckpt_dir,
             TempNamedDir(tmp_path_dist_ckpt / 'sync_checkpoint', sync=True) as sync_ckpt_dir,
@@ -126,41 +145,61 @@ class TestAsyncSave:
                 ), f"Mismatch for key '{key}' between async checkpoint and original state_dict."
             async_queue.close()
 
-    def test_cached_metadata(self, tmp_path_dist_ckpt):
+    def test_errors_are_reported(self, tmp_path_dist_ckpt, async_queue):
         Utils.initialize_distributed()
-        async_queue = AsyncCallsQueue()
+        rank = torch.distributed.get_rank()
+        model = FSDP(Model((1024, 1024), 8))
+        state_dict = model.state_dict()
+        planner = DefaultSavePlanner()
 
-        model = FSDP(TestModel((1024, 1024), 8))
+        if rank == 1:
+            open_file = mock_open
+        else:
+            open_file = open
+
+        with TempNamedDir(tmp_path_dist_ckpt / 'test_errors_are_reported', sync=True) as ckpt_dir:
+            self.async_save_checkpoint(
+                ckpt_dir, state_dict, planner, async_queue, open_file=open_file
+            )
+            with pytest.raises(CheckpointException) as exc_info:
+                async_queue.maybe_finalize_async_calls(blocking=True, no_dist=False)
+            if rank == 0:
+                assert 'Worker failure' in str(exc_info.value)
+            else:
+                assert 'Worker failure' not in str(exc_info.value)
+
+    def test_cached_metadata(self, tmp_path_dist_ckpt, async_queue):
+        Utils.initialize_distributed()
+        model = FSDP(Model((1024, 1024), 8))
         state_dict_non_cached = model.state_dict()
         state_dict_cached = deepcopy(state_dict_non_cached)
         loaded_non_cached, loaded_cached = None, None
         md_non_cached, md_cached = None, None
         planner = DefaultSavePlanner()
 
-        with TempNamedDir(tmp_path_dist_ckpt / 'ckpt_dir', sync=True) as ckpt_dir:
+        with TempNamedDir(tmp_path_dist_ckpt / 'ckpt_dir', sync=True) as ckpt_path:
             self.async_save_checkpoint(
-                ckpt_dir, state_dict_non_cached, planner, async_queue, caching=True
+                ckpt_path, state_dict_non_cached, planner, async_queue, caching=True
             )
             async_queue.maybe_finalize_async_calls(blocking=True, no_dist=False)
-            loaded_non_cached = self.load_checkpoint(ckpt_dir, state_dict_non_cached)
-            md_path = ckpt_dir.__enter__() / '.metadata'
+            loaded_non_cached = self.load_checkpoint(ckpt_path, state_dict_non_cached)
+            md_path = ckpt_path / '.metadata'
             with md_path.open('rb') as f:
                 md_non_cached = pickle.load(f)
 
         # Run over 3 iterations with cached metadata enabled
         # The 3rd iteration will run with cached metadata
         # `ckpt_dir` at the 3rd iteration 2 will be maintained for comparison
-        ckpt_dir = None
         for i in range(3):
             ckpt_dir = TempNamedDir(tmp_path_dist_ckpt / f'ckpt_dir_{i}_cached', sync=True)
             self.async_save_checkpoint(
-                ckpt_dir.__enter__(), state_dict_cached, planner, async_queue, caching=True
+                ckpt_dir, state_dict_cached, planner, async_queue, caching=True
             )
             async_queue.maybe_finalize_async_calls(blocking=True, no_dist=False)
             if i < 2:
                 ckpt_dir.cleanup()
-        loaded_cached = self.load_checkpoint(ckpt_dir.__enter__(), state_dict_cached)
-        md_path = ckpt_dir.__enter__() / '.metadata'
+        loaded_cached = self.load_checkpoint(ckpt_dir, state_dict_cached)
+        md_path = ckpt_dir.path() / '.metadata'
 
         with md_path.open('rb') as f:
             md_cached = pickle.load(f)

--- a/tests/checkpointing/unit/test_async_writer_msc.py
+++ b/tests/checkpointing/unit/test_async_writer_msc.py
@@ -24,7 +24,7 @@ from torch.distributed.checkpoint import (
     state_dict_saver,
 )
 
-from nvidia_resiliency_ext.checkpointing.async_ckpt.core import AsyncCallsQueue, AsyncRequest
+from nvidia_resiliency_ext.checkpointing.async_ckpt.core import AsyncRequest
 from nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async import FileSystemWriterAsync
 from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
     save_state_dict_async_finalize,
@@ -32,7 +32,7 @@ from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
 )
 
 from . import TempNamedDir
-from .test_utilities import TestModel, Utils
+from .test_utilities import Model, Utils
 
 
 class TestAsyncSaveWithMSC:
@@ -78,11 +78,10 @@ class TestAsyncSaveWithMSC:
         )
         return state_dict
 
-    def test_async_is_equivalent_to_sync(self, tmp_path_dist_ckpt):
+    def test_async_is_equivalent_to_sync(self, tmp_path_dist_ckpt, async_queue):
         """Verifies that async checkpointing produces the same results as sync checkpointing."""
         Utils.initialize_distributed()
-        model = TestModel((1024, 1024), 10)
-        async_queue = AsyncCallsQueue()
+        model = Model((1024, 1024), 10)
 
         with (
             TempNamedDir(tmp_path_dist_ckpt / 'async_checkpoint', sync=True) as async_ckpt_dir,

--- a/tests/checkpointing/unit/test_utilities.py
+++ b/tests/checkpointing/unit/test_utilities.py
@@ -69,6 +69,7 @@ class Utils:
             and Utils.world_size != torch.distributed.get_world_size()
         ):
             torch.distributed.destroy_process_group()
+            Utils.inited = False
 
         if rank is None:
             Utils.rank = int(os.environ['LOCAL_RANK'])
@@ -78,7 +79,7 @@ class Utils:
             Utils.rank = rank
 
 
-class TestModel(torch.nn.Module):
+class Model(torch.nn.Module):
     def __init__(self, size: Tuple, ntensor: int) -> None:
         super().__init__()
         for i in range(ntensor):


### PR DESCRIPTION
Fixes error propagation during checkpoint saving by using torch's DistWrapper to send the exception to the coordinator instead of killing the process early, and then notifies the other ranks of the exception so they can also abort.

Adds a test and slightly refactors the multiprocessing invocation to allow overriding the open() function with one that raises an exception. This enables the test. In the future we will factor our the filesystem operations into a delegate so it can be more easily mocked.

Backport of #138 

NVRX-196