### PR TITLE
Simplify ft_launcher default settings.

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/config.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/config.py
@@ -53,7 +53,7 @@ class FaultToleranceConfig:
     * `enable_nic_healthcheck` - Enable NIC link state health check before rendezvous. This checks if
       network interface ports (RDMA/InfiniBand and Ethernet) are in ACTIVE state and fails if any port transitioned from ACTIVE to non-ACTIVE.
       Unlike enable_nic_monitor (which periodically monitors link_downed counters), this performs a one-time
-      state check during rendezvous. Can be used independently or together with enable_nic_monitor. Default: False.
+      state check during rendezvous. Can be used independently or together with enable_nic_monitor. Default: True.
     * `pci_topo_file` - PCI topo file that describes GPU and NIC topology.
     * `link_down_path_template` - Template path for NIC link down files. Should contain '{dev_name}'
       placeholder which will be replaced with actual NIC device name.
@@ -77,9 +77,9 @@ class FaultToleranceConfig:
         min_nodes must be divisible by segment. When set, ClusterUUID is automatically queried.
       Note: segment=None and segment=1 have similar behavior in rank assignment, but segment=1
       requires ClusterUUID while segment=None does not.
-    * `numa_bind_strict` - If True, use strict NUMA binding with both CPU and memory bound to the
-      same NUMA node (--cpunodebind=N --membind=N). If False (default), only bind CPU to NUMA node
-      and allow local memory allocation (--cpunodebind=N --localalloc). Default: False.
+    * `numa_bind_strict` - If True (default), use strict NUMA binding with both CPU and memory bound to the
+      same NUMA node (--cpunodebind=N --membind=N). If False, only bind CPU to NUMA node
+      and allow local memory allocation (--cpunodebind=N --localalloc). Default: True.
     * `gpu_memory_reclaim_timeout` [float] timeout (in seconds) to wait for GPU memory to be reclaimed
       after worker shutdown before starting new workers. Default: 50.0.
     * `gpu_memory_tolerance_mb` [float] maximum allowed GPU memory usage (in MB) when checking if
@@ -109,8 +109,8 @@ class FaultToleranceConfig:
     """
 
     workload_check_interval: float = 5.0
-    initial_rank_heartbeat_timeout: Optional[float] = 60.0 * 60.0
-    rank_heartbeat_timeout: Optional[float] = 45.0 * 60.0
+    initial_rank_heartbeat_timeout: Optional[float] = None
+    rank_heartbeat_timeout: Optional[float] = None
     rank_section_timeouts: Mapping[str, Optional[float]] = dataclasses.field(default_factory=dict)
     rank_out_of_section_timeout: Optional[float] = None
     node_health_check_interval: float = 5.0
@@ -119,7 +119,7 @@ class FaultToleranceConfig:
     log_level: int = logging.INFO
     restart_check_interval: float = 60.0
     enable_nic_monitor: bool = False
-    enable_nic_healthcheck: bool = False
+    enable_nic_healthcheck: bool = True
     enable_dist_storage_healthcheck: bool = False
     storage_healthcheck_path: Optional[str] = None
     pci_topo_file: Optional[str] = None
@@ -127,7 +127,7 @@ class FaultToleranceConfig:
     link_state_path_template: Optional[str] = None
     skip_section_response: bool = True
     segment: Optional[int] = None
-    numa_bind_strict: bool = False
+    numa_bind_strict: bool = True
     gpu_memory_reclaim_timeout: float = 50.0
     gpu_memory_tolerance_mb: float = 512.0  # Maximum allowed GPU memory usage (in MB)
     gpu_memory_poll_interval: float = 2.0  # Poll interval for GPU memory check (in seconds)

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -21,6 +21,7 @@ import importlib.metadata as metadata
 import json
 import logging
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -137,13 +138,13 @@ def init_node_health_check(endpoint: Optional[str]) -> None:
 def get_node_health_check() -> Optional[NodeHealthCheck]:
     return _NODE_HEALTH_CHECK_INSTANCE
 
-def _register_ft_rdzv_handler(impl_type: str = "legacy"):
+def _register_ft_rdzv_handler(impl_type: str = "barrier"):
     """Register the fault-tolerant rendezvous handler.
 
     Args:
         impl_type: FT rendezvous implementation to use.
                   "barrier" - New atomic barrier-based algorithm
-                  "legacy" - Original compare-and-set algorithm (default)
+                  "legacy" - Original compare-and-set algorithm
     """
     from torch.distributed.elastic.rendezvous import rendezvous_handler_registry
     from torch.distributed.elastic.rendezvous.c10d_rendezvous_backend import create_backend
@@ -2449,7 +2450,7 @@ def get_args_parser() -> ArgumentParser:
         "--ft_enable_log_server",
         action=env,
         type=lambda x: x.lower() == 'true',
-        default=False,
+        default=None,
         dest="ft_enable_log_server",
         help="Enable gRPC-based log funneling to a single Lustre file. "
         "When enabled with --ft-per-cycle-applog-prefix, the launcher automatically: "
@@ -2730,7 +2731,7 @@ def get_args_parser() -> ArgumentParser:
         "in ACTIVE state and fails if any port transitioned from ACTIVE to non-ACTIVE. "
         "Unlike --ft-enable-nic-monitor (which periodically monitors link_downed counters), "
         "this performs a one-time state check during rendezvous. Can be used independently "
-        "or together with --ft-enable-nic-monitor. Default: False.",
+        "or together with --ft-enable-nic-monitor. Default: True.",
     )
 
     parser.add_argument(
@@ -2828,13 +2829,13 @@ def get_args_parser() -> ArgumentParser:
     parser.add_argument(
         "--ft-numa-bind-strict",
         "--ft-numa_bind_strict",
-        action="store_true",
+        type=lambda x: str(x).lower() not in ["false", "0", "no"],
         default=None,
         dest="ft_numa_bind_strict",
-        help="Enable strict NUMA binding with both CPU and memory bound to the same NUMA node "
-        "(--cpunodebind=N --membind=N). By default, only CPU is bound to NUMA node with local "
-        "memory allocation (--cpunodebind=N --localalloc). This option only affects behavior when "
-        "NVRX_GPUS_PER_NUMA environment variable is set. Default: False.",
+        help="Enable or disable strict NUMA binding with both CPU and memory bound to the same NUMA node "
+        "(--cpunodebind=N --membind=N). Set to false to use --localalloc instead of --membind. "
+        "This option only affects behavior when NVRX_GPUS_PER_NUMA environment variable is set. "
+        "Default: True. Example: --ft-numa-bind-strict false",
     )
 
     parser.add_argument(
@@ -2934,8 +2935,6 @@ def get_args_parser() -> ArgumentParser:
     parser.add_argument(
         "--ft-max-no-progress-cycles",
         "--ft-max_no_progress_cycles",
-        "--ft-max-no-progress-restarts",
-        "--ft-max_no_progress_restarts",
         type=int,
         default=2,
         dest="ft_max_no_progress_cycles",
@@ -3083,17 +3082,91 @@ def _get_logs_specs_class(logs_specs_name: Optional[str]) -> Type[LogsSpecs]:
     return logs_specs_cls
 
 
+def _parse_bool_env(var_name: str) -> bool:
+    """Parse a boolean-like env var. Unset means False."""
+    raw = os.getenv(var_name)
+    if raw is None:
+        return False
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes"}:
+        return True
+    if value in {"0", "false", "no"}:
+        return False
+    raise ValueError(
+        f"Invalid value for {var_name}: {raw!r}. "
+        "Expected one of: 1/0, true/false, yes/no."
+    )
+
+
+def _validate_slurm_single_launcher_per_node() -> None:
+    """
+    Validate Slurm launch shape to prevent accidental multiple ft_launchers per node.
+
+    Override for intentional simulation:
+      NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE=1
+    """
+    if os.getenv("SLURM_JOB_ID") is None:
+        return
+
+    if _parse_bool_env("NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE"):
+        logger.warning(
+            "NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE is enabled; "
+            "skipping one-ft-launcher-per-node Slurm validation."
+        )
+        return
+
+    tasks_per_node = os.getenv("SLURM_TASKS_PER_NODE")
+    if tasks_per_node is None:
+        raise ValueError(
+            "Invalid Slurm launcher layout for ft_launcher (one launcher per node expected).\n"
+            f"Detected: SLURM_TASKS_PER_NODE={tasks_per_node!r}\n"
+            "Requirement: SLURM_TASKS_PER_NODE must be exactly '1' or '1(xN)' format.\n"
+            "Fix: launch with one task per node, e.g.:\n"
+            "  srun -l --ntasks=$SLURM_JOB_NUM_NODES --ntasks-per-node=1 ...\n"
+            "If this is intentional simulation with multiple ft_launchers per node, set:\n"
+            "  NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE=1"
+        )
+
+    # SLURM_TASKS_PER_NODE is a comma-separated list of "count" or "count(xN)" entries
+    entries = [e.strip() for e in tasks_per_node.split(",") if e.strip()]
+    all_one = all(re.fullmatch(r"1(\(x\d+\))?", e) for e in entries)
+    if not entries or not all_one:
+        raise ValueError(
+            "Invalid Slurm launcher layout for ft_launcher (one launcher per node expected).\n"
+            f"Detected: SLURM_TASKS_PER_NODE={tasks_per_node!r}\n"
+            "Requirement: All task counts must be 1 (one launcher per node).\n"
+            "Fix: launch with one task per node, e.g.:\n"
+            "  srun -l --ntasks=$SLURM_JOB_NUM_NODES --ntasks-per-node=1 ...\n"
+            "If this is intentional simulation with multiple ft_launchers per node, set:\n"
+            "  NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE=1"
+        )
+
 def _validate_args(args: Any) -> None:
     """Centralized validation of CLI args (cross-flag consistency). Raises ValueError if invalid."""
+    _validate_slurm_single_launcher_per_node()
     if getattr(args, "ft_cycle_info_dir", None) and not getattr(args, "ft_per_cycle_applog_prefix", None):
         raise ValueError(
             "--ft-cycle-info-dir requires --ft-per-cycle-applog-prefix to be specified. "
             "Cycle info needs per-cycle log file path from the applog prefix."
         )
+    if getattr(args, "ft_nvrx_logfile", None) and not getattr(args, "ft_per_cycle_applog_prefix", None):
+        raise ValueError(
+            "--ft-nvrx-logfile requires --ft-per-cycle-applog-prefix to be specified."
+        )
+    if getattr(args, "ft_nvrx_logfile", None) and os.getenv("NVRX_NODE_LOCAL_TMPDIR"):
+        raise ValueError(
+            "--ft-nvrx-logfile cannot be used when NVRX_NODE_LOCAL_TMPDIR is set."
+        )
 
 def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -> Tuple[LaunchConfig, Union[Callable, str], List[str]]:
     # If ``args`` not passed, defaults to ``sys.argv[:1]``
     _validate_args(args)
+    if getattr(args, "ft_nvrx_logfile", None):
+        if getattr(args, "ft_enable_log_server", None) is None:
+            logger.info(
+                "--ft-nvrx-logfile is set; enabling --ft-enable-log-server automatically."
+            )
+            args.ft_enable_log_server = True
 
     min_nodes, max_nodes = parse_min_max_nnodes(args.nnodes)
     assert 0 < min_nodes <= max_nodes
@@ -3247,7 +3320,7 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
 
         if getattr(args, 'ft_enable_log_server', False):
             # Build gRPC server address
-            rdzv_endpoint = parse_rendezvous_endpoint(args.rdzv_endpoint, default_port=-1)[0]
+            rdzv_endpoint_host = parse_rendezvous_endpoint(args.rdzv_endpoint, default_port=-1)[0]
             grpc_port = getattr(args, 'ft_log_server_port', 50051)
 
             # Node ID: hostname + PID for uniqueness in simulated multi-launcher environments
@@ -3284,7 +3357,7 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
             else:
                 # Writer is on a different host than the gRPC server
                 # Use the rendezvous endpoint to connect to the remote server
-                grpc_server_address = f"{rdzv_endpoint}:{grpc_port}"
+                grpc_server_address = f"{rdzv_endpoint_host}:{grpc_port}"
 
         # CRITICAL: Create rank monitors BEFORE PipeBasedLogsSpecs (which starts gRPC client thread)
         # This ensures rank monitors are forked before any threads exist (fork-safe)
@@ -3522,7 +3595,7 @@ def run(args):
         )
 
     # Register the selected FT rendezvous implementation
-    impl_type = getattr(args, 'ft_rdzv_impl', 'legacy')
+    impl_type = getattr(args, 'ft_rdzv_impl', 'barrier')
     _register_ft_rdzv_handler(impl_type)
     ft_hc_endpoint = getattr(args, "ft_node_health_check_endpoint", None)
     # Initialize NodeHealthCheck singleton at launcher start

--- a/tests/fault_tolerance/unit/test_config.py
+++ b/tests/fault_tolerance/unit/test_config.py
@@ -28,10 +28,10 @@ def test_from_kwargs():
     ref_conf = fault_tolerance.FaultToleranceConfig()
 
     conf_with_item_modified = fault_tolerance.FaultToleranceConfig.from_kwargs(
-        rank_heartbeat_timeout=ref_conf.rank_heartbeat_timeout + 1,
+        rank_heartbeat_timeout=123.0,
         ignore_not_recognized=False,
     )
-    assert conf_with_item_modified.rank_heartbeat_timeout == ref_conf.rank_heartbeat_timeout + 1
+    assert conf_with_item_modified.rank_heartbeat_timeout == 123.0
 
     not_modified_conf = fault_tolerance.FaultToleranceConfig.from_kwargs(
         ignore_not_recognized=False


### PR DESCRIPTION
Made the following config default:
  -. Barrier rdzv impl
  -. NIC healthcheck on
  -. Strict NUMA on
  -. Heartbeat timeouts null

Add Slurm one-launcher-per-node validation.
Auto-enable log server if not specified by user and `--ft-nvrx-logfile` is defined.