### PR TITLE
Fix: out-of-section timeout never fires for section-less workloads

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/rank_monitor_server.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/rank_monitor_server.py
@@ -526,7 +526,8 @@ class RankMonitorServer:
                 is_elapsed = True
         if not self.open_sections:
             if (
-                "warmup" not in self.cfg.rank_section_timeouts
+                self.cfg.rank_section_timeouts
+                and "warmup" not in self.cfg.rank_section_timeouts
                 and not self._step_section_seen_this_cycle
             ):
                 return False


### PR DESCRIPTION
Add self.cfg.rank_section_timeouts check. Activate the warmup guard when section timeouts are actually configured.