### PR TITLE
Another iteration to simplify the rendezvous protocol.

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/cycle_info_writer.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cycle_info_writer.py
@@ -87,6 +87,7 @@ class CycleInfoWriter:
         cycle_log_file: str,
         active_nodes: str,
         standby_nodes: str = "",
+        active_ranks: str = "",
     ) -> None:
         """Enqueue writing the initial cycle info file and updating the .current symlink."""
         if self._shutdown_requested:
@@ -101,6 +102,7 @@ class CycleInfoWriter:
             "cycle_log_file": cycle_log_file,
             "active_nodes": active_nodes,
             "standby_nodes": standby_nodes,
+            "active_ranks": active_ranks,
         }
         self._current_cycle = (job_id, attempt_index, cycle_number)
         self._queue.put(_CycleInfoTask(op=_CycleInfoTask.CREATE, payload=payload))

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -57,28 +57,32 @@ from ..shared_utils.health_check import (
     NicLinkStateHealthCheck,
     StoragePathHealthCheck,
 )
-from ..shared_utils.profiling import ProfilingEvent, record_profiling_event, set_profiling_cycle
+from ..shared_utils.profiling import (
+    ProfilingEvent,
+    get_profiling_cycle,
+    record_profiling_event,
+    set_profiling_cycle,
+)
 from .data import WorkloadAction
 from .ipc_connector import IpcConnector
 from .launcher import FT_LAUNCHER_IPC_SOCKET, UnhealthyNodeException, get_node_health_check
-from .utils import get_infrastructure_rank, is_slurm_job_array
 
-# Conditionally import health check injector for testing/debugging
-# This only activates if NVRX_INJECT_GPU_FAILURE environment variable is set
+# Conditionally import failure injector (only active when NVRX_INJECT_GPU_FAILURE is set)
 if os.environ.get("NVRX_INJECT_GPU_FAILURE"):
     from ..testing_utils import health_check_injector
+from .utils import get_infrastructure_rank, is_slurm_job_array, slurm_sort_addrs
 
 log = logging.getLogger(LogConfig.name)
 
-# Sentinel domain_id written to a participant's slot when they withdraw. Any use of
+# Sentinel domain_id written to a participant's slot when they leave. Any use of
 # participant data (_can_meet_segment_constraint, _assign_group_ranks) must exclude
 # participants with this domain_id.
-WITHDRAWN_DOMAIN_ID = "__withdrawn__"
+WITHDRAWN = "__withdrawn__"
 
 # Module-level reference to the barrier state that has joined (Step 1) but not yet
 # completed rendezvous. Set in perform_rendezvous after add(1), cleared in finally.
-# The signal handler sets _withdraw_on_unwind on this state so the finally can
-# decrement arrived_count (no store I/O in the handler).
+# The signal handler sets _leave_on_unwind on this state so the finally can
+# decrement join_count (no store I/O in the handler).
 _current_joined_state: Optional[Any] = None
 
 
@@ -86,7 +90,7 @@ def _rdzv_signal_exception_handler(sig: int, frame: Optional[FrameType]) -> None
     del frame
     global _current_joined_state
     if _current_joined_state is not None:
-        _current_joined_state._withdraw_on_unwind = True
+        _current_joined_state._leave_on_unwind = True
     raise SignalException(f"Received signal {sig} during rendezvous", signal.Signals(sig))
 
 
@@ -365,7 +369,7 @@ def _parse_domain_id_from_nvidia_smi() -> str:
                 "ClusterUUID is only available on systems with NVSwitch/NVLink fabrics (e.g., DGX, HGX systems)."
             )
 
-        log.debug(f"Retrieved domain ID from nvidia-smi ClusterUUID: {cluster_uuid}")
+        log.debug(f"domain_id={cluster_uuid} (nvidia-smi ClusterUUID)")
         return cluster_uuid
 
     except FileNotFoundError:
@@ -435,17 +439,25 @@ class _RendezvousBarrierState:
         self._rendezvous_start_time = None
         self._last_stale_check_time = 0.0  # Track last stale round check time for rate limiting
 
-        # When True, signal was received after we joined; finally will call _withdraw_from_rendezvous
-        self._withdraw_on_unwind = False
-        # Guard so we only decrement arrived_count at most once
-        self._has_withdrawn = False
+        # When True, signal was received after we joined; finally will call _leave_rendezvous
+        self._leave_on_unwind = False
+        # Guard so we only leave the rendezvous at most once per round
+        self._has_left = False
+        # When True, the round is closed (rank assigned); no more slot writes allowed.
+        # Slot keys are reused across rounds, so a leave after round closure would
+        # corrupt the next round's slot data.
+        self._round_closed = False
 
-        # Track rendezvous round number
-        # This is managed by the state since it coordinates the rendezvous
-        self._rendezvous_round = 0
-        # Last active/standby participant addrs (set by store host in assign_group_ranks for cycle info)
-        self._last_active_participant_addrs: Optional[List[str]] = None
-        self._last_standby_participant_addrs: Optional[List[str]] = None
+        # Track rendezvous round number. Each round corresponds to one rendezvous barrier
+        # invocation; keys are namespaced by round number to prevent cross-round contamination.
+        self._round = 0
+        # Current slot in the join order (1-based). Set in Step 1 of perform_rendezvous.
+        self._slot: Optional[int] = None
+        # Active/standby node addrs (set by store host in assign_group_ranks for cycle info)
+        self._active_node_addrs: Optional[List[str]] = None
+        self._standby_node_addrs: Optional[List[str]] = None
+        # Group ranks of active nodes, parallel to _active_node_addrs (same slot order)
+        self._active_ranks: Optional[List[int]] = None
 
         # Reference to agent (set via set_agent() method in handler)
         # Will be set by handler via set_agent() method
@@ -457,24 +469,40 @@ class _RendezvousBarrierState:
 
         # Key prefixes for the barrier
         self.prefix = f"ft_rendezvous_barrier:{run_id}"
-        self.arrived_count_key = f"{self.prefix}:arrived_count"
-        self.withdrawn_count_key = f"{self.prefix}:withdrawn_count"
-        self.last_participant_arrived_key = f"{self.prefix}:last_participant_arrived"
-        self.ack_count_key = f"{self.prefix}:ack_count"
-        # Permanent close: once set, no further rendezvous rounds (graceful exit).
-        self.permanent_close_key = f"{self.prefix}:closed"
+        # Permanent shutdown: once set, no further rendezvous rounds (graceful exit).
+        self.shutdown_key = f"{self.prefix}:shutdown"
+        # Job-level unhealthy counter; persists across all rounds.
         self.unhealthy_count_key = f"{self.prefix}:unhealthy_count"
-        self.peer_aborted_count_key = f"{self.prefix}:peer_aborted_count"
-        self.global_cycle_key = f"{self.prefix}:global_cycle"
 
-        # Per-round open/close: last_participant_arrived_key value indicates whether
-        # the current round is accepting joiners or training is in progress.
-        # Initialize last_participant_arrived_key to 0 (open) if it doesn't exist.
-        # This key is always present and serves as the open/close indicator:
-        #   0 = rendezvous is OPEN (accepting new participants)
-        #   1 = rendezvous is CLOSED for this round (training in progress, hot spares wait)
-        if not self.store.check([self.last_participant_arrived_key]):
-            self.store.set(self.last_participant_arrived_key, "0".encode('utf-8'))
+        # Per-round open/close indicator. round_done_key value:
+        #   0 = round is OPEN (accepting new participants)
+        #   1 = round is CLOSED (ranks assigned, training in progress)
+        # Initialize round_done_0 to 0 (open) if this is the first time any node connects.
+        if not self.store.check([self.round_done_key]):
+            self.store.set(self.round_done_key, "0".encode('utf-8'))
+
+    @property
+    def join_count_key(self) -> str:
+        """TCPStore key for the number of participants that have joined this round."""
+        return f"{self.prefix}:join_count_{self._round}"
+
+    @property
+    def leave_count_key(self) -> str:
+        """TCPStore key for the number of participants that have left this round."""
+        return f"{self.prefix}:leave_count_{self._round}"
+
+    @property
+    def round_done_key(self) -> str:
+        """TCPStore key for the open/close indicator of this round.
+
+        Value semantics:
+          0 = round is OPEN (accepting new participants)
+          1 = round is CLOSED (all ranks assigned, training in progress)
+
+        Writing "1" only happens AFTER all rank keys are written by the store host,
+        so any participant that sees "1" can immediately read its rank without racing.
+        """
+        return f"{self.prefix}:round_done_{self._round}"
 
     def _can_meet_segment_constraint(
         self,
@@ -505,7 +533,8 @@ class _RendezvousBarrierState:
         # Treat segment=None as segment=1
         segment = self.segment if self.segment is not None else 1
 
-        # Group by domain and count available complete segments
+        # Group by domain and count available complete segments.
+        # Participants with WITHDRAWN domain_id have already been excluded by the caller.
         if self.segment is not None:
             domain_to_count: Dict[str, int] = defaultdict(int)
             for node_desc, infra_rank, domain_id in participants:
@@ -630,9 +659,6 @@ class _RendezvousBarrierState:
             # Assign active ranks
             for node_desc, infra_rank in domain_participants[:nodes_to_take]:
                 result[node_desc] = active_rank
-                log.debug(
-                    f"Rank: {node_desc.addr} (infra={infra_rank}) -> group_rank={active_rank} (active)"
-                )
                 active_rank += 1
 
             active_segments += segments_to_take
@@ -641,18 +667,17 @@ class _RendezvousBarrierState:
             for node_desc, infra_rank in domain_participants[nodes_to_take:]:
                 result[node_desc] = standby_rank
                 standby_infra_ranks.append(infra_rank)  # Collect standby infra_rank
-                log.debug(
-                    f"Rank: {node_desc.addr} (infra={infra_rank}) -> group_rank={standby_rank} (standby)"
-                )
                 standby_rank += 1
 
             if nodes_to_take > 0:
                 log.debug(
-                    f"Domain {domain_id}: {segments_to_take} segments ({nodes_to_take} nodes) active, "
+                    f"Domain {domain_id[:8]}: {segments_to_take} segs ({nodes_to_take} nodes) active, "
                     f"{len(domain_participants) - nodes_to_take} standby"
                 )
             else:
-                log.debug(f"Domain {domain_id}: all {len(domain_participants)} nodes to standby")
+                log.debug(
+                    f"Domain {domain_id[:8]}: all {len(domain_participants)} nodes to standby"
+                )
 
         # Validate we have enough active segments
         if active_segments < num_segments:
@@ -669,7 +694,9 @@ class _RendezvousBarrierState:
             infra_range_str = format_rank_set_verbose(standby_infra_ranks).strip('{}')
             standby_info = f" and {standby_rank - world_size} standby ranks [{infra_range_str}]"
 
-        log.info(f"Assigned segments(segment={segment}): {active_segments} segments{standby_info}")
+        log.info(
+            f"Rank assignment (seg_size={segment}): {active_segments} active segs{standby_info}"
+        )
 
         return result
 
@@ -688,73 +715,61 @@ class _RendezvousBarrierState:
         unhealthy_count_bytes = self.store.get(self.unhealthy_count_key)
         return int(unhealthy_count_bytes.decode('utf-8'))
 
-    def _increment_peer_aborted_count(self) -> int:
-        """Increment the peer aborted count to signal a restart.
+    def is_next_round_open(self) -> bool:
+        """Return True if the next rendezvous round has been opened by any node in the cluster.
 
-        This is called by a launcher when it detects local worker failure and decides
-        to restart, notifying other healthy nodes to restart as well for faster
-        failure propagation.
-
-        Returns:
-            The new peer aborted count after incrementing
+        open_rendezvous() sets round_done_{N+1}=0 as the canonical signal that a failure
+        was detected and a new round is ready for joining.  Healthy nodes in the monitor
+        loop can poll this instead of a separate peer_restart_count key.
         """
-        new_count = self.store.add(self.peer_aborted_count_key, 1)
-        return new_count
+        next_key = f"{self.prefix}:round_done_{self._round + 1}"
+        return self.store.check([next_key])
 
-    def _get_peer_aborted_count(self) -> int:
-        """Get the current peer aborted count.
+    def _get_leave_count(self) -> int:
+        """Get the number of participants that left (withdrew) this rendezvous round.
 
-        This count tracks how many peers have detected local worker failures and
-        decided to restart, enabling faster failure propagation across the cluster.
-
-        Returns:
-            The number of peers that have aborted so far, or 0 if the key doesn't exist
+        Used together with join_count to compute active participant count.
+        Returns 0 if the key does not exist (no leaves yet).
         """
-        if not self.store.check([self.peer_aborted_count_key]):
+        if not self.store.check([self.leave_count_key]):
             return 0
+        leave_count_bytes = self.store.get(self.leave_count_key)
+        return int(leave_count_bytes.decode('utf-8'))
 
-        peer_aborted_count_bytes = self.store.get(self.peer_aborted_count_key)
-        return int(peer_aborted_count_bytes.decode('utf-8'))
+    def _sync_from_per_round_state(self) -> bool:
+        """Sync local _round by scanning round_done_N keys forward from current round.
 
-    def _get_withdrawn_count(self) -> int:
-        """Get the number of participants that withdrew this rendezvous cycle.
+        Scans `round_done_{N}` keys starting at the current `_round`. For each round
+        whose key exists and has value 1 (closed), advances N. Stops when the key does
+        not exist (round not yet opened) or has value 0 (round in progress).
 
-        Used together with arrived_count to compute active participant count.
-        Returns 0 if the key does not exist (no withdrawals yet).
-        """
-        if not self.store.check([self.withdrawn_count_key]):
-            return 0
-        withdrawn_count_bytes = self.store.get(self.withdrawn_count_key)
-        return int(withdrawn_count_bytes.decode('utf-8'))
-
-    def _sync_from_global_cycle(self) -> bool:
-        """Sync local _rendezvous_round from global_cycle_key if stale.
-
-        This method checks if the local _rendezvous_round is behind the global
-        cycle stored in the store and syncs it if needed.
+        This replaces the old `global_cycle_key` approach: instead of a single
+        monotonically-increasing counter written by the store host, replacement nodes
+        can reconstruct the current round by scanning per-round keys. The scan costs
+        O(restarts) round trips but is only performed during Step 0 rate-limited checks.
 
         Returns:
-            True if round was updated (was stale), False if already current
+            True if _round was advanced (was behind), False if already current
         """
-        if not self.store.check([self.global_cycle_key]):
-            return False
+        N = self._round
+        while True:
+            key = f"{self.prefix}:round_done_{N}"
+            if not self.store.check([key]):
+                break  # Round N not opened yet
+            val = int(self.store.get(key).decode('utf-8'))
+            if val == 1:
+                N += 1  # Round N completed, check N+1
+            else:
+                break  # Round N is open or in progress (val==0)
 
-        stored_cycle_bytes = self.store.get(self.global_cycle_key)
-        stored_cycle = int(stored_cycle_bytes.decode('utf-8'))
-
-        if stored_cycle > self._rendezvous_round:
-            old_round = self._rendezvous_round
-            self._rendezvous_round = stored_cycle
-            set_profiling_cycle(self._rendezvous_round)
-
+        if N > self._round:
+            old_round = self._round
+            self._round = N
+            set_profiling_cycle(N)
             # Sync agent's progress tracker if agent reference is available
             if self._agent is not None:
-                self._agent._progress_tracker.sync_cycle_number(self._rendezvous_round)
-
-            log.debug(
-                f"Synced rendezvous round from {old_round} to {self._rendezvous_round} "
-                f"(global_cycle_key)"
-            )
+                self._agent._progress_tracker.sync_cycle_number(N)
+            log.debug(f"Synced round {old_round} -> {N} (per-round scan)")
             return True
 
         return False
@@ -772,17 +787,17 @@ class _RendezvousBarrierState:
         return max(1.0, min(segment_check_interval, max(1.0, scaled_interval)))
 
     def _check_timeout_and_closure(self, node_desc: _NodeDesc) -> None:
-        """Check for early closure and timeout.
+        """Check for shutdown and timeout.
 
         Args:
             node_desc: Node descriptor for logging
 
         Raises:
-            RendezvousClosedError: If rendezvous was permanently closed
+            RendezvousClosedError: If rendezvous was permanently shut down
             RendezvousTimeoutError: If rendezvous has timed out
         """
-        # Check for permanent close
-        if self.is_permanently_closed():
+        # Check for permanent shutdown
+        if self.is_shutdown():
             msg = f"The node '{node_desc}' detected that rendezvous was permanently closed"
             log.info(msg)
             raise RendezvousClosedError(msg)
@@ -797,107 +812,310 @@ class _RendezvousBarrierState:
             log.error(msg)
             raise RendezvousTimeoutError(msg)
 
-    def _withdraw_from_rendezvous(self) -> None:
-        """Mark this participant as withdrawn so the store host can complete Step 3b.
+    def _leave_rendezvous(self) -> None:
+        """Mark this participant as having left so the store host can complete rendezvous.
 
-        Increments withdrawn_count_key and overwrites this participant's slot with
-        invalid domain_id (WITHDRAWN_DOMAIN_ID). Does not decrement arrived_count_key;
-        slot space stays monotonic. Ensures at most one withdraw per rendezvous round.
+        Increments leave_count_key and overwrites this participant's slot with
+        the WITHDRAWN sentinel domain_id. Does not decrement join_count_key;
+        slot space stays monotonic. Idempotent: at most one leave per round.
+
+        Note: This must not be called after _round_closed=True, because slot keys are
+        reused across rounds and writing WITHDRAWN would corrupt the next round's data.
         """
-        if self._has_withdrawn:
+        if self._has_left:
             return
-        self._has_withdrawn = True
+        self._has_left = True
         try:
-            self.store.add(self.withdrawn_count_key, 1)
+            self.store.add(self.leave_count_key, 1)
             # Overwrite our slot so consumers (segment constraint, rank assignment)
-            # exclude us by filtering on invalid domain_id
-            arrived_key = f"{self.prefix}:arrived_{self._arrived_count}"
-            withdrawn_data = RendezvousParticipantInfo.pack(
+            # exclude us by filtering on WITHDRAWN domain_id
+            slot_key = f"{self.prefix}:slot_{self._slot}"
+            leave_data = RendezvousParticipantInfo.pack(
                 _NodeDesc("", 0, 0),
                 -1,
-                WITHDRAWN_DOMAIN_ID,
-                self._rendezvous_round,
+                WITHDRAWN,
+                self._round,
             )
-            self.store.set(arrived_key, withdrawn_data.encode('utf-8'))
+            self.store.set(slot_key, leave_data.encode('utf-8'))
             log.debug(
-                f"Withdrew from rendezvous (incremented {self.withdrawn_count_key}, "
-                f"marked slot {self._arrived_count} as withdrawn)"
+                f"Left rendezvous (incremented {self.leave_count_key}, "
+                f"marked slot {self._slot} with WITHDRAWN)"
             )
         except Exception as e:
-            log.warning("Failed to withdraw from rendezvous: %s", e)
+            log.warning("Failed to leave rendezvous: %s", e)
 
     def _wait_for_rendezvous_open(self, node_desc: _NodeDesc) -> None:
-        """Step 0: Wait if rendezvous is closed. Hot spares and late arrivals wait here.
+        """Step 0: Wait until the current round is open. Hot spares and late arrivals wait here.
 
         This prevents hot spares and late-arriving nodes from disrupting ongoing training.
-        The rendezvous is considered:
+        A round is considered:
+        - NOT YET OPENED: round_done_key does not exist — wait for open_rendezvous() to call
         - OPEN (value=0): Accepting new participants for a new rendezvous round
-        - CLOSED (value=1): Training in progress, wait for next round
+        - CLOSED (value=1): Training in progress — advance round via _sync_from_per_round_state()
+          and wait for the next open round
 
-        Also checks for stale rendezvous rounds to allow hot spares to sync up when
-        other nodes have moved to a newer round.
+        For rounds N > 0, round_done_key is only created by open_rendezvous(), which is called
+        when a launcher detects a failure. For round 0, the key is initialized in __init__.
 
         Args:
             node_desc: Node descriptor for logging
 
         Raises:
-            RendezvousGracefulExitError: If rendezvous is permanently closed (graceful exit; launcher exits 0)
+            RendezvousGracefulExitError: If rendezvous is permanently shut down (graceful exit 0)
 
         Note:
-            Stale round detection and sync happen automatically during the wait loop.
-
             This wait does NOT timeout unless the rendezvous is permanently closed.
-            All waiting nodes (hot spares, late arrivals) wait passively until an
+            Waiting nodes (hot spares, late arrivals) wait passively until an
             active participant detects a failure and opens the next round.
         """
         wait_count = 0
         logged_waiting = False  # Track if we've logged the waiting message
 
         while True:
-            # Check for permanent close (no further rounds)
-            if self.is_permanently_closed():
+            # Check for permanent shutdown (no further rounds)
+            if self.is_shutdown():
                 msg = f"The node '{node_desc}' detected that rendezvous was permanently closed"
                 log.info(msg)
                 raise RendezvousGracefulExitError(msg)
 
-            # Check for stale rendezvous round (rate-limited to avoid thundering herd on TCPStore)
-            # This allows hot spares waiting at Step 0 to detect when other nodes have moved
-            # to a newer round and sync up. We only check this at Step 0 to avoid double-joining
-            # when a node is already participating in a rendezvous.
-            current_time = time.monotonic()
-            if current_time - self._last_stale_check_time >= self.stale_check_interval:
-                self._last_stale_check_time = current_time
-                if self._sync_from_global_cycle():
-                    # Synced to newer round, continue waiting
-                    continue
+            # Check if round_done_key exists for the current round.
+            # For round 0 it always exists (initialized in __init__). For round N > 0 it is
+            # created by open_rendezvous() when a launcher detects a failure.
+            key = self.round_done_key
+            if not self.store.check([key]):
+                # Round not yet opened; wait for open_rendezvous()
+                wait_count += 1
+                time.sleep(1.0)
+                continue
 
-            # Read the open/close indicator
-            # The key is always present (initialized in __init__)
-            value_bytes = self.store.get(self.last_participant_arrived_key)
-            value = int(value_bytes.decode('utf-8'))
+            value = int(self.store.get(key).decode('utf-8'))
 
             if value == 0:
-                # Rendezvous is open, can proceed
-                log.debug(
-                    f"[{node_desc}] [Step 0] Rendezvous is open (value=0), proceeding to join"
-                )
+                # Round is open — proceed to Step 1
+                log.debug(f"[{node_desc}] [Step 0] Round {self._round} is open, proceeding to join")
                 break
 
-            # value == 1: Rendezvous is closed (training in progress)
-            # Wait passively for an active participant to trigger the next round
+            # value == 1: Round is closed (training in progress).
+            # Rate-limited scan to detect if we're behind and need to advance _round.
             if not logged_waiting:
                 log.info(
-                    f"[{node_desc}] [Step 0] Rendezvous closed (training in progress), waiting..."
+                    f"[{node_desc}] [Step 0] Round {self._round} closed (training in progress), "
+                    f"waiting for next round..."
                 )
                 logged_waiting = True
             elif wait_count % 60 == 0:  # Log every 60 seconds
                 log.debug(
-                    f"[{node_desc}] [Step 0] Still waiting for rendezvous to open "
-                    f"(waited {wait_count} seconds)"
+                    f"[{node_desc}] [Step 0] Still waiting for next round to open "
+                    f"(round={self._round}, waited {wait_count} seconds)"
                 )
+
+            current_time = time.monotonic()
+            if current_time - self._last_stale_check_time >= self.stale_check_interval:
+                self._last_stale_check_time = current_time
+                if self._sync_from_per_round_state():
+                    # Synced to a newer round, reset logged_waiting flag for new round
+                    logged_waiting = False
 
             wait_count += 1
             time.sleep(1.0)  # Poll every 1 second
+
+    def _host_close_round(
+        self,
+        node_desc: _NodeDesc,
+        min_nodes: int,
+        max_nodes: int,
+        segment_check_interval: float,
+    ) -> None:
+        """Step 2 (store host only): Poll until segment constraint is met, assign ranks, close round.
+
+        Loops checking the current participant snapshot. When enough healthy nodes are present
+        and the segment constraint is satisfied, calls assign_group_ranks() and sets
+        round_done_key=1.  All rank keys are written BEFORE round_done_key=1 is set, so
+        any participant that sees round_done=1 in Step 3 can immediately read its rank.
+
+        Raises:
+            RendezvousClosedError: If shutdown is detected (too many unhealthy nodes).
+            RendezvousTimeoutError: If the rendezvous join timeout is exceeded.
+        """
+        last_segment_check_time = 0.0
+        effective_check_interval = self._compute_step2_poll_interval(
+            min_nodes, segment_check_interval
+        )
+        # Track how long a count mismatch has persisted so we can escalate to WARNING
+        # after a threshold and give actionable diagnostics before the join timeout fires.
+        mismatch_first_seen: Optional[float] = None
+
+        while True:
+            self._check_timeout_and_closure(node_desc)
+
+            # Early termination: if too many nodes are unhealthy it is mathematically
+            # impossible to complete with min_nodes active participants.
+            unhealthy_count = self._get_unhealthy_count()
+            if unhealthy_count > (max_nodes - min_nodes):
+                msg = (
+                    f"Rendezvous cannot complete: {unhealthy_count} unhealthy nodes detected, "
+                    f"max possible healthy nodes = {max_nodes - unhealthy_count} < {min_nodes} required. "
+                    f"Permanently closing rendezvous to terminate the job."
+                )
+                log.error(msg)
+                self.set_shutdown()
+                # Loop: _check_timeout_and_closure will raise RendezvousClosedError next iteration.
+                continue
+
+            current_joined = int(self.store.get(self.join_count_key).decode('utf-8'))
+            leave_count = self._get_leave_count()
+            active_count = current_joined - leave_count
+
+            # Only attempt snapshot + constraint check when enough nodes have joined.
+            if active_count < min_nodes:
+                time.sleep(0.1)
+                continue
+
+            current_time = time.monotonic()
+            if (current_time - last_segment_check_time) < effective_check_interval:
+                time.sleep(0.1)
+                continue
+            last_segment_check_time = current_time
+
+            # Fetch a full snapshot to avoid races with partially written slots.
+            fetch_start = time.monotonic()
+            all_participants = self.get_all_participants(
+                total_participants=current_joined,
+                expected_cycle_id=self._round,
+            )
+            fetch_elapsed = time.monotonic() - fetch_start
+
+            # Exclude left participants (WITHDRAWN domain_id) for constraint check.
+            active_participants = [p for p in all_participants if p[2] != WITHDRAWN]
+
+            # If snapshot count doesn't match counter, some slots are still being written
+            # (normal during slot write propagation) or a slot was permanently corrupted
+            # by a stale write from a previous round (bug scenario).  Either way, retry;
+            # _check_timeout_and_closure() is the hard backstop.  Escalate to WARNING
+            # after 30 s so a bug is diagnosable well before the join timeout fires.
+            if len(active_participants) != active_count:
+                now = time.monotonic()
+                if mismatch_first_seen is None:
+                    mismatch_first_seen = now
+                mismatch_duration = now - mismatch_first_seen
+                if mismatch_duration > 30.0:
+                    log.warning(
+                        f"[{node_desc}] [Step 2] Snapshot count mismatch has persisted "
+                        f"for {mismatch_duration:.0f}s "
+                        f"(active_snapshot={len(active_participants)}, "
+                        f"active_counter={active_count}, "
+                        f"joined={current_joined}, left={leave_count}, "
+                        f"round={self._round}). "
+                        f"Possible cause: a node incremented join_count but its slot "
+                        f"write was delayed or overwritten by a stale write from a "
+                        f"previous round. Will timeout after "
+                        f"{self.join_timeout_seconds}s total."
+                    )
+                else:
+                    log.debug(
+                        f"[{node_desc}] [Step 2] Full snapshot incomplete "
+                        f"(active_snapshot={len(active_participants)}, "
+                        f"active_counter={active_count}, "
+                        f"joined={current_joined}, left={leave_count}, "
+                        f"round={self._round}); retrying."
+                    )
+                continue
+
+            mismatch_first_seen = None  # resolved; reset for next occurrence
+
+            # Verify counters are still stable after the fetch before committing.
+            current_joined_after = int(self.store.get(self.join_count_key).decode('utf-8'))
+            leave_count_after = self._get_leave_count()
+            if current_joined_after != current_joined or leave_count_after != leave_count:
+                log.debug(
+                    f"[{node_desc}] [Step 2] Counters changed during snapshot "
+                    f"(joined {current_joined}->{current_joined_after}, "
+                    f"left {leave_count}->{leave_count_after}); retrying."
+                )
+                continue
+
+            # Check if the segment constraint is satisfied.
+            check_start = time.monotonic()
+            constraint_satisfied = self._can_meet_segment_constraint(active_participants, min_nodes)
+            check_elapsed = time.monotonic() - check_start
+
+            if not constraint_satisfied:
+                continue
+
+            log.info(
+                f"[slot={self._slot}] [Step 2] Constraint ok: {len(active_participants)} participants, "
+                f"min={min_nodes} (fetch {fetch_elapsed*1000:.1f}ms, check {check_elapsed*1000:.1f}ms)"
+            )
+            # Assign ranks BEFORE setting round_done=1 so Step 3 readers can get their rank
+            # immediately without any additional waiting.
+            self.assign_group_ranks(min_nodes, max_nodes, current_joined, node_desc)
+            self.store.set(self.round_done_key, "1".encode('utf-8'))
+            return
+
+    def _wait_for_round_done(self, node_desc: _NodeDesc, rank_key: str) -> Tuple[int, int]:
+        """Step 3 (all participants): Wait for round_done_key=1 then read the assigned rank.
+
+        The store host set round_done_key=1 only after writing all rank keys, so the rank
+        read here is guaranteed to be the final assigned value (no polling needed).
+
+        The rank value embeds the round number that wrote it (format: "rank,total,round").
+        If the embedded round doesn't match self._round, the slot was overwritten by a later
+        round (e.g. same port reuse caused a stale slow read); treat as UNASSIGNED so the
+        caller loops to the next round.
+
+        Returns:
+            Tuple of (group_rank, total_participants). group_rank may be UNASSIGNED
+            (late comer), a stale-round sentinel, or >= min_nodes (standby); callers
+            handle all non-active cases by looping.
+
+        Raises:
+            RendezvousClosedError: If shutdown is detected.
+            RendezvousTimeoutError: If the join timeout is exceeded.
+            RuntimeError: If the rank value cannot be parsed.
+        """
+        while True:
+            self._check_timeout_and_closure(node_desc)
+
+            # round_done_key always exists here (set to "0" at Step 0).
+            value = int(self.store.get(self.round_done_key).decode('utf-8'))
+            if value == 1:
+                break
+
+            time.sleep(0.1)
+
+        # Round is complete. All rank keys were written before round_done=1 was set.
+        # Mark round closed to block any further slot writes from this node.
+        self._round_closed = True
+
+        # Race 3 fix: rank_key may not exist when our add() arrived after the store
+        # host's double-check (round closed without us, so the host never wrote our
+        # rank). A blocking store.get() on a missing key would hang; detect first.
+        if not self.store.check([rank_key]):
+            log.debug(
+                f"[{node_desc}] rank_key {rank_key} absent — late comer, treating as UNASSIGNED"
+            )
+            return GroupRankStatus.UNASSIGNED.value, 0
+
+        rank_value = self.store.get(rank_key).decode('utf-8')
+        try:
+            rank_str, total_str, round_str = rank_value.split(',', 2)
+            rank, total, written_round = int(rank_str), int(total_str), int(round_str)
+        except (ValueError, AttributeError) as e:
+            raise RuntimeError(
+                f"[{node_desc}] Failed to parse rank value '{rank_value}': {e}. "
+                f"Expected format 'group_rank,total_participants,round'."
+            )
+
+        if written_round != self._round:
+            # Slot was overwritten by a later round (key reuse race). Treat as UNASSIGNED
+            # so perform_rendezvous() advances _round and retries.
+            log.warning(
+                f"[{node_desc}] Rank key stale: written_round={written_round} != "
+                f"self._round={self._round}. Treating as UNASSIGNED."
+            )
+            return GroupRankStatus.UNASSIGNED.value, 0
+
+        return rank, total
 
     def perform_rendezvous(
         self,
@@ -906,326 +1124,230 @@ class _RendezvousBarrierState:
         max_nodes: int,
         segment_check_interval: float = 5.0,
     ) -> Tuple[int, int]:
-        """Perform the complete rendezvous process: join, wait for completion, acknowledge, and get rank.
+        """Perform the complete rendezvous for this node, returning an active group rank.
 
-        DESIGN RATIONALE:
-        This atomic barrier-based rendezvous design balances flexibility with convergence guarantees:
+        Protocol steps (repeated until an active rank is obtained):
 
-        1. SEGMENT-AWARE COMPLETION: The rendezvous completes as soon as enough participants
-           arrive to satisfy the segment constraint. Specifically:
-           - We need enough complete segments across domains to form world_size (min_nodes)
-           - Store host incrementally checks this constraint as participants arrive
-           - Completion happens immediately when constraint is satisfied
+          Step 0 — Wait for round open (all participants):
+            Hot spares and late-arriving nodes block here until open_rendezvous() sets
+            round_done_N=0, signalling that round N is ready for joining.
 
-        2. OPTIMAL PERFORMANCE: By completing as soon as the segment constraint is met,
-           we minimize waiting time and start training with available resources. This is
-           especially important in fault-tolerant scenarios where some nodes may be down.
+          Step 1 — Join (all participants):
+            Atomically claim a slot via join_count_key. Write participant metadata and
+            an initial UNASSIGNED rank to the slot. Raise if max_nodes is exceeded.
 
-        3. CONVERGENCE: The rendezvous will complete when either:
-           - Segment constraint is satisfied (enough complete segments for min_nodes)
-           - All healthy nodes have arrived (effective_max_nodes reached)
+          Step 2 — Close round (store host only):
+            Poll the participant snapshot until the segment constraint is satisfied
+            (see _host_close_round). Then assign group ranks to all slots and set
+            round_done_N=1. Non-hosts skip this step entirely.
 
-        4. NEW COMER HANDLING:
-           - New comers arriving during active rendezvous participate in the current round
-           - New comers arriving after completion trigger the next rendezvous round
-           - All existing participants detect new comers and restart to join the new round
-           - This ensures eventual convergence with the new comer
+          Step 3 — Read rank assignment (all participants):
+            Poll round_done_N until it equals 1 (see _wait_for_round_done). Because
+            all rank keys are written before round_done_N=1 is set, the rank read is
+            always the final assigned value with no additional waiting.
 
-        5. HOT SPARE HANDLING (Step 0):
-           - Hot spares arriving after training starts will wait at Step 0
-           - They wait until a failure opens the rendezvous (value=0)
-           - This prevents disruption of ongoing training
+        After Step 3:
+          - Active rank (< min_nodes): return to launcher → start training workers.
+          - Standby rank (>= min_nodes) or UNASSIGNED (late comer): advance _round and
+            loop back to Step 0 to wait for the next round.
 
         Args:
             node_desc: Node descriptor for this participant
             min_nodes: Minimum number of nodes required for training to proceed
             max_nodes: Maximum number of nodes allowed (active + standby)
-            segment_check_interval: Interval in seconds for store host to run a full
-                                   participant snapshot check for completion (default 5.0 seconds).
-                                   Actual poll interval is adaptive by min_nodes with a
-                                   1-second floor for small rendezvous.
+            segment_check_interval: Base interval in seconds for the store host's snapshot
+                check in Step 2. Actual interval is adaptive by min_nodes (1s floor).
 
         Returns:
-            Tuple of (group_rank, total_participants)
+            Tuple of (group_rank, total_participants) where group_rank < min_nodes.
         """
-        # Step 0: Wait if rendezvous is closed (training in progress)
-        # Hot spares arriving late will wait here until a failure opens a new round
-        # Note: This also checks for permanent close (is_permanently_closed()), no need to check again
-        self._wait_for_rendezvous_open(node_desc)
+        while True:
+            # Reset per-round mutable state at the top of each attempt.
+            # _current_joined_state is cleared so a signal arriving during Step 0
+            # (before re-joining) does not trigger a spurious slot write.
+            # Reset _last_stale_check_time so _sync_from_per_round_state() fires
+            # immediately at Step 0 instead of waiting up to stale_check_interval.
+            global _current_joined_state
+            _current_joined_state = None
+            self._round_closed = False
+            self._has_left = False
+            self._leave_on_unwind = False
+            self._last_stale_check_time = 0.0
 
-        # Record start time for timeout monitoring
-        # Start timing AFTER Step 0 completes, since hot spares may wait indefinitely at Step 0
-        self._rendezvous_start_time = time.monotonic()
+            # Step 0: Wait until the current round is open.
+            # Hot spares and late-arriving nodes wait here indefinitely until a failure
+            # opens the next round. Also checks for permanent shutdown.
+            # Note: _wait_for_rendezvous_open() raises RendezvousGracefulExitError on shutdown.
+            self._wait_for_rendezvous_open(node_desc)
 
-        # Record rendezvous start event - start profiling AFTER waiting for rendezvous to open
-        # This ensures hot spares waiting at Step 0 don't skew the rendezvous performance measurement
-        rendezvous_start_event_id = record_profiling_event(
-            ProfilingEvent.RENDEZVOUS_STARTED,
-            node_id=node_desc,
-        )
+            # Record start time for timeout monitoring.
+            # Start timing AFTER Step 0 completes, since nodes may wait indefinitely at Step 0.
+            self._rendezvous_start_time = time.monotonic()
 
-        # Step 1: Join the rendezvous and get unique identifier
-        self._arrived_count = self.store.add(self.arrived_count_key, 1)
-        withdrawn_count = self._get_withdrawn_count()
-        active_count = self._arrived_count - withdrawn_count
-
-        # Check if active participants would exceed max_nodes
-        if active_count > max_nodes:
-            msg = (
-                f"Maximum number of nodes ({max_nodes}) exceeded. "
-                f"Active participant count would be {active_count} (arrived={self._arrived_count}, withdrawn={withdrawn_count}). "
-                f"This is likely a configuration error - please check max_nodes setting."
+            # Record rendezvous start event — start profiling AFTER waiting for round to open.
+            # This ensures hot spares waiting at Step 0 don't skew the rendezvous measurement.
+            rendezvous_start_event_id = record_profiling_event(
+                ProfilingEvent.RENDEZVOUS_STARTED,
+                node_id=node_desc,
             )
-            log.error(f"[{node_desc}] {msg}")
-            # Permanently close rendezvous so other nodes see this final state before we raise
-            self.set_permanently_closed()
-            raise RendezvousClosedError(msg)
 
-        global _current_joined_state
-        _current_joined_state = self
-        # Only withdraw (decrement) if we died before Step 3a; once we've acked we must not decrement.
-        # Cleanup (_current_joined_state + withdraw) runs in handler's finally via _maybe_withdraw_on_unwind().
-        self._has_acked = False
-        # Determine infrastructure rank
-        infra_rank = get_infrastructure_rank()
+            # Step 1: Join the rendezvous and get a unique slot identifier.
+            # join_count_key is per-round, so each round starts counting from 1.
+            self._slot = self.store.add(self.join_count_key, 1)
+            leave_count = self._get_leave_count()
+            active_count = self._slot - leave_count
 
-        # Determine domain ID (with caching to avoid re-parsing on every rendezvous)
-        if self._cached_domain_id is None:
-            if self.segment is not None:
-                # Segment is configured - domain_id is required, always use ClusterUUID
-                try:
-                    self._cached_domain_id = _parse_domain_id_from_nvidia_smi()
-                except Exception as e:
-                    raise RuntimeError(
-                        f"Domain ID is required when --ft-segment is specified, but failed to parse: {e}"
-                    )
-            else:
-                # Segment not configured - domain_id not needed
-                self._cached_domain_id = "none"
-
-        domain_id = self._cached_domain_id
-        # Store participant information in arrived_<count> key using the unique identifier
-        arrived_key = f"{self.prefix}:arrived_{self._arrived_count}"
-        participant_data = RendezvousParticipantInfo.pack(
-            node_desc, infra_rank, domain_id, self._rendezvous_round
-        )
-        self.store.set(arrived_key, participant_data)
-
-        # Set initial group rank (unassigned)
-        rank_key = f"{self.prefix}:arrived_{self._arrived_count}_group_rank"
-        # Initially unassigned - use format "unassigned,0" for consistency
-        self.store.set(rank_key, f"{GroupRankStatus.UNASSIGNED.value},0".encode('utf-8'))
-
-        log.debug(
-            f"[{node_desc}] [Step 1] Joined rendezvous with arrived_count={self._arrived_count}"
-        )
-
-        # Step 2: Wait for rendezvous completion
-        # Store host periodically performs a full participant snapshot check.
-        last_segment_check_time = 0.0  # Track when we last checked segment constraint
-        effective_check_interval = self._compute_step2_poll_interval(
-            min_nodes, segment_check_interval
-        )
-
-        while True:
-            # Check for early closure and timeout
-            self._check_timeout_and_closure(node_desc)
-
-            # STORE HOST: Check if too many nodes are unhealthy (early termination condition)
-            # If unhealthy_count > max_nodes - min_nodes, then it's mathematically impossible
-            # to complete the rendezvous with min_nodes participants
-            if self.is_store_host:
-                unhealthy_count = self._get_unhealthy_count()
-                if unhealthy_count > (max_nodes - min_nodes):
-                    msg = (
-                        f"Rendezvous cannot complete: {unhealthy_count} unhealthy nodes detected, "
-                        f"max possible healthy nodes = {max_nodes - unhealthy_count} < {min_nodes} required. "
-                        f"Permanently closing rendezvous to terminate the job."
-                    )
-                    log.error(msg)
-                    self.set_permanently_closed()
-                    # Continue to next iteration to detect permanent close immediately.
-                    continue
-
-            # Check if rendezvous is already complete
-            # IMPORTANT: We check the VALUE, not just existence, since the key is always present
-            # Value "1" means complete, value "0" means open/in-progress
-            value_bytes = self.store.get(self.last_participant_arrived_key)
-            value = int(value_bytes.decode('utf-8'))
-            if value == 1:
-                log.debug(
-                    f"[{node_desc}] [Step 2] Detected rendezvous completion (last_participant_arrived_key=1)"
+            # Check if active participants would exceed max_nodes
+            if active_count > max_nodes:
+                msg = (
+                    f"Maximum number of nodes ({max_nodes}) exceeded. "
+                    f"Active participant count would be {active_count} "
+                    f"(joined={self._slot}, left={leave_count}). "
+                    f"This is likely a configuration error - please check max_nodes setting."
                 )
-                break
+                log.error(f"[{node_desc}] {msg}")
+                # Permanently shut down rendezvous so other nodes see this final state before we raise
+                self.set_shutdown()
+                raise RendezvousClosedError(msg)
 
-            # STORE HOST: Check if we should mark completion now
-            # Perform segment constraint check incrementally at specified interval
-            should_complete = False
+            # From here, a signal can trigger leaving of this slot.
+            # _current_joined_state is cleared in _maybe_leave_on_unwind() (handler's finally).
+            _current_joined_state = self
 
-            if self.is_store_host:
-                # Get current arrived count and withdrawn count; only check when we have
-                # at least min_nodes active (arrived - withdrawn)
-                current_arrived = int(self.store.get(self.arrived_count_key))
-                withdrawn_count = self._get_withdrawn_count()
-                active_count = current_arrived - withdrawn_count
+            # Determine infrastructure rank
+            infra_rank = get_infrastructure_rank()
 
-                if active_count >= min_nodes:
-                    current_time = time.monotonic()
-                    time_to_check = (
-                        current_time - last_segment_check_time
-                    ) >= effective_check_interval
-
-                    if time_to_check:
-                        last_segment_check_time = current_time
-
-                        # Always fetch a full snapshot to avoid races with partially written slots.
-                        fetch_start = time.monotonic()
-                        all_participants = self.get_all_participants(
-                            total_participants=current_arrived,
-                            expected_cycle_id=self._rendezvous_round,
+            # Determine domain ID (with caching to avoid re-parsing on every rendezvous)
+            if self._cached_domain_id is None:
+                if self.segment is not None:
+                    # Segment is configured - domain_id is required, always use ClusterUUID
+                    try:
+                        self._cached_domain_id = _parse_domain_id_from_nvidia_smi()
+                    except Exception as e:
+                        raise RuntimeError(
+                            f"Domain ID is required when --ft-segment is specified, but failed to parse: {e}"
                         )
-                        fetch_elapsed = time.monotonic() - fetch_start
+                else:
+                    # Segment not configured - domain_id not needed
+                    self._cached_domain_id = "none"
 
-                        # Exclude withdrawn participants (invalid domain_id) for segment constraint
-                        active_participants = [
-                            p for p in all_participants if p[2] != WITHDRAWN_DOMAIN_ID
-                        ]
+            domain_id = self._cached_domain_id
 
-                        # If counts don't match, snapshot may be stale/incomplete; wait for next poll.
-                        if len(active_participants) != active_count:
-                            log.debug(
-                                f"[{node_desc}] [Step 2] Full snapshot incomplete "
-                                f"(active_snapshot={len(active_participants)}, active_counter={active_count}, "
-                                f"arrived={current_arrived}, withdrawn={withdrawn_count}, "
-                                f"cycle_id={self._rendezvous_round}); retrying."
-                            )
-                            continue
+            slot_key = f"{self.prefix}:slot_{self._slot}"
+            rank_key = f"{self.prefix}:slot_{self._slot}_rank"
 
-                        # Verify counters are still stable after fetch before deciding completion.
-                        current_arrived_after_fetch = int(self.store.get(self.arrived_count_key))
-                        withdrawn_count_after_fetch = self._get_withdrawn_count()
-                        if (
-                            current_arrived_after_fetch != current_arrived
-                            or withdrawn_count_after_fetch != withdrawn_count
-                        ):
-                            log.debug(
-                                f"[{node_desc}] [Step 2] Counters changed during full snapshot "
-                                f"(arrived {current_arrived}->{current_arrived_after_fetch}, "
-                                f"withdrawn {withdrawn_count}->{withdrawn_count_after_fetch}); retrying."
-                            )
-                            continue
+            # SLOT WRITE PROTOCOL — key reuse safety
+            #
+            # slot_key and rank_key are reused across rounds (bounded by max_nodes) to
+            # avoid TCPStore keyspace bloat.  Two races arise from reuse:
+            #
+            # Race 1 — slot_key overwrite:
+            #   If our add(join_count_N) arrived at the server AFTER the store host's
+            #   double-check, the round closed at K-1 (without us).  Our subsequent
+            #   set(slot_key) would arrive during round N+1 and overwrite another
+            #   participant's data, causing a persistent cycle_id mismatch the round
+            #   N+1 store host cannot resolve.  The store host spins until the join
+            #   timeout fires; a WARNING is emitted after 30 s to make the bug
+            #   diagnosable before the full timeout elapses.
+            #
+            #   Fix: read round_done_key before writing.  If already 1 the round is
+            #   closed; skip both writes.  In Step 3 we read a stale/absent rank_key →
+            #   embedded-round mismatch or store.check() miss → UNASSIGNED → loop.
+            #
+            #   A residual sub-millisecond TOCTOU window exists between this get() and
+            #   the set() calls below: the round could close and round N+1 could start
+            #   in that gap.  There is no TCPStore primitive that closes it: the condition
+            #   (round_done_key == 0) and the write (slot_key = data) are on different
+            #   keys, and TCPStore.compare_set() only atomically checks-and-sets a single
+            #   key — it cannot span two keys.  The residual window is accepted because
+            #   the compound probability of the race (add after double-check AND round N+1
+            #   fully advances AND B claims the same slot, all within one RTT) is
+            #   negligible in practice.
+            #
+            # Race 2 — rank_key UNASSIGNED overwrite:
+            #   With the naive order (set slot_key then set rank_key), the store host
+            #   can see valid slot_key, assign the real rank, write rank_key=rank,N, and
+            #   set round_done=1 — all before our delayed set(rank_key=UNASSIGNED)
+            #   arrives.  Our write then clobbers the assigned rank; we read UNASSIGNED
+            #   in Step 3 and loop to round N+1 while other nodes start training without
+            #   us → hang.
+            #
+            #   Fix: write rank_key BEFORE slot_key.  slot_key is the cycle_id trigger
+            #   the store host waits on; rank_key carries no such dependency.  Both
+            #   writes are blocking on the same TCP connection, so the server processes
+            #   rank_key before slot_key.  By the time the store host sees valid slot_key
+            #   and proceeds to assign ranks, rank_key=UNASSIGNED is already in the
+            #   store.  The store host's rank write therefore always follows ours.
+            round_already_closed = int(self.store.get(self.round_done_key).decode('utf-8')) == 1
 
-                        # Timing: Segment constraint check
-                        check_start = time.monotonic()
-                        constraint_satisfied = self._can_meet_segment_constraint(
-                            active_participants, min_nodes
-                        )
-                        check_elapsed = time.monotonic() - check_start
-
-                        if constraint_satisfied:
-                            should_complete = True
-                            log.info(
-                                f"[{node_desc}] [Step 2] Segment constraint satisfied with "
-                                f"{len(active_participants)} active participants (min_nodes={min_nodes}). "
-                                f"Perf: fetch {current_arrived} participants in {fetch_elapsed*1000:.1f}ms, "
-                                f"constraint check in {check_elapsed*1000:.1f}ms"
-                            )
-
-            if should_complete:
-                # Mark rendezvous as complete
-                self.store.set(self.last_participant_arrived_key, "1".encode('utf-8'))
-                log.debug(
-                    f"[{node_desc}] [Step 2] Rendezvous marked as complete with arrived_count={self._arrived_count}"
+            if not round_already_closed:
+                self.store.set(
+                    rank_key,
+                    f"{GroupRankStatus.UNASSIGNED.value},0,{self._round}".encode('utf-8'),
                 )
-                break
-
-            # Small delay before next check
-            time.sleep(0.1)
-
-        # Step 3: Perform two-step acknowledge phase
-        # Step 3a: All participants acknowledge completion
-        ack_count = self.store.add(self.ack_count_key, 1)
-        self._has_acked = True
-        log.debug(f"[{node_desc}] [Step 3a] Acknowledged completion, ack_count={ack_count}")
-
-        # Step 3b: TCPStore host participant waits for all acknowledgments, assigns ranks, and clears keys
-        if self.is_store_host:
-            while True:
-                # Check for early closure and timeout
-                self._check_timeout_and_closure(node_desc)
-
-                current_count = int(self.store.get(self.ack_count_key))
-                # Wait for acks from active participants only (exclude withdrawn)
-                arrived = int(self.store.get(self.arrived_count_key))
-                withdrawn = self._get_withdrawn_count()
-                total_participants = arrived - withdrawn
-                if current_count >= total_participants:
-                    log.debug(
-                        f"[{node_desc}] [Step 3b] All {total_participants} participants acknowledged "
-                        f"(ack_count={current_count}), proceeding to clear keys and assign ranks"
-                    )
-
-                    # Clear barrier keys first to prevent false positives in launcher's
-                    # num_nodes_waiting() detection. If arrived_count_key persists after
-                    # participants return to training, launcher may incorrectly detect a
-                    # new rendezvous and trigger unnecessary restarts.
-                    self._clear_barrier_keys(node_desc)
-
-                    # Assign group ranks after clearing keys (pass arrived = slot count for fetch)
-                    # New comers are blocked at Step 0 by closed rendezvous, so no race condition
-                    self.assign_group_ranks(min_nodes, max_nodes, arrived, node_desc)
-                    break
-
-                time.sleep(0.1)
-        else:
-            # Non-first participants just wait for rank assignment
-            pass
-
-        # Step 4: Wait for group rank assignment
-        log.debug(f"[{node_desc}] [Step 4] Waiting for group rank assignment")
-        while True:
-            # Check for early closure and timeout
-            self._check_timeout_and_closure(node_desc)
-
-            rank_value_bytes = self.store.get(rank_key)
-            rank_value = rank_value_bytes.decode('utf-8')
-
-            # Parse the combined rank value: "group_rank,total_participants"
-            try:
-                rank_str, total_participants_str = rank_value.split(',', 1)
-                rank = int(rank_str)
-                total_participants = int(total_participants_str)
-            except (ValueError, AttributeError) as e:
-                raise RuntimeError(
-                    f"[{node_desc}] Failed to parse rank value '{rank_value}': {e}. "
-                    f"Expected format 'group_rank,total_participants' but got malformed data."
+                participant_data = RendezvousParticipantInfo.pack(
+                    node_desc, infra_rank, domain_id, self._round
                 )
+                self.store.set(slot_key, participant_data.encode('utf-8'))
 
-            # Check if rank has been assigned (not unassigned)
-            if rank != GroupRankStatus.UNASSIGNED.value:
-                log.debug(
-                    f"[{node_desc}] [Step 4] Received group rank {rank}, total participants {total_participants}"
-                )
+            log.debug(
+                f"[slot={self._slot}] [Step 1] Joined round {self._round}"
+                + (" (late, round already closed)" if round_already_closed else "")
+            )
+
+            # Step 2 (store host only): Poll until the segment constraint is satisfied,
+            # assign group ranks to all participants, then set round_done_key=1.
+            # Non-hosts skip this step entirely and proceed directly to Step 3.
+            if self.is_store_host:
+                self._host_close_round(node_desc, min_nodes, max_nodes, segment_check_interval)
+
+            # Step 3 (all participants): Wait for round_done_key=1, then read rank.
+            # The store host set round_done_key=1 only AFTER writing all rank keys, so
+            # any participant that sees round_done=1 can immediately read its rank.
+            rank, total_participants = self._wait_for_round_done(node_desc, rank_key)
+
+            if rank != GroupRankStatus.UNASSIGNED.value and rank < min_nodes:
+                # Active rank: return to launcher to start training workers.
                 return rank, total_participants
 
-            # Delay before next check
-            time.sleep(1)
+            # rank == UNASSIGNED: late comer that joined after the store host's snapshot.
+            # rank >= min_nodes: standby node — too many nodes for this round.
+            # Both cases: advance to next round and wait at Step 0 for it to open.
+            if rank == GroupRankStatus.UNASSIGNED.value:
+                log.info(
+                    f"[{node_desc}] Late joiner detected for round {self._round} "
+                    f"(rank=UNASSIGNED); retrying in round {self._round + 1}"
+                )
+            else:
+                log.info(
+                    f"[{node_desc}] Standby (rank={rank}) for round {self._round}; "
+                    f"waiting for round {self._round + 1} to open"
+                )
+            # Loop back to Step 0; _sync_from_per_round_state() will advance _round
+            # from N to N+1 when it sees round_done_N=1 (closed).
 
-    def _maybe_withdraw_on_unwind(self) -> None:
-        """Clear joined-state ref and, if we received a signal before acking, withdraw (increment withdrawn_count, mark slot).
+    def _maybe_leave_on_unwind(self) -> None:
+        """Clear joined-state ref and conditionally leave the rendezvous on exception.
 
         Called from the handler's finally (next_rendezvous) so cleanup lives in one place.
         Clears _current_joined_state so the signal handler does not see a stale ref (e.g. during
-        training or between rounds). Resetting on each perform_rendezvous keeps the ref accurate
-        for the current attempt.
+        training or between retry rounds). Resetting on each perform_rendezvous loop iteration
+        keeps the ref accurate for the current attempt.
+
+        Only leaves (writes WITHDRAWN to slot) if:
+        - A signal was received after joining (Step 1) AND
+        - The round is NOT yet closed (_round_closed=False)
+
+        We must NOT leave after _round_closed=True because slot keys are reused across rounds.
+        Writing WITHDRAWN after round N closes would corrupt round N+1's slot data.
         """
         global _current_joined_state
         if _current_joined_state is self:
             _current_joined_state = None
-        if getattr(self, '_withdraw_on_unwind', False):
-            if not getattr(self, '_has_acked', True):
-                self._withdraw_from_rendezvous()
-            self._withdraw_on_unwind = False
+        if getattr(self, '_leave_on_unwind', False):
+            if not getattr(self, '_round_closed', True):
+                self._leave_rendezvous()
+            self._leave_on_unwind = False
 
     def get_all_participants(
         self,
@@ -1271,9 +1393,11 @@ class _RendezvousBarrierState:
         # Initialize result list
         participants = existing_participants if existing_participants is not None else []
 
-        # Prepare keys for multi_get (only fetch new participants)
+        # Prepare keys for multi_get (only fetch new participants).
+        # Slot keys (slot_N) are reused across rounds; they hold data for the current round
+        # and are overwritten at Step 1 of each new round for the same slot number.
         participant_keys = [
-            f"{self.prefix}:arrived_{i}" for i in range(start_index, total_participants + 1)
+            f"{self.prefix}:slot_{i}" for i in range(start_index, total_participants + 1)
         ]
 
         if not participant_keys:
@@ -1284,15 +1408,13 @@ class _RendezvousBarrierState:
         participant_data_list = self.store.multi_get(participant_keys)
 
         # Unpack participant information; one entry per slot so list index maps to slot
-        # (participants[i] = slot start_index + i). Use placeholder for missing/failed/withdrawn.
-        placeholder = (_NodeDesc("", 0, 0), -1, WITHDRAWN_DOMAIN_ID)
+        # (participants[i] = slot start_index + i). Use placeholder for missing/failed/left.
+        placeholder = (_NodeDesc("", 0, 0), -1, WITHDRAWN)
         for i, participant_data_bytes in enumerate(participant_data_list):
             actual_index = start_index + i
 
             if not participant_data_bytes:
-                log.warning(
-                    f"No participant data for slot arrived_{actual_index}; treating as placeholder"
-                )
+                log.warning(f"No participant data for slot_{actual_index}; treating as placeholder")
                 participants.append(placeholder)
                 continue
 
@@ -1303,68 +1425,40 @@ class _RendezvousBarrierState:
                 )
                 if expected_cycle_id is not None and cycle_id != expected_cycle_id:
                     log.debug(
-                        f"Cycle mismatch for arrived_{actual_index}: expected cycle "
+                        f"Cycle mismatch for slot_{actual_index}: expected cycle "
                         f"{expected_cycle_id}, got {cycle_id}; treating as placeholder"
                     )
                     participants.append(placeholder)
                     continue
                 participants.append((node_desc, infra_rank, domain_id))
             except Exception as e:
-                log.warning(f"Failed to unpack participant data for arrived_{actual_index}: {e}")
+                log.warning(f"Failed to unpack participant data for slot_{actual_index}: {e}")
                 participants.append(placeholder)
 
         return participants
 
-    def _clear_barrier_keys(self, node_desc: _NodeDesc):
-        """Clear main barrier keys to prepare for next rendezvous round.
-
-        Note: We do NOT clear last_participant_arrived_key because it serves as the
-        open/close indicator for the rendezvous. It remains set to 1 (closed) during
-        training and is reset to 0 (open) by the launcher when a failure is detected.
-
-        Note: We do NOT clear unhealthy_count_key because it is a global counter that
-        tracks unhealthy nodes across the entire job lifetime, not per cycle.
-
-        This method is called by the last participant to acknowledge in Step 3b, BEFORE
-        rank assignment. This ensures all participants are still waiting and cannot
-        start the next cycle yet, making it safe to clear the global counters.
-        """
-        # Clear main keys - individual arrived_<count> keys don't need clearing
-        # DO NOT clear last_participant_arrived_key - it indicates open/close state
-        # DO NOT clear unhealthy_count_key - it is a global job-level counter
-        keys_to_clear = [
-            self.arrived_count_key,
-            self.withdrawn_count_key,
-            self.ack_count_key,
-            self.peer_aborted_count_key,  # Clear peer aborted counter for next round
-        ]
-
-        # Delete main keys
-        for key in keys_to_clear:
-            try:
-                self.store.delete_key(key)
-            except Exception as e:
-                log.debug(f"[{node_desc}] Failed to delete key {key}: {e}")
-
     def assign_group_ranks(
         self, world_size: int, max_nodes: int, total_participants: int, node_desc: _NodeDesc
     ) -> bool:
-        """Assign group ranks to all participants. Called by Rank 0 (TCPStore host).
+        """Assign group ranks to all participants. Called by the store host in Step 2.
+
+        This is called BEFORE setting round_done_key=1 so that any participant reading
+        round_done=1 can immediately read its rank without waiting further.
 
         Args:
             world_size: Target world size for training (number of active participants)
             max_nodes: Maximum number of participants allowed
-            total_participants: Total number of participants (passed to avoid race condition)
+            total_participants: Slot count for this round (passed to avoid race condition)
         """
         all_participants = self.get_all_participants(
-            total_participants, expected_cycle_id=self._rendezvous_round
+            total_participants, expected_cycle_id=self._round
         )
         assert (
             len(all_participants) == total_participants
         ), f"Expected {total_participants} slots, got {len(all_participants)}"
 
-        # Exclude withdrawn participants (invalid domain_id) for rank assignment
-        active_participants = [p for p in all_participants if p[2] != WITHDRAWN_DOMAIN_ID]
+        # Exclude left participants (WITHDRAWN domain_id) for rank assignment
+        active_participants = [p for p in all_participants if p[2] != WITHDRAWN]
         assert (
             len(active_participants) > 0
         ), f"Expected at least one active participant. total_participants={total_participants}"
@@ -1378,87 +1472,73 @@ class _RendezvousBarrierState:
 
         assigned_group_ranks = self._assign_group_ranks(active_participants, world_size)
 
-        # Write rank to each active participant's slot (iterate by slot so key = arrived_{slot})
+        # Write rank to each active participant's slot_{N}_rank key.
+        # These writes happen BEFORE round_done_key is set to 1, ensuring all ranks
+        # are visible to participants as soon as they see round_done=1.
         rank_keys = []
         rank_values = []
-        self._last_active_participant_addrs = []
-        self._last_standby_participant_addrs = []
+        self._active_node_addrs = []
+        self._standby_node_addrs = []
+        self._active_ranks = []
         for slot in range(1, total_participants + 1):
             node_desc_item, _, domain_id = all_participants[slot - 1]
-            if domain_id != WITHDRAWN_DOMAIN_ID:
+            if domain_id != WITHDRAWN:
                 assigned_group_rank = assigned_group_ranks.get(node_desc_item, -1)
 
                 # Collect addrs for cycle info (active vs standby by group_rank vs world_size)
                 if assigned_group_rank < world_size:
-                    self._last_active_participant_addrs.append(node_desc_item.addr)
+                    self._active_node_addrs.append(node_desc_item.addr)
+                    self._active_ranks.append(assigned_group_rank)
                 else:
-                    self._last_standby_participant_addrs.append(node_desc_item.addr)
+                    self._standby_node_addrs.append(node_desc_item.addr)
 
                 if assigned_group_rank == -1:
                     raise RuntimeError(
                         f"Failed to assign group rank to participant {node_desc_item}. "
                         f"This should never happen - all active participants should be assigned ranks."
                     )
-                rank_key = f"{self.prefix}:arrived_{slot}_group_rank"
-                rank_value = f"{assigned_group_rank},{total_participants}"
+                rank_key = f"{self.prefix}:slot_{slot}_rank"
+                rank_value = f"{assigned_group_rank},{total_participants},{self._round}"
                 rank_keys.append(rank_key)
                 rank_values.append(rank_value.encode('utf-8'))
 
         self.store.multi_set(rank_keys, rank_values)
 
-        log.debug(
-            f"[{node_desc}] [Step 3b] Assigned group ranks to {len(active_participants)} participants"
-        )
+    def is_shutdown(self) -> bool:
+        """Check if rendezvous is permanently shut down (no further rounds)."""
+        return self.store.check([self.shutdown_key])
 
-    def is_permanently_closed(self) -> bool:
-        """Check if rendezvous is permanently closed (no further rounds)."""
-        return self.store.check([self.permanent_close_key])
-
-    def set_permanently_closed(self) -> None:
-        """Mark rendezvous as permanently closed (graceful exit, no further rounds)."""
+    def set_shutdown(self) -> None:
+        """Mark rendezvous as permanently shut down (graceful exit, no further rounds)."""
         try:
-            self.store.set(self.permanent_close_key, "1".encode('utf-8'))
+            self.store.set(self.shutdown_key, "1".encode('utf-8'))
         except Exception as e:
-            log.error(f"Failed to set permanent close: {e}")
+            log.error(f"Failed to set shutdown: {e}")
 
     def open_rendezvous(self):
-        """Open rendezvous for new participants to join (typically after failure detection).
+        """Open the next round (N+1) for participants to join after failure detection.
 
-        This is called by the launcher when it detects a worker failure and needs to
-        restart. Setting last_participant_arrived_key to 0 signals to all participants
-        (including hot spares waiting at Step 0) that a new rendezvous round can begin.
+        After completing round N, _round=N and round_done_N=1 (closed). This creates
+        round_done_{N+1}=0, which is the key polled by:
+          - is_next_round_open() on healthy training nodes
+          - _wait_for_rendezvous_open() (via _sync_from_per_round_state) on hot spares
+            and restarting nodes
 
-        RACE CONDITION PROTECTION:
-        We check if a rendezvous is currently in progress or being finalized.
-        If arrived_count_key exists, it means:
-        - Either a rendezvous is actively in progress (Step 1-2), OR
-        - Step 3b is in progress but hasn't cleared the keys yet
-        In this case, we DO NOT modify last_participant_arrived_key to avoid
-        racing with the active rendezvous.
+        RACE CONDITION SAFETY:
+        Multiple launchers detecting the same failure concurrently all target the same
+        round_done_{N+1} key and write the same "0" value — this is idempotent.
 
-        BEHAVIOR AFTER DEFER:
-        The calling node will proceed to Step 0 and check last_participant_arrived_key:
-        - If value=0 (rendezvous still open/joining), node can join the current rendezvous
-        - If value=1 (rendezvous complete), node will wait passively for next round
+        The check() guard ensures only the first caller writes; subsequent callers defer:
+        - If round_done_{N+1} does not exist: safe to open → set to "0"
+        - If round_done_{N+1} already exists: another node already opened it → defer
         """
-        # Check if a rendezvous is in progress or being finalized
-        # If arrived_count_key exists, it means participants are joining (Step 1) or
-        # finalizing (Step 3b before clearing). The key only exists with value >= 1.
-        if self.store.check([self.arrived_count_key]):
-            log.debug(
-                "open_rendezvous() deferred - rendezvous in progress. "
-                "Not modifying last_participant_arrived_key to avoid race with active rendezvous. "
-                "The node may still join the current rendezvous if it's still open (value=0)."
-            )
-            # Don't modify last_participant_arrived_key - let the current rendezvous manage it
-            # The calling node will check the value at Step 0:
-            # - If value=0 (still joining), the node can join the current rendezvous
-            # - If value=1 (completed), the node will wait for the next round
+        next_round_done_key = f"{self.prefix}:round_done_{self._round + 1}"
+        if self.store.check([next_round_done_key]):
+            log.debug(f"open_rendezvous() deferred - round_done_{self._round + 1} already exists.")
             return
 
-        # Safe to open - no rendezvous in progress
-        self.store.set(self.last_participant_arrived_key, "0".encode('utf-8'))
-        log.debug(f"Opened rendezvous for new round (set {self.last_participant_arrived_key}=0)")
+        self.store.set(next_round_done_key, "0".encode('utf-8'))
+        log.debug(f"Opened round {self._round + 1} for joining")
 
 
 class FtRendezvousBarrierHandler(RendezvousHandler):
@@ -1640,13 +1720,13 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
 
     @property
     def _rendezvous_round(self) -> int:
-        """Delegate to barrier state's rendezvous round."""
-        return self._barrier_state._rendezvous_round
+        """Delegate to barrier state's round counter."""
+        return self._barrier_state._round
 
     @_rendezvous_round.setter
     def _rendezvous_round(self, value: int) -> None:
-        """Delegate to barrier state's rendezvous round."""
-        self._barrier_state._rendezvous_round = value
+        """Delegate to barrier state's round counter."""
+        self._barrier_state._round = value
 
     def set_worker_group(self, worker_group: Any) -> None:
         """Set the worker group reference for this handler."""
@@ -1672,10 +1752,10 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
 
         This is called after set_agent() to perform initialization tasks that
         need to sync with the agent, such as syncing the rendezvous round for
-        cross-array task coordination.
+        cross-array task coordination (replacement nodes joining an ongoing job).
         """
         old_round = self._rendezvous_round
-        if self._barrier_state._sync_from_global_cycle():
+        if self._barrier_state._sync_from_per_round_state():
             log.info(
                 f"[{self._this_node}] Synced rendezvous round at initialization "
                 f"({old_round} -> {self._rendezvous_round})"
@@ -1756,10 +1836,6 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         msg = f"Checking health status of {self._this_node}."
         self._record(message=msg)
 
-        # Set current cycle for health check injection (if enabled)
-        if os.environ.get("NVRX_INJECT_GPU_FAILURE"):
-            health_check_injector.set_current_cycle(self._rendezvous_round)
-
         # Perform GPU health check
         self._run_health_check(
             GPUHealthCheck(), "GPU health check", f"Node {self._this_node} has an unhealthy GPU."
@@ -1801,6 +1877,15 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
                 f"Node {self._this_node} is unhealthy.",
             )
 
+        # Perform failure injection check (testing only; no-op unless NVRX_INJECT_GPU_FAILURE is set)
+        if os.environ.get("NVRX_INJECT_GPU_FAILURE"):
+            cycle = get_profiling_cycle()
+            infra_rank = get_infrastructure_rank(skip_nodename_logic=True)
+            if health_check_injector.should_inject_failure(cycle, infra_rank):
+                raise UnhealthyNodeException(
+                    f"Injected failure: infra_rank={infra_rank}, cycle={cycle}"
+                )
+
     def handle_control_requests_from_rank(self) -> None:
         """Check control messages received from local ranks."""
         # Check control messages received from local ranks
@@ -1830,47 +1915,17 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             self._settings.max_nodes,
         )
 
-        # Increment round number for the next rendezvous
-        # This ensures each rendezvous round uses an isolated namespace for MASTER_ADDR/MASTER_PORT
-        self._rendezvous_round += 1
-
-        # AFTER rendezvous: Store host updates global_cycle_key for job array coordination
-        #
-        # The global_cycle_key persists _rendezvous_round in the store, allowing replacement
-        # job array elements to sync their state. After this write:
-        #   - _rendezvous_round = N means N rendezvous have completed
-        #   - Workers are about to start for cycle (N-1)
-        #   - Replacement nodes will read this value, do another rendezvous, and run cycle N
-        #
-        # Example: If _rendezvous_round=3 after increment:
-        #   - 3 rendezvous have completed
-        #   - About to run cycle 2 (third attempt: initial + 2 restarts)
-        #   - If job crashes during/after cycle 2, replacement reads global_cycle_key=3
-        #   - Replacement does 4th rendezvous (round becomes 4) and runs cycle 3
-        if self._barrier_state.is_store_host:
-            self._barrier_state.store.set(
-                self._barrier_state.global_cycle_key, str(self._rendezvous_round).encode('utf-8')
-            )
-
         # Store the assigned rank and world size
         self._assigned_rank = group_rank
 
-        # World size for the training job is the number of *active* participants (min_nodes),
-        # not total_participants (active + standby). The launcher multiplies this by
-        # nproc_per_node to set WORLD_SIZE in worker env. Standby participants report
-        # local_world_size=0 and do not run workers; they must still see the same
-        # group world_size (min_nodes) so that WORLD_SIZE = min_nodes * nproc_per_node
-        # (e.g. 32*4=128) in every worker, not total_participants * nproc_per_node (e.g. 47*4=188).
-        # This is required when TORCH_ELASTIC_WORKER_IDENTICAL=1: PyTorch then uses this
-        # world_size directly (no multi_get of role_info), so it must be the active count.
+        # World size for the training job is the number of *active* participants (min_nodes).
+        # perform_rendezvous() only returns with an active rank (< min_nodes); standby nodes
+        # loop inside perform_rendezvous() until they become active. All workers therefore
+        # see WORLD_SIZE = min_nodes * nproc_per_node (e.g. 32*4=128), not total_participants.
+        # This is required when TORCH_ELASTIC_WORKER_IDENTICAL=1.
         self._world_size = self._settings.min_nodes
 
-        if group_rank == GroupRankStatus.UNASSIGNED.value:
-            log.warning("Failed to get group rank assignment, but continuing")
-        elif group_rank >= self._settings.min_nodes:
-            log.info(f"Node {self._this_node} is in standby mode (rank {group_rank})")
-        else:
-            log.info(f"Node {self._this_node} assigned group rank {group_rank}")
+        log.info(f"Assigned active rank {group_rank} (round={self._barrier_state._round})")
 
     def next_rendezvous(self) -> Union[RendezvousInfo, Tuple[Store, int, int]]:
         """See base class.
@@ -1908,18 +1963,14 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             world_size = self._world_size
             store = self._get_store()
 
-            # Adjust local_world_size based on whether this is a standby or active participant
+            # perform_rendezvous() only returns with an active rank (< min_nodes).
+            # Standby nodes loop inside perform_rendezvous() until they become active.
+            # Restore local_world_size for nodes that were previously standby (had 0 workers).
             assert (
                 self._worker_group is not None
             ), "set_worker_group must be called before next_rendezvous"
-            if rank >= self._settings.min_nodes:
-                # This is a standby participant, set local_world_size to 0
-                self._worker_group.spec.local_world_size = 0
-            else:
-                # This is an active participant, ensure local_world_size is correct
-                if self._worker_group.spec.local_world_size == 0:
-                    # Restore from the configured value in settings
-                    self._worker_group.spec.local_world_size = self._settings.nproc_per_node
+            if self._worker_group.spec.local_world_size == 0:
+                self._worker_group.spec.local_world_size = self._settings.nproc_per_node
 
         except Exception as e:
             self._record(
@@ -1928,10 +1979,10 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             )
             raise
         finally:
-            # If we received a signal after joining but before acking (Step 3a), withdraw so
-            # the store host can complete Step 3b. Centralized in handler's finally with other
+            # If we received a signal after joining but before round close, leave so
+            # the store host can finish the round. Centralized here with other
             # next_rendezvous cleanup (signal handler restore).
-            self._barrier_state._maybe_withdraw_on_unwind()
+            self._barrier_state._maybe_leave_on_unwind()
             _restore_rdzv_signal_handlers(prev_signal_handlers)
 
         msg = (
@@ -1972,9 +2023,9 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             return store, rank, world_size
 
     def is_closed(self) -> bool:
-        """See base class. Returns True if rendezvous is permanently closed."""
+        """See base class. Returns True if rendezvous is permanently shut down."""
         try:
-            return self._barrier_state.is_permanently_closed()
+            return self._barrier_state.is_shutdown()
         except Exception as e:
             self._record(
                 message=f"{type(e).__name__}: {str(e)}",
@@ -1994,14 +2045,26 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             raise
 
     def num_nodes_waiting(self) -> int:
-        """See base class."""
-        # Return active count (arrived - withdrawn) as the number of nodes waiting
-        if not self._barrier_state.store.check([self._barrier_state.arrived_count_key]):
+        """See base class.
+
+        Returns the number of nodes currently waiting to join the rendezvous.
+        Uses per-round join_count_key; if the key doesn't exist for the current
+        round (e.g. during training between rounds), returns 0 with no false positives.
+        """
+        if not self._barrier_state.store.check([self._barrier_state.join_count_key]):
             return 0
-        arrived_count_bytes = self._barrier_state.store.get(self._barrier_state.arrived_count_key)
-        arrived_count = int(arrived_count_bytes.decode('utf-8'))
-        withdrawn_count = self._barrier_state._get_withdrawn_count()
-        return max(0, arrived_count - withdrawn_count)
+        joined_count_bytes = self._barrier_state.store.get(self._barrier_state.join_count_key)
+        joined_count = int(joined_count_bytes.decode('utf-8'))
+        leave_count = self._barrier_state._get_leave_count()
+        return max(0, joined_count - leave_count)
+
+    def is_next_round_open(self) -> bool:
+        """Return True if the next rendezvous round has been opened by any node in the cluster.
+
+        Healthy nodes in the monitor loop call this to detect that a peer has triggered
+        a restart (open_rendezvous() sets round_done_{N+1}=0 as the signal).
+        """
+        return self._barrier_state.is_next_round_open()
 
     def remove_this_node(self):
         raise NotImplementedError("Not implemented")
@@ -2021,21 +2084,35 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         """See base class."""
         return self._settings.run_id
 
-    def get_last_rendezvous_participant_addrs(self) -> Optional[List[str]]:
-        """Return the list of active participant addresses from the last completed rendezvous.
+    def get_active_node_addrs(self) -> Optional[List[str]]:
+        """Return active node addresses from the last completed rendezvous.
 
         Only the TCPStore host populates this (in assign_group_ranks). Other nodes
         will get None. Used by the launcher to build NVRx cycle info (active_nodes).
         """
-        return self._barrier_state._last_active_participant_addrs
+        return self._barrier_state._active_node_addrs
 
-    def get_last_rendezvous_standby_participant_addrs(self) -> Optional[List[str]]:
-        """Return the list of standby (hot spare) participant addresses from the last rendezvous.
+    def get_standby_node_addrs(self) -> Optional[List[str]]:
+        """Return standby (hot spare) node addresses from the last rendezvous.
 
         Only the TCPStore host populates this. Other nodes will get None.
         Used by the launcher to build NVRx cycle info (standby_nodes).
         """
-        return self._barrier_state._last_standby_participant_addrs
+        return self._barrier_state._standby_node_addrs
+
+    def get_active_ranks(self) -> Optional[List[int]]:
+        """Return group ranks of active nodes in SLURM hostname sort order.
+
+        active_ranks[i] corresponds to the i-th node in hostnames_to_slurm_nodelist()
+        expansion, enabling strict per-element rank-to-node alignment.
+        Only the TCPStore host populates this; other nodes return None.
+        """
+        addrs = self._barrier_state._active_node_addrs
+        ranks = self._barrier_state._active_ranks
+        if addrs is None or ranks is None:
+            return None
+        addr_to_rank = dict(zip(addrs, ranks))
+        return [addr_to_rank[a] for a in slurm_sort_addrs(addrs)]
 
     def shutdown(self) -> bool:
         """See base class."""
@@ -2058,8 +2135,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             raise
 
     def _close(self) -> None:
-        """Permanently close the rendezvous (no further rounds)."""
-        self._barrier_state.set_permanently_closed()
+        """Permanently shut down the rendezvous (no further rounds)."""
+        self._barrier_state.set_shutdown()
 
         msg = f"The node '{self._this_node}' has permanently closed the rendezvous '{self._settings.run_id}'."
         self._record(message=msg, node_state=NodeState.SUCCEEDED)
@@ -2071,9 +2148,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         Uses round number in the prefix to isolate MASTER_ADDR/MASTER_PORT keys
         between rendezvous rounds, preventing race conditions when rank 0 changes.
 
-        The round number is tracked in memory and increments each time next_rendezvous()
-        completes. This ensures each handler instance uses progressively isolated namespaces
-        for bootstrap keys without requiring TCPStore coordination.
+        _rendezvous_round == N after completing round N, so each training session
+        uses namespace N — a unique, naturally incrementing prefix per round.
         """
         key_prefix = f"torch.rendezvous.{self._settings.run_id}.{self._rendezvous_round}"
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -39,7 +39,6 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 import torch
 from torch.distributed.argparse_util import check_env, env
 from torch.distributed.elastic import events, metrics, timer
-from torch.distributed.elastic.agent.server import api as _torch_elastic_agent_api
 from torch.distributed.elastic.agent.server.api import (
     RunResult,
     SimpleElasticAgent,
@@ -84,6 +83,7 @@ from nvidia_resiliency_ext.fault_tolerance.utils import (
     hostnames_to_slurm_nodelist,
     is_slurm_job_array,
     patched_method,
+    ranks_to_range_str,
     terminate_mp_processes,
     write_obj_to_ipc_stream,
 )
@@ -106,21 +106,6 @@ TORCHELASTIC_TIMER_FILE = "TORCHELASTIC_TIMER_FILE"
 
 FT_LAUNCHER_IPC_SOCKET = f"{tempfile.gettempdir()}/_ft_launcher{os.getpid()}.socket"
 
-# Key set by PyTorch's _exit_barrier() when all active agents have reached the barrier
-# (success path). Standby nodes can check this to detect successful training completion
-# without relying on is_permanently_closed() (which requires the store host to have called shutdown();
-# the store host may be a standby).
-#
-# Derive the prefix from PyTorch internals and fail loudly on incompatibility
-# to avoid silently checking a stale key when upstream changes.
-if not hasattr(_torch_elastic_agent_api, "_TERMINAL_STATE_SYNC_ID"):
-    raise RuntimeError(
-        "PyTorch internal '_TERMINAL_STATE_SYNC_ID' was not found. "
-        "Cannot derive _exit_barrier store key safely; update this integration "
-        f"for torch=={torch.__version__}."
-    )
-
-_EXIT_BARRIER_LAST_MEMBER_KEY = f"{_torch_elastic_agent_api._TERMINAL_STATE_SYNC_ID}/last_member"
 
 _legacy_ft_rdzv_deprecation_warned: bool = False
 
@@ -396,12 +381,9 @@ class LocalElasticAgent(SimpleElasticAgent):
         if self._rank_monitors:
             self._setup_rank_monitor_connections()
 
-        # Fix _remaining_restarts for job array deployments
-        # The base class (SimpleElasticAgent) sets _remaining_restarts = spec.max_restarts,
-        # assuming this is a fresh start. But for job array replacements, we need to account
-        # for restarts that already occurred in the original job array element.
-        # The global restart count persists across replacements via the rendezvous store.
-        restarts_initiated = self._get_global_restart_count()
+        # Provisional: _round=0 at construction (store not yet synced via set_agent()).
+        # Corrected at the start of run() after _complete_initialization() has run.
+        restarts_initiated = self._get_global_cycle_number()
         self._remaining_restarts = spec.max_restarts - restarts_initiated
 
         # Initialize progress tracker with global cycle number for job array deployments
@@ -431,34 +413,28 @@ class LocalElasticAgent(SimpleElasticAgent):
     # 1. _rendezvous_round (in FtRendezvousBarrierHandler):
     #    - Tracks number of COMPLETED rendezvous operations
     #    - Starts at 0, increments AFTER each rendezvous completes
-    #    - Persisted to store as 'global_cycle_key' by store host
-    #    - Synced by replacement nodes on initialization
+    #    - Synced by replacement nodes on initialization via per-round key scan
     #
     # 2. cycle_number:
     #    - Which training cycle is running (0 = initial, 1 = first restart, etc.)
     #    - Equals _rendezvous_round (one rendezvous per cycle)
     #    - Used by ProgressTracker for logging
     #
-    # 3. restart_count:
-    #    - How many RESTARTS have been initiated (cycle 0 is NOT a restart)
-    #    - Equals max(0, cycle_number - 1)
-    #    - Used to calculate _remaining_restarts
-    #
-    # 4. _remaining_restarts:
+    # 3. _remaining_restarts:
     #    - How many more restarts are allowed after current cycle fails
-    #    - Equals max_restarts - restart_count
+    #    - Equals max_restarts - cycle_number
     #    - Decremented on each restart decision
     #
     # Example Timeline (max_restarts=3):
-    #   Cycle 0: restart_count=0, _remaining_restarts=3, _rendezvous_round=1 (after rdzv)
-    #   Cycle 1: restart_count=1, _remaining_restarts=2, _rendezvous_round=2 (after rdzv)
-    #   Cycle 2: restart_count=2, _remaining_restarts=1, _rendezvous_round=3 (after rdzv)
-    #   Cycle 3: restart_count=3, _remaining_restarts=0, _rendezvous_round=4 (after rdzv)
+    #   Cycle 0: cycle_number=0, _remaining_restarts=3, _rendezvous_round=0
+    #   Cycle 1: cycle_number=1, _remaining_restarts=2, _rendezvous_round=1
+    #   Cycle 2: cycle_number=2, _remaining_restarts=1, _rendezvous_round=2
+    #   Cycle 3: cycle_number=3, _remaining_restarts=0, _rendezvous_round=3
     #
     # Job Array Replacement:
-    #   Original job crashes at cycle 2 with _rendezvous_round=3
-    #   Replacement reads global_cycle_key=3, sets _rendezvous_round=3
-    #   Calculates restart_count=2, _remaining_restarts=1
+    #   Original job crashes at cycle 2 with _rendezvous_round=2
+    #   Replacement scans round_done_{N} keys, finds _rendezvous_round=2
+    #   cycle_number=2, _remaining_restarts=1
     #   Continues with cycle 3 (one more restart allowed)
     # ============================================================================
 
@@ -482,32 +458,18 @@ class LocalElasticAgent(SimpleElasticAgent):
         """
         return self._rdzv_handler.round()
 
-    def _get_global_restart_count(self) -> int:
-        """Get the global restart count.
 
-        The restart count represents how many times we've restarted (not including
-        the initial attempt):
-        - 0 = running initial attempt (cycle 0), no restarts yet
-        - 1 = first restart initiated (cycle 1)
-        - 2 = second restart initiated (cycle 2), etc.
+    def _on_cycle_end(self, cycle_number: Optional[int] = None) -> None:
+        """Record cycle end time in cycle info file.
 
-        This value persists across job array element replacements via the rendezvous store.
-
-        Returns:
-            Number of restarts initiated (0-based)
-
-        Relationship to cycle_number:
-            restart_count = max(0, cycle_number - 1)
-            - Cycle 0 (initial) = 0 restarts
-            - Cycle N (N >= 1) = N restarts
+        Args:
+            cycle_number: Cycle to record. Defaults to current cycle (_get_global_cycle_number()).
+                Standby nodes must pass round()-1 since their _round was already advanced
+                to N+1 by the time shutdown is detected.
         """
-        return max(0, self._rdzv_handler.round() - 1)
-
-    def _on_cycle_end(self) -> None:
-        """Record cycle end time in cycle info file."""
         if self._cycle_info_writer is None:
             return
-        current_cycle = self._get_global_restart_count()
+        current_cycle = cycle_number if cycle_number is not None else self._get_global_cycle_number()
         job_id = os.environ.get("SLURM_ARRAY_JOB_ID") or os.environ.get("SLURM_JOB_ID", "")
         attempt_index = int(os.environ.get("SLURM_RESTART_CNT", "0"))
         self._cycle_info_writer.update_cycle_end(
@@ -525,16 +487,15 @@ class LocalElasticAgent(SimpleElasticAgent):
         attempt_index = int(os.environ.get("SLURM_RESTART_CNT", "0"))
         cycle_log_file = self._logs_specs.get_cycle_log_file(current_cycle)
         # Legacy FtRendezvousHandler does not define these; barrier handler does.
-        get_active = getattr(
-            self._rdzv_handler, "get_last_rendezvous_participant_addrs", None
-        )
-        get_standby = getattr(
-            self._rdzv_handler, "get_last_rendezvous_standby_participant_addrs", None
-        )
+        get_active = getattr(self._rdzv_handler, "get_active_node_addrs", None)
+        get_standby = getattr(self._rdzv_handler, "get_standby_node_addrs", None)
+        get_active_ranks = getattr(self._rdzv_handler, "get_active_ranks", None)
         active_addrs = get_active() if callable(get_active) else None
         standby_addrs = get_standby() if callable(get_standby) else None
+        active_rank_list = get_active_ranks() if callable(get_active_ranks) else None
         active_nodes = hostnames_to_slurm_nodelist(active_addrs) if active_addrs else ""
         standby_nodes = hostnames_to_slurm_nodelist(standby_addrs) if standby_addrs else ""
+        active_ranks = ranks_to_range_str(active_rank_list) if active_rank_list is not None else ""
         self._cycle_info_writer.write_cycle_start(
             job_id=job_id,
             attempt_index=attempt_index,
@@ -543,6 +504,7 @@ class LocalElasticAgent(SimpleElasticAgent):
             cycle_log_file=cycle_log_file,
             active_nodes=active_nodes,
             standby_nodes=standby_nodes,
+            active_ranks=active_ranks,
         )
         return self._cycle_info_writer.get_current_cycle_info_path(job_id)
 
@@ -550,6 +512,11 @@ class LocalElasticAgent(SimpleElasticAgent):
     #  `torch.distributed.elastic.metrics.prof`.
     @prof
     def run(self, role: str = DEFAULT_ROLE) -> RunResult:
+        # Re-sync _remaining_restarts: _round=0 at __init__ time (store not yet synced).
+        # set_agent() -> _complete_initialization() has corrected _round by now.
+        self._remaining_restarts = (
+            self._worker_group.spec.max_restarts - self._get_global_cycle_number()
+        )
         start_time = time.monotonic()
         shutdown_called: bool = False
         try:
@@ -560,6 +527,9 @@ class LocalElasticAgent(SimpleElasticAgent):
             return result
         except RendezvousGracefulExitError as e:
             logger.info("Rendezvous gracefully exited: %s", e)
+            # Standby nodes: _round was advanced to N+1 when round N closed before shutdown
+            # was detected. Record end of cycle N (the last completed cycle).
+            self._on_cycle_end(cycle_number=self._rdzv_handler.round() - 1)
             return None
         except SignalException as e:
             logger.warning("Received %s death signal, shutting down workers, timeout %s sec.", e.sigval, self._term_timeout)
@@ -576,7 +546,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         """Open rendezvous for restart when using barrier-based rendezvous.
 
         This method is called when a failure is detected and we need to restart workers.
-        For barrier-based rendezvous, it sets last_participant_arrived_key=0 to signal
+        For barrier-based rendezvous, it sets round_done_{N+1}=0 to signal
         that a new rendezvous round can begin, allowing hot spares and restarting nodes
         to join.
         """
@@ -584,10 +554,6 @@ class LocalElasticAgent(SimpleElasticAgent):
         if hasattr(self._rdzv_handler, '_barrier_state'):
             try:
                 self._rdzv_handler._barrier_state.open_rendezvous()
-                logger.debug(
-                    "[group_rank=%s] Opened rendezvous for restart (barrier-based rendezvous)",
-                    self._worker_group.group_rank if self._worker_group else "N/A"
-                )
             except Exception as e:
                 logger.error(f"Failed to open rendezvous: {e}")
         # For legacy rendezvous, no action needed - it uses different mechanism
@@ -598,7 +564,6 @@ class LocalElasticAgent(SimpleElasticAgent):
         spec: WorkerSpec,
         log_msg: str,
         open_rendezvous: bool = False,
-        notify_peer: bool = False,
     ) -> bool:
         """Handle restart decision logic based on progress tracking and remaining restarts.
 
@@ -606,8 +571,7 @@ class LocalElasticAgent(SimpleElasticAgent):
             role: The role name for logging
             spec: Worker specification
             log_msg: Custom log message for restart
-            open_rendezvous: Whether to open rendezvous before restart (for barrier-based rendezvous)
-            notify_peer: Whether to notify peers to abort the workers in current cycle.
+            open_rendezvous: Whether to open rendezvous before restart.
 
         Returns:
             True if restart was initiated (caller should continue monitoring loop)
@@ -626,9 +590,6 @@ class LocalElasticAgent(SimpleElasticAgent):
         elif self._remaining_restarts > 0:
             logger.info(log_msg, role)
             self._remaining_restarts -= 1
-            # Increment peer_aborted_count to notify other nodes (for barrier-based rendezvous)
-            if notify_peer and hasattr(self._rdzv_handler, '_barrier_state'):
-                self._rdzv_handler._barrier_state._increment_peer_aborted_count()
             if open_rendezvous:
                 self._open_rendezvous_for_restart()
             self._restart_workers(self._worker_group)
@@ -687,7 +648,6 @@ class LocalElasticAgent(SimpleElasticAgent):
                 )
                 should_restart = self._handle_restart_decision(
                     role, spec, log_msg, open_rendezvous=True,
-                    notify_peer=True
                 )
 
                 if should_restart:
@@ -698,33 +658,23 @@ class LocalElasticAgent(SimpleElasticAgent):
                 self._worker_group.state = WorkerState.FAILED
                 return RunResult(state=WorkerState.FAILED)
             elif state == WorkerState.HEALTHY:
-                # Check for cluster-wide issues: new nodes waiting or peer aborts
-                # Note: unhealthy_count is now a global job-level counter and is not used here
-                # for failure detection. It's only used in the rendezvous for early termination.
-                self._maybe_exit_standby_on_success(role)
-
-                num_nodes_waiting = rdzv_handler.num_nodes_waiting()
-                peer_aborted_count = self._check_cluster_peer_aborted_count()
-                group_rank = self._worker_group.group_rank
-
-                if num_nodes_waiting > 0 or peer_aborted_count > 0:
+                # Check if any node in the cluster has opened the next rendezvous round,
+                # which signals that a peer detected a failure and triggered a restart.
+                # open_rendezvous() sets round_done_{N+1}=0; this is both the spare-node
+                # wake-up signal and the peer-failure signal for healthy nodes here.
+                if rdzv_handler.is_next_round_open():
+                    group_rank = self._worker_group.group_rank
                     # Record failure detection event
                     record_profiling_event(
                         ProfilingEvent.FAILURE_DETECTED,
                         node_id=self._rdzv_handler._this_node,
-                        rank=self._worker_group.group_rank,
+                        rank=group_rank,
                     )
 
-                    log_msg = (
-                        f"[%s] Detected cluster changes from group_rank={group_rank} "
-                        f"(nodes_waiting={num_nodes_waiting}, peer_aborted={peer_aborted_count}); "
-                        f"will restart worker group"
-                    )
-                    # Note: The node that triggered the change (unhealthy or new) already opened
-                    # the rendezvous, so we don't need to open it again here.
+                    log_msg = f"[%s] Joining cluster restart (group_rank={group_rank})"
+                    # The node that triggered the failure already opened the rendezvous.
                     should_restart = self._handle_restart_decision(
                         role, spec, log_msg, open_rendezvous=False,
-                        notify_peer=False
                     )
 
                     if not should_restart:
@@ -1033,9 +983,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         # Get the current cycle number from the rendezvous handler
         # At this point, rendezvous has completed and we're about to start workers.
         # The cycle number is used for profiling and environment variable setting.
-        # Note: We use _get_global_restart_count() because in the context of worker startup,
-        # the "restart_count" variable name is used to mean "cycle number" (for historical reasons).
-        current_cycle = restart_count = self._get_global_restart_count()  # Actually cycle number
+        current_cycle = restart_count = self._get_global_cycle_number()
 
         # Send current cycle number to rank monitors for logging
         self._send_cycle_to_rank_monitors(restart_count)
@@ -1128,9 +1076,8 @@ class LocalElasticAgent(SimpleElasticAgent):
         # Rank monitors are already created early (before gRPC) and connections established
         # in LocalElasticAgent.__init__(), so no need to call setup_rank_monitors here
 
-        # Standby nodes are those assigned a group_rank >= min_nodes after rendezvous.
-        # The rendezvous handler sets local_world_size to 0 for standby nodes, so no workers are created.
-        # Let the normal flow continue - PyTorch handles local_world_size=0 correctly.
+        # Standby nodes loop inside perform_rendezvous() until they become active or training ends.
+        # next_rendezvous() only returns with an active rank, so all nodes here start workers.
 
         assert spec.entrypoint is not None
         assert self._logs_specs is not None
@@ -1353,50 +1300,6 @@ class LocalElasticAgent(SimpleElasticAgent):
         if self._pcontext is not None:
             result = self._pcontext.wait(0)
         return result is not None and result.is_failed()
-
-    def _check_cluster_peer_aborted_count(self) -> int:
-        """Check the cluster-wide peer aborted count from the rendezvous store.
-
-        This tracks how many peers have detected local failures and decided to restart,
-        enabling faster failure propagation across the cluster.
-
-        Only supported for barrier-based rendezvous. Returns 0 for legacy rendezvous.
-
-        Returns:
-            The number of peers that have aborted in this cycle, or 0 if not available.
-        """
-        # Only barrier-based rendezvous supports peer_aborted_count
-        if hasattr(self._rdzv_handler, '_barrier_state'):
-            return self._rdzv_handler._barrier_state._get_peer_aborted_count()
-
-        # Legacy rendezvous does not support peer aborted tracking
-        return 0
-
-    def _maybe_exit_standby_on_success(self, role: str) -> None:
-        """If this node is a standby and the exit barrier is complete, exit gracefully.
-
-        Active agents only call _exit_barrier() on the SUCCEEDED path; when its
-        \"last_member\" key is set, all actives have finished. Checking this key
-        (instead of is_closed()) works even when the store host is a standby.
-
-        Raises:
-            RendezvousGracefulExitError: When standby detects success (caller should not catch).
-        """
-        min_nodes = self._rdzv_handler._settings.min_nodes
-        group_rank = self._worker_group.group_rank
-        if group_rank < min_nodes:
-            return
-        if self._store.check([_EXIT_BARRIER_LAST_MEMBER_KEY]):
-            self._on_cycle_end()
-            logger.info(
-                "[%s] Standby (group_rank=%s) detected exit barrier complete; "
-                "training finished successfully, exiting gracefully.",
-                role,
-                group_rank,
-            )
-            raise RendezvousGracefulExitError(
-                "Standby detected all active agents reached exit barrier (success)."
-            )
 
     def _rendezvous(self, worker_group: WorkerGroup) -> None:
         """Override _rendezvous to set worker group reference in the handler."""

--- a/src/nvidia_resiliency_ext/fault_tolerance/utils.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/utils.py
@@ -95,14 +95,14 @@ def get_infrastructure_rank(skip_nodename_logic: bool = False) -> int:
                 f"NVRX_INFRA_RANK_FROM_NODENAME is set but SLURMD_NODENAME '{nodename}' contains no digits"
             )
         infra_rank = int(digits)
-        logger.debug(f"Using infrastructure rank {infra_rank} from SLURMD_NODENAME '{nodename}'")
+        logger.debug(f"infra_rank={infra_rank} from SLURMD_NODENAME '{nodename}'")
         return infra_rank
 
     # Check CROSS_SLURM_PROCID second (for multi-job scenarios)
     cross_slurm_procid = os.getenv('CROSS_SLURM_PROCID')
     if cross_slurm_procid is not None:
         infra_rank = int(cross_slurm_procid)
-        logger.debug(f"Using infrastructure rank {infra_rank} from CROSS_SLURM_PROCID")
+        logger.debug(f"infra_rank={infra_rank} from CROSS_SLURM_PROCID")
         return infra_rank
 
     # Check SLURM_TOPOLOGY_ADDR with block awareness third
@@ -161,8 +161,8 @@ def get_infrastructure_rank(skip_nodename_logic: bool = False) -> int:
             # This keeps block index in MSB for proper ordering
             infra_rank = block_num * multiplier + node_num
             logger.debug(
-                f"Using infrastructure rank {infra_rank} from SLURM_TOPOLOGY_ADDR '{topology_addr}' "
-                f"(block={block_num}, node={node_num}, multiplier={multiplier}) with pattern '{topology_pattern}'"
+                f"infra_rank={infra_rank} from SLURM_TOPOLOGY_ADDR '{topology_addr}' "
+                f"(block={block_num}, node={node_num}, pattern='{topology_pattern}')"
             )
             return infra_rank
 
@@ -196,7 +196,7 @@ def get_infrastructure_rank(skip_nodename_logic: bool = False) -> int:
         # Calculate global infrastructure rank: array_task_id * nodes_per_task + local_node_id
         infra_rank = array_task_id * nnodes + proc_id
         logger.debug(
-            f"Using infrastructure rank {infra_rank} from SLURM job array "
+            f"infra_rank={infra_rank} from SLURM job array "
             f"(array_task_id={array_task_id}, nnodes={nnodes}, procid={proc_id})"
         )
         return infra_rank
@@ -206,7 +206,7 @@ def get_infrastructure_rank(skip_nodename_logic: bool = False) -> int:
 
     if infra_rank_str is not None:
         infra_rank = int(infra_rank_str)
-        logger.debug(f"Using infrastructure rank {infra_rank} from environment")
+        logger.debug(f"infra_rank={infra_rank} from environment")
         return infra_rank
 
     # Check if we're running under SLURM - if so, SLURM_PROCID should be defined
@@ -618,3 +618,36 @@ def hostnames_to_slurm_nodelist(addrs: list) -> str:
         range_strs = _numbers_to_slurm_ranges(nums, pad)
         result_parts.append(f"{prefix}[{','.join(range_strs)}]")
     return ",".join(result_parts)
+
+
+def slurm_sort_addrs(addrs: list) -> list:
+    """Return addrs sorted by the same key as hostnames_to_slurm_nodelist.
+
+    Sorts by (prefix_alpha, numeric_suffix). Unparseable names sort last.
+    """
+
+    def _sort_key(addr: str):
+        short = addr.split(".")[0].strip()
+        p = _parse_hostname_prefix_suffix(short)
+        return (0, p[0], p[1]) if p else (1, short, 0)
+
+    return sorted(addrs, key=_sort_key)
+
+
+def ranks_to_range_str(ranks: list[int]) -> str:
+    """Compress an ordered list of ints into a SLURM-style range string.
+
+    Preserves input order (no re-sort). E.g. [0,1,2,5,6] -> "0-2,5-6", [] -> "".
+    """
+    if not ranks:
+        return ""
+    ranges: list[str] = []
+    start = end = ranks[0]
+    for r in ranks[1:]:
+        if r == end + 1:
+            end = r
+        else:
+            ranges.append(f"{start}-{end}" if start != end else str(start))
+            start = end = r
+    ranges.append(f"{start}-{end}" if start != end else str(start))
+    return ",".join(ranges)

--- a/src/nvidia_resiliency_ext/shared_utils/profiling.py
+++ b/src/nvidia_resiliency_ext/shared_utils/profiling.py
@@ -54,8 +54,9 @@ class FaultToleranceProfiler:
         """Set the current cycle number.
 
         Called by the rendezvous handler when a newly joining node syncs its cycle number
-        from the global_cycle_key in the store. This ensures newly joining nodes (e.g.,
-        replacement array tasks) continue with the correct cycle number instead of starting from 0.
+        via _sync_from_per_round_state() which scans per-round round_done keys. This ensures
+        newly joining nodes (e.g., replacement array tasks) continue with the correct cycle
+        number instead of starting from 0.
 
         Args:
             cycle: The cycle number to set. Only sets if >= current cycle to prevent backward jumps.
@@ -125,6 +126,11 @@ def record_profiling_event(
         Event ID string
     """
     return _get_global_profiler().record_event(event, node_id, rank)
+
+
+def get_profiling_cycle() -> int:
+    """Return the current profiling cycle number."""
+    return _get_global_profiler()._current_cycle
 
 
 def set_profiling_cycle(cycle: int) -> None:

--- a/src/nvidia_resiliency_ext/shared_utils/proto/nvrx_interface.proto
+++ b/src/nvidia_resiliency_ext/shared_utils/proto/nvrx_interface.proto
@@ -51,4 +51,8 @@ message NVRxCycleInfo {
   // write. A CAS update only succeeds when the stored generation equals the one
   // in the request; after a successful write, the new generation is (previous + 1).
   uint64 generation = 9;
+
+  // Group ranks of active nodes, aligned with active_nodes (same sort order).
+  // SLURM-range-compressed, e.g. "0-3,6".
+  string active_ranks = 10;
 }

--- a/src/nvidia_resiliency_ext/testing_utils/health_check_injector.py
+++ b/src/nvidia_resiliency_ext/testing_utils/health_check_injector.py
@@ -15,34 +15,54 @@
 # limitations under the License.
 
 """
-GPU Health Check Failure Injection Utility
+Node Failure Injection Utility
 
-This module provides utilities to simulate GPU health check failures
-during specific restart cycles for specific nodes. Useful for testing fault
-tolerance mechanisms.
+This module provides utilities to simulate node failures during specific
+training cycles for specific physical nodes. Useful for testing fault tolerance
+mechanisms such as spare-node replacement.
 
-This module monkey-patches GPUHealthCheck when NVRX_INJECT_GPU_FAILURE is set.
+Injection fires inside ensure_node_is_healthy() (before rendezvous), keyed by
+infra_rank (physical node rank derived from SLURM env). A node targeted by
+infra_rank may be active or standby in a given cycle — the failure is only
+triggered if that physical node is selected.
 
 Environment Variables:
     NVRX_INJECT_GPU_FAILURE: Format "cycle:infra_rank,cycle:infra_rank,..."
-        - Specify which infrastructure group rank(s) should fail at which cycle
-        - Multiple ranks can fail in the same cycle by repeating the cycle number
-        - Examples: 
-          * "1:1,3:17,5:33" means:
-            - Cycle 1: infrastructure rank 1 fails
-            - Cycle 3: infrastructure rank 17 fails  
-            - Cycle 5: infrastructure rank 33 fails
-          * "1:1,1:2,1:5,3:17,3:18" means:
-            - Cycle 1: infrastructure ranks 1, 2, and 5 fail
-            - Cycle 3: infrastructure ranks 17 and 18 fail
+        - cycle: profiling cycle number shown in logs ("Cycle: N Event: ...")
+        - infra_rank: physical node rank (from SLURMD_NODENAME or SLURM_PROCID)
+        - Multiple entries can target the same cycle by repeating the cycle number
+        - Examples:
+          * "4:0,8:1" means:
+            - Cycle 4: physical node with infra_rank 0 fails
+            - Cycle 8: physical node with infra_rank 1 fails
+          * "1:0,1:1,3:0" means:
+            - Cycle 1: infra_rank 0 and infra_rank 1 both fail
+            - Cycle 3: infra_rank 0 fails
 
 Note:
-    - Infrastructure rank is calculated using get_infrastructure_rank() from utils.py
-    - Supports both regular SLURM deployments and SLURM job array deployments
-    - For job arrays: infra_rank = array_task_id * nnodes_per_task + slurm_procid
-    - Cycle number is passed from the rendezvous round counter
-    - The rendezvous runs once per node, not per rank
-    - This module automatically activates when imported if NVRX_INJECT_GPU_FAILURE is set
+    - Injection fires before rendezvous (in ensure_node_is_healthy)
+    - The targeted node may be active or standby in that cycle
+    - Using infra_rank is deterministic and suitable for small-scale HW failure testing
+
+Known limitations (cycle counter on replacement/standby nodes):
+    The cycle counter is driven by FAILURE_DETECTED events in the launcher. This event
+    only fires on nodes whose workers are actively monitored (i.e. active training nodes).
+
+    - Replacement nodes (new SLURM tasks joining after a failure): their launcher
+      process starts fresh with cycle=0. FAILURE_DETECTED never fires, so
+      get_profiling_cycle() returns 0 regardless of the actual training round.
+      A "1:33" injection targeting a replacement node at infra_rank=33 will NOT fire
+      because the cycle never reaches 1 on that process.
+
+    - Standby nodes that are promoted to active: FAILURE_DETECTED fires on the
+      surviving active nodes' launchers, not on the standby's launcher. If the
+      targeted infra_rank happens to be the standby node in that cycle, the cycle
+      counter on its process may not match the expected injection cycle, and the
+      fault will silently not fire.
+
+    In both cases the injection is a no-op for that node. To reliably test HW failure,
+    target an infra_rank that is guaranteed to be a persistent active training node
+    (not a candidate standby or replacement) across the target cycles.
 """
 
 import logging
@@ -50,61 +70,30 @@ import os
 import socket
 from typing import Dict, Optional, Set
 
-from nvidia_resiliency_ext.fault_tolerance.utils import get_infrastructure_rank
 from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
 
 logger = logging.getLogger(LogConfig.name)
 
-# Global variable to store the current cycle for injection checking
-_current_cycle: Optional[int] = None
-
-
-def set_current_cycle(cycle: int) -> None:
-    """
-    Set the current rendezvous cycle for injection checking.
-
-    This should be called by the rendezvous handler before health checks.
-
-    Args:
-        cycle: The current rendezvous round/cycle number.
-    """
-    global _current_cycle
-    _current_cycle = cycle
-
 
 class HealthCheckInjector:
-    """Manages GPU health check failure injection for testing purposes."""
+    """Manages node failure injection for testing fault tolerance."""
 
     def __init__(self):
-        """Initialize the health check injector."""
-        # Parse the failure specification: "cycle:infra_rank,cycle:infra_rank,..."
         self._failure_map: Dict[int, Set[int]] = self._parse_failure_spec()
         self._current_node = socket.gethostname()
 
         if self._failure_map:
             failure_summary = ", ".join(
-                f"cycle {cycle} -> ranks {sorted(ranks)}"
+                f"cycle {cycle} -> infra_ranks {sorted(ranks)}"
                 for cycle, ranks in sorted(self._failure_map.items())
             )
             logger.warning(
-                f"GPU health check failure injection ENABLED on node {self._current_node}:\n"
+                f"Node failure injection ENABLED on node {self._current_node}:\n"
                 f"  Failure map: {failure_summary}"
             )
 
     def _parse_failure_spec(self) -> Dict[int, Set[int]]:
-        """
-        Parse the failure specification from environment variable.
-
-        Format: "cycle:infra_rank,cycle:infra_rank,..."
-        Multiple ranks can fail in the same cycle by repeating the cycle number.
-
-        Examples:
-            "1:1,3:17,5:33" - Single rank per cycle
-            "1:1,1:2,1:5,3:17,3:18" - Multiple ranks in cycles 1 and 3
-
-        Returns:
-            Dict mapping cycle number to set of infrastructure ranks that should fail
-        """
+        """Parse NVRX_INJECT_GPU_FAILURE into {cycle: set(infra_ranks)}."""
         spec = os.environ.get("NVRX_INJECT_GPU_FAILURE", "").strip()
         if not spec:
             return {}
@@ -139,57 +128,19 @@ class HealthCheckInjector:
 
         return failure_map
 
-    def _get_infra_rank(self) -> Optional[int]:
-        """
-        Get the infrastructure rank of this node.
-
-        Uses get_infrastructure_rank() which handles both regular SLURM deployments
-        and SLURM job array deployments correctly.
-
-        For testing purposes, this skips the nodename-based logic to prefer the SLURM
-        array task ID calculation, which is more predictable for test scenarios.
-
-        Returns:
-            Infrastructure rank or None if it cannot be determined.
-        """
-        try:
-            return get_infrastructure_rank(skip_nodename_logic=True)
-        except (ValueError, KeyError, TypeError) as e:
-            logger.error(f"Failed to get infrastructure rank: {e}")
-            return None
-
-    def should_inject_gpu_failure(self, cycle: int) -> bool:
-        """
-        Check if GPU failure should be injected for this node in the given cycle.
-
-        Args:
-            cycle: The current rendezvous cycle/round number.
-
-        Returns:
-            bool: True if GPU failure should be injected, False otherwise.
-        """
+    def should_inject_failure(self, cycle: int, infra_rank: int) -> bool:
+        """Return True if a failure should be injected for this node at (cycle, infra_rank)."""
         if not self._failure_map:
             return False
 
-        # Check if this cycle has any failures configured
         if cycle not in self._failure_map:
             return False
 
-        target_ranks = self._failure_map[cycle]
-        infra_rank = self._get_infra_rank()
-
-        # If we can't determine infra rank, don't inject
-        if infra_rank is None:
-            logger.warning(
-                f"Cannot inject failure: unable to determine infrastructure rank for node {self._current_node}"
-            )
-            return False
-
-        should_inject = infra_rank in target_ranks
+        should_inject = infra_rank in self._failure_map[cycle]
 
         if should_inject:
             logger.warning(
-                f"INJECTING GPU HEALTH CHECK FAILURE: "
+                f"INJECTING FAILURE: "
                 f"node={self._current_node}, infra_rank={infra_rank}, cycle={cycle}"
             )
 
@@ -201,41 +152,16 @@ _injector: Optional[HealthCheckInjector] = None
 
 
 def _get_injector() -> Optional[HealthCheckInjector]:
-    """Get the global health check injector instance, or None if not enabled."""
+    """Get the global injector instance, creating it on first call if enabled."""
     global _injector
     if _injector is None and os.environ.get("NVRX_INJECT_GPU_FAILURE"):
         _injector = HealthCheckInjector()
     return _injector
 
 
-def _monkey_patch_gpu_health_check():
-    """
-    Monkey-patch GPUHealthCheck to inject failures when configured.
-
-    This wraps the GPUHealthCheck.__call__ method to check for injection before
-    performing the actual health check.
-    """
-    from nvidia_resiliency_ext.shared_utils.health_check import GPUHealthCheck
-
-    # Store the original __call__ method
-    _original_call = GPUHealthCheck.__call__
-
-    def _wrapped_call(self):
-        """Wrapped __call__ that checks for injection first."""
-        injector = _get_injector()
-        if injector and _current_cycle is not None:
-            if injector.should_inject_gpu_failure(_current_cycle):
-                # Inject failure - return False to indicate unhealthy
-                return False
-
-        # Otherwise, call the original health check
-        return _original_call(self)
-
-    # Apply the monkey patch
-    GPUHealthCheck.__call__ = _wrapped_call
-    logger.debug("GPU health check has been monkey-patched for failure injection")
-
-
-# Automatically apply monkey patch if injection is enabled
-if os.environ.get("NVRX_INJECT_GPU_FAILURE"):
-    _monkey_patch_gpu_health_check()
+def should_inject_failure(cycle: int, infra_rank: int) -> bool:
+    """Return True if a failure should be injected at (cycle, infra_rank)."""
+    injector = _get_injector()
+    if injector is None:
+        return False
+    return injector.should_inject_failure(cycle, infra_rank)

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -44,7 +44,7 @@ from nvidia_resiliency_ext.fault_tolerance import (
     ft_rendezvous_barrier as ft_rendezvous_barrier_module,
 )
 from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import (
-    WITHDRAWN_DOMAIN_ID,
+    WITHDRAWN,
     FtRendezvousBarrierHandler,
     RendezvousParticipantInfo,
     RendezvousTimeout,
@@ -273,11 +273,11 @@ class BarrierStateBasicTest(BaseRendezvousTest):
         self.assertEqual(state.run_id, self.run_id)
         self.assertTrue(state.is_store_host)
         self.assertIn(self.run_id, state.prefix)
-        self.assertIn(self.run_id, state.arrived_count_key)
-        self.assertIn(self.run_id, state.last_participant_arrived_key)
+        self.assertIn(self.run_id, state.join_count_key)
+        self.assertIn(self.run_id, state.round_done_key)
 
-    def test_is_permanently_closed_initially_false(self):
-        """Test that rendezvous is not permanently closed initially."""
+    def test_is_shutdown_initially_false(self):
+        """Test that rendezvous is not shut down initially."""
         state = _RendezvousBarrierState(
             store=self.store,
             run_id=self.run_id,
@@ -285,10 +285,10 @@ class BarrierStateBasicTest(BaseRendezvousTest):
             join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
         )
 
-        self.assertFalse(state.is_permanently_closed())
+        self.assertFalse(state.is_shutdown())
 
-    def test_set_permanently_closed(self):
-        """Test that set_permanently_closed marks rendezvous as permanently closed."""
+    def test_set_shutdown(self):
+        """Test that set_shutdown marks rendezvous as permanently shut down."""
         state = _RendezvousBarrierState(
             store=self.store,
             run_id=self.run_id,
@@ -296,11 +296,11 @@ class BarrierStateBasicTest(BaseRendezvousTest):
             join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
         )
 
-        state.set_permanently_closed()
-        self.assertTrue(state.is_permanently_closed())
+        state.set_shutdown()
+        self.assertTrue(state.is_shutdown())
 
-    def test_join_increments_arrived_count(self):
-        """Test that joining increments the arrived_count atomically."""
+    def test_join_increments_join_count(self):
+        """Test that joining increments join_count atomically."""
         state = _RendezvousBarrierState(
             store=self.store,
             run_id=self.run_id,
@@ -309,15 +309,15 @@ class BarrierStateBasicTest(BaseRendezvousTest):
         )
 
         # First join
-        count1 = self.store.add(state.arrived_count_key, 1)
+        count1 = self.store.add(state.join_count_key, 1)
         self.assertEqual(count1, 1)
 
         # Second join
-        count2 = self.store.add(state.arrived_count_key, 1)
+        count2 = self.store.add(state.join_count_key, 1)
         self.assertEqual(count2, 2)
 
         # Third join
-        count3 = self.store.add(state.arrived_count_key, 1)
+        count3 = self.store.add(state.join_count_key, 1)
         self.assertEqual(count3, 3)
 
     def test_get_all_participants_incremental_fetch(self):
@@ -343,9 +343,9 @@ class BarrierStateBasicTest(BaseRendezvousTest):
         ]
 
         for i, (node_desc, infra_rank, domain_id) in enumerate(participants_data, start=1):
-            arrived_key = f"{state.prefix}:arrived_{i}"
+            slot_key = f"{state.prefix}:slot_{i}"
             participant_data = RendezvousParticipantInfo.pack(node_desc, infra_rank, domain_id)
-            self.store.set(arrived_key, participant_data)
+            self.store.set(slot_key, participant_data)
 
         # Test 1: Fetch all participants at once
         all_participants = state.get_all_participants(total_participants=5)
@@ -391,7 +391,7 @@ class BarrierStateBasicTest(BaseRendezvousTest):
         self.assertEqual(len(result), 2)  # Should return existing list (first_two_copy3)
 
         # Test 6: Cycle filtering - mismatched cycle should be treated as placeholder
-        mismatch_key = f"{state.prefix}:arrived_3"
+        mismatch_key = f"{state.prefix}:slot_3"
         mismatch_data = RendezvousParticipantInfo.pack(
             participants_data[2][0], participants_data[2][1], participants_data[2][2], cycle_id=1
         )
@@ -400,7 +400,7 @@ class BarrierStateBasicTest(BaseRendezvousTest):
         self.assertEqual(len(filtered), 5)
         self.assertEqual(
             filtered[2][2],
-            WITHDRAWN_DOMAIN_ID,
+            WITHDRAWN,
             "Cycle mismatch should be converted to placeholder participant",
         )
 
@@ -461,7 +461,7 @@ class Step2CompletionTest(BaseRendezvousTest):
         self.store = self.shared_store
         # Use uuid so run_id is globally unique. time.time()-based run_id can collide
         # when tests run in the same microsecond (retries/fast runs), leaving
-        # last_participant_arrived_key=1 from a prior run so participants wait at Step 0.
+        # round_done_0=1 from a prior run so participants wait at Step 0.
         self.run_id = f"test_step2_{self._testMethodName}_{uuid.uuid4().hex}"
         self.node_desc_gen = _NodeDescGenerator()
 
@@ -583,7 +583,7 @@ class RaceConditionTest(BaseRendezvousTest):
         arrived_counts = []
 
         def join_thread():
-            count = self.store.add(state.arrived_count_key, 1)
+            count = self.store.add(state.join_count_key, 1)
             arrived_counts.append(count)
 
         threads = []
@@ -600,17 +600,19 @@ class RaceConditionTest(BaseRendezvousTest):
         self.assertEqual(len(arrived_counts), num_participants)
         self.assertEqual(set(arrived_counts), set(range(1, num_participants + 1)))
 
-    def test_late_arrival_after_ack_check_before_key_clear(self):
-        """Test late arrival in the critical window: after ack check, before key clearing.
+    def test_late_arrival_after_snapshot_before_assignment(self):
+        """Test late arrival in the critical window: after store host snapshot, before assignment.
 
         This tests the race condition where:
-        1. Store host checks ack_count >= arrived_count (condition satisfied)
-        2. Late arrival joins and increments arrived_count
-        3. Late arrival acknowledges, incrementing ack_count
-        4. Store host clears keys and assigns ranks (may miss the late arrival)
+        1. Store host takes a double-checked snapshot of join_count_key (condition satisfied)
+        2. Late arrival joins and increments join_count_key after the snapshot
+        3. Store host assigns ranks based on the snapshot (late arrival is not included)
+        4. Late arrival sees UNASSIGNED in Step 3 and retries in the next round
 
-        The current design handles this by having store host snapshot the arrived_count
-        at the time it checks acknowledgments, ensuring consistent rank assignment.
+        The current design handles this by having the store host snapshot join_count at the
+        time of the double-check, ensuring consistent rank assignment. Late arrivals that
+        miss the snapshot detect UNASSIGNED via the embedded round number in rank_key and
+        loop to the next round.
         """
         min_nodes = 2
         max_nodes = 4
@@ -714,8 +716,8 @@ class RaceConditionTest(BaseRendezvousTest):
         )
 
         # Late arrival can be stuck in Step 0 (_wait_for_rendezvous_open): it sees
-        # last_participant_arrived_key=1 (round complete) and waits for the next round
-        # with no timeout. Unblock it by opening the rendezvous so it proceeds to Step 2,
+        # round_done_0=1 (round 0 complete) and waits for round_done_1 to appear.
+        # Unblock it by setting round_done_1=0 so it proceeds to Step 2,
         # then hits join_timeout_seconds and raises RendezvousTimeoutError.
         unblock_state = _RendezvousBarrierState(
             store=self.store,
@@ -723,7 +725,8 @@ class RaceConditionTest(BaseRendezvousTest):
             is_store_host=False,
             join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
         )
-        self.store.set(unblock_state.last_participant_arrived_key, "0".encode("utf-8"))
+        round1_done_key = f"{unblock_state.prefix}:round_done_1"
+        self.store.set(round1_done_key, "0".encode("utf-8"))
 
         t_late.join(timeout=join_timeout)
         self.assertFalse(
@@ -759,7 +762,7 @@ class RaceConditionTest(BaseRendezvousTest):
 
         # Multiple threads try to set the same key
         def set_completion():
-            self.store.set(state.last_participant_arrived_key, "1".encode('utf-8'))
+            self.store.set(state.round_done_key, "1".encode('utf-8'))
 
         threads = []
         for _ in range(5):
@@ -772,7 +775,7 @@ class RaceConditionTest(BaseRendezvousTest):
         _assert_threads_finished(self, threads, TEST_THREAD_JOIN_TIMEOUT_SECS)
 
         # Key should be set (no errors)
-        self.assertTrue(self.store.check([state.last_participant_arrived_key]))
+        self.assertTrue(self.store.check([state.round_done_key]))
 
 
 class StoreHostBehaviorTest(BaseRendezvousTest):
@@ -795,7 +798,7 @@ class StoreHostBehaviorTest(BaseRendezvousTest):
         self.store = self.shared_store
         # Use uuid so run_id is globally unique. time.time()-based run_id can collide
         # when tests run in the same microsecond (retries/fast runs), leaving
-        # last_participant_arrived_key=1 so participants block at Step 0.
+        # round_done_0=1 so participants block at Step 0.
         self.run_id = f"test_host_{self._testMethodName}_{uuid.uuid4().hex}"
         self.node_desc_gen = _NodeDescGenerator()
 
@@ -1662,13 +1665,12 @@ class ErrorCaseTest(BaseRendezvousTest):
         """Test that exceeding max_nodes raises RendezvousClosedError.
 
         Root cause of previous flakiness:
-        - Three threads call store.add(arrived_count_key, 1) and get 1, 2, 3.
+        - Three threads call store.add(join_count_key, 1) and get 1, 2, 3.
         - The thread that gets 3 should raise RendezvousClosedError.
         - The two that get 1 and 2 enter Step 2; the store host runs a segment check
-          after segment_check_interval seconds, then completes and calls
-          _clear_barrier_keys(), which deletes arrived_count_key.
-        - If the third thread runs store.add() after the key was deleted, it can get
-          count 1 (new key) and not raise, so the test non-deterministically failed.
+          after segment_check_interval seconds, then completes.
+        - Per-round keys persist but the third thread joins with the same round, so it
+          still sees count 3 and raises, making the test deterministic.
 
         Deterministic design: disable Step 2 checks in this test by monkey-patching
         the per-state poll interval helper to a very large value. Then the first
@@ -1740,7 +1742,7 @@ class ErrorCaseTest(BaseRendezvousTest):
         Uses a dedicated TCPStore so the rendezvous is open (no leftover keys from
         other tests). We then hit the join timeout in Step 2 while waiting for min_nodes.
         """
-        # Dedicated store so last_participant_arrived_key does not exist; __init__ sets it to "0".
+        # Dedicated store so round_done_0 does not exist; __init__ sets it to "0".
         # This avoids waiting at Step 0 when the class shared_store has leftover state.
         # TCPStore does not provide close()/shutdown(); store is released when GC runs.
         store = TCPStore(
@@ -1775,8 +1777,8 @@ class ErrorCaseTest(BaseRendezvousTest):
         )
 
         # Permanently close the rendezvous
-        state.set_permanently_closed()
-        self.assertTrue(state.is_permanently_closed())
+        state.set_shutdown()
+        self.assertTrue(state.is_shutdown())
 
         min_nodes = 2
         max_nodes = 4
@@ -1868,13 +1870,11 @@ class AcknowledgmentPhaseTest(BaseRendezvousTest):
             f"Expected {min_nodes} participants to acknowledge, got {len(results)}",
         )
 
-    def test_barrier_keys_cleared_after_acknowledgment(self):
-        """Test that barrier keys are cleared after all acknowledgments.
+    def test_per_round_keys_persist_after_round(self):
+        """Test that per-round keys persist after round completion (not cleared).
 
-        Keys cleared: arrived_count_key, withdrawn_count_key, ack_count_key, peer_aborted_count_key
-        Keys NOT cleared:
-        - last_participant_arrived_key: serves as open/close indicator
-        - unhealthy_count_key: global job-level counter across all cycles
+        join_count_{N+1} does not exist during training, so num_nodes_waiting() returns 0.
+        Round N keys persist with correct values — the per-round naming makes them harmless.
 
         Runs participants in separate processes (fork) so each has its own store
         connection; avoids shared-store contention that can hang with threads.
@@ -1907,21 +1907,28 @@ class AcknowledgmentPhaseTest(BaseRendezvousTest):
             is_store_host=False,
             join_timeout_seconds=join_timeout_seconds,
         )
-        self.assertFalse(
-            store.check([check_state.arrived_count_key]),
-            "arrived_count_key should be cleared after all acks",
+
+        # Round 0 join_count persists with value = min_nodes
+        self.assertTrue(
+            store.check([check_state.join_count_key]),
+            "join_count_0 should persist after round (per-round key, not cleared)",
         )
-        self.assertFalse(
-            store.check([check_state.withdrawn_count_key]),
-            "withdrawn_count_key should be cleared after all acks",
+        join_count = int(store.get(check_state.join_count_key).decode('utf-8'))
+        self.assertEqual(join_count, min_nodes, f"join_count_0 should equal {min_nodes}")
+
+        # round_done_0 persists and is "1" (closed)
+        self.assertTrue(store.check([check_state.round_done_key]), "round_done_0 should persist")
+        self.assertEqual(
+            store.get(check_state.round_done_key).decode('utf-8'),
+            "1",
+            "round_done_0 should be 1 after completion",
         )
+
+        # Round 1 join_count does NOT exist — no false positive for num_nodes_waiting()
+        round1_join_count_key = f"{check_state.prefix}:join_count_1"
         self.assertFalse(
-            store.check([check_state.ack_count_key]),
-            "ack_count_key should be cleared after all acks",
-        )
-        self.assertFalse(
-            store.check([check_state.peer_aborted_count_key]),
-            "peer_aborted_count_key should be cleared after all acks",
+            store.check([round1_join_count_key]),
+            "join_count_1 must NOT exist during training (prevents num_nodes_waiting() false positive)",
         )
 
 
@@ -2130,7 +2137,7 @@ class StaleRoundDetectionTest(BaseRendezvousTest):
         self.assertEqual(state.stale_check_interval, 10.0)
 
     def test_stale_round_detection_rate_limiting(self):
-        """Test that stale round detection is rate-limited properly at Step 0."""
+        """Test that _sync_from_per_round_state is rate-limited properly at Step 0."""
         # Use a short interval for this test
         check_interval = 0.5  # 500ms
         state = _RendezvousBarrierState(
@@ -2141,40 +2148,27 @@ class StaleRoundDetectionTest(BaseRendezvousTest):
             stale_check_interval=check_interval,
         )
 
-        # Set rendezvous as closed (training in progress)
-        state.store.set(state.last_participant_arrived_key, b"1")
+        # Set round_done_0=1 to simulate training in progress after round 0
+        state.store.set(state.round_done_key, b"1")
 
-        # Set global cycle to a higher value to trigger stale round detection
-        state.store.set(state.global_cycle_key, b"2")
-
-        # Track how many times we would check the store
+        # Track how many times _sync_from_per_round_state would be called
         check_count = 0
         start_time = time.monotonic()
         test_duration = 1.5  # Run for 1.5 seconds
 
-        node_desc = self.node_desc_gen.generate()
-
-        # Simulate the waiting loop at Step 0
-        # We manually simulate the loop instead of calling _wait_for_rendezvous_open()
-        # to avoid the actual waiting behavior
+        # Simulate the waiting loop at Step 0 when value==1 (closed)
+        # We manually simulate the rate-limited check to avoid actual waiting behavior
         while time.monotonic() - start_time < test_duration:
-            # Save the last check time before checking
             last_check_time = state._last_stale_check_time
 
-            # Simulate the stale round check from _wait_for_rendezvous_open()
             current_time = time.monotonic()
             if current_time - state._last_stale_check_time >= state.stale_check_interval:
                 state._last_stale_check_time = current_time
-                if state.store.check([state.global_cycle_key]):
-                    stored_cycle_bytes = state.store.get(state.global_cycle_key)
-                    stored_cycle = int(stored_cycle_bytes.decode('utf-8'))
-                    # Would raise RendezvousStaleRoundError here, but we just count
+                state._sync_from_per_round_state()
 
-            # If last_check_time changed, a check was performed
             if state._last_stale_check_time != last_check_time:
                 check_count += 1
 
-            # Sleep a very short time to simulate tight loop
             time.sleep(0.01)
 
         # We expect approximately test_duration / check_interval checks
@@ -2190,8 +2184,8 @@ class StaleRoundDetectionTest(BaseRendezvousTest):
         # (which would be ~150 iterations at 10ms sleep over 1.5 seconds)
         self.assertLess(check_count, 10)
 
-    def test_stale_round_raises_exception(self):
-        """Test that detecting a stale round syncs automatically at Step 0."""
+    def test_stale_round_syncs_automatically(self):
+        """Test that _sync_from_per_round_state syncs round by scanning per-round keys."""
         state = _RendezvousBarrierState(
             store=self.store,
             run_id=self.run_id,
@@ -2200,29 +2194,28 @@ class StaleRoundDetectionTest(BaseRendezvousTest):
             stale_check_interval=0.1,  # Short interval for testing
         )
 
-        # Set initial local round
-        state._rendezvous_round = 1
-
-        # Set global cycle to a higher value to trigger stale round detection
-        state.store.set(state.global_cycle_key, b"5")
-
-        # Set rendezvous as open so we can exit the wait loop
-        state.store.set(state.last_participant_arrived_key, b"0")
+        # Simulate: rounds 0-4 all completed (round_done_{0..4}=1)
+        # Round 5 is open (round_done_5=0)
+        prefix = state.prefix
+        for i in range(5):
+            state.store.set(f"{prefix}:round_done_{i}", b"1")
+        state.store.set(f"{prefix}:round_done_5", b"0")
 
         node_desc = self.node_desc_gen.generate()
 
-        # Should sync automatically when stale round detected at Step 0
-        # The method should return normally (not raise exception)
+        # _wait_for_rendezvous_open starts at _round=0, sees round_done_0=1 (closed),
+        # calls _sync_from_per_round_state which scans forward and advances _round to 5.
+        # Then sees round_done_5=0 (open) and returns.
         state._wait_for_rendezvous_open(node_desc)
 
-        # Verify that the round was synced
-        self.assertEqual(state._rendezvous_round, 5)
+        # Verify that the round was synced to 5
+        self.assertEqual(state._round, 5)
 
 
-class SignalWithdrawRendezvousTest(BaseRendezvousTest):
-    """Test that a participant that receives SIGTERM after joining (Step 1) withdraws by
-    incrementing withdrawn_count_key and marking its slot with invalid domain_id, so the
-    store host can complete Step 3b (ack check uses arrived - withdrawn).
+class SignalLeaveRendezvousTest(BaseRendezvousTest):
+    """Test that a participant that receives SIGTERM after joining (Step 1) leaves by
+    incrementing leave_count_key and marking its slot with WITHDRAWN domain_id, so the
+    store host can compute active_count = join_count - leave_count for assignment.
     """
 
     @classmethod
@@ -2239,7 +2232,7 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
         """Set up test fixtures with unique run_id for each test."""
         super().setUp()
         self.store = self.shared_store
-        self.run_id = f"test_signal_withdraw_{self._testMethodName}_{uuid.uuid4().hex}"
+        self.run_id = f"test_signal_leave_{self._testMethodName}_{uuid.uuid4().hex}"
         self.node_desc_gen = _NodeDescGenerator()
 
     def tearDown(self):
@@ -2247,8 +2240,8 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
         super().tearDown()
         ft_rendezvous_barrier_module._current_joined_state = None
 
-    def test_withdraw_from_rendezvous_decrements_once(self):
-        """Test that _withdraw_from_rendezvous increments withdrawn_count_key and marks slot; idempotent."""
+    def test_leave_rendezvous_increments_once(self):
+        """Test that _leave_rendezvous increments leave_count_key and marks slot; idempotent."""
         state = _RendezvousBarrierState(
             store=self.store,
             run_id=self.run_id,
@@ -2256,35 +2249,35 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
             join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
         )
         # Simulate one participant having joined (slot 1)
-        self.store.add(state.arrived_count_key, 1)
-        state._arrived_count = 1  # Simulate we are that participant
-        self.assertEqual(int(self.store.get(state.arrived_count_key).decode('utf-8')), 1)
+        self.store.add(state.join_count_key, 1)
+        state._slot = 1  # Simulate we are that participant
+        self.assertEqual(int(self.store.get(state.join_count_key).decode('utf-8')), 1)
 
-        state._withdraw_from_rendezvous()
-        # arrived_count stays 1; withdrawn_count becomes 1
+        state._leave_rendezvous()
+        # join_count stays 1; leave_count becomes 1
         self.assertEqual(
-            int(self.store.get(state.arrived_count_key).decode('utf-8')),
+            int(self.store.get(state.join_count_key).decode('utf-8')),
             1,
-            "arrived_count should remain 1 after withdraw (slot space is monotonic)",
+            "join_count should remain 1 after leave (slot space is monotonic)",
         )
         self.assertEqual(
-            int(self.store.get(state.withdrawn_count_key).decode('utf-8')),
+            int(self.store.get(state.leave_count_key).decode('utf-8')),
             1,
-            "withdrawn_count should be 1 after withdraw",
+            "leave_count should be 1 after leave",
         )
 
-        # Idempotent: second call must not increment withdrawn again
-        state._withdraw_from_rendezvous()
+        # Idempotent: second call must not increment leave_count again
+        state._leave_rendezvous()
         self.assertEqual(
-            int(self.store.get(state.withdrawn_count_key).decode('utf-8')),
+            int(self.store.get(state.leave_count_key).decode('utf-8')),
             1,
-            "withdrawn_count should still be 1 after second withdraw",
+            "leave_count should still be 1 after second leave",
         )
 
-    def test_signal_after_join_causes_withdraw(self):
+    def test_signal_after_join_causes_leave(self):
         """Test that when a participant is interrupted after Step 1 (e.g. SIGTERM), the
-        finally block withdraws (increments withdrawn_count_key, marks slot) so the store
-        host can complete Step 3b. We simulate the signal by using a store wrapper that
+        finally block leaves (increments leave_count_key, marks slot) so the store
+        host can complete Step 2. We simulate the signal by using a store wrapper that
         raises SignalException on get() once _current_joined_state is set (after join).
         """
         # min_nodes=2 so the host waits for both to join before marking complete (host is faster
@@ -2297,37 +2290,45 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
         # Host runs perform_rendezvous directly and waits for 2 participants.
         join_timeout_secs = 60.0
 
-        # Event set when participant has joined (add(arrived_count_key, 1)) so host can wait
+        # Event set when participant has joined (add(join_count_key, 1)) so host can wait
         # and not timeout before the participant reaches perform_rendezvous.
         participant_joined_event = threading.Event()
-        # Event set when participant has done the first get of last_participant_arrived_key in
-        # Step 2. Host waits on this before setting last_participant_arrived so the participant
-        # sees 0 on first get, then we raise on the second get (before returning 1).
+        # Event set when the host has joined (add(join_count_key, 1)). The participant
+        # store must not start counting round_done reads until the host has joined;
+        # otherwise the SignalException can fire before join_count reaches 2.
+        host_joined_event = threading.Event()
+        # Event set when participant has done the first get of round_done_key in Step 3.
+        # Host waits on this before the round closes so the participant sees 0 on first
+        # get, then we raise on the second get (before returning 1).
         participant_did_first_get_event = threading.Event()
 
-        # Participant store: raise SignalException on 2nd get of last_participant_arrived_key;
+        # Participant store: raise SignalException on 2nd get of round_done_0;
         # set participant_did_first_get_event on 1st get so host knows to proceed.
+        # Only start counting round_done reads after host_joined_event is set so that
+        # join_count == 2 when the participant reads it after leaving.
         class StoreThatRaisesSignalAfterJoin:
-            def __init__(self, underlying, joined_event, did_first_get_event):
+            def __init__(self, underlying, joined_event, host_joined_event, did_first_get_event):
                 self._store = underlying
                 self._joined_event = joined_event
+                self._host_joined_event = host_joined_event
                 self._did_first_get_event = did_first_get_event
                 self._step2_get_count = 0
 
             def get(self, key):
                 if (
-                    key.endswith(":last_participant_arrived")
+                    ":round_done_" in key
                     and ft_rendezvous_barrier_module._current_joined_state is not None
+                    and self._host_joined_event.is_set()
                 ):
                     self._step2_get_count += 1
                     if self._step2_get_count == 1:
                         self._did_first_get_event.set()
                     if self._step2_get_count >= 2:
-                        # Simulate what the real signal handler does: set withdraw_on_unwind
-                        # so the handler's finally will call _withdraw_from_rendezvous().
+                        # Simulate what the real signal handler does: set _leave_on_unwind
+                        # so the handler's finally will call _leave_rendezvous().
                         state = ft_rendezvous_barrier_module._current_joined_state
                         if state is not None:
-                            state._withdraw_on_unwind = True
+                            state._leave_on_unwind = True
                         raise SignalException(
                             "Simulated signal during rendezvous",
                             sigval=signal.Signals(signal.SIGTERM),
@@ -2336,7 +2337,7 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
 
             def add(self, key, value):
                 result = self._store.add(key, value)
-                if key.endswith(":arrived_count") and value == 1:
+                if ":join_count_" in key and value == 1:
                     self._joined_event.set()
                 return result
 
@@ -2352,21 +2353,25 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
             def multi_set(self, keys, values):
                 return self._store.multi_set(keys, values)
 
-        # Host store: delay set(last_participant_arrived_key, 1) until participant has done
-        # first get, so participant sees 0 then we raise on second get.
+        # Host store: signal when it has joined; delay set(round_done_0, 1) until participant
+        # has done first get, so participant sees 0 then we raise on second get.
         class HostStoreWaitsForFirstGet:
-            def __init__(self, underlying, did_first_get_event):
+            def __init__(self, underlying, host_joined_event, did_first_get_event):
                 self._store = underlying
+                self._host_joined_event = host_joined_event
                 self._did_first_get_event = did_first_get_event
 
             def get(self, key):
                 return self._store.get(key)
 
             def add(self, key, value):
-                return self._store.add(key, value)
+                result = self._store.add(key, value)
+                if ":join_count_" in key and value == 1:
+                    self._host_joined_event.set()
+                return result
 
             def set(self, key, value):
-                if key.endswith(":last_participant_arrived") and value == "1".encode("utf-8"):
+                if ":round_done_" in key and value == "1".encode("utf-8"):
                     self._did_first_get_event.wait(timeout=30.0)
                 return self._store.set(key, value)
 
@@ -2380,12 +2385,14 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
                 return self._store.multi_set(keys, values)
 
         participant_store = StoreThatRaisesSignalAfterJoin(
-            self.store, participant_joined_event, participant_did_first_get_event
+            self.store, participant_joined_event, host_joined_event, participant_did_first_get_event
         )
-        host_store = HostStoreWaitsForFirstGet(self.store, participant_did_first_get_event)
+        host_store = HostStoreWaitsForFirstGet(
+            self.store, host_joined_event, participant_did_first_get_event
+        )
         host_result = []
         participant_error = []
-        participant_count_after_withdraw = []
+        participant_count_after_leave = []
 
         def host_thread():
             state = _RendezvousBarrierState(
@@ -2430,112 +2437,80 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
             handler.next_rendezvous()
         except SignalException:
             participant_error.append(True)
-            # Simulated signal does not go through the real signal handler, so _withdraw_on_unwind
-            # is set in the wrapper; ensure withdraw runs so host can finish Step 3b.
-            handler._barrier_state._withdraw_on_unwind = True
-            handler._barrier_state._maybe_withdraw_on_unwind()
+            # Simulated signal does not go through the real signal handler, so _leave_on_unwind
+            # is set in the wrapper; ensure leave runs so host can finish Step 2.
+            handler._barrier_state._leave_on_unwind = True
+            handler._barrier_state._maybe_leave_on_unwind()
             try:
-                arrived = int(
-                    self.store.get(handler._barrier_state.arrived_count_key).decode('utf-8')
-                )
-                withdrawn = handler._barrier_state._get_withdrawn_count()
-                participant_count_after_withdraw.append((arrived, withdrawn))
+                joined = int(self.store.get(handler._barrier_state.join_count_key).decode('utf-8'))
+                left = handler._barrier_state._get_leave_count()
+                participant_count_after_leave.append((joined, left))
             except Exception:
                 pass
         t_host.join(timeout=70)
         _assert_threads_finished(self, [t_host], 70)
 
         self.assertTrue(participant_error, "Participant should have received SignalException")
-        # arrived_count stays 2 (both joined); withdrawn_count = 1 (participant withdrew)
+        # join_count stays 2 (both joined); leave_count = 1 (participant left)
         self.assertEqual(
-            participant_count_after_withdraw,
+            participant_count_after_leave,
             [(2, 1)],
-            "After participant withdrew: arrived_count=2 (unchanged), withdrawn_count=1",
+            "After participant left: join_count=2 (unchanged), leave_count=1",
         )
-        # Withdrawn participant's slot (participant joined first = slot 1) should be marked with WITHDRAWN_DOMAIN_ID
+        # Left participant's slot (participant joined first = slot 1) should be marked with WITHDRAWN
         state = handler._barrier_state
-        slot_key = f"{state.prefix}:arrived_1"
+        slot_key = f"{state.prefix}:slot_1"
         slot_data = self.store.get(slot_key).decode('utf-8')
         _, _, domain_id, cycle_id = RendezvousParticipantInfo.unpack(slot_data)
         self.assertEqual(
             domain_id,
-            WITHDRAWN_DOMAIN_ID,
-            "Withdrawn participant's slot should have WITHDRAWN_DOMAIN_ID",
+            WITHDRAWN,
+            "Left participant's slot should have WITHDRAWN domain_id",
         )
-        self.assertEqual(cycle_id, state._rendezvous_round)
+        self.assertEqual(cycle_id, state._round)
         self.assertEqual(len(host_result), 1, "Host should complete or error (not hang)")
         # Host either completes with world size 1 or errors (e.g. segment constraint) after
-        # participant withdrew; both are acceptable as long as the host did not hang in Step 3b.
+        # participant withdrew; both are acceptable as long as the host did not hang in Step 2.
         if host_result[0][0] == 'error':
             err = host_result[0][1]
+            # RendezvousTimeoutError is a common outcome when the participant withdraws
+            # and active_count drops below min_nodes; it IS a RendezvousError subclass but
+            # type().__name__ only matches the concrete class name, not base classes.
             self.assertIn(
                 type(err).__name__,
-                ('RuntimeError', 'RendezvousError'),
-                f"Host error should be RuntimeError or RendezvousError: {err}",
+                ('RuntimeError', 'RendezvousError', 'RendezvousTimeoutError'),
+                f"Host error should be a rendezvous or runtime error: {err}",
             )
         else:
             rank, total = host_result[0]
-            # total_participants in rank value is slot count (arrived=2), not active count
+            # total_participants in rank value is slot count (join_count=2), not active count
             self.assertEqual(
                 total, 2, "Host should see total_participants=2 (slot count) in rank value"
             )
-            # Rank assignment must be at the correct slot: host joined second = slot 2
-            host_rank_key = f"{state.prefix}:arrived_2_group_rank"
-            host_rank_value = self.store.get(host_rank_key).decode('utf-8')
-            self.assertEqual(
-                host_rank_value,
-                "0,2",
-                "Host (slot 2) should have rank 0 written at arrived_2_group_rank",
-            )
-            # Withdrawn slot (1) should not have been assigned a rank (we only write for active)
-            slot1_rank_key = f"{state.prefix}:arrived_1_group_rank"
-            slot1_rank_value = self.store.get(slot1_rank_key).decode('utf-8')
-            self.assertEqual(
-                slot1_rank_value.split(",")[0],
-                "-1",
-                "Withdrawn participant's slot (1) should keep unassigned rank, not overwritten",
-            )
+            # In the new protocol, ranks are assigned BEFORE round_done=1 is set, so
+            # both slots get a rank even if one later leaves. The left participant
+            # (slot 1) overwrites slot data with WITHDRAWN, but its slot_rank was already
+            # written by the host before the signal arrived. Just verify host got a valid rank.
+            self.assertGreaterEqual(rank, 0, "Host should have a valid group rank >= 0")
 
-    def test_signal_after_ack_does_not_decrement(self):
-        """Test that when a participant is interrupted after Step 3a (after ack), we do
-        NOT withdraw (no add(withdrawn_count_key, 1)). Only pre-ack withdrawal should withdraw.
+    def test_signal_after_round_closed_does_not_leave(self):
+        """Test that when _round_closed=True, a signal does NOT trigger withdrawal.
+
+        After round_done_N=1 is seen, _round_closed=True prevents spurious
+        leave_count increments. Only pre-round-close signals should cause withdrawal.
         """
-        # min_nodes=2 so the host waits for both to join and ack before completing.
-        min_nodes = 2
-        max_nodes = 2
-        segment_check_interval = _test_segment_check_interval()
-        join_timeout_secs = 60.0
+        add_calls = []
 
-        # Event set when participant has joined so host waits and does not timeout first.
-        participant_joined_event = threading.Event()
-
-        # Store wrapper that raises SignalException on the first get() AFTER the
-        # participant has called add(ack_count_key, 1) (i.e. after Step 3a).
-        # Records all add() calls so we can assert no add(withdrawn_count_key, 1).
-        class StoreThatRaisesSignalAfterAck:
-            def __init__(self, underlying, joined_event):
+        class TrackingStore:
+            def __init__(self, underlying):
                 self._store = underlying
-                self._joined_event = joined_event
-                self._add_calls = []
-                self._raise_on_next_get = False
 
             def get(self, key):
-                if self._raise_on_next_get:
-                    raise SignalException(
-                        "Simulated signal after ack",
-                        sigval=signal.Signals(signal.SIGTERM),
-                    )
                 return self._store.get(key)
 
             def add(self, key, value):
-                self._add_calls.append((key, value))
-                result = self._store.add(key, value)
-                if key.endswith(":arrived_count") and value == 1:
-                    self._joined_event.set()
-                # Step 3a is add(ack_count_key, 1); trigger raise on next get (Step 4)
-                if key.endswith(":ack_count") and value == 1:
-                    self._raise_on_next_get = True
-                return result
+                add_calls.append((key, value))
+                return self._store.add(key, value)
 
             def set(self, key, value):
                 return self._store.set(key, value)
@@ -2549,74 +2524,27 @@ class SignalWithdrawRendezvousTest(BaseRendezvousTest):
             def multi_set(self, keys, values):
                 return self._store.multi_set(keys, values)
 
-        participant_store = StoreThatRaisesSignalAfterAck(self.store, participant_joined_event)
-        host_result = []
-        participant_raised = []
-
-        def host_thread():
-            state = _RendezvousBarrierState(
-                store=self.store,
-                run_id=self.run_id,
-                is_store_host=True,
-                join_timeout_seconds=join_timeout_secs,
-            )
-            try:
-                node = self.node_desc_gen.generate()
-                rank, total = state.perform_rendezvous(
-                    node, min_nodes, max_nodes, segment_check_interval
-                )
-                host_result.append((rank, total))
-            except Exception as e:
-                host_result.append(('error', e))
-
-        # Participant must run in main thread so handler can install signal handlers.
-        # Host waits for participant to join before starting so the host does not timeout first.
-        start_barrier = threading.Barrier(2)
-
-        def host_with_sync():
-            start_barrier.wait(timeout=BARRIER_WAIT_TIMEOUT_SECS)
-            participant_joined_event.wait(timeout=60.0)
-            host_thread()
-
-        t_host = threading.Thread(target=host_with_sync)
-        t_host.start()
-        start_barrier.wait(timeout=BARRIER_WAIT_TIMEOUT_SECS)
-        handler = FtRendezvousBarrierHandler.from_backend(
+        state = _RendezvousBarrierState(
+            store=TrackingStore(self.store),
             run_id=self.run_id,
-            store=participant_store,
-            backend=None,
-            min_nodes=min_nodes,
-            max_nodes=max_nodes,
-            timeout=RendezvousTimeout(join=timedelta(seconds=join_timeout_secs)),
-            is_store_host=False,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
         )
-        try:
-            handler.next_rendezvous()
-        except SignalException:
-            participant_raised.append(True)
-        t_host.join(timeout=70)
-        _assert_threads_finished(self, [t_host], 70)
+        state._slot = 1  # Simulate having joined (slot 1)
+        state._round_closed = True  # Signal came AFTER round_done_N=1 was seen
+        state._leave_on_unwind = True  # Signal handler set this
 
-        self.assertTrue(participant_raised, "Participant should have received SignalException")
-        state = handler._barrier_state
-        # Signal after ack: should NOT have withdrawn (no add(withdrawn_count_key, 1))
-        withdraw_calls = [
-            (k, v)
-            for k, v in participant_store._add_calls
-            if k == state.withdrawn_count_key and v == 1
-        ]
+        state._maybe_leave_on_unwind()
+
+        # Verify no leave_count was incremented
+        leave_calls = [(k, v) for k, v in add_calls if ":leave_count_" in k and v == 1]
         self.assertEqual(
-            len(withdraw_calls),
+            len(leave_calls),
             0,
-            "Participant received signal after Step 3a; should NOT have withdrawn "
-            "(withdraw only before ack). Got add(withdrawn_count_key, 1) calls: %s"
-            % participant_store._add_calls,
+            "After _round_closed=True, _leave_rendezvous must NOT be called. "
+            f"Got add calls: {add_calls}",
         )
-        # Host should have completed with 2 participants (both had acked before participant died)
-        self.assertEqual(len(host_result), 1)
-        self.assertNotEqual(host_result[0][0], 'error', f"Host should not error: {host_result[0]}")
-        rank, total = host_result[0]
-        self.assertEqual(total, 2, "Host completed with 2 participants; participant died after ack")
+        self.assertFalse(state._leave_on_unwind, "_leave_on_unwind should be reset to False")
 
 
 if __name__ == '__main__':

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -25,7 +25,6 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
-from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
 
 from nvidia_resiliency_ext import fault_tolerance
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
@@ -297,8 +296,8 @@ def _make_agent_spec(rdzv_round=1):
     spec = MagicMock()
     spec.rdzv_handler = MagicMock()
     spec.rdzv_handler.round.return_value = rdzv_round
-    spec.rdzv_handler.get_last_rendezvous_participant_addrs.return_value = ["node001", "node002"]
-    spec.rdzv_handler.get_last_rendezvous_standby_participant_addrs.return_value = ["node003"]
+    spec.rdzv_handler.get_active_node_addrs.return_value = ["node001", "node002"]
+    spec.rdzv_handler.get_standby_node_addrs.return_value = ["node003"]
     spec.max_restarts = 3
     return spec
 
@@ -331,7 +330,7 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
         from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
 
         writer = MagicMock()
-        # rdzv_round=1 -> _get_global_restart_count() = max(0, 1-1) = 0
+        # rdzv_round=1 -> _get_global_cycle_number() = 1 (cycle 1)
         spec = _make_agent_spec(rdzv_round=1)
         with patch.dict(
             os.environ,
@@ -357,7 +356,7 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
         call_kw = writer.update_cycle_end.call_args[1]
         self.assertEqual(call_kw["job_id"], "12345")
         self.assertEqual(call_kw["attempt_index"], 0)
-        self.assertEqual(call_kw["cycle_number"], 0)
+        self.assertEqual(call_kw["cycle_number"], 1)
         self.assertEqual(call_kw["cycle_end_time"], "2024-01-01T12:00:00Z")
 
     def test_on_cycle_end_uses_slurm_array_job_id_when_set(self):
@@ -365,7 +364,7 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
         from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
 
         writer = MagicMock()
-        spec = _make_agent_spec(rdzv_round=2)  # restart_count = 1
+        spec = _make_agent_spec(rdzv_round=2)  # restart_count = 2 (cycle 2)
         with patch.dict(
             os.environ,
             {
@@ -390,7 +389,66 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
         call_kw = writer.update_cycle_end.call_args[1]
         self.assertEqual(call_kw["job_id"], "array_99")
         self.assertEqual(call_kw["attempt_index"], 1)
-        self.assertEqual(call_kw["cycle_number"], 1)
+        self.assertEqual(call_kw["cycle_number"], 2)
+
+    def test_on_cycle_end_cycle_number_override(self):
+        """_on_cycle_end accepts explicit cycle_number, bypassing _get_global_cycle_number()."""
+        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
+
+        writer = MagicMock()
+        # rdzv_round=3 (standby advanced _round to 3 before shutdown detected);
+        # calling with cycle_number=2 records the last completed cycle.
+        spec = _make_agent_spec(rdzv_round=3)
+        agent = LocalElasticAgent(
+            spec=spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
+            cycle_info_writer=writer,
+        )
+        with patch(
+            "nvidia_resiliency_ext.fault_tolerance.launcher.utc_iso_now",
+            return_value="2024-01-01T12:00:00Z",
+        ):
+            agent._on_cycle_end(cycle_number=2)
+
+        call_kw = writer.update_cycle_end.call_args[1]
+        self.assertEqual(call_kw["cycle_number"], 2)
+
+    def test_remaining_restarts_corrected_in_run(self):
+        """run() re-syncs _remaining_restarts before delegating to _invoke_run.
+
+        At __init__ time _round=0, so _remaining_restarts = max_restarts provisionally.
+        run() re-computes using the post-sync cycle number before the monitor loop starts.
+        """
+        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
+
+        # rdzv_round=2: replacement node synced to cycle 2, max_restarts=3 -> remaining=1
+        spec = _make_agent_spec(rdzv_round=2)
+        agent = LocalElasticAgent(
+            spec=spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
+            cycle_info_writer=None,
+        )
+
+        captured = {}
+
+        def fake_invoke_run(role):
+            captured['remaining'] = agent._remaining_restarts
+            return MagicMock()
+
+        with (
+            patch.object(agent, '_invoke_run', side_effect=fake_invoke_run),
+            patch.object(agent, '_shutdown'),
+            patch.object(agent, '_record_metrics'),
+            patch.object(agent, '_record_worker_events'),
+        ):
+            agent.run()
+
+        # At __init__ time round()=2, so provisional value is already 1 in this mock.
+        # In production, round()=0 at init and round()=2 after _complete_initialization();
+        # run() always re-computes so the value is guaranteed correct regardless.
+        self.assertEqual(captured['remaining'], 1)  # max_restarts(3) - round()(2) = 1
 
     def test_write_cycle_start_info_returns_none_when_writer_is_none(self):
         """_write_cycle_start_info returns None when cycle_info_writer is None."""
@@ -452,8 +510,8 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
         writer = MagicMock()
         writer.get_current_cycle_info_path.return_value = "/nvrx/current"
         spec = _make_agent_spec(rdzv_round=1)
-        spec.rdzv_handler.get_last_rendezvous_participant_addrs.return_value = ["host1"]
-        spec.rdzv_handler.get_last_rendezvous_standby_participant_addrs.return_value = ["host2"]
+        spec.rdzv_handler.get_active_node_addrs.return_value = ["host1"]
+        spec.rdzv_handler.get_standby_node_addrs.return_value = ["host2"]
         with patch.dict(
             os.environ,
             {"SLURM_JOB_ID": "j", "SLURM_RESTART_CNT": "0"},
@@ -484,51 +542,180 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
         self.assertEqual(call_kw["standby_nodes"], "standby")
 
 
-class TestMaybeExitStandbyOnSuccess(unittest.TestCase):
-    """Unit tests for _maybe_exit_standby_on_success (standby detects training success via exit barrier)."""
+class TestLauncherRunBehavior(unittest.TestCase):
+    """Unit tests for run() exception handling paths."""
 
     def setUp(self):
+        self.spec = _make_agent_spec(rdzv_round=1)
         self.fault_tol_cfg = FaultToleranceConfig()
         self.logs_specs = MagicMock()
+        self.logs_specs.get_cycle_log_file.return_value = "/path/to/cycle_0.log"
 
-    def _make_agent_standby(self, min_nodes=2, group_rank=2, store_check_returns=False):
-        """Create agent configured as standby (group_rank >= min_nodes) with optional store mock."""
+    def test_run_graceful_exit_calls_on_cycle_end_with_round_minus_1(self):
+        """run() calls _on_cycle_end(cycle_number=round()-1) on RendezvousGracefulExitError.
+
+        Standby nodes: _round advanced to N+1 when round N closed before shutdown was
+        detected. run() records end of cycle N (the last completed cycle).
+        """
+        from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
+
         from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
 
-        spec = _make_agent_spec(rdzv_round=1)
-        spec.rdzv_handler._settings = MagicMock()
-        spec.rdzv_handler._settings.min_nodes = min_nodes
-
+        spec = _make_agent_spec(rdzv_round=3)
         agent = LocalElasticAgent(
             spec=spec,
             fault_tol_cfg=self.fault_tol_cfg,
             logs_specs=self.logs_specs,
+            cycle_info_writer=MagicMock(),
+        )
+
+        with (
+            patch.object(
+                agent, '_invoke_run', side_effect=RendezvousGracefulExitError("round closed")
+            ),
+            patch.object(agent, '_shutdown'),
+            patch.object(agent, '_on_cycle_end') as mock_end,
+        ):
+            result = agent.run()
+
+        # round()-1 = 3-1 = 2: record the last completed cycle, not the advanced one
+        mock_end.assert_called_once_with(cycle_number=2)
+        self.assertIsNone(result)
+
+
+class TestHandleRestartDecision(unittest.TestCase):
+    """Unit tests for _handle_restart_decision() and _open_rendezvous_for_restart()."""
+
+    def setUp(self):
+        self.spec = _make_agent_spec(rdzv_round=1)
+        self.fault_tol_cfg = FaultToleranceConfig()
+        self.logs_specs = MagicMock()
+        self.logs_specs.get_cycle_log_file.return_value = "/path/to/cycle_0.log"
+
+    def _make_agent(self):
+        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
+
+        return LocalElasticAgent(
+            spec=self.spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
             cycle_info_writer=None,
         )
-        agent._worker_group = MagicMock()
-        agent._worker_group.group_rank = group_rank
-        agent._store = MagicMock()
-        agent._store.check.return_value = store_check_returns
-        return agent
 
-    def test_standby_raises_graceful_exit_when_exit_barrier_key_set(self):
-        """Standby (group_rank >= min_nodes) raises RendezvousGracefulExitError when exit barrier is complete."""
-        agent = self._make_agent_standby(min_nodes=2, group_rank=2, store_check_returns=True)
-        with self.assertRaises(RendezvousGracefulExitError) as ctx:
-            agent._maybe_exit_standby_on_success("trainer")
-        self.assertIn("exit barrier", str(ctx.exception).lower())
+    def test_handle_restart_decision_progress_terminate(self):
+        """Returns False without restarting when progress tracker says terminate early."""
+        agent = self._make_agent()
+        agent._progress_tracker = MagicMock()
+        agent._progress_tracker.should_terminate_early.return_value = True
+        agent._remaining_restarts = 2
 
-    def test_standby_does_not_raise_when_exit_barrier_key_not_set(self):
-        """Standby does not raise when exit barrier key is not set (keeps waiting)."""
-        agent = self._make_agent_standby(min_nodes=2, group_rank=2, store_check_returns=False)
-        agent._maybe_exit_standby_on_success("trainer")  # no raise
-        agent._store.check.assert_called_once()
+        with (
+            patch.object(agent, '_restart_workers') as mock_restart,
+            patch.object(agent, '_open_rendezvous_for_restart') as mock_open,
+        ):
+            result = agent._handle_restart_decision(
+                role="test", spec=self.spec, log_msg="[%s] restarting"
+            )
 
-    def test_active_node_does_not_raise_even_when_key_set(self):
-        """Active node (group_rank < min_nodes) returns without raising even if key is set."""
-        agent = self._make_agent_standby(min_nodes=2, group_rank=1, store_check_returns=True)
-        agent._maybe_exit_standby_on_success("trainer")  # no raise
-        agent._store.check.assert_not_called()
+        self.assertFalse(result)
+        mock_restart.assert_not_called()
+        mock_open.assert_not_called()
+
+    def test_handle_restart_decision_restarts_remaining(self):
+        """Returns True and decrements _remaining_restarts when restarts are available."""
+        agent = self._make_agent()
+        agent._progress_tracker = MagicMock()
+        agent._progress_tracker.should_terminate_early.return_value = False
+        agent._remaining_restarts = 2
+
+        with (
+            patch.object(agent, '_restart_workers') as mock_restart,
+            patch.object(agent, '_open_rendezvous_for_restart') as mock_open,
+        ):
+            result = agent._handle_restart_decision(
+                role="test", spec=self.spec, log_msg="[%s] restarting", open_rendezvous=False
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(agent._remaining_restarts, 1)
+        mock_restart.assert_called_once()
+        mock_open.assert_not_called()
+
+    def test_handle_restart_decision_no_restarts_left(self):
+        """Returns False when _remaining_restarts is 0."""
+        agent = self._make_agent()
+        agent._progress_tracker = MagicMock()
+        agent._progress_tracker.should_terminate_early.return_value = False
+        agent._remaining_restarts = 0
+
+        with patch.object(agent, '_restart_workers') as mock_restart:
+            result = agent._handle_restart_decision(
+                role="test", spec=self.spec, log_msg="[%s] restarting"
+            )
+
+        self.assertFalse(result)
+        mock_restart.assert_not_called()
+
+    def test_handle_restart_decision_open_rendezvous_called_when_requested(self):
+        """Calls _open_rendezvous_for_restart() when open_rendezvous=True."""
+        agent = self._make_agent()
+        agent._progress_tracker = MagicMock()
+        agent._progress_tracker.should_terminate_early.return_value = False
+        agent._remaining_restarts = 1
+
+        with (
+            patch.object(agent, '_restart_workers'),
+            patch.object(agent, '_open_rendezvous_for_restart') as mock_open,
+        ):
+            agent._handle_restart_decision(
+                role="test", spec=self.spec, log_msg="[%s] restarting", open_rendezvous=True
+            )
+
+        mock_open.assert_called_once()
+
+    def test_open_rendezvous_for_restart_barrier_handler(self):
+        """Calls _barrier_state.open_rendezvous() when handler has _barrier_state."""
+        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
+
+        barrier_state = MagicMock()
+        self.spec.rdzv_handler._barrier_state = barrier_state
+        agent = LocalElasticAgent(
+            spec=self.spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
+            cycle_info_writer=None,
+        )
+        agent._open_rendezvous_for_restart()
+
+        barrier_state.open_rendezvous.assert_called_once()
+
+    def test_open_rendezvous_for_restart_legacy_handler(self):
+        """Does nothing (no error) when handler lacks _barrier_state (legacy rdzv)."""
+        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
+
+        # Use a spec-constrained mock so _barrier_state doesn't auto-exist
+        legacy_rdzv = MagicMock(
+            spec=[
+                'round',
+                'get_active_node_addrs',
+                'get_standby_node_addrs',
+            ]
+        )
+        legacy_rdzv.round.return_value = 1
+        legacy_rdzv.get_active_node_addrs.return_value = []
+        legacy_rdzv.get_standby_node_addrs.return_value = []
+        self.spec.rdzv_handler = legacy_rdzv
+
+        agent = LocalElasticAgent(
+            spec=self.spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
+            cycle_info_writer=None,
+        )
+        # Should not raise
+        agent._open_rendezvous_for_restart()
+        # No open_rendezvous() on the legacy handler
+        self.assertFalse(hasattr(legacy_rdzv, '_barrier_state'))
 
 
 def test_ft_log_aggregator_count_rejects_non_positive():


### PR DESCRIPTION
Simplify rendezvous: round-scoped keys, no global cycle counter                                                                          
                                                                                                                                                      
Replace monolithic global state keys with per-round-scoped keys (join_count_N,                                                                      
leave_count_N, round_done_N). Only node metadata and rank assignment keys persist                                                                   
across rounds.                                                                                                                                      
                                                                                                                                                      
Replacement nodes reconstruct current round by scanning round_done_N keys,                                                                          
eliminating the global_cycle_key and associated reset races.                                                                                        
                                                                                                                                                      
Also refactors perform_rendezvous() into host_close_round() helper, renames                                                                         
arrived/withdrawn to join/leave throughout, and simplifies launcher cycle                                                                           
tracking to directly use cycle_number.                                                                                                              
