### PR TITLE
Deprecate ptl_resiliency. Deprecate legacy rendezvous.

### DIFF
--- a/docs/source/fault_tolerance/integration/ptl.rst
+++ b/docs/source/fault_tolerance/integration/ptl.rst
@@ -1,6 +1,10 @@
 PyTorch Lightning Integration
 *****************************
 
+.. deprecated::
+   The :mod:`nvidia_resiliency_ext.ptl_resiliency` package (PyTorch Lightning integration with
+   ``ft_launcher`` / InJob fault tolerance) is deprecated and will be removed in a future release.
+
 This section describes Fault Tolerance integration with a PTL-based workload (i.e., NeMo) using ``FaultToleranceCallback``.
 
 1. Use ``ft_launcher`` to start the workload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,3 +120,6 @@ ignore = ["F841"]
 
 [tool.pytest.ini_options]
 markers = []
+filterwarnings = [
+    "ignore:.*ptl_resiliency.*ft_launcher.*InJob.*deprecated.*:DeprecationWarning",
+]

--- a/src/nvidia_resiliency_ext/fault_tolerance/_ft_rendezvous.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/_ft_rendezvous.py
@@ -12,6 +12,9 @@
 
 # This file is based on torch.distributed.elastic.rendezvous.dynamic_rendezvous
 # It includes NVRx related modifications for the node health checking, KSO and others.
+#
+# Deprecated: This legacy compare-and-set fault-tolerant rendezvous remains for backward
+# compatibility only. Prefer ft_rendezvous_barrier (CLI: --ft-rdzv-impl barrier, the default).
 
 
 import inspect
@@ -1754,6 +1757,10 @@ def create_handler(
     store: Store, backend: RendezvousBackend, params: RendezvousParameters
 ) -> FtRendezvousHandler:
     """Create a new :py:class:`FtRendezvousHandler` from the specified parameters.
+
+    .. deprecated::
+        Prefer :mod:`ft_rendezvous_barrier` via ``--ft-rdzv-impl barrier``; this legacy
+        implementation is deprecated and will be removed in a future release.
 
     Args:
         store:

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -121,6 +121,8 @@ if not hasattr(_torch_elastic_agent_api, "_TERMINAL_STATE_SYNC_ID"):
 
 _EXIT_BARRIER_LAST_MEMBER_KEY = f"{_torch_elastic_agent_api._TERMINAL_STATE_SYNC_ID}/last_member"
 
+_legacy_ft_rdzv_deprecation_warned: bool = False
+
 # Logger instance (configured later in run() via setup_logger())
 # Note: Must call run() before using logger to ensure proper configuration
 logger = logging.getLogger(LogConfig.name)
@@ -143,9 +145,11 @@ def _register_ft_rdzv_handler(impl_type: str = "barrier"):
 
     Args:
         impl_type: FT rendezvous implementation to use.
-                  "barrier" - New atomic barrier-based algorithm
-                  "legacy" - Original compare-and-set algorithm
+            ``"barrier"`` — atomic barrier-based algorithm (recommended default).
+            ``"legacy"`` — original compare-and-set implementation in ``_ft_rendezvous``;
+            deprecated and scheduled for removal; use ``"barrier"``.
     """
+    global _legacy_ft_rdzv_deprecation_warned
     from torch.distributed.elastic.rendezvous import rendezvous_handler_registry
     from torch.distributed.elastic.rendezvous.c10d_rendezvous_backend import create_backend
 
@@ -157,6 +161,15 @@ def _register_ft_rdzv_handler(impl_type: str = "barrier"):
             return create_barrier_handler(store, backend, params)
 
     elif impl_type == "legacy":
+        if not _legacy_ft_rdzv_deprecation_warned:
+            warnings.warn(
+                "FT rendezvous implementation 'legacy' (_ft_rendezvous compare-and-set) is "
+                "deprecated and will be removed in a future release. Use the default "
+                "'barrier' implementation (--ft-rdzv-impl barrier / ft_rendezvous_barrier).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _legacy_ft_rdzv_deprecation_warned = True
         from ._ft_rendezvous import create_handler as create_legacy_handler
         from .c10d_monkey_patch import apply_c10d_patch
 
@@ -2805,9 +2818,10 @@ def get_args_parser() -> ArgumentParser:
         default="barrier",
         dest="ft_rdzv_impl",
         help="FT rendezvous implementation to use. "
-        "'barrier' uses the new atomic barrier-based algorithm (ft_rendezvous_barrier.py), "
-        "'legacy' uses the original compare-and-set algorithm (_ft_rendezvous.py). "
-        "Default: barrier. Note: This is independent of --rdzv-backend (which specifies "
+        "'barrier' uses the atomic barrier-based algorithm (ft_rendezvous_barrier.py; default, recommended). "
+        "'legacy' uses the original compare-and-set algorithm (_ft_rendezvous.py); deprecated and "
+        "will be removed in a future release—migrate to 'barrier'. "
+        "Note: This is independent of --rdzv-backend (which specifies "
         "the coordination backend like c10d or etcd).",
     )
 

--- a/src/nvidia_resiliency_ext/ptl_resiliency/__init__.py
+++ b/src/nvidia_resiliency_ext/ptl_resiliency/__init__.py
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""PyTorch Lightning helpers for fault tolerance with ``ft_launcher`` (InJob).
+
+.. deprecated::
+    This package is deprecated and will be removed in a future release.
+    Importing public symbols from this package may emit :exc:`DeprecationWarning`.
+"""
+
 from ._utils import SimulatedFaultParams  # noqa: F401
 from .fault_tolerance_callback import FaultToleranceCallback  # noqa: F401
 from .fault_tolerance_sections_callback import FaultToleranceSectionsCallback  # noqa: F401

--- a/src/nvidia_resiliency_ext/ptl_resiliency/_utils.py
+++ b/src/nvidia_resiliency_ext/ptl_resiliency/_utils.py
@@ -20,10 +20,27 @@ import signal
 import sys
 import threading
 import time
+import warnings
 from dataclasses import dataclass
 from typing import Optional
 
 import torch
+
+_PTL_INJOB_LIGHTNING_DEPRECATION_EMITTED = False
+
+
+def warn_ptl_injob_lightning_deprecated() -> None:
+    """Emit a single process-wide deprecation for the InJob + PyTorch Lightning integration."""
+    global _PTL_INJOB_LIGHTNING_DEPRECATION_EMITTED
+    if _PTL_INJOB_LIGHTNING_DEPRECATION_EMITTED:
+        return
+    warnings.warn(
+        "nvidia_resiliency_ext.ptl_resiliency (PyTorch Lightning callbacks for "
+        "ft_launcher / InJob fault tolerance) is deprecated and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _PTL_INJOB_LIGHTNING_DEPRECATION_EMITTED = True
 
 
 def is_module_available(module: str) -> bool:
@@ -36,6 +53,10 @@ def is_module_available(module: str) -> bool:
 class SimulatedFaultParams:
     """
     Description of a simulated rank fault, used for FT testing and debugging.
+
+    .. deprecated::
+        Part of the deprecated InJob PyTorch Lightning integration
+        (:mod:`nvidia_resiliency_ext.ptl_resiliency`); will be removed together with that package.
 
     Simulated fault types are:
     - 'rank_killed' a rank is killed with SIGKILL

--- a/src/nvidia_resiliency_ext/ptl_resiliency/fault_tolerance_callback.py
+++ b/src/nvidia_resiliency_ext/ptl_resiliency/fault_tolerance_callback.py
@@ -26,6 +26,7 @@ from ._utils import (
     is_module_available,
     parse_simulated_fault_params,
     setup_simulated_fault,
+    warn_ptl_injob_lightning_deprecated,
 )
 
 if is_module_available("lightning"):
@@ -37,6 +38,8 @@ else:
 
 
 import nvidia_resiliency_ext.fault_tolerance as ft
+
+warn_ptl_injob_lightning_deprecated()
 
 
 class _TrainingStateMachine:
@@ -166,6 +169,10 @@ class _TrainingStateMachine:
 class FaultToleranceCallback(Callback):
     """
     FaultToleranceCallback is a Torch Lightning callback for integration with the Fault Tolerance package.
+
+    .. deprecated::
+        InJob (``ft_launcher``) PyTorch Lightning integration is deprecated and will be removed
+        in a future release.
 
     FT is only active during a 'fit' stage.
     Training should be run with 'ft_launcher' for the callback to work.

--- a/src/nvidia_resiliency_ext/ptl_resiliency/fault_tolerance_sections_callback.py
+++ b/src/nvidia_resiliency_ext/ptl_resiliency/fault_tolerance_sections_callback.py
@@ -29,6 +29,7 @@ from ._utils import (
     is_module_available,
     parse_simulated_fault_params,
     setup_simulated_fault,
+    warn_ptl_injob_lightning_deprecated,
 )
 
 if is_module_available("lightning"):
@@ -41,10 +42,16 @@ else:
 
 import nvidia_resiliency_ext.fault_tolerance as ft
 
+warn_ptl_injob_lightning_deprecated()
+
 
 class FaultToleranceSectionsCallback(Callback):
     """
     FaultToleranceSectionsCallback is a Torch Lightning callback for integration with the Fault Tolerance package.
+
+    .. deprecated::
+        InJob (``ft_launcher``) PyTorch Lightning integration is deprecated and will be removed
+        in a future release.
 
     ``FaultToleranceSectionsCallback`` uses the new section-based FT API.
     In this implementation, there are 3 sections:

--- a/src/nvidia_resiliency_ext/ptl_resiliency/local_checkpoint_callback.py
+++ b/src/nvidia_resiliency_ext/ptl_resiliency/local_checkpoint_callback.py
@@ -20,7 +20,7 @@ from functools import partial
 from typing import Any, Callable, Dict, NewType, Optional
 
 from ..checkpointing.async_ckpt.core import AsyncRequest
-from ._utils import is_module_available
+from ._utils import is_module_available, warn_ptl_injob_lightning_deprecated
 
 if is_module_available("lightning"):
     import lightning.pytorch as pl
@@ -41,6 +41,8 @@ from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.base_manager import
     BaseCheckpointManager,
 )
 
+warn_ptl_injob_lightning_deprecated()
+
 logger = logging.getLogger(__name__)
 
 StateDict = NewType('StateDict', Any)
@@ -50,6 +52,9 @@ LOCAL_CKPT_OPTS_KEY = 'local_checkpoint_options'
 
 class LocalCheckpointCallback(pl.callbacks.ModelCheckpoint):
     """ModelCheckpoint with basic functionality. Only train_batch_end simple save.
+
+    .. deprecated::
+        InJob PyTorch Lightning integration is deprecated and will be removed in a future release.
 
     Simple callback for initiating local checkpoint save in `on_train_batch_end` method.
     Since local checkpoints are ephemeral, they shouldn't be used for "major" checkpoint
@@ -100,6 +105,9 @@ class LocalCheckpointCallback(pl.callbacks.ModelCheckpoint):
 
 class HierarchicalCheckpointIO(_WrappingCheckpointIO):
     """Wrapper for a global CheckpointIO enabling local checkpointing.
+
+    .. deprecated::
+        InJob PyTorch Lightning integration is deprecated and will be removed in a future release.
 
     Based on the presence of local checkpointing options in saving `storage_options`,
     routes the save to the original global CheckpointIO or the local checkpoint manager.

--- a/src/nvidia_resiliency_ext/ptl_resiliency/straggler_det_callback.py
+++ b/src/nvidia_resiliency_ext/ptl_resiliency/straggler_det_callback.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 import torch
 
-from ._utils import is_module_available
+from ._utils import is_module_available, warn_ptl_injob_lightning_deprecated
 
 if is_module_available("lightning"):
     from lightning.pytorch.callbacks import Callback
@@ -31,8 +31,16 @@ else:
 
 import nvidia_resiliency_ext.attribution.straggler as straggler
 
+warn_ptl_injob_lightning_deprecated()
+
 
 class StragglerDetectionCallback(Callback):
+    """
+    PyTorch Lightning callback for straggler detection when using ``ft_launcher`` (InJob).
+
+    .. deprecated::
+        InJob PyTorch Lightning integration is deprecated and will be removed in a future release.
+    """
 
     def __init__(
         self,

--- a/tests/fault_tolerance/unit/conftest.py
+++ b/tests/fault_tolerance/unit/conftest.py
@@ -1,10 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pytest configuration for barrier rendezvous tests.
+"""Pytest configuration for fault_tolerance unit tests (e.g. barrier rendezvous).
 
-TCPStore creates non-daemon background threads that don't terminate properly,
-causing pytest to hang after all tests complete. This hook ensures clean exit.
+Some tests run rendezvous participants in child processes, but the pytest worker
+process still creates ``torch.distributed.TCPStore`` objects (master store,
+class-scoped fixtures, etc.). Each TCPStore uses c10d non-daemon background
+threads inside that process; they often do not exit cleanly on normal interpreter
+shutdown, so pytest can hang after the session. On successful sessions we call
+``os._exit(0)`` to skip that shutdown (see ``pytest_sessionfinish``).
 """
 
 import logging
@@ -20,7 +24,14 @@ def pytest_configure():
 
 
 def pytest_sessionfinish(session, exitstatus):
-    """Force exit after test session to avoid TCPStore thread hang."""
-    # Force exit with the test result status to bypass TCPStore background threads
-    if os.environ.get('PYTEST_FORCE_EXIT', '1') == '1':
-        os._exit(exitstatus)
+    """On success, exit immediately so c10d TCPStore threads in this process cannot block shutdown.
+
+    Those threads live in the pytest worker, independent of subprocess-based test
+    participants. We only use ``os._exit`` when ``exitstatus == 0`` so failures
+    still get a normal teardown and full tracebacks (``os._exit`` would truncate
+    output under ``-x`` / ``-sv``); that path can still hang if TCPStore was used.
+    """
+    # Success: skip interpreter shutdown (avoids TCPStore thread join hang).
+    # Failure: normal exit for complete pytest output; may hang until CI timeout.
+    if os.environ.get('PYTEST_FORCE_EXIT', '1') == '1' and exitstatus == 0:
+        os._exit(0)

--- a/tests/fault_tolerance/unit/test_dynamic_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_dynamic_rendezvous.py
@@ -4,6 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""Unit tests for the deprecated legacy FT rendezvous (`fault_tolerance._ft_rendezvous`).
+
+The suite is skipped by default (module-level ``pytest.mark.skip``). Remove the skip and this
+module when ``--ft-rdzv-impl legacy`` and `_ft_rendezvous` are removed.
+"""
+
 import copy
 import os
 import pickle
@@ -15,6 +21,7 @@ from typing import Callable, Optional, Tuple, cast
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, call, patch
 
+import pytest
 import torch
 from torch.distributed import Store
 from torch.distributed.elastic.agent.server.api import WorkerState
@@ -38,6 +45,10 @@ from nvidia_resiliency_ext.fault_tolerance._ft_rendezvous import (
     _RendezvousState,
     _RendezvousStateHolder,
     create_handler,
+)
+
+pytestmark = pytest.mark.skip(
+    reason="Deprecated legacy FT rendezvous (_ft_rendezvous); remove this skip when deleting the implementation.",
 )
 
 

--- a/tests/ptl_resiliency/func/nemo20/check_straggler_log.py
+++ b/tests/ptl_resiliency/func/nemo20/check_straggler_log.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Log checker helper for deprecated ``ptl_resiliency`` NeMo straggler runs (not pytest tests)."""
+
 import argparse
 import re
 

--- a/tests/ptl_resiliency/func/nemo20/ft_test_llama3.py
+++ b/tests/ptl_resiliency/func/nemo20/ft_test_llama3.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""NeMo 2.0 functional script using deprecated ``ptl_resiliency`` (InJob + Lightning).
+
+Remove or rewrite when ``nvidia_resiliency_ext.ptl_resiliency`` is removed.
+"""
+
 import argparse
 from dataclasses import dataclass
 

--- a/tests/ptl_resiliency/func/nemo20/straggler_test_llama3.py
+++ b/tests/ptl_resiliency/func/nemo20/straggler_test_llama3.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""NeMo 2.0 functional script using deprecated ``ptl_resiliency`` straggler callback.
+
+Remove or rewrite when ``nvidia_resiliency_ext.ptl_resiliency`` is removed.
+"""
+
 import argparse
 import math
 from dataclasses import dataclass

--- a/tests/ptl_resiliency/func/nemo20/test_local_ckpt_llama3.py
+++ b/tests/ptl_resiliency/func/nemo20/test_local_ckpt_llama3.py
@@ -17,6 +17,9 @@
 This module exemplifies NeMo 2.0 integration with NVRx local checkpointing.
 The key parts is the implementation of MCore specific HierarchicalCheckpointIO
 (MCoreHierarchicalCheckpointIO) which can be plugged into PTL strategy.
+
+Deprecated: uses ``ptl_resiliency`` (InJob PyTorch Lightning). Remove or rewrite when that
+package is removed.
 """
 
 import argparse

--- a/tests/ptl_resiliency/unit/test_ft_callback_hb.py
+++ b/tests/ptl_resiliency/unit/test_ft_callback_hb.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Unit tests for deprecated InJob PyTorch Lightning FT hooks (`ptl_resiliency`).
+
+Skipped by default (module-level ``pytest.mark.skip``). Remove the skip and this module when
+``nvidia_resiliency_ext.ptl_resiliency`` is removed.
+"""
+
 import contextlib
 import gc
 import logging
@@ -44,6 +50,10 @@ from torch import nn
 
 import nvidia_resiliency_ext.fault_tolerance as fault_tolerance
 from nvidia_resiliency_ext.ptl_resiliency import FaultToleranceCallback, SimulatedFaultParams
+
+pytestmark = pytest.mark.skip(
+    reason="Deprecated InJob PyTorch Lightning (ptl_resiliency); remove this skip when deleting the package.",
+)
 
 TEST_WORLD_SIZE = 1
 

--- a/tests/ptl_resiliency/unit/test_ft_callback_sections.py
+++ b/tests/ptl_resiliency/unit/test_ft_callback_sections.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Unit tests for deprecated InJob PyTorch Lightning section FT callbacks (`ptl_resiliency`).
+
+Skipped by default (module-level ``pytest.mark.skip``). Remove the skip and this module when
+``nvidia_resiliency_ext.ptl_resiliency`` is removed.
+"""
+
 import contextlib
 import gc
 import json
@@ -48,6 +54,10 @@ import nvidia_resiliency_ext.fault_tolerance as fault_tolerance
 from nvidia_resiliency_ext.ptl_resiliency import (
     FaultToleranceSectionsCallback,
     SimulatedFaultParams,
+)
+
+pytestmark = pytest.mark.skip(
+    reason="Deprecated InJob PyTorch Lightning (ptl_resiliency); remove this skip when deleting the package.",
 )
 
 TEST_WORLD_SIZE = 1

--- a/tests/ptl_resiliency/unit/test_ft_state_machine.py
+++ b/tests/ptl_resiliency/unit/test_ft_state_machine.py
@@ -13,8 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Unit tests for deprecated InJob PyTorch Lightning FT state machine internals (`ptl_resiliency`).
+
+Skipped by default (module-level ``pytest.mark.skip``). Remove the skip and this module when
+``nvidia_resiliency_ext.ptl_resiliency`` is removed.
+"""
+
+import pytest
 
 from nvidia_resiliency_ext.ptl_resiliency.fault_tolerance_callback import _TrainingStateMachine
+
+pytestmark = pytest.mark.skip(
+    reason="Deprecated InJob PyTorch Lightning (ptl_resiliency); remove this skip when deleting the package.",
+)
 
 
 class TestFaultTolerance:

--- a/tests/ptl_resiliency/unit/test_local_ckpt_callback.py
+++ b/tests/ptl_resiliency/unit/test_local_ckpt_callback.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Unit tests for deprecated InJob PyTorch Lightning local checkpoint helpers (`ptl_resiliency`).
+
+Skipped by default (module-level ``pytest.mark.skip``). Remove the skip and this module when
+``nvidia_resiliency_ext.ptl_resiliency`` is removed.
+"""
+
 import logging
 from datetime import timedelta
 from typing import Any, Dict, Iterable
@@ -26,6 +32,7 @@ elif is_module_available("pytorch_lightning"):
 else:
     raise ImportError("Could not find 'lightning' or 'pytorch_lightning' module")
 
+import pytest
 import torch
 
 from nvidia_resiliency_ext.checkpointing.local.base_state_dict import TensorAwareStateDict
@@ -40,6 +47,10 @@ from nvidia_resiliency_ext.ptl_resiliency.local_checkpoint_callback import (
 )
 
 from .test_ft_callback_hb import SimpleModel
+
+pytestmark = pytest.mark.skip(
+    reason="Deprecated InJob PyTorch Lightning (ptl_resiliency); remove this skip when deleting the package.",
+)
 
 
 def _run_trainining(

--- a/tests/ptl_resiliency/unit/test_straggler_det_callback.py
+++ b/tests/ptl_resiliency/unit/test_straggler_det_callback.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Unit tests for deprecated InJob PyTorch Lightning straggler callback (`ptl_resiliency`).
+
+Skipped by default (module-level ``pytest.mark.skip``). Remove the skip and this module when
+``nvidia_resiliency_ext.ptl_resiliency`` is removed.
+"""
+
 import logging
 import os
 import pathlib
@@ -34,6 +40,10 @@ import torch
 from torch import nn
 
 from nvidia_resiliency_ext.ptl_resiliency import StragglerDetectionCallback
+
+pytestmark = pytest.mark.skip(
+    reason="Deprecated InJob PyTorch Lightning (ptl_resiliency); remove this skip when deleting the package.",
+)
 
 
 class OnesDataset(torch.utils.data.Dataset):


### PR DESCRIPTION
Fixed conftest to dump error stack trace.
Torch 2.11.0 breaks CI on machines having CUDA driver <= 1208