### PR TITLE
Add CPU shared-memory D2H path to FileSystemWriterAsync

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -448,6 +448,7 @@ class PersistentAsyncCaller(AsyncCaller):
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
         sigterm_timeout: float = 30.0,
+        cpu_shm_mode: bool = False,
     ):
         self.process: mp.Process = None
         self.start_time: Optional[float] = None
@@ -471,6 +472,7 @@ class PersistentAsyncCaller(AsyncCaller):
         self.background_worker_is_daemon = is_daemon
         self.cpu_priority = cpu_priority
         self.io_priority = io_priority
+        self.cpu_shm_mode = cpu_shm_mode
 
     def _start_worker(self, rank: int) -> None:
         """Start the background worker process.
@@ -495,6 +497,7 @@ class PersistentAsyncCaller(AsyncCaller):
                 logger.getEffectiveLevel(),
                 self.cpu_priority,
                 self.io_priority,
+                self.cpu_shm_mode,
             ),
             daemon=self.background_worker_is_daemon,
         )
@@ -670,6 +673,7 @@ class PersistentAsyncCaller(AsyncCaller):
         log_level: int = logging.INFO,
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
+        cpu_shm_mode: bool = False,
     ):
         """Main function for the persistent checkpoint worker
 
@@ -706,18 +710,19 @@ class PersistentAsyncCaller(AsyncCaller):
             logger.info(f"PersistentAsyncCaller: persistent ckpt worker for {rank} has started")
         else:
             logger.debug(f"PersistentAsyncCaller: persistent ckpt worker for {rank} has started")
-        # Set CUDA device to appropriate local_rank to ensure allocations / CUDA contexts
-        # in this new process are on the right device, and device 0 on the node does not
-        # take on undue memory burden from other devices on node (default behavior without
-        # this line).
-        device_id = rank % torch.cuda.device_count()
-        torch.cuda.set_device(device_id)
-        # Allocate a small dummy tensor to force CUDA context initialization before any
-        # IPC handle is received via the queue. This prevents a handle type mismatch
-        # between the producer and consumer that otherwise manifests as:
-        #   RuntimeError: pidfd_getfd: Bad file descriptor
-        # See https://github.com/pytorch/pytorch/issues/179220 for details.
-        torch.empty(1, device=f'cuda:{device_id}')
+        if not cpu_shm_mode:
+            # Set CUDA device to appropriate local_rank to ensure allocations / CUDA contexts
+            # in this new process are on the right device, and device 0 on the node does not
+            # take on undue memory burden from other devices on node (default behavior without
+            # this line).
+            device_id = rank % torch.cuda.device_count()
+            torch.cuda.set_device(device_id)
+            # Allocate a small dummy tensor to force CUDA context initialization before any
+            # IPC handle is received via the queue. This prevents a handle type mismatch
+            # between the producer and consumer that otherwise manifests as:
+            #   RuntimeError: pidfd_getfd: Bad file descriptor
+            # See https://github.com/pytorch/pytorch/issues/179220 for details.
+            torch.empty(1, device=f'cuda:{device_id}')
 
         # Set QoS to deprioritize checkpoint writing vs training.
         # This prevents checkpoint I/O from interfering with data loader.
@@ -784,13 +789,14 @@ class PersistentAsyncCaller(AsyncCaller):
         log_level: int = logging.INFO,
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
+        cpu_shm_mode: bool = False,
     ):
         """
         Main function for the persistent checkpoint worker called by a non daemon async process.
         In this loop, child processes may be created (For example: to parallelize File IO)
         """
         PersistentAsyncCaller.async_process_target(
-            rank, queue, preload_q, comp_q, log_level, cpu_priority, io_priority
+            rank, queue, preload_q, comp_q, log_level, cpu_priority, io_priority, cpu_shm_mode
         )
 
     @staticmethod
@@ -802,12 +808,13 @@ class PersistentAsyncCaller(AsyncCaller):
         log_level: int = logging.INFO,
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
+        cpu_shm_mode: bool = False,
     ):
         """
         Main function for the persistent checkpoint worker called by a daemon async process
         """
         PersistentAsyncCaller.async_process_target(
-            rank, queue, preload_q, comp_q, log_level, cpu_priority, io_priority
+            rank, queue, preload_q, comp_q, log_level, cpu_priority, io_priority, cpu_shm_mode
         )
 
 
@@ -844,6 +851,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
         sigterm_timeout: float = 30.0,
+        cpu_shm_mode: bool = False,
     ):
         self.async_calls: deque[_ActiveAsyncRequest] = deque([])
         self.call_idx: int = -1
@@ -852,6 +860,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
         self.cpu_priority = cpu_priority
         self.io_priority = io_priority
         self.sigterm_timeout = sigterm_timeout
+        self.cpu_shm_mode = cpu_shm_mode
         self.persistent_caller: AsyncCaller = None
 
     def _get_async_caller(self):
@@ -881,6 +890,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                     cpu_priority=self.cpu_priority,
                     io_priority=self.io_priority,
                     sigterm_timeout=self.sigterm_timeout,
+                    cpu_shm_mode=self.cpu_shm_mode,
                 )
         return self.persistent_caller
 

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -928,6 +928,12 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                 This can help the user keep track of the async calls.
         """
         self.call_idx += 1
+        # For CPU shm path: shm tensors are shared between training and worker, so the
+        # previous write must complete before training overwrites them with new values.
+        # Drain any pending writes now, before dispatching the next checkpoint.
+        # (For the GPU IPC path this is a no-op since write_fence is not set.)
+        if getattr(async_request.preload_fn, 'write_fence', False) and self.async_calls:
+            self.maybe_finalize_async_calls(blocking=True, no_dist=True)
         async_caller = self._get_async_caller()
         # Backward compatibility for local checkpointing built with the old AsyncRequest
         if len(async_request._fields) != len(AsyncRequest._fields):

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -902,6 +902,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
         sigterm_timeout: float = 30.0,
+        cpu_shm_mode: bool = False,
     ):
         """Pre-start the persistent async worker to avoid startup latency on the first checkpoint.
 
@@ -913,6 +914,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                 deprioritize checkpoint I/O. NOTE: class 1 = realtime (highest priority —
                 NOT recommended for checkpoint workers).
             sigterm_timeout (float): seconds to wait after SIGTERM before escalating to SIGKILL.
+            cpu_shm_mode (bool): if True, skip CUDA device init in the worker (no CUDA IPC needed).
         """
         if cls._warmup_persistent_caller is None:
             caller = PersistentAsyncCaller(
@@ -920,6 +922,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                 cpu_priority=cpu_priority,
                 io_priority=io_priority,
                 sigterm_timeout=sigterm_timeout,
+                cpu_shm_mode=cpu_shm_mode,
             )
             caller._start_worker(rank)
             caller.rank = rank

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -863,6 +863,17 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
         self.cpu_shm_mode = cpu_shm_mode
         self.persistent_caller: AsyncCaller = None
 
+        if cpu_shm_mode:
+            # Deferred import avoids circular dependency (filesystem_async imports core).
+            # Registers a blocking drain that fires from prepare_write_data before any
+            # shm tensor is overwritten, closing the race between the prior write's
+            # disk-read pass and the current checkpoint's D2H copy.
+            from .filesystem_async import FileSystemWriterAsync
+
+            FileSystemWriterAsync.register_shm_drain_callback(
+                lambda: self.maybe_finalize_async_calls(blocking=True, no_dist=True)
+            )
+
     def _get_async_caller(self):
         if not self.persistent:
             logger.warning("The TemporalAsyncCaller will be deprecated soon. ")
@@ -941,12 +952,6 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                 This can help the user keep track of the async calls.
         """
         self.call_idx += 1
-        # For CPU shm path: shm tensors are shared between training and worker, so the
-        # previous write must complete before training overwrites them with new values.
-        # Drain any pending writes now, before dispatching the next checkpoint.
-        # (For the GPU IPC path this is a no-op since write_fence is not set.)
-        if getattr(async_request.preload_fn, 'write_fence', False) and self.async_calls:
-            self.maybe_finalize_async_calls(blocking=True, no_dist=True)
         async_caller = self._get_async_caller()
         # Backward compatibility for local checkpointing built with the old AsyncRequest
         if len(async_request._fields) != len(AsyncRequest._fields):
@@ -1002,6 +1007,11 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
             abort (bool, optional): Default to False. Needs to be manually set to true when
                 the checkpoint async process needs to be aborted.
         """
+        if self.cpu_shm_mode:
+            from .filesystem_async import FileSystemWriterAsync
+
+            FileSystemWriterAsync.register_shm_drain_callback(None)
+
         # For a clean shut down scenario with valid async processes running,
         # finalize all pending async calls
         if not abort and (self.persistent is False or self.persistent_caller is not None):

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -27,7 +27,7 @@ from abc import ABC, abstractmethod
 from collections import deque
 from queue import Empty
 from time import sleep, time
-from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
+from typing import Callable, ClassVar, Dict, List, NamedTuple, Optional, Tuple
 
 import torch
 from torch import multiprocessing as mp
@@ -432,6 +432,16 @@ class PersistentAsyncCaller(AsyncCaller):
     # This cache contains IPC handles and must be cleaned up properly.
     _worker_data_cache: Dict = {}
 
+    # Callbacks invoked in the training process whenever a fresh worker is spawned.
+    # Used by FileSystemWriterAsync to invalidate training-side shm caches so the
+    # next checkpoint re-sends actual tensor data to the new worker.
+    _worker_restart_callbacks: ClassVar[List[Callable]] = []
+
+    @classmethod
+    def register_worker_restart_callback(cls, fn: Callable) -> None:
+        """Register a callable to be invoked when a new worker process is started."""
+        cls._worker_restart_callbacks.append(fn)
+
     def __init__(
         self,
         is_daemon: bool = True,
@@ -490,6 +500,8 @@ class PersistentAsyncCaller(AsyncCaller):
         )
         self.process.start()
         logger.debug(f"PersistentAsyncCaller: {rank}, Started Async Caller {self.process}")
+        for cb in PersistentAsyncCaller._worker_restart_callbacks:
+            cb()
 
     def schedule_async_call(self, async_req: AsyncRequest) -> None:
         """Put `AsyncRequest` to the Persistent Async Caller

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -32,7 +32,7 @@ from heapq import heappop, heappush
 from itertools import chain
 from operator import itemgetter
 from time import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import multiprocessing as mp
@@ -156,6 +156,11 @@ class FileSystemWriterAsync(FileSystemWriter):
     # Class-level cache to track identifiers that have been sent to worker across instances
     _cached_identifiers: set = set()
 
+    # Training-side shm tensor cache: keeps shm tensors alive (and reuses allocations) across
+    # checkpoints.  Key: same SHA-256 as ConsistentDataIdentifier.
+    # Value: (gpu_items, shm_tensors) where shm_tensors are CPU shared-memory tensors.
+    _shm_tensor_cache: ClassVar[Dict[str, Tuple[List, List]]] = {}
+
     def __init__(
         self,
         path: Union[str, os.PathLike],
@@ -164,6 +169,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         use_msc: bool = False,
         is_multiproc_io: bool = False,
         use_cached_data_structure: bool = False,
+        use_cpu_shm_for_gpu_tensors: bool = False,
         **kwargs,
     ):
         self.checkpoint_dir = path
@@ -182,7 +188,12 @@ class FileSystemWriterAsync(FileSystemWriter):
         self.has_data_to_write: bool = False
         self.results_queue: Optional[mp.Queue] = None
         self.separation_hint = separation_hint
-        self.use_cached_data_structure = use_cached_data_structure
+        # Enable cached data structure via constructor arg or env var.
+        # NVRX_CKPT_USE_CACHED_STRUCTURE=1 lets callers (e.g. Megatron) opt in without
+        # changing their FileSystemWriterAsync construction call.
+        self.use_cached_data_structure = use_cached_data_structure or (
+            os.environ.get("NVRX_CKPT_USE_CACHED_STRUCTURE", "0") == "1"
+        )
         self.consistent_data_identifier: Optional[ConsistentDataIdentifier] = None
         # When this flag is True, the FileWriter can create multiple child processes
         # to parallelize File IO in the background async checkpoint process.
@@ -190,6 +201,25 @@ class FileSystemWriterAsync(FileSystemWriter):
         # Note: multi-proc IO requires is_daemon=False on PersistentAsyncCaller (AsyncCallsQueue),
         # whereas the default multithreaded IO is compatible with is_daemon=True (the default).
         self.is_multi_proc_io = is_multiproc_io
+        # Use CPU shared-memory tensors instead of GPU IPC fabric handles.
+        # Avoids cuMemImportFromShareableHandle on MNNVL systems where NVLink fabric
+        # resources are exhausted by the training ranks.
+        # Also controllable via NVRX_CKPT_USE_CPU_SHM=1 (no Megatron changes needed).
+        self.use_cpu_shm_for_gpu_tensors = use_cpu_shm_for_gpu_tensors or (
+            os.environ.get("NVRX_CKPT_USE_CPU_SHM", "0") == "1"
+        )
+        # shm path requires the cached-data-structure code path — enable it automatically
+        # so callers that don't explicitly set use_cached_data_structure still benefit.
+        if self.use_cpu_shm_for_gpu_tensors and not self.use_cached_data_structure:
+            logger.info(
+                "NVRX_CKPT_USE_CPU_SHM is set: enabling use_cached_data_structure automatically"
+            )
+            self.use_cached_data_structure = True
+        if self.use_cached_data_structure or self.use_cpu_shm_for_gpu_tensors:
+            logger.info(
+                f"FileSystemWriterAsync: use_cached_data_structure={self.use_cached_data_structure}, "
+                f"use_cpu_shm_for_gpu_tensors={self.use_cpu_shm_for_gpu_tensors}"
+            )
 
     def prepare_write_data(self, plan: SavePlan, planner: SavePlanner) -> None:
         """
@@ -285,7 +315,7 @@ class FileSystemWriterAsync(FileSystemWriter):
 
             return (gpu_items, gpu_data), (uncached_items, uncached_data)
 
-        # Handle GPU tensor caching (only GPU tensors can benefit from IPC)
+        # Handle GPU tensor caching (only GPU tensors can benefit from IPC or shm)
         # Uncached tensors (CPU or dequantized) are always resolved fresh
         if self.use_cached_data_structure and tensor_items:
             key = _compute_data_structure_key_from_plan(tensor_items)
@@ -297,8 +327,83 @@ class FileSystemWriterAsync(FileSystemWriter):
                 tensor_items, resolved_tensors, dequantized_flags
             )
 
-            if cache_exists:
-                # Reuse cached GPU tensors from worker
+            if gpu_items and self.use_cpu_shm_for_gpu_tensors:
+                # --- CPU shared-memory path ---
+                # D2H is done here (training side) into a SINGLE flat shared-memory buffer
+                # so the worker subprocess never needs CUDA IPC / fabric handles.
+                # Using one flat buffer instead of one share_memory_() per tensor avoids
+                # exhausting the kernel's POSIX shm segment limit.
+                if key in FileSystemWriterAsync._shm_tensor_cache:
+                    # Reuse existing flat buffer; overwrite views with fresh GPU values.
+                    _, existing_shm, _ = FileSystemWriterAsync._shm_tensor_cache[key]
+                    for shm_t, gpu_t in zip(existing_shm, gpu_data):
+                        shm_t.copy_(gpu_t, non_blocking=True)
+                    logger.debug(
+                        f"Overwrote {len(existing_shm)} shm tensors with fresh GPU values "
+                        f"(key={key})"
+                    )
+                else:
+                    # First checkpoint: build aligned layout, allocate one flat shm buffer,
+                    # and create per-tensor views into it.
+                    #
+                    # Each tensor's offset is aligned to max(element_size, 16) bytes so that
+                    # flat_buf[offset:offset+nbytes].view(dtype) is always valid.
+                    _ALIGN = 16
+
+                    def _aligned_up(off, elem_size):
+                        a = max(elem_size, _ALIGN)
+                        return (off + a - 1) & ~(a - 1)
+
+                    tensor_layout = []  # [(shape, dtype, offset, numel)]
+                    cur = 0
+                    for t in gpu_data:
+                        tc = t.contiguous()
+                        off = _aligned_up(cur, tc.element_size())
+                        nb = tc.numel() * tc.element_size()
+                        tensor_layout.append((tc.shape, tc.dtype, off, tc.numel()))
+                        cur = off + nb
+
+                    flat_buf = torch.empty(cur, dtype=torch.uint8).share_memory_()
+
+                    shm_tensors = []
+                    for t, (shape, dtype, off, numel) in zip(gpu_data, tensor_layout):
+                        nb = numel * t.element_size()
+                        view = flat_buf[off : off + nb].view(dtype).reshape(shape)
+                        view.copy_(t, non_blocking=True)
+                        shm_tensors.append(view)
+
+                    FileSystemWriterAsync._shm_tensor_cache[key] = (
+                        gpu_items,
+                        shm_tensors,
+                        flat_buf,   # keep flat_buf alive
+                    )
+                    logger.debug(
+                        f"Allocated 1 flat shm buffer ({cur} bytes) for "
+                        f"{len(shm_tensors)} tensors and D2H'd GPU values (key={key})"
+                    )
+
+                # Ensure D2H is complete before the worker process can read the shm tensors.
+                torch.cuda.synchronize()
+
+                _, shm_tensors, _ = FileSystemWriterAsync._shm_tensor_cache[key]
+                self.consistent_data_identifier = ConsistentDataIdentifier(key)
+                if cache_exists:
+                    # Worker already has shm tensor references cached; just update values.
+                    self.cached_tensor_data = None
+                    logger.debug(
+                        f"Reusing worker-cached shm tensors (key={key}), "
+                        f"{len(uncached_items)} uncached tensors passed fresh"
+                    )
+                else:
+                    # First checkpoint: send shm tensors to worker so it can cache them.
+                    self.cached_tensor_data = (gpu_items, shm_tensors)
+                    FileSystemWriterAsync._cached_identifiers.add(key)
+                    logger.debug(
+                        f"Sending {len(shm_tensors)} shm tensors to worker (key={key}), "
+                        f"{len(uncached_items)} uncached tensors passed fresh"
+                    )
+            elif cache_exists:
+                # --- original GPU IPC path, reuse ---
                 self.consistent_data_identifier = ConsistentDataIdentifier(key)
                 self.cached_tensor_data = None  # Signal to reuse cached data
                 logger.debug(
@@ -306,7 +411,7 @@ class FileSystemWriterAsync(FileSystemWriter):
                     f"resolved {len(uncached_items)} uncached tensors fresh"
                 )
             elif gpu_items:
-                # First time caching - send GPU tensor data to worker
+                # --- original GPU IPC path, first time ---
                 self.consistent_data_identifier = ConsistentDataIdentifier(key)
                 self.cached_tensor_data = (gpu_items, gpu_data)
                 FileSystemWriterAsync._cached_identifiers.add(key)
@@ -322,6 +427,21 @@ class FileSystemWriterAsync(FileSystemWriter):
                     f"No GPU tensors to cache (key={key}), "
                     f"{len(uncached_items)} uncached tensors passed fresh"
                 )
+
+            # When using CPU shm path, also D2H-copy any dequantized GPU tensors in
+            # uncached_data so they don't require CUDA IPC / fabric handles in the worker.
+            if self.use_cpu_shm_for_gpu_tensors and uncached_items:
+                needs_sync = False
+                new_uncached_data = []
+                for t in uncached_data:
+                    if isinstance(t, torch.Tensor) and t.is_cuda:
+                        new_uncached_data.append(t.to("cpu", non_blocking=True))
+                        needs_sync = True
+                    else:
+                        new_uncached_data.append(t)
+                if needs_sync:
+                    torch.cuda.synchronize()
+                uncached_data = new_uncached_data
 
             # Uncached tensors are always passed fresh (never cached)
             self.uncached_tensor_data = (uncached_items, uncached_data) if uncached_items else None
@@ -353,6 +473,21 @@ class FileSystemWriterAsync(FileSystemWriter):
         self.results_queue = get_write_results_queue() if self.has_data_to_write else None
         end = time()
         logger.debug(f"prepare_write_data, time: {end - start}")
+
+    @classmethod
+    def cleanup_shm_tensor_cache(cls) -> None:
+        """Release training-side shm tensor references and invalidate the identifier cache.
+
+        Must be called whenever the worker process is restarted so the next checkpoint
+        re-sends actual shm tensor objects instead of ``None`` (which would cause a
+        worker-side cache miss on the freshly restarted worker).
+        """
+        if cls._shm_tensor_cache:
+            logger.info(
+                f"Clearing shm tensor cache ({len(cls._shm_tensor_cache)} entries)"
+            )
+            cls._shm_tensor_cache.clear()
+        cls._cached_identifiers.clear()
 
     def get_save_function_and_args(self) -> Tuple[Optional[Callable], Optional[Callable], List]:
         """
@@ -1137,6 +1272,14 @@ class FileSystemWriterAsync(FileSystemWriter):
             return FileSystemWriter.validate_checkpoint_id(checkpoint_id)
 
         return False
+
+
+# Register cleanup hook so that when PersistentAsyncCaller spawns a new worker process
+# (e.g., after an abort/restart), the training-side shm tensor cache is invalidated and
+# the next checkpoint re-sends actual shm tensors to the fresh worker.
+PersistentAsyncCaller.register_worker_restart_callback(
+    FileSystemWriterAsync.cleanup_shm_tensor_cache
+)
 
 
 def _split_by_size_and_type(bins: int, items: List[WriteItem]) -> List[List[WriteItem]]:

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -481,9 +481,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         worker-side cache miss on the freshly restarted worker).
         """
         if cls._shm_tensor_cache:
-            logger.info(
-                f"Clearing shm tensor cache ({len(cls._shm_tensor_cache)} entries)"
-            )
+            logger.info(f"Clearing shm tensor cache ({len(cls._shm_tensor_cache)} entries)")
             cls._shm_tensor_cache.clear()
         cls._cached_identifiers.clear()
 

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -156,10 +156,10 @@ class FileSystemWriterAsync(FileSystemWriter):
     # Class-level cache to track identifiers that have been sent to worker across instances
     _cached_identifiers: set = set()
 
-    # Training-side shm tensor cache: keeps shm tensors alive (and reuses allocations) across
-    # checkpoints.  Key: same SHA-256 as ConsistentDataIdentifier.
-    # Value: (gpu_items, shm_tensors) where shm_tensors are individual CPU shared-memory
-    # tensors (one per GPU tensor, each with its own independent storage).
+    # Training-side shm tensor cache: reuses allocations across checkpoints.
+    # Only populated when use_cpu_shm_for_gpu_tensors=True AND use_cached_data_structure=True.
+    # Key: SHA-256 of plan items (same as ConsistentDataIdentifier).
+    # Value: (gpu_items, shm_tensors) — one independent share_memory_() tensor per GPU tensor.
     _shm_tensor_cache: ClassVar[Dict[str, Tuple[List, List]]] = {}
 
     # Blocking drain registered by AsyncCallsQueue when cpu_shm_mode=True.
@@ -326,19 +326,17 @@ class FileSystemWriterAsync(FileSystemWriter):
                 # --- CPU shared-memory path ---
                 # D2H is done here (training side) into per-tensor CPU shared-memory tensors
                 # so the worker subprocess never needs CUDA IPC / fabric handles.
-                # Each tensor gets its own independent share_memory_() allocation.
-                if key in FileSystemWriterAsync._shm_tensor_cache:
-                    # Drain any in-flight write BEFORE overwriting these shm tensors.
-                    # The worker for checkpoint N may still be iterating over the same
-                    # shared-memory buffers; without this drain the D2H copy below races
-                    # with that read and silently corrupts checkpoint N.
-                    # AsyncCallsQueue.register_shm_drain_callback sets this callback when
-                    # cpu_shm_mode=True; callers that bypass AsyncCallsQueue must drain
-                    # themselves before calling prepare_write_data.
+                if (
+                    self.use_cached_data_structure
+                    and key in FileSystemWriterAsync._shm_tensor_cache
+                ):
+                    # Reuse existing allocations.  Drain any in-flight write first:
+                    # the worker for checkpoint N may still be reading these buffers
+                    # while we are about to overwrite them with checkpoint N+1 values.
                     if FileSystemWriterAsync._shm_drain_callback is not None:
                         FileSystemWriterAsync._shm_drain_callback()
-                    _, existing_shm = FileSystemWriterAsync._shm_tensor_cache[key]
-                    for i, (shm_t, gpu_t) in enumerate(zip(existing_shm, gpu_data)):
+                    _, shm_tensors = FileSystemWriterAsync._shm_tensor_cache[key]
+                    for i, (shm_t, gpu_t) in enumerate(zip(shm_tensors, gpu_data)):
                         shm_t.copy_(gpu_t, non_blocking=True)
                         # Periodically sync to avoid exhausting CUDA's pageable staging
                         # pages (shm tensors are not pinned so copy_ is not a pinned DMA).
@@ -346,12 +344,15 @@ class FileSystemWriterAsync(FileSystemWriter):
                             torch.cuda.synchronize()
                     torch.cuda.synchronize()
                     logger.debug(
-                        f"D2H'd {len(existing_shm)} shm tensors into reused allocations "
+                        f"D2H'd {len(shm_tensors)} shm tensors into reused allocations "
                         f"(key={key})"
                     )
                 else:
-                    # First checkpoint: allocate one independent shm tensor per GPU tensor
-                    # and D2H-copy the current values in.
+                    # Allocate one independent shm tensor per GPU tensor and D2H-copy
+                    # current values in.  Allocations are stored in _shm_tensor_cache
+                    # only when use_cached_data_structure=True so they are reused on
+                    # subsequent checkpoints; otherwise fresh tensors are allocated each
+                    # time and the worker receives them directly without caching.
                     shm_tensors = []
                     total_bytes = 0
                     for i, t in enumerate(gpu_data):
@@ -363,32 +364,38 @@ class FileSystemWriterAsync(FileSystemWriter):
                         # Periodically sync to avoid exhausting CUDA's pageable staging pages
                         if (i + 1) % 8 == 0:
                             torch.cuda.synchronize()
-
-                    FileSystemWriterAsync._shm_tensor_cache[key] = (gpu_items, shm_tensors)
+                    torch.cuda.synchronize()
+                    if self.use_cached_data_structure:
+                        FileSystemWriterAsync._shm_tensor_cache[key] = (gpu_items, shm_tensors)
                     logger.debug(
                         f"Allocated {len(shm_tensors)} shm tensors ({total_bytes} bytes total) "
                         f"and D2H'd GPU values (key={key})"
                     )
 
-                _, shm_tensors = FileSystemWriterAsync._shm_tensor_cache[key]
-                self.consistent_data_identifier = ConsistentDataIdentifier(key)
-                if cache_exists:
-                    # Subsequent checkpoint: D2H already done into reused shm buffer above.
-                    # Worker already has the shm tensor references cached; send None to
-                    # signal it should reuse them (values are fresh after the D2H above).
-                    self.cached_tensor_data = None
-                    logger.debug(
-                        f"Reusing worker-cached shm tensors (key={key}), "
-                        f"{len(uncached_items)} uncached tensors passed fresh"
-                    )
+                if self.use_cached_data_structure:
+                    self.consistent_data_identifier = ConsistentDataIdentifier(key)
+                    if cache_exists:
+                        # Worker already has the shm tensor references cached; send None to
+                        # signal it should reuse them (values are fresh after the D2H above).
+                        self.cached_tensor_data = None
+                        logger.debug(
+                            f"Reusing worker-cached shm tensors (key={key}), "
+                            f"{len(uncached_items)} uncached tensors passed fresh"
+                        )
+                    else:
+                        # First checkpoint with caching: send shm tensors to worker.
+                        self.cached_tensor_data = (gpu_items, shm_tensors)
+                        FileSystemWriterAsync._cached_identifiers.add(key)
+                        logger.debug(
+                            f"Sending {len(shm_tensors)} shm tensors to worker (key={key}), "
+                            f"{len(uncached_items)} uncached tensors passed fresh"
+                        )
                 else:
-                    # First checkpoint: D2H already done above, synchronize now.
-                    torch.cuda.synchronize()
-                    # Send shm tensors to worker so it can cache them.
+                    # No caching: always send fresh shm tensors; worker uses them directly.
+                    self.consistent_data_identifier = None
                     self.cached_tensor_data = (gpu_items, shm_tensors)
-                    FileSystemWriterAsync._cached_identifiers.add(key)
                     logger.debug(
-                        f"Sending {len(shm_tensors)} shm tensors to worker (key={key}), "
+                        f"Sending {len(shm_tensors)} fresh shm tensors to worker (no caching), "
                         f"{len(uncached_items)} uncached tensors passed fresh"
                     )
             elif cache_exists:

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -133,26 +133,6 @@ def get_write_results_queue(mp_mode: str = 'spawn') -> mp.Queue:
     return _results_queue
 
 
-class _FencedPreloadFn:
-    """Wraps a preload_fn and marks it as requiring shm write serialisation.
-
-    The ``write_fence = True`` attribute is detected by
-    ``AsyncCallsQueue.schedule_async_request``, which will call
-    ``maybe_finalize_async_calls(blocking=True)`` before dispatching the next
-    checkpoint.  This ensures any pending write completes before the training
-    process overwrites the shared-memory tensors with new values.
-    """
-
-    write_fence: bool = True
-    __slots__ = ('_fn',)
-
-    def __init__(self, fn: Callable) -> None:
-        self._fn = fn
-
-    def __call__(self, *args, **kwargs):
-        return self._fn(*args, **kwargs)
-
-
 class FileSystemWriterAsync(FileSystemWriter):
     """
     Async-enabled implementation of FileSystemWriter using file I/O.
@@ -181,6 +161,11 @@ class FileSystemWriterAsync(FileSystemWriter):
     # Value: (gpu_items, shm_tensors) where shm_tensors are individual CPU shared-memory
     # tensors (one per GPU tensor, each with its own independent storage).
     _shm_tensor_cache: ClassVar[Dict[str, Tuple[List, List]]] = {}
+
+    # Blocking drain registered by AsyncCallsQueue when cpu_shm_mode=True.
+    # Called in prepare_write_data before the first copy_() into a reused shm tensor,
+    # so any prior write that is still reading from those tensors completes first.
+    _shm_drain_callback: ClassVar[Optional[Callable[[], None]]] = None
 
     def __init__(
         self,
@@ -343,9 +328,15 @@ class FileSystemWriterAsync(FileSystemWriter):
                 # so the worker subprocess never needs CUDA IPC / fabric handles.
                 # Each tensor gets its own independent share_memory_() allocation.
                 if key in FileSystemWriterAsync._shm_tensor_cache:
-                    # Reuse existing shm tensors.  The caller (Megatron) must have called
-                    # wait_for_async_call() before this, which drains comp_q and guarantees
-                    # the previous write has finished reading from these buffers.
+                    # Drain any in-flight write BEFORE overwriting these shm tensors.
+                    # The worker for checkpoint N may still be iterating over the same
+                    # shared-memory buffers; without this drain the D2H copy below races
+                    # with that read and silently corrupts checkpoint N.
+                    # AsyncCallsQueue.register_shm_drain_callback sets this callback when
+                    # cpu_shm_mode=True; callers that bypass AsyncCallsQueue must drain
+                    # themselves before calling prepare_write_data.
+                    if FileSystemWriterAsync._shm_drain_callback is not None:
+                        FileSystemWriterAsync._shm_drain_callback()
                     _, existing_shm = FileSystemWriterAsync._shm_tensor_cache[key]
                     for i, (shm_t, gpu_t) in enumerate(zip(existing_shm, gpu_data)):
                         shm_t.copy_(gpu_t, non_blocking=True)
@@ -485,6 +476,15 @@ class FileSystemWriterAsync(FileSystemWriter):
             cls._shm_tensor_cache.clear()
         cls._cached_identifiers.clear()
 
+    @classmethod
+    def register_shm_drain_callback(cls, fn: Optional[Callable[[], None]]) -> None:
+        """Register (or clear with None) the blocking drain called before reusing shm tensors.
+
+        AsyncCallsQueue registers this when cpu_shm_mode=True so that
+        prepare_write_data drains any in-flight write before overwriting shm tensors.
+        """
+        cls._shm_drain_callback = fn
+
     def get_save_function_and_args(self) -> Tuple[Optional[Callable], Optional[Callable], List]:
         """
         Get function that saves the data to storage along with its arguments.
@@ -534,17 +534,7 @@ class FileSystemWriterAsync(FileSystemWriter):
                 self.write_preloaded_data_multithread, transform_list, self.use_msc, open_file
             )
 
-        inner_preload_fn = partial(
-            self.preload_tensors, (str(self.checkpoint_dir), data_to_pass), True
-        )
-
-        if self.use_cpu_shm_for_gpu_tensors:
-            # Shm path: wrap with write_fence marker so AsyncCallsQueue.schedule_async_request
-            # calls maybe_finalize_async_calls(blocking=True) before dispatching, ensuring any
-            # previous write completes before training overwrites the shm tensors with new values.
-            preload_fn = _FencedPreloadFn(inner_preload_fn)
-        else:
-            preload_fn = inner_preload_fn
+        preload_fn = partial(self.preload_tensors, (str(self.checkpoint_dir), data_to_pass), True)
 
         return (
             write_func,

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -464,12 +464,19 @@ class FileSystemWriterAsync(FileSystemWriter):
         logger.debug(f"prepare_write_data, time: {end - start}")
 
     @classmethod
-    def cleanup_shm_tensor_cache(cls) -> None:
-        """Release training-side shm tensor references and invalidate the identifier cache.
+    def cleanup_tensor_caches(cls) -> None:
+        """Release training-side tensor caches and invalidate the identifier set.
 
-        Must be called whenever the worker process is restarted so the next checkpoint
-        re-sends actual shm tensor objects instead of ``None`` (which would cause a
-        worker-side cache miss on the freshly restarted worker).
+        Must be called whenever the worker process is restarted.  A fresh worker
+        has an empty ``_worker_data_cache``, so both paths need re-priming:
+
+        - **CPU shm path** (``use_cpu_shm_for_gpu_tensors=True``): clears
+          ``_shm_tensor_cache`` so the next checkpoint re-allocates shm tensors
+          and sends them to the worker instead of sending ``None`` (which would
+          cause a worker-side cache miss).
+        - **GPU IPC path** (``use_cached_data_structure=True``): clearing
+          ``_cached_identifiers`` forces the next checkpoint to re-send the GPU
+          tensor IPC handles rather than assuming the worker already has them.
         """
         if cls._shm_tensor_cache:
             logger.info(f"Clearing shm tensor cache ({len(cls._shm_tensor_cache)} entries)")
@@ -1280,9 +1287,7 @@ class FileSystemWriterAsync(FileSystemWriter):
 # Register cleanup hook so that when PersistentAsyncCaller spawns a new worker process
 # (e.g., after an abort/restart), the training-side shm tensor cache is invalidated and
 # the next checkpoint re-sends actual shm tensors to the fresh worker.
-PersistentAsyncCaller.register_worker_restart_callback(
-    FileSystemWriterAsync.cleanup_shm_tensor_cache
-)
+PersistentAsyncCaller.register_worker_restart_callback(FileSystemWriterAsync.cleanup_tensor_caches)
 
 
 def _split_by_size_and_type(bins: int, items: List[WriteItem]) -> List[List[WriteItem]]:

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -133,6 +133,26 @@ def get_write_results_queue(mp_mode: str = 'spawn') -> mp.Queue:
     return _results_queue
 
 
+class _FencedPreloadFn:
+    """Wraps a preload_fn and marks it as requiring shm write serialisation.
+
+    The ``write_fence = True`` attribute is detected by
+    ``AsyncCallsQueue.schedule_async_request``, which will call
+    ``maybe_finalize_async_calls(blocking=True)`` before dispatching the next
+    checkpoint.  This ensures any pending write completes before the training
+    process overwrites the shared-memory tensors with new values.
+    """
+
+    write_fence: bool = True
+    __slots__ = ('_fn',)
+
+    def __init__(self, fn: Callable) -> None:
+        self._fn = fn
+
+    def __call__(self, *args, **kwargs):
+        return self._fn(*args, **kwargs)
+
+
 class FileSystemWriterAsync(FileSystemWriter):
     """
     Async-enabled implementation of FileSystemWriter using file I/O.
@@ -158,7 +178,8 @@ class FileSystemWriterAsync(FileSystemWriter):
 
     # Training-side shm tensor cache: keeps shm tensors alive (and reuses allocations) across
     # checkpoints.  Key: same SHA-256 as ConsistentDataIdentifier.
-    # Value: (gpu_items, shm_tensors) where shm_tensors are CPU shared-memory tensors.
+    # Value: (gpu_items, shm_tensors) where shm_tensors are individual CPU shared-memory
+    # tensors (one per GPU tensor, each with its own independent storage).
     _shm_tensor_cache: ClassVar[Dict[str, Tuple[List, List]]] = {}
 
     def __init__(
@@ -290,23 +311,28 @@ class FileSystemWriterAsync(FileSystemWriter):
         byte_io_items = [item for item in plan.items if item.type == WriteItemType.BYTE_IO]
 
         # Helper to separate resolved tensors into cacheable (GPU) vs uncached buckets.
-        # Uncached tensors include: CPU tensors and dequantized GPU tensors.
         # Dequantized tensors are tracked explicitly via dequantized_flags because
         # some frameworks (e.g. TransformerEngine MXFP8) report bfloat16 as the dtype
         # for quantized tensors, making dtype-based detection unreliable.
-        def separate_cacheable(items, resolved_data, dequantized_flags):
-            """Separate tensor items into IPC-cacheable (GPU) and uncached categories.
+        def separate_cacheable(items, resolved_data, dequantized_flags, include_dequantized=False):
+            """Separate tensor items into cacheable (GPU) and uncached categories.
 
-            GPU tensors that were not dequantized are cacheable via IPC.
-            CPU tensors and dequantized GPU tensors are always passed fresh and never cached.
+            For the GPU IPC path (include_dequantized=False): dequantized tensors are
+            excluded because dequantize() produces a new temporary GPU allocation each
+            checkpoint, so a cached IPC handle from the previous step would be stale.
+
+            For the CPU shm path (include_dequantized=True): dequantized GPU tensors are
+            included — we copy values in from whatever GPU tensor the current step produces,
+            regardless of whether it was dequantized.
             """
             gpu_items, gpu_data = [], []
             uncached_items, uncached_data = [], []
 
             for item, data, was_dequantized in zip(items, resolved_data, dequantized_flags):
-                if (
-                    isinstance(data, torch.Tensor) and data.device.type == "cpu"
-                ) or was_dequantized:
+                if isinstance(data, torch.Tensor) and data.device.type == "cpu":
+                    uncached_items.append(item)
+                    uncached_data.append(data)
+                elif was_dequantized and not include_dequantized:
                     uncached_items.append(item)
                     uncached_data.append(data)
                 else:
@@ -316,7 +342,8 @@ class FileSystemWriterAsync(FileSystemWriter):
             return (gpu_items, gpu_data), (uncached_items, uncached_data)
 
         # Handle GPU tensor caching (only GPU tensors can benefit from IPC or shm)
-        # Uncached tensors (CPU or dequantized) are always resolved fresh
+        # Uncached tensors: CPU tensors always; dequantized GPU tensors only on GPU IPC path
+        # (on the CPU shm path, dequantized GPU tensors ARE included)
         if self.use_cached_data_structure and tensor_items:
             key = _compute_data_structure_key_from_plan(tensor_items)
             cache_exists = key in FileSystemWriterAsync._cached_identifiers
@@ -324,78 +351,69 @@ class FileSystemWriterAsync(FileSystemWriter):
             # Always resolve tensors to separate uncached tensors (which can't be cached)
             resolved_tensors, dequantized_flags = resolve_data(tensor_items)
             (gpu_items, gpu_data), (uncached_items, uncached_data) = separate_cacheable(
-                tensor_items, resolved_tensors, dequantized_flags
+                tensor_items,
+                resolved_tensors,
+                dequantized_flags,
+                include_dequantized=self.use_cpu_shm_for_gpu_tensors,
             )
 
             if gpu_items and self.use_cpu_shm_for_gpu_tensors:
                 # --- CPU shared-memory path ---
-                # D2H is done here (training side) into a SINGLE flat shared-memory buffer
+                # D2H is done here (training side) into per-tensor CPU shared-memory tensors
                 # so the worker subprocess never needs CUDA IPC / fabric handles.
-                # Using one flat buffer instead of one share_memory_() per tensor avoids
-                # exhausting the kernel's POSIX shm segment limit.
+                # Each tensor gets its own independent share_memory_() allocation.
                 if key in FileSystemWriterAsync._shm_tensor_cache:
-                    # Reuse existing flat buffer; overwrite views with fresh GPU values.
-                    _, existing_shm, _ = FileSystemWriterAsync._shm_tensor_cache[key]
-                    for shm_t, gpu_t in zip(existing_shm, gpu_data):
+                    # Reuse existing shm tensors.  The caller (Megatron) must have called
+                    # wait_for_async_call() before this, which drains comp_q and guarantees
+                    # the previous write has finished reading from these buffers.
+                    _, existing_shm = FileSystemWriterAsync._shm_tensor_cache[key]
+                    for i, (shm_t, gpu_t) in enumerate(zip(existing_shm, gpu_data)):
                         shm_t.copy_(gpu_t, non_blocking=True)
+                        # Periodically sync to avoid exhausting CUDA's pageable staging
+                        # pages (shm tensors are not pinned so copy_ is not a pinned DMA).
+                        if (i + 1) % 8 == 0:
+                            torch.cuda.synchronize()
+                    torch.cuda.synchronize()
                     logger.debug(
-                        f"Overwrote {len(existing_shm)} shm tensors with fresh GPU values "
+                        f"D2H'd {len(existing_shm)} shm tensors into reused allocations "
                         f"(key={key})"
                     )
                 else:
-                    # First checkpoint: build aligned layout, allocate one flat shm buffer,
-                    # and create per-tensor views into it.
-                    #
-                    # Each tensor's offset is aligned to max(element_size, 16) bytes so that
-                    # flat_buf[offset:offset+nbytes].view(dtype) is always valid.
-                    _ALIGN = 16
-
-                    def _aligned_up(off, elem_size):
-                        a = max(elem_size, _ALIGN)
-                        return (off + a - 1) & ~(a - 1)
-
-                    tensor_layout = []  # [(shape, dtype, offset, numel)]
-                    cur = 0
-                    for t in gpu_data:
-                        tc = t.contiguous()
-                        off = _aligned_up(cur, tc.element_size())
-                        nb = tc.numel() * tc.element_size()
-                        tensor_layout.append((tc.shape, tc.dtype, off, tc.numel()))
-                        cur = off + nb
-
-                    flat_buf = torch.empty(cur, dtype=torch.uint8).share_memory_()
-
+                    # First checkpoint: allocate one independent shm tensor per GPU tensor
+                    # and D2H-copy the current values in.
                     shm_tensors = []
-                    for t, (shape, dtype, off, numel) in zip(gpu_data, tensor_layout):
-                        nb = numel * t.element_size()
-                        view = flat_buf[off : off + nb].view(dtype).reshape(shape)
-                        view.copy_(t, non_blocking=True)
-                        shm_tensors.append(view)
+                    total_bytes = 0
+                    for i, t in enumerate(gpu_data):
+                        tc = t.contiguous()
+                        shm_t = torch.empty(tc.shape, dtype=tc.dtype).share_memory_()
+                        shm_t.copy_(tc, non_blocking=True)
+                        shm_tensors.append(shm_t)
+                        total_bytes += shm_t.nbytes
+                        # Periodically sync to avoid exhausting CUDA's pageable staging pages
+                        if (i + 1) % 8 == 0:
+                            torch.cuda.synchronize()
 
-                    FileSystemWriterAsync._shm_tensor_cache[key] = (
-                        gpu_items,
-                        shm_tensors,
-                        flat_buf,   # keep flat_buf alive
-                    )
+                    FileSystemWriterAsync._shm_tensor_cache[key] = (gpu_items, shm_tensors)
                     logger.debug(
-                        f"Allocated 1 flat shm buffer ({cur} bytes) for "
-                        f"{len(shm_tensors)} tensors and D2H'd GPU values (key={key})"
+                        f"Allocated {len(shm_tensors)} shm tensors ({total_bytes} bytes total) "
+                        f"and D2H'd GPU values (key={key})"
                     )
 
-                # Ensure D2H is complete before the worker process can read the shm tensors.
-                torch.cuda.synchronize()
-
-                _, shm_tensors, _ = FileSystemWriterAsync._shm_tensor_cache[key]
+                _, shm_tensors = FileSystemWriterAsync._shm_tensor_cache[key]
                 self.consistent_data_identifier = ConsistentDataIdentifier(key)
                 if cache_exists:
-                    # Worker already has shm tensor references cached; just update values.
+                    # Subsequent checkpoint: D2H already done into reused shm buffer above.
+                    # Worker already has the shm tensor references cached; send None to
+                    # signal it should reuse them (values are fresh after the D2H above).
                     self.cached_tensor_data = None
                     logger.debug(
                         f"Reusing worker-cached shm tensors (key={key}), "
                         f"{len(uncached_items)} uncached tensors passed fresh"
                     )
                 else:
-                    # First checkpoint: send shm tensors to worker so it can cache them.
+                    # First checkpoint: D2H already done above, synchronize now.
+                    torch.cuda.synchronize()
+                    # Send shm tensors to worker so it can cache them.
                     self.cached_tensor_data = (gpu_items, shm_tensors)
                     FileSystemWriterAsync._cached_identifiers.add(key)
                     logger.debug(
@@ -538,9 +556,21 @@ class FileSystemWriterAsync(FileSystemWriter):
                 self.write_preloaded_data_multithread, transform_list, self.use_msc, open_file
             )
 
+        inner_preload_fn = partial(
+            self.preload_tensors, (str(self.checkpoint_dir), data_to_pass), True
+        )
+
+        if self.use_cpu_shm_for_gpu_tensors:
+            # Shm path: wrap with write_fence marker so AsyncCallsQueue.schedule_async_request
+            # calls maybe_finalize_async_calls(blocking=True) before dispatching, ensuring any
+            # previous write completes before training overwrites the shm tensors with new values.
+            preload_fn = _FencedPreloadFn(inner_preload_fn)
+        else:
+            preload_fn = inner_preload_fn
+
         return (
             write_func,
-            partial(self.preload_tensors, (str(self.checkpoint_dir), data_to_pass), True),
+            preload_fn,
             [torch.distributed.get_rank(), None, self.results_queue],
         )
 
@@ -593,7 +623,7 @@ class FileSystemWriterAsync(FileSystemWriter):
 
         if isinstance(identifier, ConsistentDataIdentifier):
             # Caching enabled: get or cache GPU tensor data in the worker process
-            # Uncached tensors (CPU or dequantized) are NOT cached (treated like ByteIO)
+            # Uncached tensors (CPU tensors, or dequantized on the GPU IPC path) are NOT cached
             key = identifier.key
             if cached_tensor_data is not None:
                 PersistentAsyncCaller._worker_data_cache[key] = cached_tensor_data
@@ -651,18 +681,23 @@ class FileSystemWriterAsync(FileSystemWriter):
                         )
                     )
 
-        # Now move GPU tensors to CPU (CPU tensors are already on CPU)
+        # Move GPU tensors to CPU.  For the shm path, tensors are already on CPU so the
+        # .to("cpu") branch is skipped entirely — no D2H, no sync needed.
         result: List[WriteBucket] = []
+        needs_sync = False
         for bucket in write_buckets:
             bucket_path, bucket_key, bucket_data = bucket
             bytes_data, tensor_data = bucket_data
             tensor_list = []
             for item, tensor in tensor_data:
-                # Move to CPU if needed (no-op if already on CPU)
-                tensor_list.append((item, tensor.to("cpu", non_blocking=non_blocking)))
+                if tensor.is_cuda:
+                    needs_sync = True
+                    tensor_list.append((item, tensor.to("cpu", non_blocking=non_blocking)))
+                else:
+                    tensor_list.append((item, tensor))
             result.append((bucket_path, bucket_key, (bytes_data, tensor_list)))
 
-        if non_blocking:
+        if non_blocking and needs_sync:
             torch.cuda.synchronize()
 
         end = time()

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -209,12 +209,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         self.has_data_to_write: bool = False
         self.results_queue: Optional[mp.Queue] = None
         self.separation_hint = separation_hint
-        # Enable cached data structure via constructor arg or env var.
-        # NVRX_CKPT_USE_CACHED_STRUCTURE=1 lets callers (e.g. Megatron) opt in without
-        # changing their FileSystemWriterAsync construction call.
-        self.use_cached_data_structure = use_cached_data_structure or (
-            os.environ.get("NVRX_CKPT_USE_CACHED_STRUCTURE", "0") == "1"
-        )
+        self.use_cached_data_structure = use_cached_data_structure
         self.consistent_data_identifier: Optional[ConsistentDataIdentifier] = None
         # When this flag is True, the FileWriter can create multiple child processes
         # to parallelize File IO in the background async checkpoint process.
@@ -225,22 +220,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         # Use CPU shared-memory tensors instead of GPU IPC fabric handles.
         # Avoids cuMemImportFromShareableHandle on MNNVL systems where NVLink fabric
         # resources are exhausted by the training ranks.
-        # Also controllable via NVRX_CKPT_USE_CPU_SHM=1 (no Megatron changes needed).
-        self.use_cpu_shm_for_gpu_tensors = use_cpu_shm_for_gpu_tensors or (
-            os.environ.get("NVRX_CKPT_USE_CPU_SHM", "0") == "1"
-        )
-        # shm path requires the cached-data-structure code path — enable it automatically
-        # so callers that don't explicitly set use_cached_data_structure still benefit.
-        if self.use_cpu_shm_for_gpu_tensors and not self.use_cached_data_structure:
-            logger.info(
-                "NVRX_CKPT_USE_CPU_SHM is set: enabling use_cached_data_structure automatically"
-            )
-            self.use_cached_data_structure = True
-        if self.use_cached_data_structure or self.use_cpu_shm_for_gpu_tensors:
-            logger.info(
-                f"FileSystemWriterAsync: use_cached_data_structure={self.use_cached_data_structure}, "
-                f"use_cpu_shm_for_gpu_tensors={self.use_cpu_shm_for_gpu_tensors}"
-            )
+        self.use_cpu_shm_for_gpu_tensors = use_cpu_shm_for_gpu_tensors
 
     def prepare_write_data(self, plan: SavePlan, planner: SavePlanner) -> None:
         """
@@ -344,7 +324,7 @@ class FileSystemWriterAsync(FileSystemWriter):
         # Handle GPU tensor caching (only GPU tensors can benefit from IPC or shm)
         # Uncached tensors: CPU tensors always; dequantized GPU tensors only on GPU IPC path
         # (on the CPU shm path, dequantized GPU tensors ARE included)
-        if self.use_cached_data_structure and tensor_items:
+        if (self.use_cached_data_structure or self.use_cpu_shm_for_gpu_tensors) and tensor_items:
             key = _compute_data_structure_key_from_plan(tensor_items)
             cache_exists = key in FileSystemWriterAsync._cached_identifiers
 

--- a/tests/checkpointing/unit/test_async_writer.py
+++ b/tests/checkpointing/unit/test_async_writer.py
@@ -80,6 +80,7 @@ class TestAsyncSave:
         open_file=open,
         is_multiproc_io=False,
         use_cached_data_structure=False,
+        use_cpu_shm_for_gpu_tensors=False,
     ):
         """Performs an asynchronous model checkpoint save."""
         writer = FileSystemWriterAsync(
@@ -88,6 +89,7 @@ class TestAsyncSave:
             open_file=open_file,
             is_multiproc_io=is_multiproc_io,
             use_cached_data_structure=use_cached_data_structure,
+            use_cpu_shm_for_gpu_tensors=use_cpu_shm_for_gpu_tensors,
         )
         coordinator_rank = 0
 
@@ -325,6 +327,58 @@ class TestAsyncSave:
         ), 'Cached data structure produced a state_dict that differs from the original'
 
         ckpt_dir.cleanup()
+        async_queue.close()
+
+    def test_cpu_shm_for_gpu_tensors(self, tmp_path_dist_ckpt):
+        """CPU shm path: D2H done in training process, worker streams from shm.
+
+        Runs 3 iterations with explicitly mutated state-dict values to verify:
+          - shm tensors are allocated on the first checkpoint
+          - shm allocations are reused (not re-allocated) on subsequent checkpoints
+          - each checkpoint saves the *current* values, not stale cached ones
+        """
+        Utils.initialize_distributed()
+
+        # Clear class-level caches to avoid cross-test contamination
+        FileSystemWriterAsync._cached_identifiers.clear()
+        FileSystemWriterAsync._shm_tensor_cache.clear()
+        async_queue = AsyncCallsQueue(persistent=True, is_daemon=True)
+
+        model = FSDP(Model((1024, 1024), 8))
+        planner = DefaultSavePlanner()
+
+        last_ckpt_dir = None
+        for i in range(3):
+            # Overwrite all parameter values with a known scalar so we can verify freshness.
+            state_dict = model.state_dict()
+            for v in state_dict.values():
+                if isinstance(v, torch.Tensor):
+                    v.fill_(float(i))
+
+            ckpt_dir = TempNamedDir(tmp_path_dist_ckpt / f'shm_ckpt_{i}', sync=True)
+            self.async_save_checkpoint(
+                ckpt_dir,
+                state_dict,
+                planner,
+                async_queue,
+                use_cached_data_structure=True,
+                use_cpu_shm_for_gpu_tensors=True,
+            )
+            async_queue.maybe_finalize_async_calls(blocking=True, no_dist=False)
+            if last_ckpt_dir is not None:
+                last_ckpt_dir.cleanup()
+            last_ckpt_dir = ckpt_dir
+
+        # The last checkpoint was saved with all tensors == 2.0.
+        # Load and verify — stale-cache bug would produce 0.0 or 1.0 here.
+        loaded = self.load_checkpoint(last_ckpt_dir, deepcopy(state_dict))
+        for key, tensor in loaded.items():
+            assert torch.all(tensor.cpu() == 2.0), (
+                f"Key '{key}': expected 2.0 (fresh values from iteration 2), "
+                f"got unique values {tensor.cpu().unique().tolist()}"
+            )
+
+        last_ckpt_dir.cleanup()
         async_queue.close()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
New `use_cpu_shm_for_gpu_tensors` option
performs D2H transfers in the training process into buffered shared memory cpu tensors
so the async worker never needs GPU IPC / NVLink fabric handles.
Avoids `cuMemImportFromShareableHandle` failures on MNNVL systems where fabric
resources are exhausted by training ranks.

- Stage the set of shared memory tensors for the model in both the trainer and async process
- Adds `_worker_restart_callbacks` to `PersistentAsyncCaller` so that
  `FileSystemWriterAsync.cleanup_shm_tensor_cache` is invoked whenever the
  worker is restarted, preventing stale-cache misses on the fresh worker.
- Test: three-iteration roundtrip that verifies shm allocations are reused and
  each checkpoint captures the current tensor values (not stale cached ones).