### PR TITLE
Traceback indents lost during aggregation

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/rank_monitor_server.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/rank_monitor_server.py
@@ -539,10 +539,6 @@ class RankMonitorServer:
 
         try:
             setup_logger(force_reset=True, node_local_tmp_prefix="rankmonsvr")
-            rmlogger = RankMonitorLogger(
-                level=cfg.log_level, is_restarter_logger=is_restarter_logger
-            )
-
             logger = logging.getLogger(LogConfig.name)
 
             logger.debug(f"Starting RankMonitorServer... PID={os.getpid()}")

--- a/src/nvidia_resiliency_ext/shared_utils/log_node_local_tmp.py
+++ b/src/nvidia_resiliency_ext/shared_utils/log_node_local_tmp.py
@@ -220,7 +220,7 @@ class NodeLogAggregator:
         for msg in messages:
             try:
                 # The message is already formatted by the formatter, just write it
-                output.write(msg.log_message + '\n')
+                output.write(msg.log_message)
                 output.flush()
             except Exception as e:
                 # Fallback to stderr if output fails
@@ -368,8 +368,8 @@ class NodeLogAggregator:
         # Process each line
         log_msg_q = queue.SimpleQueue()
         for line in lines:
-            line = line.strip()
-            if not line:
+            lineChk = line.strip()
+            if not lineChk:
                 continue
             log_msg = LogMessage(line)
             log_msg_q.put(log_msg)

--- a/tests/shared_utils/test_logger.py
+++ b/tests/shared_utils/test_logger.py
@@ -19,6 +19,7 @@ import multiprocessing
 import os
 import random
 import shutil
+import textwrap
 import time
 import unittest
 from datetime import datetime
@@ -58,6 +59,21 @@ def gen_log_msg(logger, num_msg, log_type="info"):
             logger.info(f"My Info Logging Message {i}")
         if log_type == "debug":
             logger.debug(f"My Debug Logging Message {i}")
+        if log_type == "error":
+            msg = textwrap.dedent(
+                """\
+            monitor_process.py:316 Traceback (most recent call last):
+              File "/usr/local/lib/python3.12/dist-packages/nvidia_resiliency_ext/inprocess/monitor_process.py", line 297, in run
+                store.iteration_barrier(
+
+              File "/usr/local/lib/python3.12/dist-packages/nvidia_resiliency_ext/inprocess/store.py", line 303, in reentrant_barrier
+                self.wait([last_worker_arrived_key], timeout_chunk)
+              torch.distributed.DistNetworkError: Failed to recv, got 0 bytes. Connection was likely closed. Did the remote server shutdown or crash?
+
+
+            """
+            )
+            logger.error(msg)
 
 
 def worker_process(id, num_msg, file_size):
@@ -192,6 +208,9 @@ class TestLogger(unittest.TestCase):
 
     def test_single_msg(self):
         self.check_msg(1, 1024, 1, True, "info", "0")
+
+    def test_traceback_msg(self):
+        self.check_msg(2, 1024, 1, True, "error", "0")
 
     def test_single_dbg_msg(self):
         self.check_msg(1, 1024, 1, True, "debug", "1")


### PR DESCRIPTION
Fixes https://nvbugspro.nvidia.com/bug/5497923: Traceback indents lost during aggregation
https://nvbugspro.nvidia.com/bug/5510103: Double NestedRestarter logs in rc4

[5497923]: We are stripping the line when moving from temp file to aggregated file, which removes the indentation. The intention was to filter out empty lines, which we still do but we leave the indentation as-is. Added UT for verification.

 [5510103]: Restart log handler handler was created twice, removing the unused one. 