### PR TITLE
feat: Add infrastructure rank support and optimize section monitoring

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/_ft_rendezvous.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/_ft_rendezvous.py
@@ -17,6 +17,7 @@
 import inspect
 import logging
 import os
+import random
 
 # Issue: [B403:blacklist] Consider possible security implications associated with pickle module.
 # Severity: Low   Confidence: High
@@ -878,10 +879,10 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
     ) -> Dict[_NodeDesc, int]:
         # Assign ranks. Re-use assigment from the previous round as much as possible
         world_size = len(participants)
-        sorted_keys = sorted(participants.keys())
+        randomized_keys = random.sample(list(participants.keys()), len(participants))
         free_ranks = set(range(world_size))
         res = {}
-        for p in sorted_keys:
+        for p in randomized_keys:
             prev_rank = prev.get(p, -1)
             if prev_rank >= 0 and prev_rank < world_size:
                 # if this node can have the same rank, use it
@@ -891,7 +892,7 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
                 res[p] = -1
         # Fill the gaps with the remaining free rank ids
         free_ranks = sorted(free_ranks)
-        for p in sorted_keys:
+        for p in randomized_keys:
             if res[p] < 0:
                 res[p] = free_ranks.pop(0)
         assert not free_ranks

--- a/src/nvidia_resiliency_ext/fault_tolerance/_ft_rendezvous.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/_ft_rendezvous.py
@@ -17,7 +17,6 @@
 import inspect
 import logging
 import os
-import random
 
 # Issue: [B403:blacklist] Consider possible security implications associated with pickle module.
 # Severity: Low   Confidence: High
@@ -879,10 +878,10 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
     ) -> Dict[_NodeDesc, int]:
         # Assign ranks. Re-use assigment from the previous round as much as possible
         world_size = len(participants)
-        randomized_keys = random.sample(list(participants.keys()), len(participants))
+        sorted_keys = sorted(participants.keys())
         free_ranks = set(range(world_size))
         res = {}
-        for p in randomized_keys:
+        for p in sorted_keys:
             prev_rank = prev.get(p, -1)
             if prev_rank >= 0 and prev_rank < world_size:
                 # if this node can have the same rank, use it
@@ -892,7 +891,7 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
                 res[p] = -1
         # Fill the gaps with the remaining free rank ids
         free_ranks = sorted(free_ranks)
-        for p in randomized_keys:
+        for p in sorted_keys:
             if res[p] < 0:
                 res[p] = free_ranks.pop(0)
         assert not free_ranks

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -1752,46 +1752,46 @@ def get_args_parser() -> ArgumentParser:
     parser.add_argument(
         "--ft-workload-check-interval",
         "--ft-workload_check_interval",
-        type=float,
+        type=str,
         default=None,
         dest="ft_workload_check_interval",
-        help="Part of Fault Tolerance pkg config (workload_check_interval).",
+        help="Part of Fault Tolerance pkg config (workload_check_interval). Use 'null'|'none'|'' for None.",
     )
 
     parser.add_argument(
         "--ft-initial-rank-heartbeat-timeout",
         "--ft-initial_rank_heartbeat_timeout",
-        type=float,
+        type=str,
         default=None,
         dest="ft_initial_rank_heartbeat_timeout",
-        help="Part of Fault Tolerance pkg config (initial_rank_heartbeat_timeout).",
+        help="Part of Fault Tolerance pkg config (initial_rank_heartbeat_timeout). Use 'null'|'none'|'' for None.",
     )
 
     parser.add_argument(
         "--ft-rank-heartbeat-timeout",
         "--ft-rank_heartbeat_timeout",
-        type=float,
+        type=str,
         default=None,
         dest="ft_rank_heartbeat_timeout",
-        help="Part of Fault Tolerance pkg config (rank_heartbeat_timeout).",
+        help="Part of Fault Tolerance pkg config (rank_heartbeat_timeout). Use 'null'|'none'|'' for None.",
     )
 
     parser.add_argument(
         "--ft-node-health-check-interval",
         "--ft-node_health_check_interval",
-        type=float,
+        type=str,
         default=None,
         dest="ft_node_health_check_interval",
-        help="Part of Fault Tolerance pkg config (node_health_check_interval).",
+        help="Part of Fault Tolerance pkg config (node_health_check_interval). Use 'null'|'none'|'' for None.",
     )
 
     parser.add_argument(
         "--ft-safety-factor",
         "--ft-safety_factor",
-        type=float,
+        type=str,
         default=None,
         dest="ft_safety_factor",
-        help="Part of Fault Tolerance pkg config (safety_factor).",
+        help="Part of Fault Tolerance pkg config (safety_factor). Use 'null'|'none'|'' for None.",
     )
 
     parser.add_argument(
@@ -1815,10 +1815,10 @@ def get_args_parser() -> ArgumentParser:
     parser.add_argument(
         "--ft-rank-out-of-section-timeout",
         "--ft-rank_out_of_section_timeout",
-        type=float,
+        type=str,
         default=None,
         dest="ft_rank_out_of_section_timeout",
-        help="Part of Fault Tolerance pkg config (rank_out_of_section_timeout).",
+        help="Part of Fault Tolerance pkg config (rank_out_of_section_timeout). Use 'null'|'none'|'' for None.",
     )
 
     parser.add_argument(
@@ -1834,10 +1834,10 @@ def get_args_parser() -> ArgumentParser:
     parser.add_argument(
         "--ft-restart-check-interval",
         "--ft-restart_check_interval",
-        type=float,
+        type=str,
         default=None,
         dest="ft_restart_check_interval",
-        help="Part of Fault Tolerance pkg config (restart_check_interval).",
+        help="Part of Fault Tolerance pkg config (restart_check_interval). Use 'null'|'none'|'' for None.",
     )
 
     parser.add_argument(

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -1881,6 +1881,30 @@ def get_args_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--ft-skip-section-response",
+        "--ft-skip_section_response",
+        type=lambda x: str(x).lower() in ["true", "1", "yes"],
+        default=True,
+        dest="ft_skip_section_response",
+        help="Part of Fault Tolerance pkg config (skip_section_response). "
+        "If enabled (default), section and heartbeat messages are sent without waiting "
+        "for server response, significantly reducing latency. "
+        "Set to false during development to catch programming errors immediately.",
+    )
+
+    parser.add_argument(
+        "--ft-use-infra-group-rank",
+        "--ft-use_infra_group_rank",
+        type=lambda x: str(x).lower() in ["true", "1", "yes"],
+        default=False,
+        dest="ft_use_infra_group_rank",
+        help="Part of Fault Tolerance pkg config (use_infra_group_rank). "
+        "If enabled, use infrastructure group rank for rank assignment instead of sorted "
+        "participant-based assignment. Reads from SLURM_PROCID (SLURM) or GROUP_RANK (launcher). "
+        "This ensures rank consistency with static deployments. Default: False.",
+    )
+
+    parser.add_argument(
         action='store_true',
         dest="ft_ignore_missing_cfg",
         help="Do not raise an error if there is no Fault Tolerance pkg config provided, just use default settings.",
@@ -2046,6 +2070,9 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
 
 
     fault_tol_cfg = FaultToleranceConfig.from_args(args)
+
+    # Pass use_infra_group_rank from fault tolerance config to rendezvous config
+    rdzv_configs['use_infra_group_rank'] = fault_tol_cfg.use_infra_group_rank
 
     ranks: Optional[Set[int]] = None
     if args.local_ranks_filter:

--- a/src/nvidia_resiliency_ext/fault_tolerance/rank_monitor_client.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/rank_monitor_client.py
@@ -236,19 +236,55 @@ class RankMonitorClient:
                 f"RankMonitorClient could not send the heartbeat. Exception: {e}"
             )
 
+    def _should_monitor_section(self, section: str) -> bool:
+        """
+        Check if a section should be monitored (i.e., IPC messages should be sent).
+
+        A section is monitored if it has a timeout configured in rank_section_timeouts.
+        Sections without a timeout (not in the config) don't need IPC overhead.
+
+        Args:
+            section (str): Section name
+
+        Returns:
+            bool: True if section should be monitored, False otherwise
+        """
+        # If section is not in config, don't monitor it
+        if section not in self.cfg.rank_section_timeouts:
+            return False
+
+        return True
+
     def _send_section_msg_impl(self, section: str, action: SectionAction) -> None:
         """
         Implementation of section related update sending.
+
+        If a section is not configured for monitoring (not in rank_section_timeouts),
+        IPC is skipped and local timing data collection is also skipped for minimal overhead.
+
+        If skip_section_response is enabled (default), messages are sent without waiting
+        for server response (unidirectional communication), reducing latency significantly.
+        The server processes messages but doesn't send responses back.
 
         Args:
             section (str): Section name
             action (SectionAction): Section related action
         """
         self._ensure_is_ready()
+
+        # Skip both IPC and timing collection if section is not being monitored
+        if not self._should_monitor_section(section):
+            return
+
         try:
             msg = SectionMsg(rank=self.rank_info.global_rank, section=section, action=action)
             write_object_to_ipc_socket(msg, self.rank_monitor_socket)
-            self._ensure_response_is_ok(self.rank_monitor_socket)
+
+            # Only wait for response if skip_section_response is disabled
+            # When enabled, server doesn't send responses (true unidirectional)
+            if not self.cfg.skip_section_response:
+                self._ensure_response_is_ok(self.rank_monitor_socket)
+
             self.timeouts_calc.update_on_section_event(section=section, action=action)
         except Exception as e:
             raise RankMonitorClientError(

--- a/tests/fault_tolerance/unit/test_rank_monitor_server.py
+++ b/tests/fault_tolerance/unit/test_rank_monitor_server.py
@@ -33,8 +33,12 @@ class TestRankMonitorServer(unittest.TestCase):
             tempfile.gettempdir(), "test_rank_monitor_worker.socket"
         )
 
-        # Create a basic config
-        self.config = FaultToleranceConfig()
+        # Create a basic config with skip_section_response=False for testing
+        # (tests expect to receive responses)
+        # Also add test_section to rank_section_timeouts to avoid KeyError
+        self.config = FaultToleranceConfig(
+            skip_section_response=False, rank_section_timeouts={"test_section": 60.0}
+        )
 
         # Create a mock logger
         self.logger = MagicMock()
@@ -300,6 +304,88 @@ class TestRankMonitorServer(unittest.TestCase):
             await writer.wait_closed()
 
         asyncio.run(run_test())
+
+    def test_skip_section_response_enabled(self):
+        """Test unidirectional communication when skip_section_response=True"""
+        # Create a new server with skip_section_response=True (default behavior)
+        config_unidirectional = FaultToleranceConfig(
+            skip_section_response=True, rank_section_timeouts={"test_section": 60.0}
+        )
+
+        worker_socket_path_unidirectional = os.path.join(
+            tempfile.gettempdir(), "test_rank_monitor_worker_unidirectional.socket"
+        )
+
+        server_process = RankMonitorServer.run_in_subprocess(
+            cfg=config_unidirectional,
+            ipc_socket_path=worker_socket_path_unidirectional,
+            is_restarter_logger=False,
+            mp_ctx=torch.multiprocessing,
+        )
+
+        try:
+            # Wait for server to start
+            time.sleep(0.5)
+
+            async def run_test():
+                reader, writer = await asyncio.open_unix_connection(
+                    worker_socket_path_unidirectional
+                )
+
+                # Send authkey first
+                await self._send_authkey_msg(writer)
+                await read_obj_from_ipc_stream(reader)  # Authkey still gets response
+
+                # Send init message
+                rank_info = RankInfo(
+                    global_rank=0, local_rank=0, host=socket.gethostname(), pid=os.getpid()
+                )
+                await self._send_init_msg(writer, rank_info)
+                response = await read_obj_from_ipc_stream(reader)  # Init still gets response
+                self.assertIsInstance(response, OkMsg)
+
+                # Send heartbeat - should NOT receive response when skip_section_response=True
+                await self._send_heartbeat_msg(writer)
+
+                # Try to read with a timeout - should timeout since no response is sent
+                try:
+                    response = await asyncio.wait_for(read_obj_from_ipc_stream(reader), timeout=0.5)
+                    # If we get here, the test should fail because we shouldn't receive a response
+                    self.fail("Expected no response for heartbeat when skip_section_response=True")
+                except asyncio.TimeoutError:
+                    # This is expected - no response sent
+                    pass
+
+                # Send section message - should also NOT receive response
+                await self._send_section_msg(writer, "test_section", SectionAction.OPEN)
+
+                try:
+                    response = await asyncio.wait_for(read_obj_from_ipc_stream(reader), timeout=0.5)
+                    self.fail(
+                        "Expected no response for section message when skip_section_response=True"
+                    )
+                except asyncio.TimeoutError:
+                    # This is expected - no response sent
+                    pass
+
+                # Send another heartbeat to verify server is still processing messages
+                await self._send_heartbeat_msg(writer)
+
+                # Close section
+                await self._send_section_msg(writer, "test_section", SectionAction.CLOSE)
+
+                # Clean up
+                writer.close()
+                await writer.wait_closed()
+
+            asyncio.run(run_test())
+
+        finally:
+            # Clean up
+            server_process.terminate()
+            server_process.join(timeout=5)
+            if os.path.exists(worker_socket_path_unidirectional):
+                os.unlink(worker_socket_path_unidirectional)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
    1. Infrastructure Group Rank Assignment
       - Add `use_infra_group_rank` config option to use
         infrastructure-provided ranks (e.g., SLURM_PROCID) instead of
         sorted participant-based assignment
    
    2. Selective Section Monitoring
       - Only send IPC messages for sections configured in
         `rank_section_timeouts`
       - Sections not in config have near-zero overhead (no IPC, no timing)
    
    3. Unidirectional Section Communication
       - Add `skip_section_response` config option (default: True)
       - Section and heartbeat messages sent without waiting for server
         response
       - Significantly reduces latency for high-frequency monitoring
         operations

    4. Allow null values for timeout CLI arguments
    
        Change timeout arguments from type=float to type=str to support
       'null'/'none'/'' values for disabling timeouts.