### PR TITLE
NVRx Stability - Multithread file IO to simplify error prop and shutdown cleanup logic

### DIFF
--- a/tests/checkpointing/unit/test_async_writer.py
+++ b/tests/checkpointing/unit/test_async_writer.py
@@ -76,10 +76,14 @@ class TestAsyncSave:
         thread_count=1,
         caching=False,
         open_file=open,
+        is_multiproc_io=True,
     ):
         """Performs an asynchronous model checkpoint save."""
         writer = FileSystemWriterAsync(
-            checkpoint_dir, thread_count=thread_count, open_file=open_file
+            checkpoint_dir,
+            thread_count=thread_count,
+            open_file=open_file,
+            is_multiproc_io=is_multiproc_io,
         )
         coordinator_rank = 0
 
@@ -110,9 +114,16 @@ class TestAsyncSave:
         )
         return state_dict
 
-    def test_async_is_equivalent_to_sync(self, tmp_path_dist_ckpt, async_queue):
+    @pytest.mark.parametrize(
+        ('persistent_is_daemon', 'is_multiproc_io'),
+        [(True, False), (False, True), (False, False)],
+    )
+    def test_async_is_equivalent_to_sync(
+        self, tmp_path_dist_ckpt, persistent_is_daemon, is_multiproc_io
+    ):
         """Verifies that async checkpointing produces the same results as sync checkpointing."""
         Utils.initialize_distributed()
+        async_queue = AsyncCallsQueue(is_daemon=persistent_is_daemon)
         model = FSDP(Model((1024, 1024), 8))
         with (
             TempNamedDir(tmp_path_dist_ckpt / 'async_checkpoint', sync=True) as async_ckpt_dir,
@@ -122,7 +133,9 @@ class TestAsyncSave:
             planner = DefaultSavePlanner()
 
             # Perform async and sync saves
-            self.async_save_checkpoint(async_ckpt_dir, state_dict, planner, async_queue)
+            self.async_save_checkpoint(
+                async_ckpt_dir, state_dict, planner, async_queue, is_multiproc_io=is_multiproc_io
+            )
             self.sync_save_checkpoint(sync_ckpt_dir, state_dict, planner)
 
             # Finalize async saves
@@ -154,7 +167,35 @@ class TestAsyncSave:
                 ), f"Mismatch for key '{key}' between async checkpoint and original state_dict."
             async_queue.close()
 
-    def test_errors_are_reported(self, tmp_path_dist_ckpt, async_queue):
+    @pytest.mark.parametrize(
+        ('persistent_is_daemon', 'is_multiproc_io'),
+        [(True, True)],
+    )
+    def test_invalid_async_setup(self, tmp_path_dist_ckpt, persistent_is_daemon, is_multiproc_io):
+        """
+        Verifies a clear error message when users incorrectly setup a daemon async worker
+        and configure FileWriter to perform multiprocessing.
+        """
+        Utils.initialize_distributed()
+        async_queue = AsyncCallsQueue(is_daemon=persistent_is_daemon)
+        model = FSDP(Model((1024, 1024), 8))
+        with (TempNamedDir(tmp_path_dist_ckpt / 'async_checkpoint', sync=True) as async_ckpt_dir,):
+            state_dict = model.state_dict()
+            planner = DefaultSavePlanner()
+            # Perform async and sync saves
+            self.async_save_checkpoint(
+                async_ckpt_dir, state_dict, planner, async_queue, is_multiproc_io=is_multiproc_io
+            )
+            with pytest.raises(CheckpointException) as exc_info:
+                # Finalize async saves
+                async_queue.maybe_finalize_async_calls(blocking=True, no_dist=False)
+            rank = torch.distributed.get_rank()
+            if rank == 0:
+                assert 'Invalid Setup!' in str(exc_info.value)
+            async_queue.close()
+
+    @pytest.mark.parametrize('is_multiproc_io', [True, False])
+    def test_errors_are_reported(self, tmp_path_dist_ckpt, async_queue, is_multiproc_io):
         Utils.initialize_distributed()
         rank = torch.distributed.get_rank()
         model = FSDP(Model((1024, 1024), 8))
@@ -168,7 +209,12 @@ class TestAsyncSave:
 
         with TempNamedDir(tmp_path_dist_ckpt / 'test_errors_are_reported', sync=True) as ckpt_dir:
             self.async_save_checkpoint(
-                ckpt_dir, state_dict, planner, async_queue, open_file=open_file
+                ckpt_dir,
+                state_dict,
+                planner,
+                async_queue,
+                open_file=open_file,
+                is_multiproc_io=is_multiproc_io,
             )
             with pytest.raises(CheckpointException) as exc_info:
                 async_queue.maybe_finalize_async_calls(blocking=True, no_dist=False)
@@ -229,7 +275,12 @@ class TestAsyncSave:
         ckpt_dir.cleanup()
         async_queue.close()
 
-    def test_async_cp_with_multiple_queue_and_abort(self, tmp_path_dist_ckpt):
+    @pytest.mark.parametrize(
+        ('persistent_is_daemon', 'is_multiproc_io'), [(True, False), (False, True), (False, False)]
+    )
+    def test_async_cp_with_multiple_queue_and_abort(
+        self, tmp_path_dist_ckpt, persistent_is_daemon, is_multiproc_io
+    ):
         """
         Verifies that async checkpointing backend can be used with multiple async queues.
         For example, user may want to save 2 checkpoints i.e. one sharded state and one only on rank-0.
@@ -237,7 +288,7 @@ class TestAsyncSave:
         """
         Utils.initialize_distributed()
         model = FSDP(Model((1024, 1024), 8))
-        async_queue_dist = AsyncCallsQueue()
+        async_queue_dist = AsyncCallsQueue(is_daemon=persistent_is_daemon)
         ckpt_impl = TorchAsyncCheckpoint(persistent_queue=True)
         with (
             TempNamedDir(
@@ -251,7 +302,13 @@ class TestAsyncSave:
             planner = DefaultSavePlanner()
 
             # Perform async saves for both dist CP and non-dict CP use cases.
-            self.async_save_checkpoint(async_ckpt_dir_dist, state_dict, planner, async_queue_dist)
+            self.async_save_checkpoint(
+                async_ckpt_dir_dist,
+                state_dict,
+                planner,
+                async_queue_dist,
+                is_multiproc_io=is_multiproc_io,
+            )
             self.async_save_checkpoint_on_rank0(async_ckpt_dir_no_dist, state_dict, ckpt_impl)
             async_queue_dist.maybe_finalize_async_calls(blocking=True, no_dist=False)
             ckpt_impl.finalize_async_save(blocking=True, no_dist=True)
@@ -278,7 +335,13 @@ class TestAsyncSave:
 
             # Perform async saves for both dist CP and non-dist CP use cases.
             # Validate that operations seamlessly resume after an abort operation
-            self.async_save_checkpoint(async_ckpt_dir_dist, state_dict, planner, async_queue_dist)
+            self.async_save_checkpoint(
+                async_ckpt_dir_dist,
+                state_dict,
+                planner,
+                async_queue_dist,
+                is_multiproc_io=is_multiproc_io,
+            )
             self.async_save_checkpoint_on_rank0(async_ckpt_dir_no_dist, state_dict, ckpt_impl)
             async_queue_dist.maybe_finalize_async_calls(blocking=True, no_dist=False)
             ckpt_impl.finalize_async_save(blocking=True, no_dist=True)


### PR DESCRIPTION
Our async checkpoint worker for each rank i.e. PersistentCheckpoint worker per rank “[forks](https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/blob/main/megatron/core/dist_checkpointing/strategies/filesystem_async.py?ref_type=heads#L265-302)” multiple  child processes to parallelize File IO i.e. the background work needed to persist the checkpoint state during async checkpoints.

We want to avoid this “fork” based File IO for the following reasons:
1. Having multiple child processes to the persistent async worker complicates the life cycle management and error propagation of the checkpoint save life-cycle. For example, we had tests where failure in the training process would not propagate to restart the persistent worker since it was not a daemon. Persistent worker could not be a daemon since it forked more child processes for file IO. This made life cycle management of the persistent worker complex.
2. PyTorch multi-process best practices suggest to avoid using fork [Ref](https://docs.pytorch.org/docs/stable/notes/multiprocessing.html#poison-fork-in-multiprocessing). 
3. We did not consider “spawning” the processes for File IO due to O(100s) MB overhead per spawned process, complexity of life cycle management and error propagation from File_IO process to PersistentAsyncWorker Process to Training process.
4. This PR evaluates the implication of using a multi-thread vs multi-process file writer in async checkpoints. We evaluate the impact on the background writing time.