### PR TITLE
feat: two-level gRPC log aggregation (N leaves + root)

### DIFF
--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -168,6 +168,22 @@ the tolerance threshold or the timeout is reached. Memory statistics for each GP
 and logged after the reclaim process completes. If the timeout is reached, an error is logged but the
 restart proceeds as a best effort.
 
+Per-cycle logging and gRPC log aggregation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using consolidated per-cycle application logs (for example via ``--ft-per-cycle-applog-prefix``)
+with optional gRPC log funneling (``--ft-enable-log-server``), worker and launcher output can be
+merged through pipes and streamed to one or more aggregators on the rendezvous host before a single
+writer appends to shared storage (for example Lustre).
+
+.. important::
+
+   **Best-effort semantics.** Per-cycle gRPC log aggregation is best-effort. Logs around failure
+   and restart may be incomplete; crash stack traces are not guaranteed to appear there. For
+   critical diagnostics, use rank monitor logs (launcher log) for failure/timeout correlation and
+   OS-level core dumps for reliable crash post-mortem. Do not assume aggregated logs are complete
+   or reliable.
+
 Rank assignment
 ^^^^^^^^^^^^^^^
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -32,6 +32,7 @@ import time
 import uuid
 import warnings
 from argparse import REMAINDER, ArgumentParser
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from string import Template
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
@@ -2497,9 +2498,10 @@ def get_args_parser() -> ArgumentParser:
         "--ft_log_leaf_max_queue_chunks",
         action=env,
         type=int,
-        default=8192,
+        default=-1,
         dest="ft_log_leaf_max_queue_chunks",
-        help="Max queued log chunks per leaf before client backpressure (only when N>1). Default 8192.",
+        help="Max queued log chunks per leaf (only when N>1). "
+        "Default -1: auto scale with fan-in, max(16384, min(1000000, per_leaf*256)).",
     )
 
     parser.add_argument(
@@ -2525,6 +2527,8 @@ def get_args_parser() -> ArgumentParser:
         help="Maximum seconds to wait for clients during gRPC server graceful shutdown (only used if --ft-enable-log-server is enabled). "
         "When store host exits, server will continue accepting logs from other ranks for up to this timeout "
         "or until all clients disconnect, whichever comes first. This ensures other nodes can flush their final logs. "
+        "When --ft-log-aggregator-count>1, each leaf uses this timeout; the root log server uses 2× so leaves can finish "
+        "waiting for downstream clients and drain to root first. "
         "Default: 60.0",
     )
 
@@ -3173,6 +3177,11 @@ def _validate_slurm_single_launcher_per_node() -> None:
 
 def _validate_args(args: Any) -> None:
     """Centralized validation of CLI args (cross-flag consistency). Raises ValueError if invalid."""
+    n_log_agg = int(getattr(args, "ft_log_aggregator_count", 2))
+    if n_log_agg < 1:
+        raise ValueError(
+            f"--ft-log-aggregator-count must be >= 1, got {n_log_agg}"
+        )
     _validate_slurm_single_launcher_per_node()
     if getattr(args, "ft_cycle_info_dir", None) and not getattr(args, "ft_per_cycle_applog_prefix", None):
         raise ValueError(
@@ -3503,11 +3512,21 @@ class LogFunnelPorts:
             raise ValueError(f"base_port must be a valid TCP port, got {self.base_port}")
         if self.first_level_count < 1:
             raise ValueError("first_level_count must be >= 1")
+        if self.first_level_count > 1:
+            root_port = self.base_port + self.first_level_count
+            if root_port > 65535:
+                raise ValueError(
+                    f"root_listen_port (base_port + first_level_count) = {root_port} exceeds "
+                    f"65535; reduce --ft-log-server-port (base {self.base_port}) or "
+                    f"--ft-log-aggregator-count ({self.first_level_count})"
+                )
 
     @classmethod
     def from_launcher_args(cls, args: Any) -> "LogFunnelPorts":
         base = int(getattr(args, "ft_log_server_port", 50051))
-        n = max(1, int(getattr(args, "ft_log_aggregator_count", 2)))
+        n = int(getattr(args, "ft_log_aggregator_count", 2))
+        if n < 1:
+            raise ValueError(f"ft_log_aggregator_count must be >= 1, got {n}")
         return cls(base_port=base, first_level_count=n)
 
     @property
@@ -3544,14 +3563,14 @@ def _start_grpc_log_servers(
 ) -> List[subprocess.Popen]:
     """
     On TCP store host: start root log server (Lustre writer), and optionally N leaf
-    aggregators that forward to the root.
+    aggregators that forward to the root. In two-level mode the root is given
+    ``2 * graceful_shutdown_timeout`` so it outlasts leaf drain after SIGTERM.
 
     Returns:
         Non-empty list of Popen [root] or [root, leaf0, ...] on success, [] on failure.
     """
     graceful_shutdown_timeout = getattr(args, 'ft_log_server_graceful_shutdown_timeout', 60.0)
     _, max_nodes = parse_min_max_nnodes(args.nnodes)
-    max_queue = max(64, int(getattr(args, 'ft_log_leaf_max_queue_chunks', 8192)))
 
     def _open_log(path: str):
         return open(path, 'w')
@@ -3564,23 +3583,26 @@ def _start_grpc_log_servers(
                 grpc_server_log = _grpc_log_path(base_log_file, '_grpc_root.log')
             max_workers = min(4096, max(100, max_nodes + 10))
             fd = _open_log(grpc_server_log)
-            p = subprocess.Popen(
-                [
-                    sys.executable,
-                    '-m',
-                    'nvidia_resiliency_ext.shared_utils.grpc_log_server',
-                    '--host',
-                    '0.0.0.0',
-                    '--port',
-                    str(funnel_ports.base_port),
-                    '--max-workers',
-                    str(max_workers),
-                    '--graceful-shutdown-timeout',
-                    str(graceful_shutdown_timeout),
-                ],
-                stdout=fd,
-                stderr=subprocess.STDOUT,
-            )
+            try:
+                p = subprocess.Popen(
+                    [
+                        sys.executable,
+                        '-m',
+                        'nvidia_resiliency_ext.shared_utils.grpc_log_server',
+                        '--host',
+                        '0.0.0.0',
+                        '--port',
+                        str(funnel_ports.base_port),
+                        '--max-workers',
+                        str(max_workers),
+                        '--graceful-shutdown-timeout',
+                        str(graceful_shutdown_timeout),
+                    ],
+                    stdout=fd,
+                    stderr=subprocess.STDOUT,
+                )
+            finally:
+                fd.close()
             logger.info(
                 f"gRPC log server started: PID={p.pid}, port={funnel_ports.base_port}, "
                 f"max_workers={max_workers} (for {max_nodes} nodes)"
@@ -3591,39 +3613,53 @@ def _start_grpc_log_servers(
         n = funnel_ports.first_level_count
         root_workers = max(n + 10, 32)
         per_leaf = max(100, (max_nodes + n - 1) // n + 10)
-        root_log = _grpc_log_path(base_log_file, '_grpc_root.log')
+        raw_leaf_chunks = int(getattr(args, 'ft_log_leaf_max_queue_chunks', -1))
+        if raw_leaf_chunks < 0:
+            max_queue = min(1_000_000, max(16_384, per_leaf * 256))
+        else:
+            max_queue = max(64, raw_leaf_chunks)
+        root_log = getattr(args, 'ft_log_server_log', None) or _grpc_log_path(
+            base_log_file, '_grpc_root.log'
+        )
+
+        # Root must outlive leaves: leaves may wait the full leaf grace window for downstream
+        # clients before draining their queues to root; root's own grace must still be open then.
+        root_graceful_shutdown_timeout = graceful_shutdown_timeout * 2.0
 
         root_fd = _open_log(root_log)
-        root_p = subprocess.Popen(
-            [
-                sys.executable,
-                '-m',
-                'nvidia_resiliency_ext.shared_utils.grpc_log_server',
-                '--host',
-                '0.0.0.0',
-                '--port',
-                str(root_port),
-                '--max-workers',
-                str(root_workers),
-                '--graceful-shutdown-timeout',
-                str(graceful_shutdown_timeout),
-            ],
-            stdout=root_fd,
-            stderr=subprocess.STDOUT,
-        )
+        try:
+            root_p = subprocess.Popen(
+                [
+                    sys.executable,
+                    '-m',
+                    'nvidia_resiliency_ext.shared_utils.grpc_log_server',
+                    '--host',
+                    '0.0.0.0',
+                    '--port',
+                    str(root_port),
+                    '--max-workers',
+                    str(root_workers),
+                    '--graceful-shutdown-timeout',
+                    str(root_graceful_shutdown_timeout),
+                ],
+                stdout=root_fd,
+                stderr=subprocess.STDOUT,
+            )
+        finally:
+            root_fd.close()
         procs.append(root_p)
         logger.info(
-            f"gRPC root log server: PID={root_p.pid}, port={root_port}, max_workers={root_workers}"
+            f"gRPC root log server: PID={root_p.pid}, port={root_port}, max_workers={root_workers}, "
+            f"graceful_shutdown_timeout_s={root_graceful_shutdown_timeout} (2× leaf {graceful_shutdown_timeout}s)"
         )
-        time.sleep(1.0)
 
         upstream = f'localhost:{root_port}'
         for i in range(n):
             leaf_port = funnel_ports.leaf_listen_port(i)
             leaf_log = _grpc_log_path(base_log_file, f'_grpc_leaf_{i}.log')
             lf = _open_log(leaf_log)
-            lp = subprocess.Popen(
-                [
+            try:
+                leaf_cmd = [
                     sys.executable,
                     '-m',
                     'nvidia_resiliency_ext.shared_utils.grpc_log_leaf_server',
@@ -3639,14 +3675,18 @@ def _start_grpc_log_servers(
                     str(max_queue),
                     '--graceful-shutdown-timeout',
                     str(graceful_shutdown_timeout),
-                ],
-                stdout=lf,
-                stderr=subprocess.STDOUT,
-            )
+                ]
+                lp = subprocess.Popen(
+                    leaf_cmd,
+                    stdout=lf,
+                    stderr=subprocess.STDOUT,
+                )
+            finally:
+                lf.close()
             procs.append(lp)
             logger.info(
                 f"gRPC leaf log server {i}: PID={lp.pid}, port={leaf_port}, "
-                f"max_workers={per_leaf}, upstream={upstream}"
+                f"max_workers={per_leaf}, max_queue_chunks={max_queue}, upstream={upstream}"
             )
 
         return procs
@@ -3655,7 +3695,32 @@ def _start_grpc_log_servers(
         for p in procs:
             with contextlib.suppress(Exception):
                 p.kill()
+            with contextlib.suppress(Exception):
+                p.wait()
         return []
+
+
+def _grpc_child_wait_timeout_after_terminate(graceful_shutdown_timeout: float) -> float:
+    """Seconds to wait after SIGTERM before SIGKILL for a gRPC funnel child.
+
+    Matches each server's graceful client-wait, ``server.stop(grace=5)``, and
+    ``wait_for_termination`` budget (see ``grpc_log_server`` / ``grpc_log_leaf_server``).
+    """
+    return float(graceful_shutdown_timeout) + 5.0 + 65.0
+
+
+def _wait_grpc_subprocess_after_terminate(p: subprocess.Popen, wait_timeout: float) -> None:
+    """Wait for one gRPC funnel child after SIGTERM; force-kill if still alive past timeout."""
+    try:
+        p.wait(timeout=wait_timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            f"gRPC server PID={p.pid} did not shut down within {wait_timeout}s, killing..."
+        )
+        with contextlib.suppress(Exception):
+            p.kill()
+        with contextlib.suppress(Exception):
+            p.wait()
 
 
 def run(args):
@@ -3760,25 +3825,54 @@ def main(args=None):
         # (logging cleanup already happened in run()'s finally block)
         global _GRPC_SERVER_PROCESSES
         if _GRPC_SERVER_PROCESSES:
-            grpc_graceful_shutdown_timeout = getattr(
-                args, 'ft_log_server_graceful_shutdown_timeout', 60.0
+            grpc_graceful_shutdown_timeout = float(
+                getattr(args, 'ft_log_server_graceful_shutdown_timeout', 60.0)
             )
-            wait_timeout = grpc_graceful_shutdown_timeout + 5.0
+            n_log_agg = int(getattr(args, 'ft_log_aggregator_count', 2))
+            single_wait = _grpc_child_wait_timeout_after_terminate(grpc_graceful_shutdown_timeout)
+            if n_log_agg > 1:
+                root_grace = grpc_graceful_shutdown_timeout * 2.0
+                leaf_wait = _grpc_child_wait_timeout_after_terminate(grpc_graceful_shutdown_timeout)
+                root_wait = _grpc_child_wait_timeout_after_terminate(root_grace)
+                wait_msg = (
+                    f"leaf child wait up to {leaf_wait:.0f}s, root child up to {root_wait:.0f}s "
+                    f"(ft_log_server_graceful_shutdown_timeout={grpc_graceful_shutdown_timeout}s, root uses 2×)"
+                )
+            else:
+                leaf_wait = root_wait = single_wait
+                wait_msg = (
+                    f"per-process shutdown wait up to {single_wait:.0f}s "
+                    f"(ft_log_server_graceful_shutdown_timeout={grpc_graceful_shutdown_timeout}s)"
+                )
+            logger.info(
+                "Sending SIGTERM to gRPC log funnel process(es) (root last in wait order). "
+                f"{wait_msg}. "
+                "Check *_grpc_root.log and *_grpc_leaf_*.log for Shutdown snapshot lines: "
+                "in_memory_pending_bytes, chunk_queue_depth, still_connected_streams, etc."
+            )
             # Terminate leaves first so they drain to root before root exits
             for p in reversed(_GRPC_SERVER_PROCESSES):
                 with contextlib.suppress(Exception):
                     p.terminate()
-            for p in reversed(_GRPC_SERVER_PROCESSES):
-                try:
-                    p.wait(timeout=wait_timeout)
-                except subprocess.TimeoutExpired:
-                    logger.warning(
-                        f"gRPC server PID={p.pid} did not shut down within {wait_timeout}s, killing..."
+            # All processes got SIGTERM together; wait in parallel so wall time ≈ one timeout,
+            # not (N+1) × wait_timeout.
+            procs_to_wait = list(reversed(_GRPC_SERVER_PROCESSES))
+            root_proc = _GRPC_SERVER_PROCESSES[0]
+            with ThreadPoolExecutor(max_workers=max(1, len(procs_to_wait))) as pool:
+                pending_futures = [
+                    pool.submit(
+                        _wait_grpc_subprocess_after_terminate,
+                        p,
+                        root_wait if p is root_proc else leaf_wait,
                     )
+                    for p in procs_to_wait
+                ]
+                for fut in as_completed(pending_futures):
                     with contextlib.suppress(Exception):
-                        p.kill()
-                    with contextlib.suppress(Exception):
-                        p.wait()
+                        fut.result()
+            for p in _GRPC_SERVER_PROCESSES:
+                rc = getattr(p, "returncode", None)
+                logger.info(f"gRPC log subprocess PID={p.pid} finished with returncode={rc}")
             _GRPC_SERVER_PROCESSES.clear()
 
     sys.exit(exit_code)

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -79,6 +79,7 @@ from nvidia_resiliency_ext.fault_tolerance.per_cycle_logs import PipeBasedLogsSp
 from nvidia_resiliency_ext.fault_tolerance.progress_tracker import TrainingProgressTracker
 from nvidia_resiliency_ext.fault_tolerance.rank_monitor_server import RankMonitorServer
 from nvidia_resiliency_ext.fault_tolerance.utils import (
+    get_log_aggregator_shard_index,
     get_processes_by_pgids,
     hostnames_to_slurm_nodelist,
     is_slurm_job_array,
@@ -126,7 +127,9 @@ _EXIT_BARRIER_LAST_MEMBER_KEY = f"{_torch_elastic_agent_api._TERMINAL_STATE_SYNC
 logger = logging.getLogger(LogConfig.name)
 
 _NODE_HEALTH_CHECK_INSTANCE: Optional[NodeHealthCheck] = None
-_GRPC_SERVER_PROCESS: Optional[subprocess.Popen] = None
+# Populated on TCP store host when gRPC log aggregation is enabled: root-only [Popen] or
+# [root, leaf0, ..., leaf_{N-1}] when ft_log_aggregator_count > 1.
+_GRPC_SERVER_PROCESSES: List[subprocess.Popen] = []
 
 def init_node_health_check(endpoint: Optional[str]) -> None:
     global _NODE_HEALTH_CHECK_INSTANCE
@@ -2454,12 +2457,13 @@ def get_args_parser() -> ArgumentParser:
         dest="ft_enable_log_server",
         help="Enable gRPC-based log funneling to a single Lustre file. "
         "When enabled with --ft-per-cycle-applog-prefix, the launcher automatically: "
-        "(1) Starts gRPC log server on TCP store host (rank 0 node), "
-        "(2) Configures all nodes as gRPC clients to stream logs to server, "
-        "(3) Server writes to single Lustre file (eliminates O_APPEND contention). "
-        "Benefits: No Lustre lock contention, no log corruption, scales to 1500+ nodes. "
-        "Requires: pip install grpcio grpcio-tools (protobufs auto-compiled during install). "
-        "Default: False (direct file writing). Set to 'true' to enable.",
+        "(1) Starts gRPC log server(s) on TCP store host, "
+        "(2) Configures all nodes as gRPC clients to a first-level aggregator port, "
+        "(3) Root server writes to Lustre (single writer). "
+        "With --ft-log-aggregator-count=N>1, N leaf processes plus one root use ports P..P+N (see --ft-log-server-port). "
+        "Use --ft-log-aggregator-count=1 for a single server on P only. "
+        "Benefits: No Lustre lock contention, scales to 1500+ nodes. "
+        "Requires: grpcio. Default: False.",
     )
 
     parser.add_argument(
@@ -2474,15 +2478,41 @@ def get_args_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--ft-log-aggregator-count",
+        "--ft_log_aggregator_count",
+        action=env,
+        type=int,
+        default=2,
+        dest="ft_log_aggregator_count",
+        help="Number of first-level gRPC log aggregators (default 2). "
+        "When 1: single root server listens on --ft-log-server-port (legacy). "
+        "When N>1: N leaf servers on ports [P, P+1, ..., P+N-1] and one root on P+N "
+        "(P = --ft-log-server-port). Clients pick leaf via infra_rank %% N. "
+        "Open TCP ports P through P+N on the TCP store host. "
+        "Each node picks a leaf from SLURM array/procid when set, else from hostname.",
+    )
+
+    parser.add_argument(
+        "--ft-log-leaf-max-queue-chunks",
+        "--ft_log_leaf_max_queue_chunks",
+        action=env,
+        type=int,
+        default=8192,
+        dest="ft_log_leaf_max_queue_chunks",
+        help="Max queued log chunks per leaf before client backpressure (only when N>1). Default 8192.",
+    )
+
+    parser.add_argument(
         "--ft-log-server-log",
         "--ft_log_server_log",
         action=env,
         type=str,
         default=None,
         dest="ft_log_server_log",
-        help="Path to gRPC server's own log file (only used if --ft-enable-log-server is enabled). "
-        "If not specified, derives from --ft-per-cycle-applog-prefix by appending '_log_server.log'. "
-        "Example: If --ft-per-cycle-applog-prefix=/path/to/app.log, server log defaults to /path/to/app_log_server.log",
+        help="Path to gRPC root log server's own log file (only used if --ft-enable-log-server is enabled). "
+        "If not specified, derives from --ft-per-cycle-applog-prefix by replacing the trailing '.log' with "
+        "'_grpc_root.log' (same default basename as the two-level root writer). "
+        "Example: If --ft-per-cycle-applog-prefix=/path/to/app.log, defaults to /path/to/app_grpc_root.log",
     )
 
     parser.add_argument(
@@ -3319,9 +3349,9 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
         node_id = None
 
         if getattr(args, 'ft_enable_log_server', False):
-            # Build gRPC server address
             rdzv_endpoint_host = parse_rendezvous_endpoint(args.rdzv_endpoint, default_port=-1)[0]
-            grpc_port = getattr(args, 'ft_log_server_port', 50051)
+            log_funnel_ports = LogFunnelPorts.from_launcher_args(args)
+            grpc_port = log_funnel_ports.client_connect_port()
 
             # Node ID: hostname + PID for uniqueness in simulated multi-launcher environments
             hostname = socket.gethostname()
@@ -3335,28 +3365,19 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
             is_tcp_store_host = _matches_machine_hostname(host)
 
             if is_tcp_store_host:
-                # When writer is on the same host as the gRPC server, use localhost
-                # to ensure loopback connection. This avoids DNS/hostname resolution
-                # issues that could prevent the local writer from connecting to the
-                # local server.
                 grpc_server_address = f"localhost:{grpc_port}"
 
-                # Store gRPC server process globally for cleanup in main()
-                global _GRPC_SERVER_PROCESS
-                _GRPC_SERVER_PROCESS = _start_grpc_log_server(args, base_log_file)
+                global _GRPC_SERVER_PROCESSES
+                _GRPC_SERVER_PROCESSES = _start_grpc_log_servers(args, base_log_file, log_funnel_ports)
 
-                if _GRPC_SERVER_PROCESS is None:
-                    # CRITICAL: Server failed to start on TCP store host
-                    # Disable gRPC for this node to prevent log loss
+                if not _GRPC_SERVER_PROCESSES:
                     logger.error(
-                        "Failed to start gRPC server on TCP store host. "
+                        "Failed to start gRPC log server(s) on TCP store host. "
                         "Disabling gRPC log aggregation for all nodes (falling back to direct file writing)."
                     )
                     grpc_server_address = None
                     node_id = None
             else:
-                # Writer is on a different host than the gRPC server
-                # Use the rendezvous endpoint to connect to the remote server
                 grpc_server_address = f"{rdzv_endpoint_host}:{grpc_port}"
 
         # CRITICAL: Create rank monitors BEFORE PipeBasedLogsSpecs (which starts gRPC client thread)
@@ -3455,82 +3476,186 @@ def run_script_path(training_script: str, *training_script_args: str):
     runpy.run_path(sys.argv[0], run_name="__main__")
 
 
-def _start_grpc_log_server(args, base_log_file: str) -> Optional[subprocess.Popen]:
+def _grpc_log_path(base_log_file: str, suffix: str) -> str:
+    if base_log_file.endswith('.log'):
+        return base_log_file[:-4] + suffix
+    return base_log_file + suffix
+
+
+@dataclass(frozen=True)
+class LogFunnelPorts:
+    """Port assignments for the gRPC log funnel (single root vs N leaves + root).
+
+    Single-level (``first_level_count == 1``): one root listens on ``base_port`` and
+    clients connect there.
+
+    Two-level (``first_level_count > 1``): ``first_level_count`` leaves listen on
+    ``base_port .. base_port + N - 1``; the root (sole Lustre writer) listens on
+    ``base_port + N``. Each launcher picks a leaf using ``get_log_aggregator_shard_index(N)``
+    (SLURM array / ``SLURM_PROCID`` when present, else stable hostname hashing).
     """
-    Start gRPC log aggregation server as subprocess.
 
-    This should only be called on the TCP store host (rank 0 node).
-    The server accepts log chunks from clients, with each chunk specifying its target file_path.
+    base_port: int
+    first_level_count: int
 
-    Args:
-        args: Parsed command-line arguments (Namespace)
-        base_log_file: Base log file path (used to derive server log file name if not specified)
+    def __post_init__(self) -> None:
+        if not 1 <= self.base_port <= 65535:
+            raise ValueError(f"base_port must be a valid TCP port, got {self.base_port}")
+        if self.first_level_count < 1:
+            raise ValueError("first_level_count must be >= 1")
+
+    @classmethod
+    def from_launcher_args(cls, args: Any) -> "LogFunnelPorts":
+        base = int(getattr(args, "ft_log_server_port", 50051))
+        n = max(1, int(getattr(args, "ft_log_aggregator_count", 2)))
+        return cls(base_port=base, first_level_count=n)
+
+    @property
+    def uses_two_level(self) -> bool:
+        return self.first_level_count > 1
+
+    @property
+    def root_listen_port(self) -> int:
+        """Port bound by the process that writes to Lustre."""
+        if self.uses_two_level:
+            return self.base_port + self.first_level_count
+        return self.base_port
+
+    def leaf_listen_port(self, leaf_index: int) -> int:
+        """Port for leaf ``leaf_index`` in ``[0, first_level_count)`` (two-level only)."""
+        if not self.uses_two_level:
+            raise ValueError("leaf_listen_port is only defined when first_level_count > 1")
+        if not 0 <= leaf_index < self.first_level_count:
+            raise ValueError(
+                f"leaf_index must be in [0, {self.first_level_count}), got {leaf_index}"
+            )
+        return self.base_port + leaf_index
+
+    def client_connect_port(self) -> int:
+        """Aggregator port this launcher should use (leaf shard or single root)."""
+        if not self.uses_two_level:
+            return self.base_port
+        shard = get_log_aggregator_shard_index(self.first_level_count)
+        return self.leaf_listen_port(shard)
+
+
+def _start_grpc_log_servers(
+    args: Any, base_log_file: str, funnel_ports: LogFunnelPorts
+) -> List[subprocess.Popen]:
+    """
+    On TCP store host: start root log server (Lustre writer), and optionally N leaf
+    aggregators that forward to the root.
 
     Returns:
-        subprocess.Popen object for the server process, or None if failed
-
-    Notes:
-        max_workers is dynamically sized: min(4096, max(100, num_nodes + 10))
-        - Each node runs one GrpcWriterThread (long-lived streaming connection)
-        - Floor of 100: Handles small clusters and parsing failures gracefully
-        - Cap at 4096: Safety limit for extremely large clusters
-        - Threads are I/O-bound (blocked on queue), so 2048 threads ≈ 20MB memory
-        - Insufficient workers cause clients beyond Nth to queue indefinitely!
+        Non-empty list of Popen [root] or [root, leaf0, ...] on success, [] on failure.
     """
-    # Determine server log file path
-    grpc_server_log = getattr(args, 'ft_log_server_log', None)
-    if grpc_server_log is None:
-        # Derive from base_log_file: replace .log with _grpc_server.log
-        if base_log_file.endswith('.log'):
-            grpc_server_log = base_log_file[:-4] + '_grpc_server.log'
-        else:
-            grpc_server_log = base_log_file + '_grpc_server.log'
-
-    # Parse nnodes to get max expected nodes for worker pool sizing
-    # Each node maintains one long-lived streaming connection
-    _, max_nodes = parse_min_max_nnodes(args.nnodes)
-
-    # Get gRPC port
-    grpc_port = getattr(args, 'ft_log_server_port', 50051)
-
-    # Get graceful shutdown timeout
     graceful_shutdown_timeout = getattr(args, 'ft_log_server_graceful_shutdown_timeout', 60.0)
+    _, max_nodes = parse_min_max_nnodes(args.nnodes)
+    max_queue = max(64, int(getattr(args, 'ft_log_leaf_max_queue_chunks', 8192)))
 
-    # Calculate max_workers based on expected number of nodes
-    max_workers = min(4096, max(100, max_nodes + 10))
+    def _open_log(path: str):
+        return open(path, 'w')
 
+    procs: List[subprocess.Popen] = []
     try:
-        # Open server log file for writing
-        # Note: Launcher manages this file handle, not the server itself
-        server_log_fd = open(grpc_server_log, 'w')
+        if not funnel_ports.uses_two_level:
+            grpc_server_log = getattr(args, 'ft_log_server_log', None)
+            if grpc_server_log is None:
+                grpc_server_log = _grpc_log_path(base_log_file, '_grpc_root.log')
+            max_workers = min(4096, max(100, max_nodes + 10))
+            fd = _open_log(grpc_server_log)
+            p = subprocess.Popen(
+                [
+                    sys.executable,
+                    '-m',
+                    'nvidia_resiliency_ext.shared_utils.grpc_log_server',
+                    '--host',
+                    '0.0.0.0',
+                    '--port',
+                    str(funnel_ports.base_port),
+                    '--max-workers',
+                    str(max_workers),
+                    '--graceful-shutdown-timeout',
+                    str(graceful_shutdown_timeout),
+                ],
+                stdout=fd,
+                stderr=subprocess.STDOUT,
+            )
+            logger.info(
+                f"gRPC log server started: PID={p.pid}, port={funnel_ports.base_port}, "
+                f"max_workers={max_workers} (for {max_nodes} nodes)"
+            )
+            return [p]
 
-        # Start gRPC server as subprocess with stdout/stderr redirected
-        # Note: No --output-file argument - clients specify file_path in each chunk
-        server_process = subprocess.Popen(
+        root_port = funnel_ports.root_listen_port
+        n = funnel_ports.first_level_count
+        root_workers = max(n + 10, 32)
+        per_leaf = max(100, (max_nodes + n - 1) // n + 10)
+        root_log = _grpc_log_path(base_log_file, '_grpc_root.log')
+
+        root_fd = _open_log(root_log)
+        root_p = subprocess.Popen(
             [
-                sys.executable, '-m',
+                sys.executable,
+                '-m',
                 'nvidia_resiliency_ext.shared_utils.grpc_log_server',
-                '--host', '0.0.0.0',
-                '--port', str(grpc_port),
-                '--max-workers', str(max_workers),
-                '--graceful-shutdown-timeout', str(graceful_shutdown_timeout),
+                '--host',
+                '0.0.0.0',
+                '--port',
+                str(root_port),
+                '--max-workers',
+                str(root_workers),
+                '--graceful-shutdown-timeout',
+                str(graceful_shutdown_timeout),
             ],
-            stdout=server_log_fd,
-            stderr=subprocess.STDOUT,  # Redirect stderr to stdout (both go to same file)
+            stdout=root_fd,
+            stderr=subprocess.STDOUT,
         )
-
+        procs.append(root_p)
         logger.info(
-            f"gRPC log server started: PID={server_process.pid}, port={grpc_port}, "
-            f"max_workers={max_workers} (for {max_nodes} nodes)"
+            f"gRPC root log server: PID={root_p.pid}, port={root_port}, max_workers={root_workers}"
         )
+        time.sleep(1.0)
 
-        # Note: server_log_fd will be closed when server_process terminates
-        # Clients will wait for server readiness using their own health check retry logic
-        return server_process
+        upstream = f'localhost:{root_port}'
+        for i in range(n):
+            leaf_port = funnel_ports.leaf_listen_port(i)
+            leaf_log = _grpc_log_path(base_log_file, f'_grpc_leaf_{i}.log')
+            lf = _open_log(leaf_log)
+            lp = subprocess.Popen(
+                [
+                    sys.executable,
+                    '-m',
+                    'nvidia_resiliency_ext.shared_utils.grpc_log_leaf_server',
+                    '--host',
+                    '0.0.0.0',
+                    '--port',
+                    str(leaf_port),
+                    '--upstream',
+                    upstream,
+                    '--max-workers',
+                    str(per_leaf),
+                    '--max-queue-chunks',
+                    str(max_queue),
+                    '--graceful-shutdown-timeout',
+                    str(graceful_shutdown_timeout),
+                ],
+                stdout=lf,
+                stderr=subprocess.STDOUT,
+            )
+            procs.append(lp)
+            logger.info(
+                f"gRPC leaf log server {i}: PID={lp.pid}, port={leaf_port}, "
+                f"max_workers={per_leaf}, upstream={upstream}"
+            )
 
+        return procs
     except Exception as e:
-        logger.error(f"Failed to start gRPC log server: {e}", exc_info=True)
-        return None
+        logger.error(f"Failed to start gRPC log server(s): {e}", exc_info=True)
+        for p in procs:
+            with contextlib.suppress(Exception):
+                p.kill()
+        return []
 
 
 def run(args):
@@ -3633,24 +3758,28 @@ def main(args=None):
     finally:
         # Clean up gRPC server AFTER all logging is done
         # (logging cleanup already happened in run()'s finally block)
-        global _GRPC_SERVER_PROCESS
-        if _GRPC_SERVER_PROCESS:
-            _GRPC_SERVER_PROCESS.terminate()
-            try:
-                # CRITICAL: Server has graceful_shutdown_timeout to wait for clients
-                # We must wait at least that long + margin before force-killing
-                # The server will exit earlier if all clients disconnect
-                # Read timeout directly from args (already parsed and available here)
-                grpc_graceful_shutdown_timeout = getattr(args, 'ft_log_server_graceful_shutdown_timeout', 60.0)
-                wait_timeout = grpc_graceful_shutdown_timeout + 5.0
-                _GRPC_SERVER_PROCESS.wait(timeout=wait_timeout)
-            except subprocess.TimeoutExpired:
-                # Server didn't shut down within graceful period, force kill
-                logger.warning(
-                    f"gRPC server did not shut down within {wait_timeout}s, killing..."
-                )
-                _GRPC_SERVER_PROCESS.kill()
-                _GRPC_SERVER_PROCESS.wait()
+        global _GRPC_SERVER_PROCESSES
+        if _GRPC_SERVER_PROCESSES:
+            grpc_graceful_shutdown_timeout = getattr(
+                args, 'ft_log_server_graceful_shutdown_timeout', 60.0
+            )
+            wait_timeout = grpc_graceful_shutdown_timeout + 5.0
+            # Terminate leaves first so they drain to root before root exits
+            for p in reversed(_GRPC_SERVER_PROCESSES):
+                with contextlib.suppress(Exception):
+                    p.terminate()
+            for p in reversed(_GRPC_SERVER_PROCESSES):
+                try:
+                    p.wait(timeout=wait_timeout)
+                except subprocess.TimeoutExpired:
+                    logger.warning(
+                        f"gRPC server PID={p.pid} did not shut down within {wait_timeout}s, killing..."
+                    )
+                    with contextlib.suppress(Exception):
+                        p.kill()
+                    with contextlib.suppress(Exception):
+                        p.wait()
+            _GRPC_SERVER_PROCESSES.clear()
 
     sys.exit(exit_code)
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/per_cycle_logs.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/per_cycle_logs.py
@@ -71,6 +71,21 @@ _FLUSH_INTERVAL_SECONDS = 1.0  # Flush at least every 1 second
 _GRPC_MAX_CHUNK_SIZE = 256 * 1024  # 256 KB chunks for gRPC transmission
 _GRPC_RECONNECT_INTERVAL = 5.0  # Retry connection every 5 seconds
 
+# Reader shutdown joins GrpcWriterThread for at most this long (see MultiplexingReaderThread.run
+# finally). PipeBasedLogsSpecs.cleanup() must wait longer than writer join plus reader-finally
+# work (poll interval, shutdown sleep in shutdown(), stable-empty drain, _cleanup_resources) so
+# the launcher does not return while the daemon reader is still draining tail logs to gRPC.
+_GRPC_WRITER_THREAD_JOIN_TIMEOUT_SEC = 30.0
+_READER_THREAD_SHUTDOWN_JOIN_TIMEOUT_SEC = _GRPC_WRITER_THREAD_JOIN_TIMEOUT_SEC + 10.0
+
+# Write-queue poll in GrpcWriterThread.log_generator and MultiplexingReaderThread file writer:
+# short timeout so shutdown stays responsive. GrpcWriter drain ends after shutdown_requested once
+# the queue stays empty for _GRPC_STABLE_EMPTY_POLLS_NEEDED consecutive Empty timeouts (quiet
+# window ≈ _GRPC_STABLE_EMPTY_POLLS_NEEDED × this). Keep _GRPC_WRITER_THREAD_JOIN_TIMEOUT_SEC
+# and _READER_THREAD_SHUTDOWN_JOIN_TIMEOUT_SEC comfortably above that window plus queued work.
+_WRITE_QUEUE_GET_TIMEOUT_SEC = 0.1
+_GRPC_STABLE_EMPTY_POLLS_NEEDED = 5
+
 # Module-level flag to track if we've patched get_subprocess_handler
 _SUBPROCESS_HANDLER_PATCHED = False
 
@@ -443,9 +458,8 @@ class GrpcWriterThread(threading.Thread):
                     channel.close()
                     channel = None
 
-        # When shutdown is requested, the generator exits immediately without draining.
-        # Any remaining items in the queue are not sent - during shutdown, the server
-        # may already be closing, so delivery cannot be guaranteed anyway.
+        # If shutdown happened mid-stream, log_generator drains until the queue is stably empty
+        # before the RPC completes (see log_generator).
 
         self.logger.debug(f"gRPC writer thread exiting (node_id={self.node_id})")
 
@@ -453,11 +467,8 @@ class GrpcWriterThread(threading.Thread):
         """
         Stream logs to server using provided gRPC channel.
 
-        The generator consumes the queue until shutdown is requested, then exits immediately.
-        No drain phase is performed because:
-        1. During shutdown, the server may already be closing/closed
-        2. Draining adds delay that can exceed the reader's shutdown timeout
-        3. Any logs still in queue at shutdown are not guaranteed to be delivered anyway
+        The generator consumes the queue until shutdown is requested, then drains until the
+        queue is stably empty so tail logs are handed to gRPC before the RPC ends.
 
         Args:
             channel: Existing gRPC channel (caller manages lifecycle)
@@ -465,10 +476,13 @@ class GrpcWriterThread(threading.Thread):
         stub = log_aggregation_pb2_grpc.LogAggregationServiceStub(channel)
 
         def log_generator():
-            """Generator that yields LogChunk messages from queue until shutdown."""
-            while not self.shutdown_requested:
+            """Yield LogChunk messages from queue; drain remaining items when shutdown is requested."""
+            _empty_poll_count = 0
+
+            while True:
                 try:
-                    log_file_path, data = self.write_queue.get(timeout=0.1)
+                    log_file_path, data = self.write_queue.get(timeout=_WRITE_QUEUE_GET_TIMEOUT_SEC)
+                    _empty_poll_count = 0
 
                     # Encode string to bytes (done once here, not in reader thread)
                     data_bytes = data.encode('utf-8')
@@ -485,7 +499,13 @@ class GrpcWriterThread(threading.Thread):
                     yield chunk
 
                 except queue.Empty:
-                    # Timeout - normal, just check shutdown flag
+                    if self.shutdown_requested:
+                        _empty_poll_count += 1
+                        if (
+                            _empty_poll_count >= _GRPC_STABLE_EMPTY_POLLS_NEEDED
+                            and self.write_queue.empty()
+                        ):
+                            return
                     continue
                 except UnicodeEncodeError as e:
                     # Log data encoding issue (rare - indicates non-UTF8 data)
@@ -504,8 +524,9 @@ class GrpcWriterThread(threading.Thread):
 
         try:
             # Stream logs to server until shutdown is requested
-            # No timeout on the RPC - let it run as long as needed during normal operation
-            # The reader thread's join(timeout=30s) provides protection during shutdown
+            # No timeout on the RPC - let it run as long as needed during normal operation.
+            # On launcher exit the reader thread's finally calls join(timeout=...) on this
+            # GrpcWriterThread after shutdown_requested, bounding post-shutdown drain time.
             response = stub.StreamLogs(log_generator())
             self.logger.debug(
                 f"Stream completed: {response.status}, "
@@ -606,8 +627,9 @@ class MultiplexingReaderThread(threading.Thread):
         self._clear_pipes_event = threading.Event()
         self._pipes_cleared_event = threading.Event()
 
-        # Write queue for decoupling pipe reading from writer I/O
-        # Queue items: (log_file_path, data_to_write)
+        # Unbounded queue: (log_file_path, data_to_write). Decouples pipe reads from writer I/O.
+        # Backpressure from a slow gRPC leaf/root is absorbed here (RAM) rather than blocking
+        # _stop_workers; the launcher only allows a short kernel-pipe grace before closing FDs.
         self._write_queue = queue.Queue()
         self._writer_shutdown = False
         self._grpc_config = grpc_config
@@ -688,7 +710,9 @@ class MultiplexingReaderThread(threading.Thread):
             while not self._writer_shutdown:
                 try:
                     # Get next write request with short timeout for responsive shutdown
-                    log_file_path, data = self._write_queue.get(timeout=0.1)
+                    log_file_path, data = self._write_queue.get(
+                        timeout=_WRITE_QUEUE_GET_TIMEOUT_SEC
+                    )
 
                     add_to_batch(log_file_path, data)
 
@@ -1136,11 +1160,14 @@ class MultiplexingReaderThread(threading.Thread):
                 self._writer_shutdown = True
 
             if self._writer_thread and self._writer_thread.is_alive():
-                self._writer_thread.join(timeout=30.0)  # Wait for writer to complete disconnect
+                self._writer_thread.join(
+                    timeout=_GRPC_WRITER_THREAD_JOIN_TIMEOUT_SEC
+                )  # Wait for writer to complete disconnect
                 if self._writer_thread.is_alive():
                     self.logger.warning(
-                        "Writer thread did not exit within 30s timeout during reader shutdown. "
-                        "Connection may be aborted."
+                        "Writer thread did not exit within "
+                        f"{_GRPC_WRITER_THREAD_JOIN_TIMEOUT_SEC:.0f}s timeout during reader "
+                        "shutdown. Connection may be aborted."
                     )
 
     def update_pipes(
@@ -1233,13 +1260,19 @@ class MultiplexingReaderThread(threading.Thread):
         - Write queue is drained (all pending writes complete)
         - Log files are properly closed
 
-        After calling shutdown(), use join(timeout=5.0) to wait for thread to exit.
+        After calling shutdown(), join the thread with a timeout that allows the
+        finally block to run (including join on GrpcWriterThread, bounded by
+        _GRPC_WRITER_THREAD_JOIN_TIMEOUT_SEC).
+
+        PipeBasedLogsSpecs.cleanup() uses _READER_THREAD_SHUTDOWN_JOIN_TIMEOUT_SEC so the
+        launcher waits through reader-finally work and the writer join.
+
         Daemon=True is only a safety fallback if shutdown is not called.
 
         Usage:
             if self._reader_thread:
                 self._reader_thread.shutdown()
-                self._reader_thread.join(timeout=5.0)
+                self._reader_thread.join(timeout=_READER_THREAD_SHUTDOWN_JOIN_TIMEOUT_SEC)
         """
         # First, give reader thread a moment to process any final pipe events
         # (especially POLLHUP after pipes are closed)
@@ -1561,15 +1594,15 @@ class PipeBasedLogsSpecs(LogsSpecs):
         This must be called explicitly - daemon thread alone won't flush buffers!
         """
         self._reader_thread.shutdown()
-        # Give reader thread enough time to:
-        # 1. Complete current poll cycle (0.15s sleep in shutdown())
-        # 2. Clean up resources and flush buffers
-        # 3. Shut down writer thread (which may take up to 5s to drain queue)
-        # Total: 0.15s + 5s writer timeout + 2s gRPC drain + buffer = 8s
-        self._reader_thread.join(timeout=8.0)
+        # Reader shutdown() sleeps 0.15s, then the thread exits its main loop and runs
+        # finally: cleanup_resources, launcher pipe cleanup, GrpcWriterThread.shutdown(),
+        # then join on the gRPC writer (_GRPC_WRITER_THREAD_JOIN_TIMEOUT_SEC). The join
+        # below must cover that full path (see _READER_THREAD_SHUTDOWN_JOIN_TIMEOUT_SEC).
+        self._reader_thread.join(timeout=_READER_THREAD_SHUTDOWN_JOIN_TIMEOUT_SEC)
         if self._reader_thread.is_alive():
             self.logger.warning(
-                "Reader thread did not exit within 8s timeout. Logs may be incomplete."
+                "Reader thread did not exit within "
+                f"{_READER_THREAD_SHUTDOWN_JOIN_TIMEOUT_SEC:.0f}s timeout. Logs may be incomplete."
             )
         else:
             self.logger.debug("Reader thread shutdown completed successfully.")

--- a/src/nvidia_resiliency_ext/fault_tolerance/utils.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/utils.py
@@ -16,6 +16,7 @@
 import asyncio
 import contextlib
 import ctypes
+import hashlib
 import logging
 import multiprocessing
 import os
@@ -231,6 +232,37 @@ def is_slurm_job_array() -> bool:
         bool: True if running in a SLURM job array (SLURM_ARRAY_TASK_ID is set), False otherwise
     """
     return os.getenv('SLURM_ARRAY_TASK_ID') is not None
+
+
+def get_log_aggregator_shard_index(num_aggregators: int) -> int:
+    """Shard index in ``[0, num_aggregators)`` for first-level log aggregator selection.
+
+    Static topology from minimal infra signals only (same spirit as common SLURM layouts):
+
+    - If SLURM job array: ``array_task_id * nnodes + SLURM_PROCID`` (mod N).
+    - Else if ``SLURM_PROCID`` is set: ``SLURM_PROCID`` (mod N).
+    - Else: stable spread from ``MD5(hostname)`` (mod N) for load balance without SLURM.
+
+    Args:
+        num_aggregators: Number of first-level aggregators (N).
+
+    Returns:
+        Index in ``0 .. num_aggregators-1``. If ``num_aggregators <= 1``, returns 0.
+    """
+    if num_aggregators <= 1:
+        return 0
+    if os.getenv('SLURM_ARRAY_TASK_ID') is not None and os.getenv('SLURM_PROCID') is not None:
+        nnodes_s = os.getenv('SLURM_NNODES') or os.getenv('SLURM_JOB_NUM_NODES')
+        if nnodes_s is not None:
+            r = int(os.environ['SLURM_ARRAY_TASK_ID']) * int(nnodes_s) + int(
+                os.environ['SLURM_PROCID']
+            )
+            return r % num_aggregators
+    proc = os.getenv('SLURM_PROCID')
+    if proc is not None:
+        return int(proc) % num_aggregators
+    h = int(hashlib.md5(socket.gethostname().encode()).hexdigest(), 16)
+    return h % num_aggregators
 
 
 def is_process_alive(pid):

--- a/src/nvidia_resiliency_ext/inprocess/abort.py
+++ b/src/nvidia_resiliency_ext/inprocess/abort.py
@@ -97,7 +97,7 @@ class AbortTorchDistributed(Abort):
         process_groups = list(torch.distributed.distributed_c10d._world.pg_names)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(process_groups)) as executor:
-            futures = [
+            pending_futures = [
                 executor.submit(
                     AbortTorchDistributed.shutdown_process_group_backend,
                     group,
@@ -106,7 +106,7 @@ class AbortTorchDistributed(Abort):
                 for group in process_groups
             ]
             done, not_done = concurrent.futures.wait(
-                futures,
+                pending_futures,
                 return_when=concurrent.futures.ALL_COMPLETED,
             )
 

--- a/src/nvidia_resiliency_ext/shared_utils/grpc_log_leaf_server.py
+++ b/src/nvidia_resiliency_ext/shared_utils/grpc_log_leaf_server.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+First-level gRPC log aggregator (leaf): accepts StreamLogs from training nodes,
+forwards chunks to the root log server over a single outbound StreamLogs RPC.
+
+Uses a bounded queue for backpressure when the root is slow. Root must be
+started before leaves (launcher order).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import queue
+import signal
+import sys
+import threading
+import time
+import urllib.parse
+from concurrent import futures
+from typing import Any, Iterator, Optional
+
+import grpc
+
+try:
+    from nvidia_resiliency_ext.shared_utils.proto import (
+        log_aggregation_pb2,
+        log_aggregation_pb2_grpc,
+    )
+except ImportError:
+    import os
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_utils', 'proto'))
+    import log_aggregation_pb2
+    import log_aggregation_pb2_grpc
+
+logger = logging.getLogger("LogLeafServer")
+
+# Sentinel placed on queue after graceful drain to end upstream StreamLogs
+_STOP = object()
+
+_GRPC_OPTS = [
+    ('grpc.max_send_message_length', 10 * 1024 * 1024),
+    ('grpc.max_receive_message_length', 10 * 1024 * 1024),
+    ('grpc.http2.min_time_between_pings_ms', 5000),
+    ('grpc.http2.min_ping_interval_without_data_ms', 5000),
+    ('grpc.http2.max_pings_without_data', 0),
+    ('grpc.keepalive_permit_without_calls', 1),
+]
+
+
+def _copy_chunk(chunk: log_aggregation_pb2.LogChunk) -> log_aggregation_pb2.LogChunk:
+    return log_aggregation_pb2.LogChunk(
+        node_id=chunk.node_id,
+        data=chunk.data,
+        file_path=chunk.file_path,
+    )
+
+
+def _format_grpc_peer(raw: Optional[str]) -> str:
+    """Decode URL-encoded characters in ``context.peer()`` for readable log lines."""
+    if not raw:
+        return "unknown_peer"
+    return urllib.parse.unquote(raw)
+
+
+class _UpstreamForwarder:
+    """Runs stub.StreamLogs in a thread; reconnects on failure until stopped."""
+
+    def __init__(
+        self,
+        upstream: str,
+        chunk_queue: queue.Queue,
+        stop_event: threading.Event,
+        reconnect_sleep: float = 2.0,
+    ):
+        self._upstream = upstream
+        self._q = chunk_queue
+        self._stop = stop_event
+        self._reconnect_sleep = reconnect_sleep
+        self._thread: Optional[threading.Thread] = None
+        #: Set while an active upstream StreamLogs RPC is in progress (root can receive).
+        self.upstream_ready = threading.Event()
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, name='LeafUpstream', daemon=True)
+        self._thread.start()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        if self._thread:
+            self._thread.join(timeout=timeout)
+
+    def _wait_root_ready(self, stub: Any) -> bool:
+        while not self._stop.is_set():
+            try:
+                r = stub.HealthCheck(log_aggregation_pb2.HealthRequest(), timeout=2.0)
+                if r.healthy:
+                    return True
+            except grpc.RpcError:
+                pass
+            time.sleep(0.5)
+        return False
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            ch = None
+            try:
+                ch = grpc.insecure_channel(
+                    self._upstream,
+                    options=[
+                        *_GRPC_OPTS,
+                        ('grpc.keepalive_time_ms', 60000),
+                        ('grpc.keepalive_timeout_ms', 20000),
+                    ],
+                )
+                stub = log_aggregation_pb2_grpc.LogAggregationServiceStub(ch)
+                if not self._wait_root_ready(stub):
+                    break
+
+                def gen() -> Iterator[log_aggregation_pb2.LogChunk]:
+                    while True:
+                        item = self._q.get()
+                        if item is _STOP:
+                            return
+                        yield item  # type: ignore[misc]
+
+                logger.info(f"Connected upstream StreamLogs to {self._upstream}")
+                self.upstream_ready.set()
+                stub.StreamLogs(gen())
+                logger.info("Upstream StreamLogs ended")
+            except grpc.RpcError as e:
+                if not self._stop.is_set():
+                    logger.warning(f"Upstream gRPC error, will retry: {e.code()} {e.details()}")
+            except Exception as e:
+                if not self._stop.is_set():
+                    logger.error(f"Upstream forwarder error: {e}", exc_info=True)
+            finally:
+                self.upstream_ready.clear()
+                if ch is not None:
+                    ch.close()
+            if not self._stop.is_set():
+                time.sleep(self._reconnect_sleep)
+        logger.info("Upstream forwarder stopped")
+
+
+class LeafLogServicer(log_aggregation_pb2_grpc.LogAggregationServiceServicer):
+    def __init__(
+        self,
+        chunk_queue: queue.Queue,
+        reject_new_streams: threading.Event,
+        upstream_ready: threading.Event,
+    ):
+        self._q = chunk_queue
+        self._reject = reject_new_streams
+        self._upstream_ready = upstream_ready
+        self.connected_clients = 0
+        self.clients_lock = threading.Lock()
+
+    def StreamLogs(self, request_iterator, context):
+        if self._reject.is_set():
+            context.abort(grpc.StatusCode.UNAVAILABLE, "leaf server is shutting down")
+        with self.clients_lock:
+            self.connected_clients += 1
+        peer = _format_grpc_peer(context.peer())
+        source_node_id = None
+        total = 0
+        nchunks = 0
+        try:
+            for chunk in request_iterator:
+                if self._reject.is_set():
+                    break
+                if source_node_id is None:
+                    source_node_id = chunk.node_id
+                    logger.info(
+                        f"Compute node StreamLogs opened peer={peer} source_node_id={source_node_id}"
+                    )
+                self._q.put(_copy_chunk(chunk))
+                total += len(chunk.data)
+                nchunks += 1
+            return log_aggregation_pb2.StreamResponse(status="OK", bytes_received=total)
+        finally:
+            end_src = (
+                f"source_node_id={source_node_id}"
+                if source_node_id is not None
+                else "source_node_id=n/a"
+            )
+            logger.info(
+                f"Compute node StreamLogs ended peer={peer} {end_src} "
+                f"chunks={nchunks} received_KiB={total / 1024:.1f}"
+            )
+            with self.clients_lock:
+                self.connected_clients -= 1
+
+    def HealthCheck(self, request, context):
+        with self.clients_lock:
+            n = self.connected_clients
+        ok = self._upstream_ready.is_set()
+        return log_aggregation_pb2.HealthResponse(healthy=ok, connected_clients=n)
+
+
+def serve(
+    host: str,
+    port: int,
+    upstream: str,
+    max_workers: int,
+    max_queue_chunks: int,
+    graceful_shutdown_timeout: float,
+) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] [%(process)5s] %(filename)s:%(lineno)d %(message)s',
+    )
+    chunk_queue: queue.Queue = queue.Queue(maxsize=max_queue_chunks)
+    stop_forwarder = threading.Event()
+    reject_new = threading.Event()
+
+    forwarder = _UpstreamForwarder(upstream, chunk_queue, stop_forwarder)
+    forwarder.start()
+    if not forwarder.upstream_ready.wait(timeout=120.0):
+        logger.error("Timeout waiting for upstream root; exiting")
+        stop_forwarder.set()
+        try:
+            chunk_queue.put(_STOP, timeout=1.0)
+        except queue.Full:
+            pass
+        forwarder.join(timeout=10.0)
+        sys.exit(1)
+
+    servicer = LeafLogServicer(chunk_queue, reject_new, forwarder.upstream_ready)
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=max_workers),
+        options=_GRPC_OPTS,
+    )
+    log_aggregation_pb2_grpc.add_LogAggregationServiceServicer_to_server(servicer, server)
+    addr = f'{host}:{port}'
+    server.add_insecure_port(addr)
+    server.start()
+    logger.info(
+        f"Leaf log server on {addr}, upstream={upstream}, max_queue_chunks={max_queue_chunks}"
+    )
+
+    def shutdown_leaf():
+        logger.info("Graceful shutdown: waiting for downstream clients...")
+        reject_new.set()
+        start = time.time()
+        while True:
+            with servicer.clients_lock:
+                ac = servicer.connected_clients
+            if ac == 0:
+                break
+            if time.time() - start >= graceful_shutdown_timeout:
+                logger.warning(f"{ac} client(s) still connected after {graceful_shutdown_timeout}s")
+                break
+            time.sleep(0.1)
+        stop_forwarder.set()
+        chunk_queue.put(_STOP)
+        forwarder.join(timeout=graceful_shutdown_timeout + 5.0)
+        server.stop(grace=5.0)
+        logger.info("Leaf server exit")
+
+    def on_signal(signum, frame):
+        logger.info(f"Signal {signum}, shutting down leaf...")
+        shutdown_leaf()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, on_signal)
+    signal.signal(signal.SIGTERM, on_signal)
+    try:
+        server.wait_for_termination()
+    except KeyboardInterrupt:
+        shutdown_leaf()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="First-level gRPC log aggregator (forwards to root).")
+    p.add_argument('--host', type=str, default='0.0.0.0')
+    p.add_argument('--port', type=int, required=True)
+    p.add_argument('--upstream', type=str, required=True, help='Root server host:port')
+    p.add_argument('--max-workers', type=int, default=100)
+    p.add_argument(
+        '--max-queue-chunks',
+        type=int,
+        default=8192,
+        help='Max queued chunks before blocking clients (backpressure). Default 8192.',
+    )
+    p.add_argument('--graceful-shutdown-timeout', type=float, default=60.0)
+    args = p.parse_args()
+    serve(
+        host=args.host,
+        port=args.port,
+        upstream=args.upstream,
+        max_workers=args.max_workers,
+        max_queue_chunks=args.max_queue_chunks,
+        graceful_shutdown_timeout=args.graceful_shutdown_timeout,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/src/nvidia_resiliency_ext/shared_utils/grpc_log_leaf_server.py
+++ b/src/nvidia_resiliency_ext/shared_utils/grpc_log_leaf_server.py
@@ -8,8 +8,22 @@
 First-level gRPC log aggregator (leaf): accepts StreamLogs from training nodes,
 forwards chunks to the root log server over a single outbound StreamLogs RPC.
 
-Uses a bounded queue for backpressure when the root is slow. Root must be
-started before leaves (launcher order).
+Uses a bounded queue for backpressure when the root is slow. Downstream handlers
+retry enqueue until space exists or shutdown (they do not discard the current
+chunk because the queue is full); gRPC flow-control slows senders until the
+forwarder drains toward root. That is **not** an end-to-end delivery guarantee:
+if the leaf→root ``StreamLogs`` RPC fails after items were ``get`` from the
+queue and yielded into gRPC but not yet committed at the root, they are not
+replayed on reconnect—treat leaf→root as best-effort (see also usage docs).
+Short ``put`` timeouts only exist so threads can observe ``reject_new_streams``
+during shutdown. Capacity is ``max-queue-chunks`` (item count); each ``put`` is O(1).
+
+The upstream forwarder polls the chunk queue with a timeout and exits when
+``stop_forwarder`` is set, so the leaf→root ``StreamLogs`` RPC can finish even
+if the ``_STOP`` sentinel never enters a full queue. Root must be started before
+leaves (launcher order). The leaf does not bind its downstream TCP port until the
+upstream root is healthy and ``StreamLogs`` is active, so clients may see
+``ECONNREFUSED`` until then (see log line before the upstream-ready wait).
 """
 
 from __future__ import annotations
@@ -23,7 +37,7 @@ import threading
 import time
 import urllib.parse
 from concurrent import futures
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator, Optional, Union
 
 import grpc
 
@@ -43,6 +57,23 @@ logger = logging.getLogger("LogLeafServer")
 
 # Sentinel placed on queue after graceful drain to end upstream StreamLogs
 _STOP = object()
+
+# Slice timeout for Queue.put / Condition.wait so StreamLogs handlers can poll
+# ``reject_new_streams`` and exit during shutdown (no uninterruptible block).
+_LEAF_QUEUE_PUT_SLICE_S = 0.5
+_STOP_SENTINEL_PUT_TIMEOUT_S = 5.0
+
+# Throttled diagnostics when a chunk waits a long time (backpressure / slow root).
+_LEAF_QUEUE_BACKPRESSURE_LOG_FIRST_S = 5.0
+_LEAF_QUEUE_BACKPRESSURE_LOG_INTERVAL_S = 30.0
+
+# Upstream generator must not block forever on Queue.get when ``_STOP`` could not be
+# enqueued (e.g. queue full); poll and exit if ``stop_forwarder`` is set.
+_UPSTREAM_QUEUE_GET_TIMEOUT_S = 0.5
+
+# Max seconds to wait for root health + active leaf→root ``StreamLogs`` before binding
+# the downstream port and accepting compute-node clients.
+_LEAF_UPSTREAM_ROOT_READY_TIMEOUT_S = 120.0
 
 _GRPC_OPTS = [
     ('grpc.max_send_message_length', 10 * 1024 * 1024),
@@ -69,13 +100,76 @@ def _format_grpc_peer(raw: Optional[str]) -> str:
     return urllib.parse.unquote(raw)
 
 
+class _LeafChunkQueue:
+    """Per-leaf buffer from many StreamLogs handlers to one upstream forwarder."""
+
+    def __init__(self, max_chunks: int):
+        if max_chunks < 1:
+            raise ValueError('max_chunks must be >= 1')
+        self.max_chunks = max_chunks
+        self._q: queue.Queue = queue.Queue(maxsize=max_chunks)
+
+    def qsize(self) -> int:
+        return self._q.qsize()
+
+    @property
+    def maxsize(self) -> int:
+        return self._q.maxsize
+
+    def put_stop(self, timeout: float) -> None:
+        self._q.put(_STOP, timeout=timeout)
+
+    def get_upstream(self, timeout: float) -> Union[log_aggregation_pb2.LogChunk, object]:
+        return self._q.get(timeout=timeout)
+
+    def put_chunk(
+        self,
+        chunk: log_aggregation_pb2.LogChunk,
+        reject: threading.Event,
+        *,
+        peer: str,
+        source_node_id: str,
+    ) -> bool:
+        """
+        Enqueue ``chunk`` (already a copy). Blocks until space or ``reject`` is set.
+
+        Returns:
+            True if enqueued, False if ``reject`` was set while waiting (shutdown).
+        """
+        sz = len(chunk.data)
+        wait_start = time.monotonic()
+        next_log_at = wait_start + _LEAF_QUEUE_BACKPRESSURE_LOG_FIRST_S
+
+        def maybe_log() -> None:
+            nonlocal next_log_at
+            now = time.monotonic()
+            if now < next_log_at:
+                return
+            next_log_at = now + _LEAF_QUEUE_BACKPRESSURE_LOG_INTERVAL_S
+            elapsed = now - wait_start
+            logger.warning(
+                f"Leaf queue backpressure (chunk count) after {elapsed:.1f}s "
+                f"(peer={peer} source_node_id={source_node_id} "
+                f"max_chunks={self.max_chunks} qsize≈{self._q.qsize()} chunk_bytes={sz})"
+            )
+
+        while True:
+            if reject.is_set():
+                return False
+            try:
+                self._q.put(chunk, timeout=_LEAF_QUEUE_PUT_SLICE_S)
+                return True
+            except queue.Full:
+                maybe_log()
+
+
 class _UpstreamForwarder:
     """Runs stub.StreamLogs in a thread; reconnects on failure until stopped."""
 
     def __init__(
         self,
         upstream: str,
-        chunk_queue: queue.Queue,
+        chunk_queue: _LeafChunkQueue,
         stop_event: threading.Event,
         reconnect_sleep: float = 2.0,
     ):
@@ -124,13 +218,27 @@ class _UpstreamForwarder:
 
                 def gen() -> Iterator[log_aggregation_pb2.LogChunk]:
                     while True:
-                        item = self._q.get()
+                        try:
+                            item = self._q.get_upstream(timeout=_UPSTREAM_QUEUE_GET_TIMEOUT_S)
+                        except queue.Empty:
+                            if self._stop.is_set():
+                                logger.info(
+                                    "Upstream StreamLogs generator exiting: stop requested "
+                                    f"and no chunk within {_UPSTREAM_QUEUE_GET_TIMEOUT_S}s "
+                                    "(STOP sentinel may be missing if queue was full)"
+                                )
+                                return
+                            continue
                         if item is _STOP:
                             return
                         yield item  # type: ignore[misc]
 
                 logger.info(f"Connected upstream StreamLogs to {self._upstream}")
                 self.upstream_ready.set()
+                # Chunks leave _LeafChunkQueue when gen() yields them. If this RPC errors
+                # mid-flight, yields already handed to gRPC (send path / HTTP/2 buffers) may
+                # never reach the root and are not put back on the queue—the next loop
+                # iteration starts a fresh gen() at the new head. Not end-to-end lossless.
                 stub.StreamLogs(gen())
                 logger.info("Upstream StreamLogs ended")
             except grpc.RpcError as e:
@@ -151,11 +259,11 @@ class _UpstreamForwarder:
 class LeafLogServicer(log_aggregation_pb2_grpc.LogAggregationServiceServicer):
     def __init__(
         self,
-        chunk_queue: queue.Queue,
+        chunk_queue: _LeafChunkQueue,
         reject_new_streams: threading.Event,
         upstream_ready: threading.Event,
     ):
-        self._q = chunk_queue
+        self._chunkq = chunk_queue
         self._reject = reject_new_streams
         self._upstream_ready = upstream_ready
         self.connected_clients = 0
@@ -164,6 +272,8 @@ class LeafLogServicer(log_aggregation_pb2_grpc.LogAggregationServiceServicer):
     def StreamLogs(self, request_iterator, context):
         if self._reject.is_set():
             context.abort(grpc.StatusCode.UNAVAILABLE, "leaf server is shutting down")
+            # abort() may return without raising on older grpcio; do not fall through.
+            return log_aggregation_pb2.StreamResponse(status="UNAVAILABLE", bytes_received=0)
         with self.clients_lock:
             self.connected_clients += 1
         peer = _format_grpc_peer(context.peer())
@@ -179,7 +289,14 @@ class LeafLogServicer(log_aggregation_pb2_grpc.LogAggregationServiceServicer):
                     logger.info(
                         f"Compute node StreamLogs opened peer={peer} source_node_id={source_node_id}"
                     )
-                self._q.put(_copy_chunk(chunk))
+                copied = _copy_chunk(chunk)
+                if not self._chunkq.put_chunk(
+                    copied,
+                    self._reject,
+                    peer=peer,
+                    source_node_id=source_node_id or 'n/a',
+                ):
+                    break
                 total += len(chunk.data)
                 nchunks += 1
             return log_aggregation_pb2.StreamResponse(status="OK", bytes_received=total)
@@ -215,17 +332,23 @@ def serve(
         level=logging.INFO,
         format='%(asctime)s [%(levelname)s] [%(process)5s] %(filename)s:%(lineno)d %(message)s',
     )
-    chunk_queue: queue.Queue = queue.Queue(maxsize=max_queue_chunks)
+    chunk_queue = _LeafChunkQueue(max_queue_chunks)
     stop_forwarder = threading.Event()
     reject_new = threading.Event()
+    addr = f'{host}:{port}'
 
     forwarder = _UpstreamForwarder(upstream, chunk_queue, stop_forwarder)
     forwarder.start()
-    if not forwarder.upstream_ready.wait(timeout=120.0):
+    logger.info(
+        f"Leaf waiting for upstream root {upstream!r} to become healthy "
+        f"(timeout={int(_LEAF_UPSTREAM_ROOT_READY_TIMEOUT_S)}s); downstream port {addr} "
+        "will not accept connections until upstream is ready — clients may get ECONNREFUSED."
+    )
+    if not forwarder.upstream_ready.wait(timeout=_LEAF_UPSTREAM_ROOT_READY_TIMEOUT_S):
         logger.error("Timeout waiting for upstream root; exiting")
         stop_forwarder.set()
         try:
-            chunk_queue.put(_STOP, timeout=1.0)
+            chunk_queue.put_stop(timeout=1.0)
         except queue.Full:
             pass
         forwarder.join(timeout=10.0)
@@ -237,30 +360,92 @@ def serve(
         options=_GRPC_OPTS,
     )
     log_aggregation_pb2_grpc.add_LogAggregationServiceServicer_to_server(servicer, server)
-    addr = f'{host}:{port}'
     server.add_insecure_port(addr)
     server.start()
     logger.info(
         f"Leaf log server on {addr}, upstream={upstream}, max_queue_chunks={max_queue_chunks}"
     )
 
+    def _leaf_shutdown_snapshot(phase: str, **kwargs: Any) -> None:
+        with servicer.clients_lock:
+            downstream = servicer.connected_clients
+        qdepth = chunk_queue.qsize()
+        upstream_ok = forwarder.upstream_ready.is_set()
+        fwd_alive = bool(forwarder._thread and forwarder._thread.is_alive())
+        parts = [
+            f"phase={phase!r}",
+            f"downstream_StreamLogs={downstream}",
+            f"chunk_queue_depth={qdepth}",
+            f"chunk_queue_maxsize={max_queue_chunks}",
+            f"upstream_StreamLogs_active={upstream_ok}",
+            f"forwarder_thread_alive={fwd_alive}",
+        ]
+        for k, v in sorted(kwargs.items()):
+            parts.append(f"{k}={v}")
+        logger.info("Leaf shutdown snapshot: " + ", ".join(parts))
+
     def shutdown_leaf():
         logger.info("Graceful shutdown: waiting for downstream clients...")
         reject_new.set()
+        _leaf_shutdown_snapshot("after_reject_new_streams")
         start = time.time()
+        exit_reason = "running"
         while True:
             with servicer.clients_lock:
                 ac = servicer.connected_clients
             if ac == 0:
+                exit_reason = "all_downstream_disconnected"
                 break
             if time.time() - start >= graceful_shutdown_timeout:
-                logger.warning(f"{ac} client(s) still connected after {graceful_shutdown_timeout}s")
+                exit_reason = f"timeout_after_{graceful_shutdown_timeout}s"
+                logger.warning(
+                    f"{ac} downstream StreamLogs client(s) still connected after "
+                    f"{graceful_shutdown_timeout}s — closing may drop in-flight leaf→root data"
+                )
                 break
             time.sleep(0.1)
+        _leaf_shutdown_snapshot(
+            "after_downstream_wait",
+            exit_reason=exit_reason,
+            downstream_streams_remaining=ac,
+        )
         stop_forwarder.set()
-        chunk_queue.put(_STOP)
-        forwarder.join(timeout=graceful_shutdown_timeout + 5.0)
-        server.stop(grace=5.0)
+        try:
+            chunk_queue.put_stop(timeout=_STOP_SENTINEL_PUT_TIMEOUT_S)
+        except queue.Full:
+            logger.error(
+                f"Could not enqueue upstream STOP sentinel within {_STOP_SENTINEL_PUT_TIMEOUT_S}s "
+                "(queue full). Upstream forwarder may not exit cleanly; logs may be stuck in "
+                "leaf queue."
+            )
+        join_timeout = graceful_shutdown_timeout + 5.0
+        forwarder.join(timeout=join_timeout)
+        fwd_still_alive = bool(forwarder._thread and forwarder._thread.is_alive())
+        if fwd_still_alive:
+            logger.warning(
+                f"Upstream forwarder thread still alive after join(timeout={join_timeout}s); "
+                "root may already be gone or RPC stalled — possible log loss on this leaf."
+            )
+        _leaf_shutdown_snapshot(
+            "after_forwarder_join",
+            forwarder_thread_still_alive=fwd_still_alive,
+            chunk_queue_depth_after_join=chunk_queue.qsize(),
+        )
+        # stop() returns before the internal _serve thread and executor finish; exiting the
+        # process immediately races with late RPC dispatch → RuntimeError: cannot schedule
+        # new futures after shutdown. Wait for full termination after stop().
+        stop_grace_seconds = 5.0
+        termination_wait_timeout_seconds = stop_grace_seconds + 60.0
+        logger.info(
+            f"Stopping leaf gRPC server (grace={stop_grace_seconds}s); open RPCs may be cancelled mid-stream."
+        )
+        server.stop(grace=stop_grace_seconds)
+        # wait_for_termination returns True iff the wait timed out (per grpc API).
+        if server.wait_for_termination(timeout=termination_wait_timeout_seconds):
+            logger.warning(
+                "Timed out waiting for leaf gRPC server to finish termination after stop() "
+                f"(>{termination_wait_timeout_seconds}s)"
+            )
         logger.info("Leaf server exit")
 
     def on_signal(signum, frame):
@@ -286,7 +471,9 @@ def main() -> None:
         '--max-queue-chunks',
         type=int,
         default=8192,
-        help='Max queued chunks before blocking clients (backpressure). Default 8192.',
+        help='Max queued chunks (item count) before blocking handlers (backpressure). '
+        'Clients batch lines up to 256 KiB per chunk (see per_cycle_logs); typical '
+        'chunks are often smaller.',
     )
     p.add_argument('--graceful-shutdown-timeout', type=float, default=60.0)
     args = p.parse_args()

--- a/src/nvidia_resiliency_ext/shared_utils/grpc_log_server.py
+++ b/src/nvidia_resiliency_ext/shared_utils/grpc_log_server.py
@@ -49,8 +49,8 @@ all nodes in a distributed training job and writing them to a single centralized
   ``max_workers >= N + 10`` (N = number of leaves, each holds one long-lived upstream stream).
 - **Leaves**: ``grpc_log_leaf_server.py`` on ports ``P .. P+N-1``; forward to root.
   Raise ``ulimit -n`` on the store host (many TCP clients + N root streams). Leaves use a
-  bounded queue (``--ft-log-leaf-max-queue-chunks``) so slow Lustre applies backpressure to
-  clients instead of unbounded RAM growth.
+  bounded queue (``--ft-log-leaf-max-queue-chunks``, auto-scaled by default when N>1)
+  so slow Lustre applies backpressure to clients; handlers block (lossless) until a slot exists.
 
 **Example Usage:**
 
@@ -72,7 +72,7 @@ import threading
 import time
 import urllib.parse
 from concurrent import futures
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import grpc
 
@@ -188,6 +188,41 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
                 self.logger.info(f"Opened new log file: {file_path}")
 
             return self.files[file_path]
+
+    def _pending_buffer_totals(self) -> Tuple[int, int, List[Tuple[str, int, int]]]:
+        """Sum in-memory bytes not yet flushed to disk; per-file (path, chunks, bytes)."""
+        total_bytes = 0
+        nonempty: List[Tuple[str, int, int]] = []
+        with self.files_lock:
+            snapshot = list(self.files.items())
+        for fp, fs in snapshot:
+            with fs['buffer_lock']:
+                sz = fs['buffer_size']
+                nchunks = len(fs['buffer'])
+            total_bytes += sz
+            if nchunks or sz:
+                nonempty.append((fp, nchunks, sz))
+        return total_bytes, len(nonempty), nonempty
+
+    def _log_shutdown_snapshot(self, phase: str, *, extra: str = "") -> None:
+        """Log queues / buffers that may still hold data not yet on Lustre."""
+        with self.clients_lock:
+            clients = self.connected_clients
+        pending_bytes, n_files, details = self._pending_buffer_totals()
+        line = (
+            f"Shutdown snapshot [{phase}]: connected_streams={clients}, "
+            f"in_memory_pending_bytes={pending_bytes}, files_with_pending_buffers={n_files}, "
+            f"lifetime_chunks_received={self.total_chunks_received}, "
+            f"lifetime_bytes_received={self.total_bytes_received}"
+        )
+        if extra:
+            line += f", {extra}"
+        self.logger.info(line)
+        max_detail = 15
+        for fp, nc, sz in details[:max_detail]:
+            self.logger.info(f"  buffered path={fp!r} chunks={nc} bytes={sz}")
+        if len(details) > max_detail:
+            self.logger.info(f"  ... and {len(details) - max_detail} more paths with buffered data")
 
     def StreamLogs(self, request_iterator, context):
         """
@@ -410,6 +445,10 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
             f"Graceful shutdown initiated. Will wait up to {self.graceful_shutdown_timeout}s "
             f"for clients to finish..."
         )
+        self._log_shutdown_snapshot(
+            "graceful_start",
+            extra="(in-memory buffers may still flush via periodic flush until final shutdown)",
+        )
 
         # Mark graceful shutdown as initiated (but don't stop accepting connections yet)
         self.graceful_shutdown_initiated.set()
@@ -429,6 +468,9 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
                 self.logger.info(
                     f"All clients disconnected after {elapsed:.1f}s. Proceeding with shutdown."
                 )
+                self._log_shutdown_snapshot(
+                    "graceful_all_streams_closed", extra=f"waited_s={elapsed:.1f}"
+                )
                 break
 
             # Exit if timeout reached
@@ -437,14 +479,23 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
                     f"Graceful shutdown timeout ({self.graceful_shutdown_timeout}s) reached "
                     f"with {active_clients} client(s) still connected. Proceeding with shutdown."
                 )
+                self._log_shutdown_snapshot(
+                    "graceful_timeout",
+                    extra=(
+                        f"still_connected_streams={active_clients} — "
+                        "remaining streams may be cut off by server.stop(); data may be lost"
+                    ),
+                )
                 break
 
             # Log periodic status
             remaining = self.graceful_shutdown_timeout - elapsed
             if int(elapsed / 5) != int((elapsed - check_interval) / 5):  # Log every 5s
+                pend_b, pend_nf, _ = self._pending_buffer_totals()
                 self.logger.info(
                     f"Waiting for {active_clients} client(s) to finish... "
-                    f"({remaining:.1f}s remaining)"
+                    f"({remaining:.1f}s remaining) "
+                    f"in_memory_pending_bytes={pend_b} files_with_pending_buffers={pend_nf}"
                 )
 
             time.sleep(check_interval)
@@ -455,6 +506,10 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
     def shutdown(self):
         """Perform final shutdown: flush buffers, close files, stop threads."""
         self.logger.info("Shutting down log aggregation server...")
+        self._log_shutdown_snapshot(
+            "final_before_stop_flush_thread",
+            extra="stopping periodic flush; remaining buffers will be written in final flush pass",
+        )
 
         # Stop flush thread
         self.shutdown_event.set()
@@ -486,6 +541,15 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
             with file_state['buffer_lock']:
                 file_state['buffer'].clear()
                 file_state['buffer_size'] = 0
+
+        leftover_b, leftover_nf, leftover_detail = self._pending_buffer_totals()
+        if leftover_b or leftover_nf:
+            self.logger.error(
+                f"After final flush, unexpected non-empty buffers: bytes={leftover_b}, "
+                f"files={leftover_nf}, detail={leftover_detail[:5]!r}"
+            )
+        else:
+            self.logger.info("Final flush: all per-file in-memory buffers are empty.")
 
         self.logger.info(
             f"Server shutdown complete. "
@@ -550,13 +614,23 @@ def serve(host: str, port: int, max_workers: int = 100, graceful_shutdown_timeou
     logger.info(f"Max workers: {max_workers}")
     logger.info(f"Graceful shutdown timeout: {graceful_shutdown_timeout}s")
 
+    stop_grace_seconds = 5.0
+    termination_wait_timeout_seconds = stop_grace_seconds + 60.0
+
     # Set up signal handlers for graceful shutdown
     def signal_handler(signum, frame):
         logger.info(f"Received signal {signum}, initiating graceful shutdown...")
         # Use graceful shutdown to keep server running for remaining clients
         servicer.graceful_shutdown()
-        # Now stop the gRPC server
-        server.stop(grace=5.0)
+        server.stop(grace=stop_grace_seconds)
+        # stop() returns before internal server thread exits; wait so the executor is not
+        # torn down while still scheduling RPCs (avoids RuntimeError on shutdown).
+        # wait_for_termination returns True iff the wait timed out (per grpc API).
+        if server.wait_for_termination(timeout=termination_wait_timeout_seconds):
+            logger.warning(
+                "Timed out waiting for gRPC log server to finish termination after stop() "
+                f"(>{termination_wait_timeout_seconds}s)"
+            )
         sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)
@@ -568,7 +642,12 @@ def serve(host: str, port: int, max_workers: int = 100, graceful_shutdown_timeou
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt received, initiating graceful shutdown...")
         servicer.graceful_shutdown()
-        server.stop(grace=5.0)
+        server.stop(grace=stop_grace_seconds)
+        if server.wait_for_termination(timeout=termination_wait_timeout_seconds):
+            logger.warning(
+                "Timed out waiting for gRPC log server after keyboard interrupt "
+                f"(>{termination_wait_timeout_seconds}s)"
+            )
 
 
 def main():

--- a/src/nvidia_resiliency_ext/shared_utils/grpc_log_server.py
+++ b/src/nvidia_resiliency_ext/shared_utils/grpc_log_server.py
@@ -44,6 +44,14 @@ all nodes in a distributed training job and writing them to a single centralized
 - Use `log_aggregator.py` for node-local aggregation (multiple processes → one node file)
 - Use `grpc_log_server.py` for cluster-wide centralization (multiple nodes → one global file)
 
+**Two-level aggregation (ft_launcher, ``--ft-log-aggregator-count`` > 1):**
+- **Root** (this module): listens on ``P+N``; only the root writes to Lustre; use
+  ``max_workers >= N + 10`` (N = number of leaves, each holds one long-lived upstream stream).
+- **Leaves**: ``grpc_log_leaf_server.py`` on ports ``P .. P+N-1``; forward to root.
+  Raise ``ulimit -n`` on the store host (many TCP clients + N root streams). Leaves use a
+  bounded queue (``--ft-log-leaf-max-queue-chunks``) so slow Lustre applies backpressure to
+  clients instead of unbounded RAM growth.
+
 **Example Usage:**
 
 Manually for testing:
@@ -62,8 +70,9 @@ import signal
 import sys
 import threading
 import time
+import urllib.parse
 from concurrent import futures
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import grpc
 
@@ -83,6 +92,13 @@ except ImportError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_utils', 'proto'))
     import log_aggregation_pb2
     import log_aggregation_pb2_grpc
+
+
+def _format_grpc_peer(raw: Optional[str]) -> str:
+    """Decode URL-encoded characters in ``context.peer()`` for readable log lines."""
+    if not raw:
+        return "unknown_peer"
+    return urllib.parse.unquote(raw)
 
 
 class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServicer):
@@ -175,37 +191,46 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
 
     def StreamLogs(self, request_iterator, context):
         """
-        Handle streaming logs from a client node.
+        Handle streaming logs from one upstream ``StreamLogs`` RPC.
+
+        Each RPC is one direct training node (single-level) or one leaf aggregator
+        (two-level). Logging uses neutral ``peer`` + ``source_node_id`` (``node_id`` on
+        the first chunk, from ft_launcher clients always set) so the same messages
+        apply to both topologies.
 
         Args:
-            request_iterator: Iterator of LogChunk messages from client
-            context: gRPC context
+            request_iterator: Iterator of ``LogChunk`` messages from the upstream client.
+            context: gRPC ServicerContext for this RPC.
 
         Returns:
-            StreamResponse with status and bytes received
+            ``StreamResponse`` with status and cumulative bytes received on this stream.
         """
         with self.clients_lock:
             self.connected_clients += 1
 
+        peer = _format_grpc_peer(context.peer())
         client_bytes = 0
         client_chunks = 0
-        client_node_id = None
+        source_node_id: Optional[str] = None
 
         try:
             for chunk in request_iterator:
                 if self.shutdown_event.is_set():
                     break
-                # Track which node this client is from (from first chunk)
-                if client_node_id is None:
-                    client_node_id = chunk.node_id
-                    self.logger.info(f"Client connected: node_id={client_node_id}")
+                if source_node_id is None:
+                    source_node_id = chunk.node_id
+                    self.logger.info(
+                        f"StreamLogs stream opened peer={peer} source_node_id={source_node_id}"
+                    )
 
                 # Get data and target file
                 data = chunk.data
                 file_path = chunk.file_path
 
                 if not file_path:
-                    raise ValueError(f"Client {client_node_id} sent chunk without file_path")
+                    raise ValueError(
+                        f"peer={peer} node_id={chunk.node_id!r} sent chunk without file_path"
+                    )
 
                 # Get file state for this path
                 file_state = self._get_or_create_file_state(file_path)
@@ -222,9 +247,13 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
                     client_bytes += len(data)
                     client_chunks += 1
 
+            if source_node_id is not None:
+                end_src = f"source_node_id={source_node_id}"
+            else:
+                end_src = "source_node_id=n/a"
             self.logger.info(
-                f"Client disconnected: node_id={client_node_id}, "
-                f"received {client_chunks} chunks, {client_bytes / 1024:.1f} KB"
+                f"StreamLogs stream ended peer={peer} {end_src} "
+                f"chunks={client_chunks} received_KiB={client_bytes / 1024:.1f}"
             )
 
             # No flush-on-disconnect: periodic flush thread handles flushing (every 1s)
@@ -235,37 +264,43 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
             return log_aggregation_pb2.StreamResponse(status="OK", bytes_received=client_bytes)
 
         except (OSError, IOError) as e:
-            # File I/O errors (disk full, permission denied, network filesystem issues)
-            node_info = (
-                f"node_id={client_node_id}" if client_node_id is not None else "unknown client"
+            src = (
+                f"source_node_id={source_node_id}"
+                if source_node_id is not None
+                else "source_node_id=n/a"
             )
-            self.logger.error(f"I/O error in StreamLogs ({node_info}): {e}", exc_info=True)
+            stream_info = f"peer={peer} {src}"
+            self.logger.error(f"I/O error in StreamLogs ({stream_info}): {e}", exc_info=True)
             raise
         except ValueError as e:
-            # Client protocol violation (e.g., missing file_path)
-            node_info = (
-                f"node_id={client_node_id}" if client_node_id is not None else "unknown client"
+            src = (
+                f"source_node_id={source_node_id}"
+                if source_node_id is not None
+                else "source_node_id=n/a"
             )
-            self.logger.error(f"Protocol error from client ({node_info}): {e}")
-            # Set gRPC error status with descriptive message
+            stream_info = f"peer={peer} {src}"
+            self.logger.error(f"Protocol error in StreamLogs ({stream_info}): {e}")
             context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(e))
         except grpc.RpcError as e:
-            # Client disconnect/abort - expected operational event
-            node_info = (
-                f"node_id={client_node_id}" if client_node_id is not None else "unknown client"
+            src = (
+                f"source_node_id={source_node_id}"
+                if source_node_id is not None
+                else "source_node_id=n/a"
             )
+            stream_info = f"peer={peer} {src}"
             if self.shutdown_event.is_set():
-                self.logger.debug(f"Client disconnected during shutdown ({node_info})")
+                self.logger.debug(f"StreamLogs aborted during shutdown ({stream_info}): {e}")
             else:
-                self.logger.info(f"Client aborted connection ({node_info}): {e}")
-            # Re-raise to let gRPC handle the abort properly
+                self.logger.info(f"StreamLogs aborted ({stream_info}): {e}")
             raise
         except Exception as e:
-            # Unexpected errors (catch-all for unknown issues)
-            node_info = (
-                f"node_id={client_node_id}" if client_node_id is not None else "unknown client"
+            src = (
+                f"source_node_id={source_node_id}"
+                if source_node_id is not None
+                else "source_node_id=n/a"
             )
-            self.logger.error(f"Unexpected error in StreamLogs ({node_info}): {e}", exc_info=True)
+            stream_info = f"peer={peer} {src}"
+            self.logger.error(f"Unexpected error in StreamLogs ({stream_info}): {e}", exc_info=True)
             raise
         finally:
             with self.clients_lock:

--- a/tests/fault_tolerance/unit/test_grpc_log_client.py
+++ b/tests/fault_tolerance/unit/test_grpc_log_client.py
@@ -439,13 +439,11 @@ class TestGrpcWriterThread:
                     for call in mock_logger.warning.call_args_list
                 )
 
-    def test_shutdown_exits_without_draining_queue(self, write_queue, mock_logger):
-        """Test that shutdown exits immediately without draining remaining queue items.
+    def test_shutdown_drains_write_queue_before_stream_end(self, write_queue, mock_logger):
+        """After shutdown_requested, log_generator drains the queue until stably empty.
 
-        The gRPC writer does not drain on shutdown because:
-        1. During shutdown, the server may already be closing/closed
-        2. Draining adds delay that can exceed the reader's shutdown timeout
-        3. Any logs still in queue at shutdown are not guaranteed to be delivered anyway
+        This yields any chunks already queued so tail logs can reach the leaf before
+        the StreamLogs RPC ends (several consecutive empty get() timeouts + empty queue).
         """
 
         # Add items that will be in queue during shutdown
@@ -463,11 +461,9 @@ class TestGrpcWriterThread:
             chunks_received = []
 
             def capture_chunks(chunk_iterator):
-                """Capture chunks - should exit immediately when shutdown is set."""
-                # Immediately request shutdown
+                """Request shutdown before consuming; generator still drains queued items."""
                 writer.shutdown_requested = True
 
-                # Try to consume - generator should exit immediately
                 for chunk in chunk_iterator:
                     chunks_received.append(chunk)
 
@@ -495,9 +491,7 @@ class TestGrpcWriterThread:
                 with patch('time.sleep'):
                     writer.run()
 
-                # Generator should exit immediately on shutdown, not drain queue
-                # Queue items remain unprocessed
                 assert (
-                    len(chunks_received) == 0
-                ), f"Expected 0 chunks (no drain), got {len(chunks_received)}"
-                assert write_queue.qsize() == 3, "Queue items should remain"
+                    len(chunks_received) == 3
+                ), f"Expected all 3 queued lines drained after shutdown, got {len(chunks_received)}"
+                assert write_queue.qsize() == 0, "Queue should be empty after drain"

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -529,3 +529,24 @@ class TestMaybeExitStandbyOnSuccess(unittest.TestCase):
         agent = self._make_agent_standby(min_nodes=2, group_rank=1, store_check_returns=True)
         agent._maybe_exit_standby_on_success("trainer")  # no raise
         agent._store.check.assert_not_called()
+
+
+def test_ft_log_aggregator_count_rejects_non_positive():
+    from nvidia_resiliency_ext.fault_tolerance.launcher import _validate_args, get_args_parser
+
+    parser = get_args_parser()
+    for bad in ('0', '-1'):
+        args = parser.parse_args(['--ft-log-aggregator-count', bad, 'train.py'])
+        with pytest.raises(ValueError, match='--ft-log-aggregator-count'):
+            _validate_args(args)
+
+
+def test_log_funnel_ports_from_launcher_args_rejects_non_positive_aggregator_count():
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance.launcher import LogFunnelPorts
+
+    with pytest.raises(ValueError, match='>= 1'):
+        LogFunnelPorts.from_launcher_args(
+            SimpleNamespace(ft_log_server_port=50051, ft_log_aggregator_count=0)
+        )

--- a/tests/fault_tolerance/unit/test_launcher_grpc_integration.py
+++ b/tests/fault_tolerance/unit/test_launcher_grpc_integration.py
@@ -304,15 +304,15 @@ def test_launcher_starts_grpc_server_on_correct_port(tmp_dir):
     assert f"port={custom_port}" in output, f"Server should be started on port {custom_port}"
 
 
-def test_launcher_creates_grpc_server_log(tmp_dir):
-    """Test that launcher creates a log file for the gRPC server."""
+def test_launcher_creates_grpc_root_log(tmp_dir):
+    """Test that launcher creates a log file for the gRPC root log server."""
     ft_cfg = fault_tolerance.FaultToleranceConfig()
     ft_cfg.initial_rank_heartbeat_timeout = 3.0
     ft_cfg.rank_heartbeat_timeout = 3.0
     ft_cfg_path = _save_ft_cfg(ft_cfg, tmp_dir)
 
     base_log_file = os.path.join(tmp_dir, "test.log")
-    expected_server_log = os.path.join(tmp_dir, "test_grpc_server.log")
+    expected_server_log = os.path.join(tmp_dir, "test_grpc_root.log")
 
     cmd_to_run = f"{_get_util_script_path()} --scenario=test_ranks_exit_gracefully"
 

--- a/tests/fault_tolerance/unit/test_launcher_grpc_integration.py
+++ b/tests/fault_tolerance/unit/test_launcher_grpc_integration.py
@@ -362,7 +362,7 @@ def test_launcher_without_grpc_flag_does_not_start_server(tmp_dir):
 
 
 def test_launcher_custom_server_log_path(tmp_dir):
-    """Test that custom gRPC server log path is respected."""
+    """Test that --ft-log-server-log is used for the root in two-level mode (aggregator count 2)."""
     ft_cfg = fault_tolerance.FaultToleranceConfig()
     ft_cfg.initial_rank_heartbeat_timeout = 3.0
     ft_cfg.rank_heartbeat_timeout = 3.0
@@ -370,6 +370,7 @@ def test_launcher_custom_server_log_path(tmp_dir):
 
     base_log_file = os.path.join(tmp_dir, "test.log")
     custom_server_log = os.path.join(tmp_dir, "custom_grpc_server.log")
+    default_root_log = os.path.join(tmp_dir, "test_grpc_root.log")
 
     cmd_to_run = f"{_get_util_script_path()} --scenario=test_ranks_exit_gracefully"
 
@@ -379,12 +380,28 @@ def test_launcher_custom_server_log_path(tmp_dir):
         " --ft-enable-log-server=true"
         f" --ft-per-cycle-applog-prefix={base_log_file}"
         f" --ft-log-server-log={custom_server_log}"
+        " --ft-log-aggregator-count=2"
         f" --nproc-per-node={WORLD_SIZE}"
         f" {cmd_to_run}"
     )
 
     ret_code, output = _run_launcher(launcher_cmd, timeout=15)
 
-    # Verify custom server log path is mentioned or used
-    # The test passes if launcher completes without hanging on log path issues
-    assert ret_code in [0, 1], "Launcher should complete (gracefully or with expected error)"
+    assert ret_code in [0, 1], f"Launcher should complete; output:\n{output}"
+    assert (
+        "gRPC root log server:" in output
+    ), f"Expected two-level root startup log line; output:\n{output}"
+    assert "gRPC log server started" not in output, (
+        "Single-level gRPC startup should not appear when --ft-log-aggregator-count=2 "
+        f"(would mask a silent fallback to one root on base port). Output:\n{output}"
+    )
+    assert os.path.isfile(
+        custom_server_log
+    ), f"Root log should be written to custom path {custom_server_log}. Output:\n{output}"
+    with open(custom_server_log, 'r') as f:
+        custom_content = f.read()
+    assert len(custom_content) > 0, "Custom root gRPC log file should not be empty"
+    assert not os.path.isfile(default_root_log), (
+        f"Default root log {default_root_log} should not be created when "
+        f"--ft-log-server-log is set (two-level mode regression check)"
+    )

--- a/tests/fault_tolerance/unit/test_utils.py
+++ b/tests/fault_tolerance/unit/test_utils.py
@@ -3,12 +3,16 @@
 
 """Unit tests for nvidia_resiliency_ext.fault_tolerance.utils module."""
 
+import hashlib
 import os
 from unittest.mock import patch
 
 import pytest
 
-from nvidia_resiliency_ext.fault_tolerance.utils import get_infrastructure_rank
+from nvidia_resiliency_ext.fault_tolerance.utils import (
+    get_infrastructure_rank,
+    get_log_aggregator_shard_index,
+)
 
 
 class TestGetInfrastructureRank:
@@ -348,3 +352,63 @@ class TestGetInfrastructureRank:
         assert rank == -1
         mock_logger.debug.assert_called_once()
         assert "deterministically" in mock_logger.debug.call_args[0][0]
+
+
+class TestGetLogAggregatorShardIndex:
+    """Tests for get_log_aggregator_shard_index."""
+
+    @pytest.fixture(autouse=True)
+    def clear_env(self):
+        env_vars = [
+            'SLURM_TOPOLOGY_ADDR',
+            'SLURM_TOPOLOGY_ADDR_PATTERN',
+            'NVRX_INFRA_RANK_FROM_NODENAME',
+            'SLURMD_NODENAME',
+            'CROSS_SLURM_PROCID',
+            'SLURM_PROCID',
+            'SLURM_ARRAY_TASK_ID',
+            'SLURM_NNODES',
+            'SLURM_JOB_NUM_NODES',
+            'SLURM_JOB_ID',
+            'GROUP_RANK',
+        ]
+        original = {v: os.environ.pop(v, None) for v in env_vars}
+        yield
+        for var, value in original.items():
+            if value is not None:
+                os.environ[var] = value
+            else:
+                os.environ.pop(var, None)
+
+    def test_single_aggregator_always_zero(self):
+        assert get_log_aggregator_shard_index(1) == 0
+        assert get_log_aggregator_shard_index(0) == 0
+
+    def test_job_array_shard(self):
+        os.environ['SLURM_ARRAY_TASK_ID'] = '2'
+        os.environ['SLURM_PROCID'] = '1'
+        os.environ['SLURM_NNODES'] = '8'
+        # 2*8+1 = 17, 17 % 3 = 2
+        assert get_log_aggregator_shard_index(3) == 2
+
+    def test_slurm_procid_shard(self):
+        os.environ['SLURM_PROCID'] = '10'
+        assert get_log_aggregator_shard_index(3) == 1
+
+    def test_group_rank_ignored_uses_hostname(self):
+        """Log funnel sharding does not use GROUP_RANK; falls through to hostname."""
+        os.environ['GROUP_RANK'] = '7'
+        host = 'shard-test-host.example'
+        want = int(hashlib.md5(host.encode()).hexdigest(), 16) % 11
+        with patch(
+            'nvidia_resiliency_ext.fault_tolerance.utils.socket.gethostname', return_value=host
+        ):
+            assert get_log_aggregator_shard_index(11) == want
+
+    def test_hostname_fallback_shard(self):
+        host = 'my-funnel-node'
+        want = int(hashlib.md5(host.encode()).hexdigest(), 16) % 5
+        with patch(
+            'nvidia_resiliency_ext.fault_tolerance.utils.socket.gethostname', return_value=host
+        ):
+            assert get_log_aggregator_shard_index(5) == want


### PR DESCRIPTION
  
    1) Add grpc_log_leaf_server: Funnel LogChunks from clients to root
       server.
    2) Launcher: Start root on P+N then N leaves on P..P+N-1 ports.
       Tear down leaves before root in shutdown.
    3) Introduce LogFunnelPorts for port layout.
    4) Shard first-level choice via get_log_aggregator_shard_index()
    5) CLI: Added --ft-log-aggregator-count and
       --ft-log-leaf-max-queue-chunks.
