### PR TITLE
Add backward-compat alias _get_write_results_queue in filesystem_async

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -133,6 +133,10 @@ def get_write_results_queue(mp_mode: str = 'spawn') -> mp.Queue:
     return _results_queue
 
 
+# Backward-compat alias for the former private name
+_get_write_results_queue = get_write_results_queue
+
+
 class FileSystemWriterAsync(FileSystemWriter):
     """
     Async-enabled implementation of FileSystemWriter using file I/O.


### PR DESCRIPTION
The function was renamed from _get_write_results_queue to the public get_write_results_queue. Keep the old private name as an alias so callers pinned to an older API continue to work without changes.