### PR TITLE
Configure RankMonitorServer to inherit env vars from launcher

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -478,6 +478,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                     ipc_socket_path=rmon_ipc_socket,
                     is_restarter_logger=is_restarter_logger,
                     mp_ctx=fork_mp_ctx,
+                    env=worker_env,
                 )
 
     def shutdown_rank_monitors(self):

--- a/src/nvidia_resiliency_ext/inprocess/wrap.py
+++ b/src/nvidia_resiliency_ext/inprocess/wrap.py
@@ -219,6 +219,7 @@ class Wrapper:
         self.finalize = finalize
         self.health_check = health_check
 
+        setup_logger(node_local_tmp_prefix="wrapper")
         # Construct internal restart_health_check by chaining user's health_check with GPU and NVL checks
         self._construct_restart_health_check()
 

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -215,6 +215,7 @@ class GPUHealthCheck(PynvmlMixin):
             on_failure (Optional[Callable]): Callback function to handle health check failures.
         """
         super().__init__()
+        logger = logging.getLogger(LogConfig.name)
         self.device_index = device_index
         self.interval = interval
         self.on_failure = on_failure

--- a/src/nvidia_resiliency_ext/shared_utils/log_node_local_tmp.py
+++ b/src/nvidia_resiliency_ext/shared_utils/log_node_local_tmp.py
@@ -72,7 +72,7 @@ class NodeLocalTmpLogHandler(logging.Handler):
     def _log_file_namer(self):
         backup_files = self._get_backup_files()
         if self.fname is None and backup_files:
-            return backup_files[0]
+            return backup_files[-1]
         rank_str = str(self.rank_id) if self.rank_id is not None else "unknown"
         file_prefix = f"rank_{rank_str}_{self.proc_name}.msg."
         return f"{file_prefix}{int(time.time()*1000)}"


### PR DESCRIPTION
RankMonitorServer was not inheriting the env vars from Launcher on startup, this causes local file name and its log messages to display incorrect ranks.  