### PR TITLE
micro sec were being truncated to int seconds

### DIFF
--- a/src/nvidia_resiliency_ext/shared_utils/log_node_local_tmp.py
+++ b/src/nvidia_resiliency_ext/shared_utils/log_node_local_tmp.py
@@ -161,14 +161,14 @@ class LogMessage:
                 if key == 'asctime':
                     # Convert asctime to a datetime object, then to a Unix timestamp
                     dt = datetime.strptime(value, '%Y-%m-%d %H:%M:%S,%f')
-                    timestamp = int(dt.timestamp())
+                    timestamp = int(dt.timestamp() * 1000)
                     self.hash_table[key] = timestamp
                 else:
                     self.hash_table[key] = value
 
         if 'asctime' not in self.hash_table:
             current_datetime = datetime.now()
-            self.hash_table['asctime'] = int(current_datetime.timestamp())
+            self.hash_table['asctime'] = int(current_datetime.timestamp() * 1000)
 
     def getts(self):
         return self.hash_table['asctime']


### PR DESCRIPTION
https://github.com/NVIDIA/nvidia-resiliency-ext/pull/179

Milliseconds were being lost because the formatted time was converted to a Unix timestamp and then truncated to an integer representing seconds, discarding the fractional part. As a result, messages with the same second were not ordered correctly.
After this, while in theory there could still be ordering issues but the UT has worked for 50+ invocations with 0 failures while previously were hitting 10-20% failure.

https://nvbugspro.nvidia.com/bug/5503625?commentNumber=3