### PR TITLE
fix: make launcher socket finding robust in rank monitor server test

### DIFF
--- a/tests/fault_tolerance/unit/test_rank_monitor_server.py
+++ b/tests/fault_tolerance/unit/test_rank_monitor_server.py
@@ -48,17 +48,20 @@ class TestRankMonitorServer(unittest.TestCase):
         )
 
         # Wait for the server to start and create its launcher socket
-        # The launcher socket path is constructed as: f"{tempfile.gettempdir()}/_ft_launcher{pid}_to_rmon.socket"
+        # The launcher socket path is constructed as: f"{tempfile.gettempdir()}/_ft_launcher{server_pid}_to_rmon.socket"
+        server_pid = self.server_process.pid
+        expected_socket_name = f"_ft_launcher{server_pid}_to_rmon.socket"
+        self.launcher_socket_path = os.path.join(tempfile.gettempdir(), expected_socket_name)
+
         max_wait = 5  # seconds
         start_time = time.time()
         while time.time() - start_time < max_wait:
-            # Try to find the launcher socket file
-            for file in os.listdir(tempfile.gettempdir()):
-                if file.startswith("_ft_launcher") and file.endswith("_to_rmon.socket"):
-                    self.launcher_socket_path = os.path.join(tempfile.gettempdir(), file)
-                    return
+            if os.path.exists(self.launcher_socket_path):
+                return
             time.sleep(0.1)
-        raise RuntimeError("Could not find launcher socket file after waiting")
+        raise RuntimeError(
+            f"Could not find launcher socket file {expected_socket_name} after waiting {max_wait} seconds"
+        )
 
     def tearDown(self):
         # Clean up the server process


### PR DESCRIPTION
The test was using a flaky approach to find the launcher socket file by scanning all files in /tmp and picking any file matching the pattern "_ft_launcher*_to_rmon.socket". This could fail when:

1. Historic socket files from previous test runs exist in /tmp
2. Multiple socket files match the pattern, causing the test to pick the wrong one
3. Race conditions between socket creation and file discovery

Fix by:
- Using the server process PID to construct the exact expected socket path
- Directly checking for file existence instead of scanning directory
- Including expected socket name in error messages for better debugging

This ensures the test connects to the correct socket file created by the current server process, making the test more reliable.