### PR TITLE
shared_utils: add NVLinkWindowHealthCheck for replay/recovery counter monitoring

### DIFF
--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -1164,8 +1164,12 @@ class NVLinkWindowHealthCheck(PynvmlMixin):
 
         # Tier 2: per-lane field IDs L0-L5 (older hardware, ports 0-5 only).
         if self._tier2_api_supported is not False and port < 6:
-            replay_lane = getattr(self.pynvml, f"NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L{port}", None)
-            recovery_lane = getattr(self.pynvml, f"NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L{port}", None)
+            replay_lane = getattr(
+                self.pynvml, f"NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L{port}", None
+            )
+            recovery_lane = getattr(
+                self.pynvml, f"NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L{port}", None
+            )
             field_ids = [fid for fid in (replay_lane, recovery_lane) if fid is not None]
             if field_ids:
                 try:

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -24,9 +24,9 @@ import subprocess  # nosec B404
 import sys
 import threading
 import traceback
-from collections import defaultdict
+from collections import defaultdict, deque
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 from urllib.parse import quote_plus
 
 import defusedxml.ElementTree as ET
@@ -969,6 +969,253 @@ class NVLHealthCheck(PynvmlMixin):
         except Exception as e:
             logger.warning(f"Unexpected Error checking GPU {device_index}: {str(e)}")
             return False
+
+
+class NVLinkWindowHealthCheck(PynvmlMixin):
+    """
+    Health check that counts NVLink "windows" (calls) with replay or recovery events.
+
+    Each call to _perform_health_check() is one window. A window is flagged when
+    any NVLink port shows a delta > 0 in DL_REPLAY or DL_RECOVERY error counters
+    vs. the previous call. Returns False when any single port exceeds ``threshold``
+    flagged windows within the last ``window_count`` calls.
+
+    Counter reading uses three tiers (first that works wins per port):
+
+    Tier 1 — GB200 / newer drivers (preferred):
+      ``nvmlDeviceGetFieldValues`` with per-port field IDs and scopeId = port:
+        NVML_FI_DEV_NVLINK_ERROR_DL_REPLAY   = 161
+        NVML_FI_DEV_NVLINK_ERROR_DL_RECOVERY = 162
+
+    Tier 2 — older hardware (ports 0-5 only):
+      ``nvmlDeviceGetFieldValues`` with per-lane field IDs L0..L5:
+        NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L{n}   = 46-51
+        NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L{n} = 53-58
+
+    Fallback — LEGACY (drivers <= 450):
+      ``nvmlDeviceGetNvLinkErrorCounter`` with NVML_NVLINK_ERROR_DL_REPLAY /
+      NVML_NVLINK_ERROR_DL_RECOVERY. Marked LEGACY for drivers > 450; may return
+      NVML_ERROR_NOT_SUPPORTED on GB200.
+
+    A one-time warning is logged if GB200 tier-1 field IDs exist in pynvml but the
+    driver returns not-supported, and again if all APIs fail on a port.
+    """
+
+    def __init__(
+        self,
+        device_index: Optional[int] = None,
+        interval: int = 60,
+        window_count: int = 30,
+        threshold: int = 15,
+        on_failure: Optional[Callable] = None,
+    ):
+        """
+        Args:
+            device_index: GPU device index to monitor. None checks all GPUs.
+            interval: Seconds between async health checks.
+            window_count: Rolling window size — how many past checks to consider.
+            threshold: Max allowed flagged windows before reporting failure.
+            on_failure: Callback invoked when health check fails.
+        """
+        super().__init__()
+        self.device_index = device_index
+        self.interval = interval
+        self.threshold = threshold
+        self.on_failure = on_failure
+        self.pynvml_available = self.check_pynvml_availability()
+
+        # Per-port rolling window: {(device_id, port): deque of bools}.
+        # Each bool = True if that port had a delta > 0 in that window.
+        self._window_history: Dict[Tuple[int, int], deque] = {}
+        self._window_count = window_count
+        # Cumulative error total per (device_id, port) from the previous call.
+        self._prev_counters: Dict[Tuple[int, int], int] = {}
+        # Separate probed flags for tier 1 (GB200) and tier 2 (older HW).
+        # None = not yet probed; True = supported; False = not supported.
+        self._tier1_api_supported: Optional[bool] = None
+        self._tier1_not_supported_warned = False
+        self._tier2_api_supported: Optional[bool] = None
+        # Warn only once when all APIs are unsupported for a port.
+        self._api_not_supported_warned = False
+
+    async def async_check(self) -> None:
+        """Periodically checks NVLink event windows; invokes on_failure when threshold is exceeded."""
+        while True:
+            await asyncio.sleep(self.interval)
+            result = await self._check_health()
+            if not result and self.on_failure:
+                await self.on_failure()
+
+    async def _check_health(self) -> bool:
+        return self._perform_health_check()
+
+    def __call__(self) -> Union[Optional[Exception], bool]:
+        """Synchronous NVLink window health check."""
+        return self._perform_health_check()
+
+    @with_pynvml_lock
+    def _perform_health_check(self) -> bool:
+        """
+        Sample NVLink counters, record whether this window had events, and
+        return False if the flagged window count exceeds the threshold.
+        """
+        if not self.pynvml_available:
+            return True
+
+        port_events: Dict[Tuple[int, int], bool] = {}
+        try:
+            self.pynvml.nvmlInit()
+            devices = (
+                [self.device_index]
+                if self.device_index is not None
+                else range(self.pynvml.nvmlDeviceGetCount())
+            )
+            port_events = self._sample_nvlink_events(devices)
+        except self.pynvml.NVMLError as e:
+            logger.warning(f"NVLinkWindowHealthCheck NVML error: {e}")
+            return True
+        except Exception as e:
+            logger.warning(f"NVLinkWindowHealthCheck unexpected error: {e}")
+            return True
+        finally:
+            try:
+                self.pynvml.nvmlShutdown()
+            except Exception as e:
+                logger.warning(f"NVLinkWindowHealthCheck NVML shutdown error: {e}")
+
+        # Update per-port rolling window and check threshold.
+        all_healthy = True
+        for key, had_events in port_events.items():
+            if key not in self._window_history:
+                self._window_history[key] = deque(maxlen=self._window_count)
+            self._window_history[key].append(had_events)
+            flagged = sum(self._window_history[key])
+            if flagged > self.threshold:
+                device_id, port = key
+                logger.warning(
+                    f"NVLinkWindowHealthCheck: device {device_id} port {port}: "
+                    f"{flagged}/{len(self._window_history[key])} windows had "
+                    f"NVLink replay/recovery events (threshold={self.threshold})."
+                )
+                all_healthy = False
+        return all_healthy
+
+    def _sample_nvlink_events(self, devices) -> Dict[Tuple[int, int], bool]:
+        """
+        Read replay + recovery counters per port.
+        Returns {(device_id, port): had_events_this_window}.
+        """
+        port_events: Dict[Tuple[int, int], bool] = {}
+        max_links = getattr(self.pynvml, "NVML_NVLINK_MAX_LINKS", 18)
+        for device_id in devices:
+            handle = self.pynvml.nvmlDeviceGetHandleByIndex(device_id)
+            for port in range(max_links):
+                total = self._read_port_error_total(handle, device_id, port)
+                if total is None:
+                    continue
+                key = (device_id, port)
+                prev = self._prev_counters.get(key)
+                self._prev_counters[key] = total
+                if prev is not None:
+                    port_events[key] = total > prev
+        return port_events
+
+    def _read_port_error_total(self, handle, device_id: int, port: int) -> Optional[int]:
+        """Try field-values API first (per port); fall back to legacy counter."""
+        total = self._read_via_field_values(handle, device_id, port)
+        if total is not None:
+            return total
+        return self._read_via_legacy(handle, device_id, port)
+
+    def _read_via_field_values(self, handle, device_id: int, port: int) -> Optional[int]:
+        """
+        Read replay + recovery for one port via nvmlDeviceGetFieldValues.
+
+        Tries tier 1 (GB200) then tier 2 (older HW) independently; each tier's
+        supported flag is tracked separately so a tier-2 failure never blocks tier 1.
+        Returns None if both tiers are unsupported.
+        """
+        nvml_success = getattr(self.pynvml, "NVML_SUCCESS", 0)
+
+        # Tier 1: GB200 per-port (scopeId = port number).
+        # Field IDs 161/162 with scopeId are supported on newer drivers (GB200+).
+        if self._tier1_api_supported is not False:
+            replay_fid = getattr(self.pynvml, "NVML_FI_DEV_NVLINK_ERROR_DL_REPLAY", None)
+            recovery_fid = getattr(self.pynvml, "NVML_FI_DEV_NVLINK_ERROR_DL_RECOVERY", None)
+            if replay_fid is not None or recovery_fid is not None:
+                queries = [(fid, port) for fid in (replay_fid, recovery_fid) if fid is not None]
+                try:
+                    results = self.pynvml.nvmlDeviceGetFieldValues(handle, queries)
+                    successful = [r for r in results if r.nvmlReturn == nvml_success]
+                    if successful:
+                        self._tier1_api_supported = True
+                        return sum(r.value.uiVal for r in successful)
+                    # Constants exist in pynvml but driver returned not-supported.
+                    if not self._tier1_not_supported_warned:
+                        logger.warning(
+                            f"NVLinkWindowHealthCheck: GB200 field IDs (161/162) not supported "
+                            f"on device {device_id} port {port}. "
+                            f"Falling back to tier-2 / legacy API."
+                        )
+                        self._tier1_not_supported_warned = True
+                    self._tier1_api_supported = False
+                except self.pynvml.NVMLError:
+                    pass  # fall through to tier 2
+
+        # Tier 2: per-lane field IDs L0-L5 (older hardware, ports 0-5 only).
+        if self._tier2_api_supported is not False and port < 6:
+            replay_lane = getattr(self.pynvml, f"NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L{port}", None)
+            recovery_lane = getattr(self.pynvml, f"NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L{port}", None)
+            field_ids = [fid for fid in (replay_lane, recovery_lane) if fid is not None]
+            if field_ids:
+                try:
+                    results = self.pynvml.nvmlDeviceGetFieldValues(handle, field_ids)
+                    successful = [r for r in results if r.nvmlReturn == nvml_success]
+                    if successful:
+                        self._tier2_api_supported = True
+                        return sum(r.value.uiVal for r in successful)
+                except self.pynvml.NVMLError as e:
+                    logger.warning(
+                        f"NVLinkWindowHealthCheck: nvmlDeviceGetFieldValues tier-2 not supported "
+                        f"on device {device_id}: {e}. Falling back to legacy API."
+                    )
+                self._tier2_api_supported = False
+
+        return None
+
+    def _read_via_legacy(self, handle, device_id: int, port: int) -> Optional[int]:
+        """
+        Legacy: DL_REPLAY + DL_RECOVERY for one port via nvmlDeviceGetNvLinkErrorCounter.
+        Marked LEGACY for drivers > 450; may return NVML_ERROR_NOT_SUPPORTED on GB200.
+        """
+        replay_type = getattr(self.pynvml, "NVML_NVLINK_ERROR_DL_REPLAY", None)
+        recovery_type = getattr(self.pynvml, "NVML_NVLINK_ERROR_DL_RECOVERY", None)
+        if replay_type is None and recovery_type is None:
+            return None
+
+        total = 0
+        any_supported = False
+        for counter_type in (replay_type, recovery_type):
+            if counter_type is None:
+                continue
+            try:
+                total += self.pynvml.nvmlDeviceGetNvLinkErrorCounter(handle, port, counter_type)
+                any_supported = True
+            except self.pynvml.NVMLError as e:
+                if "not supported" in str(e).lower() or "invalid argument" in str(e).lower():
+                    continue
+                raise
+
+        if not any_supported:
+            if not self._api_not_supported_warned:
+                logger.warning(
+                    f"NVLinkWindowHealthCheck: neither field-values nor legacy "
+                    f"nvmlDeviceGetNvLinkErrorCounter is supported on device {device_id} "
+                    f"port {port}. Health check will be skipped."
+                )
+                self._api_not_supported_warned = True
+            return None
+        return total
 
 
 class NodeHealthCheck:

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -24,9 +24,9 @@ import subprocess  # nosec B404
 import sys
 import threading
 import traceback
-from collections import defaultdict
+from collections import defaultdict, deque
 from functools import wraps
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import defusedxml.ElementTree as ET
 import httpx
@@ -974,6 +974,429 @@ class NVLHealthCheck(PynvmlMixin):
         except Exception as e:
             logger.warning(f"Unexpected Error checking GPU {device_index}: {str(e)}")
             return False
+
+
+class NVLinkWindowHealthCheck(PynvmlMixin):
+    """
+    Health check that counts NVLink "windows" (calls) with replay or recovery events.
+
+    Each call to _perform_health_check() is one window. A window is flagged when
+    any NVLink port shows a delta > 0 in DL_REPLAY or DL_RECOVERY error counters
+    vs. the previous call. A port is "bad" when it exceeds ``threshold`` flagged
+    windows within the last ``window_count`` calls. A GPU is reported unhealthy
+    when at least ``gpu_ports_threshold`` of its NVLink ports are bad. Returns
+    False when any GPU is unhealthy; the warning log identifies which GPU and
+    which of its ports tripped, matching the per-GPU framing of other checks
+    in this file (e.g. ``NVLHealthCheck``).
+
+    Counter reading uses three tiers (first that works wins per port):
+
+    Tier 1 — NVLink5 / GB200 / newer drivers (preferred):
+      ``nvmlDeviceGetFieldValues`` with per-port field IDs and scopeId = port.
+      Three issue indicators tracked per-counter; any individual counter's
+      delta > 0 vs. the previous call flags the window. Per-counter baselines
+      (rather than a summed total) avoid phantom deltas when the set of
+      successful FIDs varies between calls.
+        NVML_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS = 215
+            Up -> recovery transitions (any outcome)
+        NVML_FI_DEV_NVLINK_PLR_XMIT_RETRY_BLOCKS      = 295
+            PHY-layer retry blocks transmitted (NVLink5 retry pressure)
+        NVML_FI_DEV_NVLINK_COUNT_RCV_ERRORS           = 208
+            Rx packets with errors
+
+    Tier 2 — older hardware (ports 0-5 only):
+      ``nvmlDeviceGetFieldValues`` with per-lane field IDs L0..L5:
+        NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L{n}   = 46-51
+        NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L{n} = 53-58
+
+    Fallback — LEGACY (drivers <= 450):
+      ``nvmlDeviceGetNvLinkErrorCounter`` with NVML_NVLINK_ERROR_DL_REPLAY /
+      NVML_NVLINK_ERROR_DL_RECOVERY. Marked LEGACY for drivers > 450; may return
+      NVML_ERROR_NOT_SUPPORTED on GB200.
+
+    A one-time warning is logged if tier-1 field IDs are not supported by the
+    driver, and again if all APIs fail on a port.
+
+    Tier-1 first-probe edge case: the tier-1 support flag is latched on the
+    first port probed (always port 0 of the first visible GPU). If port 0
+    returns empty FIDs at process start -- e.g. an inactive port on an unusual
+    topology -- tier-1 latches False process-wide and later active ports fall
+    back to tier-2 / legacy. Restart after topology changes that bring tier-1
+    ports online. On standard GB200 deployments port 0 is always active and
+    this case does not arise.
+    """
+
+    def __init__(
+        self,
+        device_index: Optional[int] = None,
+        interval: int = 60,
+        window_count: int = 30,
+        threshold: int = 15,
+        gpu_ports_threshold: int = 1,
+        on_failure: Optional[Callable] = None,
+    ):
+        """
+        Args:
+            device_index: GPU device index to monitor. None checks all GPUs.
+            interval: Seconds between async health checks.
+            window_count: Rolling window size — how many past checks to consider.
+            threshold: Maximum flagged windows still considered healthy at the
+                per-port level. A port is "bad" when the number of flagged
+                windows in its rolling deque exceeds this value (i.e. at
+                ``threshold + 1`` or more). Default 15 with ``window_count=30``
+                means: a port is bad when more than half of the last 30 samples
+                flagged events.
+            gpu_ports_threshold: Minimum number of bad NVLink ports on a GPU
+                before the GPU is reported unhealthy. Default 1 -- any single
+                bad port flags the whole GPU, matching the per-GPU decision
+                pattern of ``NVLHealthCheck`` and the other health checks in
+                this file. Raise this to tolerate isolated noisy ports and
+                only fail when the failure is more widespread; trade-off is
+                that a GPU with one consistently noisy port produces no
+                ``WARN`` log or ``on_failure`` invocation until enough other
+                ports also exceed the per-port threshold. Values ``< 1``
+                behave identically to ``1`` (every GPU with at least one bad
+                port has ``len(bad_ports) >= 1``, so the rollup always trips).
+            on_failure: Async callable invoked (awaited) when the health
+                check fails. Must be an ``async def`` function -- synchronous
+                callables will raise ``TypeError``. Matches the await pattern
+                of ``NVLHealthCheck.async_check``.
+        """
+        super().__init__()
+        self.device_index = device_index
+        self.interval = interval
+        self.threshold = threshold
+        self.gpu_ports_threshold = gpu_ports_threshold
+        self.on_failure = on_failure
+        self.pynvml_available = self.check_pynvml_availability()
+
+        # Per-port rolling window: {(device_id, port): deque of bools}.
+        # Each bool = True if that port had a delta > 0 in that window.
+        self._window_history: Dict[Tuple[int, int], deque] = {}
+        self._window_count = window_count
+        # Per-counter cumulative error values per (device_id, port) from the
+        # previous call. Outer key: (device_id, port). Inner dict: FID (tier-1/
+        # tier-2) or counter_type (legacy) -> last-seen value. Per-counter
+        # storage lets us compute per-counter diffs even when the set of
+        # successful counters varies between calls.
+        #
+        # Inner-key namespace assumption: a given port stays on a single API
+        # path for the process lifetime — `_tier1_api_supported` /
+        # `_tier2_api_supported` are sticky flags that latch True or False
+        # on first probe and never flip back. So the inner dict only ever
+        # holds one of: tier-1 FIDs (215, 295, 208), tier-2 per-lane FIDs
+        # (46-58), or legacy counter_type enums (NVML_NVLINK_ERROR_DL_REPLAY/
+        # DL_RECOVERY ~ small ints). Current NVML enum values across these
+        # three sets do NOT overlap, so the per-port flat int->int dict is
+        # safe even on the (impossible-today) migration path. Revisit if
+        # NVML ever introduces an FID that collides with a counter_type.
+        self._prev_counters: Dict[Tuple[int, int], Dict[int, int]] = {}
+        # Separate probed flags for tier 1 (GB200) and tier 2 (older HW).
+        # None = not yet probed; True = supported; False = not supported.
+        self._tier1_api_supported: Optional[bool] = None
+        self._tier1_not_supported_warned = False
+        self._tier2_api_supported: Optional[bool] = None
+        self._tier2_not_supported_warned = False
+        # Warn only once when all APIs are unsupported for a port.
+        self._api_not_supported_warned = False
+        # Warn only once when a sample produced zero successful per-port reads
+        # (every port returned None — likely a wedged NVML or all-unsupported
+        # driver). Without this, the check silently passes forever.
+        self._zero_ports_sampled_warned = False
+
+    async def async_check(self) -> None:
+        """Periodically samples NVLink event windows and invokes ``on_failure``
+        when the per-GPU rollup fails (i.e. some GPU has at least
+        ``gpu_ports_threshold`` ports whose flagged-window count exceeds the
+        per-port ``threshold``). See ``_perform_health_check`` for the rollup
+        rule."""
+        while True:
+            await asyncio.sleep(self.interval)
+            result = await self._check_health()
+            if not result and self.on_failure:
+                await self.on_failure()
+
+    async def _check_health(self) -> bool:
+        return self._perform_health_check()
+
+    def __call__(self) -> Union[Optional[Exception], bool]:
+        """Synchronous NVLink window health check."""
+        return self._perform_health_check()
+
+    @with_pynvml_lock
+    def _perform_health_check(self) -> bool:
+        """
+        Sample NVLink counters, update each port's rolling window, then roll
+        up the per-port state to a per-GPU decision.
+
+        A port is "bad" when its flagged-window count exceeds ``threshold``.
+        A GPU is unhealthy when at least ``gpu_ports_threshold`` of its ports
+        are bad. Returns ``False`` when any GPU is unhealthy; emits one warning
+        log per unhealthy GPU listing all its bad ports.
+        """
+        if not self.pynvml_available:
+            return True
+
+        port_events: Dict[Tuple[int, int], bool] = {}
+        try:
+            self.pynvml.nvmlInit()
+            devices = (
+                [self.device_index]
+                if self.device_index is not None
+                else range(self.pynvml.nvmlDeviceGetCount())
+            )
+            port_events = self._sample_nvlink_events(devices)
+            if not port_events and not self._zero_ports_sampled_warned:
+                logger.warning(
+                    "NVLinkWindowHealthCheck: zero ports returned data this sample. "
+                    "Rolling windows will not advance and the check will pass-through "
+                    "True until at least one port produces a successful read. Verify "
+                    "NVML is responsive and NVLink is enabled on the visible GPUs."
+                )
+                self._zero_ports_sampled_warned = True
+        except self.pynvml.NVMLError as e:
+            logger.warning(f"NVLinkWindowHealthCheck NVML error: {e}")
+            return True
+        except Exception as e:
+            logger.warning(f"NVLinkWindowHealthCheck unexpected error: {e}")
+            return True
+        finally:
+            try:
+                self.pynvml.nvmlShutdown()
+            except Exception as e:
+                logger.warning(f"NVLinkWindowHealthCheck NVML shutdown error: {e}")
+
+        # Update per-port rolling window and roll up to per-GPU decision.
+        # A port is "bad" when its flagged-window count exceeds `threshold`.
+        # A GPU is unhealthy when at least `gpu_ports_threshold` of its
+        # ports are bad. The check returns False if any GPU is unhealthy
+        # (True only when every GPU passes), matching the per-GPU framing
+        # of NVLHealthCheck.
+        bad_ports_per_gpu: Dict[int, list] = {}
+        for key, had_events in port_events.items():
+            if key not in self._window_history:
+                self._window_history[key] = deque(maxlen=self._window_count)
+            self._window_history[key].append(had_events)
+            flagged = sum(self._window_history[key])
+            if flagged > self.threshold:
+                device_id, port = key
+                bad_ports_per_gpu.setdefault(device_id, []).append(
+                    (port, flagged, len(self._window_history[key]))
+                )
+
+        all_healthy = True
+        for device_id, bad_ports in bad_ports_per_gpu.items():
+            if len(bad_ports) >= self.gpu_ports_threshold:
+                port_detail = ", ".join(f"port {p} ({f}/{w} flagged)" for p, f, w in bad_ports)
+                logger.warning(
+                    f"NVLinkWindowHealthCheck: GPU {device_id} unhealthy -- "
+                    f"{len(bad_ports)} NVLink ports flagged for replay/recovery "
+                    f"events (gpu_ports_threshold={self.gpu_ports_threshold}, "
+                    f"per-port threshold={self.threshold}): {port_detail}."
+                )
+                all_healthy = False
+        return all_healthy
+
+    def _sample_nvlink_events(self, devices) -> Dict[Tuple[int, int], bool]:
+        """
+        Read replay + recovery counters per port; flag the window if ANY
+        individual counter's diff > 0 vs. the previous call.
+
+        Per-counter baselines (rather than a summed total) avoid the
+        "set of successful FIDs differs between calls" pitfall: a counter
+        that was unavailable last call doesn't contribute a phantom delta
+        on first sighting; new counters get added to the baseline silently.
+
+        Window cadence — one entry per successful sample per (device, port):
+          - First successful sample for a port emits ``False`` (no diff
+            possible yet, but the window starts filling so the rolling
+            count of last-30 events advances on every call).
+          - Subsequent successful samples emit True/False based on whether
+            any per-counter diff > 0.
+          - Failed reads (counters is None — port doesn't exist on this
+            HW, or transient NVML error) emit nothing and the window does
+            NOT advance for that port. The deque keeps its prior entries
+            and resumes appending on the next successful read.
+
+        Returns {(device_id, port): had_events_this_window}.
+        """
+        port_events: Dict[Tuple[int, int], bool] = {}
+        max_links = getattr(self.pynvml, "NVML_NVLINK_MAX_LINKS", 18)
+        for device_id in devices:
+            handle = self.pynvml.nvmlDeviceGetHandleByIndex(device_id)
+            for port in range(max_links):
+                counters = self._read_port_error_counters(handle, device_id, port)
+                if counters is None:
+                    # No data this call — don't advance this port's window.
+                    continue
+                key = (device_id, port)
+                prev = self._prev_counters.setdefault(key, {})
+                if prev:
+                    # Only counters present in BOTH calls contribute a diff.
+                    # Counters new to this call get added to the baseline
+                    # below without flagging the window.
+                    had_event = any(
+                        fid in prev and val > prev[fid] for fid, val in counters.items()
+                    )
+                else:
+                    # First successful read for this port — baseline is
+                    # established below; this window starts at 0 events.
+                    had_event = False
+                port_events[key] = had_event
+                # Update baseline: keep prior FIDs, overwrite current ones,
+                # add new ones. Stale entries from FIDs that disappeared this
+                # call are preserved so deltas across transient failures are
+                # still detected when those counters return.
+                prev.update(counters)
+        return port_events
+
+    def _read_port_error_counters(
+        self, handle, device_id: int, port: int
+    ) -> Optional[Dict[int, int]]:
+        """
+        Read the set of replay/recovery counters for one port as a dict
+        keyed by FID (tier-1/tier-2) or counter_type (legacy). Tries the
+        field-values API first; falls back to the legacy counter API.
+        Returns None if no API is supported on this port.
+        """
+        counters = self._read_via_field_values(handle, device_id, port)
+        if counters is not None:
+            return counters
+        return self._read_via_legacy(handle, device_id, port)
+
+    def _read_via_field_values(self, handle, device_id: int, port: int) -> Optional[Dict[int, int]]:
+        """
+        Read replay + recovery for one port via nvmlDeviceGetFieldValues.
+
+        Returns a dict mapping FID -> value for each FID that returned
+        NVML_SUCCESS in this call. The caller computes per-FID diffs against
+        a baseline so partial-success calls don't produce phantom deltas.
+
+        Tries tier 1 (GB200) then tier 2 (older HW) independently; each
+        tier's supported flag is tracked separately so a tier-2 failure
+        never blocks tier 1. Returns None if both tiers are unsupported.
+        """
+        nvml_success = getattr(self.pynvml, "NVML_SUCCESS", 0)
+
+        # Tier 1: NVLink5 / GB200 per-port (scopeId = port number).
+        # Three issue indicators tracked independently; any per-FID delta > 0
+        # vs. the baseline flags the window. Field IDs 215, 295, 208 are
+        # documented in the public NVML field-value enums and verified working
+        # on GB200 setups.
+        TIER1_FIDS = (
+            getattr(self.pynvml, "NVML_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS", 215),
+            getattr(self.pynvml, "NVML_FI_DEV_NVLINK_PLR_XMIT_RETRY_BLOCKS", 295),
+            getattr(self.pynvml, "NVML_FI_DEV_NVLINK_COUNT_RCV_ERRORS", 208),
+        )
+        if self._tier1_api_supported is not False:
+            queries = [(fid, port) for fid in TIER1_FIDS]
+            try:
+                results = self.pynvml.nvmlDeviceGetFieldValues(handle, queries)
+                counters: Dict[int, int] = {
+                    fid: r.value.uiVal
+                    for fid, r in zip(TIER1_FIDS, results)
+                    if r.nvmlReturn == nvml_success
+                }
+                if counters:
+                    self._tier1_api_supported = True
+                    return counters
+                # API returned but all three FIDs said "not supported" on
+                # this port. Only treat as "tier-1 unsupported by driver"
+                # on a first-time probe -- an inactive/out-of-range port
+                # must not demote a tier already confirmed working on
+                # another port (sticky-True semantic, see _prev_counters
+                # comment above).
+                if self._tier1_api_supported is None:
+                    if not self._tier1_not_supported_warned:
+                        logger.warning(
+                            f"NVLinkWindowHealthCheck: tier-1 field IDs (215/295/208) not supported "
+                            f"on device {device_id} port {port}. "
+                            f"Falling back to tier-2 / legacy API."
+                        )
+                        self._tier1_not_supported_warned = True
+                    self._tier1_api_supported = False
+            except self.pynvml.NVMLError:
+                # Persistent driver-level failure on a first-time probe --
+                # disable tier-1 so we don't retry every port every call.
+                # Same sticky-True guard: a transient NVMLError after the
+                # tier was already confirmed working doesn't disable it.
+                if self._tier1_api_supported is None:
+                    self._tier1_api_supported = False
+
+        # Tier 2: per-lane field IDs L0-L5 (older hardware, ports 0-5 only).
+        if self._tier2_api_supported is not False and port < 6:
+            replay_lane = getattr(
+                self.pynvml, f"NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L{port}", None
+            )
+            recovery_lane = getattr(
+                self.pynvml, f"NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L{port}", None
+            )
+            field_ids = [fid for fid in (replay_lane, recovery_lane) if fid is not None]
+            if field_ids:
+                try:
+                    results = self.pynvml.nvmlDeviceGetFieldValues(handle, field_ids)
+                    counters_t2: Dict[int, int] = {
+                        fid: r.value.uiVal
+                        for fid, r in zip(field_ids, results)
+                        if r.nvmlReturn == nvml_success
+                    }
+                    if counters_t2:
+                        self._tier2_api_supported = True
+                        return counters_t2
+                    # API succeeded but no results for this port -- don't
+                    # demote a tier already confirmed working on another
+                    # port (sticky-True semantic).
+                    if self._tier2_api_supported is None:
+                        self._tier2_api_supported = False
+                except self.pynvml.NVMLError as e:
+                    if self._tier2_api_supported is None:
+                        if not self._tier2_not_supported_warned:
+                            logger.warning(
+                                f"NVLinkWindowHealthCheck: nvmlDeviceGetFieldValues tier-2 not "
+                                f"supported on device {device_id}: {e}. Falling back to legacy API."
+                            )
+                            self._tier2_not_supported_warned = True
+                        self._tier2_api_supported = False
+
+        return None
+
+    def _read_via_legacy(self, handle, device_id: int, port: int) -> Optional[Dict[int, int]]:
+        """
+        Legacy: DL_REPLAY + DL_RECOVERY for one port via
+        nvmlDeviceGetNvLinkErrorCounter. Returns a dict keyed by counter_type
+        so per-counter diffs work the same way as the field-values path.
+
+        Marked LEGACY for drivers > 450; may return NVML_ERROR_NOT_SUPPORTED
+        on GB200.
+        """
+        replay_type = getattr(self.pynvml, "NVML_NVLINK_ERROR_DL_REPLAY", None)
+        recovery_type = getattr(self.pynvml, "NVML_NVLINK_ERROR_DL_RECOVERY", None)
+        if replay_type is None and recovery_type is None:
+            return None
+
+        counters: Dict[int, int] = {}
+        for counter_type in (replay_type, recovery_type):
+            if counter_type is None:
+                continue
+            try:
+                counters[counter_type] = self.pynvml.nvmlDeviceGetNvLinkErrorCounter(
+                    handle, port, counter_type
+                )
+            except self.pynvml.NVMLError as e:
+                if "not supported" in str(e).lower() or "invalid argument" in str(e).lower():
+                    continue
+                raise
+
+        if not counters:
+            if not self._api_not_supported_warned:
+                logger.warning(
+                    f"NVLinkWindowHealthCheck: neither field-values nor legacy "
+                    f"nvmlDeviceGetNvLinkErrorCounter is supported on device {device_id} "
+                    f"port {port}. Health check will be skipped."
+                )
+                self._api_not_supported_warned = True
+            return None
+        return counters
 
 
 class NodeHealthCheck:


### PR DESCRIPTION
## Summary

Adds `NVLinkWindowHealthCheck` to `src/nvidia_resiliency_ext/shared_utils/health_check.py`.

The existing `NVLHealthCheck` detects disabled NVLink ports, but does not track transient replay/recovery errors that indicate a degrading link before it goes down. `NVLinkWindowHealthCheck` fills this gap by sampling error counters every interval and reporting failure only when errors are persistent across multiple windows — reducing false positives from single transient events.

## What changed

- New class `NVLinkWindowHealthCheck(PynvmlMixin)` in `shared_utils/health_check.py`
- Two new imports: `deque` from `collections`, `Tuple` from `typing`

## How it works

Each call to `_perform_health_check()` is one **window**. A window is flagged when any NVLink port shows a delta > 0 in `DL_REPLAY` or `DL_RECOVERY` error counters vs. the previous call. Returns `False` when any port exceeds `threshold` flagged windows within the last `window_count` calls.

### Parameters

| Parameter | Default | Description |
|---|---|---|
| `device_index` | `None` | GPU index to monitor; `None` checks all GPUs |
| `interval` | `60` | Seconds between async health checks |
| `window_count` | `30` | Rolling window size (number of past checks to consider) |
| `threshold` | `15` | Max flagged windows allowed before reporting failure |
| `on_failure` | `None` | Callback invoked on failure |

### Counter reading — three tiers (first that works wins per port)

**Tier 1 — GB200 / newer drivers (preferred)**
`nvmlDeviceGetFieldValues` with per-port field IDs and `scopeId = port`:
- `NVML_FI_DEV_NVLINK_ERROR_DL_REPLAY` (161)
- `NVML_FI_DEV_NVLINK_ERROR_DL_RECOVERY` (162)

**Tier 2 — older hardware (ports 0–5 only)**
`nvmlDeviceGetFieldValues` with per-lane field IDs L0–L5:
- `NVML_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L{n}` (46–51)
- `NVML_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L{n}` (53–58)

**Fallback — legacy (drivers ≤ 450)**
`nvmlDeviceGetNvLinkErrorCounter` with `NVML_NVLINK_ERROR_DL_REPLAY` / `NVML_NVLINK_ERROR_DL_RECOVERY`. May return `NVML_ERROR_NOT_SUPPORTED` on GB200.

A one-time warning is logged if GB200 tier-1 field IDs exist in pynvml but the driver returns not-supported, and again if all APIs fail on a port (health check skipped for that port).

## What to review

- Default values for `window_count=30` and `threshold=15` — are these appropriate for the expected polling interval?
- The three-tier API fallback logic — especially the `_tier1_api_supported` / `_tier2_api_supported` flag tracking
- Whether `NVLinkWindowHealthCheck` should be exported from `shared_utils/__init__.py`