### PR TITLE
Refactor to make attribution an optional package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ For detailed documentation and usage information about each component, please re
 - `git clone https://github.com/NVIDIA/nvidia-resiliency-ext`
 - `cd nvidia-resiliency-ext`
 - `pip install .`
+- `pip install .[attribution]` if you also need log-analysis / attribution extras
 
 
 ### From PyPI wheel
 - `pip install nvidia-resiliency-ext`
+- `pip install 'nvidia-resiliency-ext[attribution]'` for attribution extras
 
 ### Platform Support
 
@@ -55,4 +57,3 @@ For detailed documentation and usage information about each component, please re
 | NVML Driver          | >= 535 (570 required for GPU health check)                                 |
 | NCCL Version         | < 2.28.3 OR >= 2.28.9 (avoid NCCL 2.28.3–2.28.8 due to inprocess issue)    |
 | TE Version           | >= 2.5                                                                     |
-

--- a/examples/attribution/README.md
+++ b/examples/attribution/README.md
@@ -2,6 +2,12 @@
 
 Minimal examples using the attribution library and MCP integration.
 
+Install the optional attribution dependencies first:
+
+```bash
+pip install 'nvidia-resiliency-ext[attribution]'
+```
+
 | File | Description |
 |------|-------------|
 | `single_server_example.py` | Single MCP server with multiple attribution modules (run from repo root). |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,14 @@ packaging = "*"
 python = ">=3.10"
 psutil = ">=6.0.0"
 pyyaml = "*"
+numpy = ">=1.26"
 nvidia-ml-py = ">=12.570.86"
 defusedxml = "*"
-langchain-openai = ">=0.3.0"
-mcp = ">=1.15.0"
-setproctitle = ">=1.3.0"
-logsage = ">=0.1.7"
+httpx = ">=0.24.0"
+langchain-openai = { version = ">=0.3.0", optional = true }
+mcp = { version = ">=1.15.0", optional = true }
+setproctitle = { version = ">=1.3.0", optional = true }
+logsage = { version = ">=0.1.7", optional = true }
 grpcio = "^1.76.0"
 grpcio-tools = "^1.76.0"
 protobuf = ">=4.22.0"
@@ -57,6 +59,9 @@ protobuf = ">=4.22.0"
 [tool.poetry.scripts]
 ft_launcher = "nvidia_resiliency_ext.fault_tolerance.launcher:main"
 nvrx-mcp-analysis = "nvidia_resiliency_ext.attribution.mcp_integration.server_launcher:main"
+
+[tool.poetry.extras]
+attribution = ["langchain-openai", "logsage", "mcp", "setproctitle"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/services/nvrx_attrsvc/__init__.py
+++ b/services/nvrx_attrsvc/__init__.py
@@ -3,7 +3,7 @@
 
 """NVRX Attribution Service package."""
 
-from nvidia_resiliency_ext.attribution import (
+from nvidia_resiliency_ext.attribution.coalescing import (
     CacheResult,
     InflightResult,
     StatsResult,

--- a/services/nvrx_attrsvc/config.py
+++ b/services/nvrx_attrsvc/config.py
@@ -18,11 +18,11 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Re-export ErrorCode from library layer so service consumers can use:
 #   from nvrx_attrsvc.config import ErrorCode
-from nvidia_resiliency_ext.attribution import ErrorCode as ErrorCode
 from nvidia_resiliency_ext.attribution.svc.config import (
     DEFAULT_LLM_BASE_URL as DEFAULT_LLM_BASE_URL,
 )
 from nvidia_resiliency_ext.attribution.svc.config import DEFAULT_LLM_MODEL as DEFAULT_LLM_MODEL
+from nvidia_resiliency_ext.attribution.svc.config import ErrorCode as ErrorCode
 
 logger = logging.getLogger(__name__)
 

--- a/services/nvrx_attrsvc/service.py
+++ b/services/nvrx_attrsvc/service.py
@@ -15,19 +15,21 @@ import logging
 import os
 from typing import Any
 
-from nvidia_resiliency_ext.attribution import (
-    Analyzer,
+from nvidia_resiliency_ext.attribution.analyzer import Analyzer
+from nvidia_resiliency_ext.attribution.coalescing import (
     CacheResult,
     InflightResult,
+    SubmittedResult,
+)
+from nvidia_resiliency_ext.attribution.postprocessing import get_posting_stats, get_slack_stats
+from nvidia_resiliency_ext.attribution.svc.config import LogSageExecutionConfig
+from nvidia_resiliency_ext.attribution.svc.types import (
     LogAnalysisCycleResult,
     LogAnalysisSplitlogResult,
     LogAnalyzerError,
     LogAnalyzerFilePreview,
     LogAnalyzerSubmitResult,
-    SubmittedResult,
 )
-from nvidia_resiliency_ext.attribution.postprocessing import get_posting_stats, get_slack_stats
-from nvidia_resiliency_ext.attribution.svc.config import LogSageExecutionConfig
 
 from .config import PRINT_PREVIEW_MAX_BYTES, Settings
 

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 
 dependencies = [
     # Core library
-    "nvidia-resiliency-ext>=0.5.0",
+    "nvidia-resiliency-ext[attribution]>=0.5.0",
 
     # Web framework
     "fastapi>=0.100.0",

--- a/src/nvidia_resiliency_ext/attribution/README.md
+++ b/src/nvidia_resiliency_ext/attribution/README.md
@@ -2,6 +2,12 @@
 
 Python library for **failure attribution** on job logs: LogSage (LLM over logs), optional **NCCL flight-recorder** analysis, optional **LLM merge** of log + trace, **request coalescing**, SLURM-oriented **splitlog** tracking, and hooks for posting results (e.g. Elasticsearch, Slack).
 
+Install the optional attribution dependency set with:
+
+```bash
+pip install 'nvidia-resiliency-ext[attribution]'
+```
+
 **How it is structured (subsystems, diagrams, `Analyzer` / `LogAnalyzerConfig`, MCP vs in-process LogSage, pipeline modes):**  
 **[ARCHITECTURE.md](./ARCHITECTURE.md)**
 

--- a/src/nvidia_resiliency_ext/attribution/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/__init__.py
@@ -23,63 +23,147 @@ Example usage (no HTTP required):
     analyzer.shutdown()
 
 See ``README.md`` and ``ARCHITECTURE.md`` in this package for how the library is organized.
+
+Log-analysis features use optional dependencies. Install them with
+``pip install nvidia-resiliency-ext[attribution]`` when you need ``Analyzer``, LogSage,
+MCP integration, or related attribution tooling.
 """
 
-from .analyzer import (
-    AnalysisPipelineMode,
-    Analyzer,
-    CombinedAnalysisResult,
-    FrDumpPathNotFoundError,
-    TraceAnalyzer,
-    run_attribution_pipeline,
-)
-from .coalescing import (
-    DEFAULT_COMPUTE_TIMEOUT_SECONDS,
-    CacheResult,
-    CoalescerStats,
-    InflightResult,
-    LogAnalysisCoalesced,
-    RequestCoalescer,
-    StatsResult,
-    SubmittedResult,
-    coalesced_from_cache,
-)
+from __future__ import annotations
 
-# Re-export from svc submodule (jobs, splitlog, wire keys, config — not orchestration types)
-from .svc.config import (  # Infrastructure
-    MAX_JOBS,
-    MIN_FILE_SIZE_KB,
-    POLL_INTERVAL_SECONDS,
-    RESP_ERROR,
-    RESP_FILES_ANALYZED,
-    RESP_LOG_FILE,
-    RESP_LOGS_DIR,
-    RESP_MODE,
-    RESP_MODULE,
-    RESP_RESULT,
-    RESP_RESULT_ID,
-    RESP_SCHED_RESTARTS,
-    RESP_STATE,
-    RESP_STATUS,
-    RESP_WL_RESTART,
-    RESP_WL_RESTART_COUNT,
-    STATE_TIMEOUT,
-    TTL_MAX_JOB_AGE_SECONDS,
-    TTL_PENDING_SECONDS,
-    TTL_TERMINATED_SECONDS,
-    ErrorCode,
-)
-from .svc.job import FileInfo, Job, JobMode
-from .svc.splitlog import SplitlogTracker
-from .svc.types import (
-    LogAnalysisCycleResult,
-    LogAnalysisSplitlogResult,
-    LogAnalyzerConfig,
-    LogAnalyzerError,
-    LogAnalyzerFilePreview,
-    LogAnalyzerOutcome,
-    LogAnalyzerSubmitResult,
-)
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+from ._optional import reraise_if_missing_attribution_dependency
+
+if TYPE_CHECKING:
+    from .analyzer import (
+        AnalysisPipelineMode,
+        Analyzer,
+        CombinedAnalysisResult,
+        FrDumpPathNotFoundError,
+        TraceAnalyzer,
+        run_attribution_pipeline,
+    )
+    from .coalescing import (
+        DEFAULT_COMPUTE_TIMEOUT_SECONDS,
+        CacheResult,
+        CoalescerStats,
+        InflightResult,
+        LogAnalysisCoalesced,
+        RequestCoalescer,
+        StatsResult,
+        SubmittedResult,
+        coalesced_from_cache,
+    )
+    from .svc.config import (
+        MAX_JOBS,
+        MIN_FILE_SIZE_KB,
+        POLL_INTERVAL_SECONDS,
+        RESP_ERROR,
+        RESP_FILES_ANALYZED,
+        RESP_LOG_FILE,
+        RESP_LOGS_DIR,
+        RESP_MODE,
+        RESP_MODULE,
+        RESP_RESULT,
+        RESP_RESULT_ID,
+        RESP_SCHED_RESTARTS,
+        RESP_STATE,
+        RESP_STATUS,
+        RESP_WL_RESTART,
+        RESP_WL_RESTART_COUNT,
+        STATE_TIMEOUT,
+        TTL_MAX_JOB_AGE_SECONDS,
+        TTL_PENDING_SECONDS,
+        TTL_TERMINATED_SECONDS,
+        ErrorCode,
+    )
+    from .svc.job import FileInfo, Job, JobMode
+    from .svc.splitlog import SplitlogTracker
+    from .svc.types import (
+        LogAnalysisCycleResult,
+        LogAnalysisSplitlogResult,
+        LogAnalyzerConfig,
+        LogAnalyzerError,
+        LogAnalyzerFilePreview,
+        LogAnalyzerOutcome,
+        LogAnalyzerSubmitResult,
+    )
+
+_EXPORTS = {
+    "AnalysisPipelineMode": ".analyzer",
+    "Analyzer": ".analyzer",
+    "CombinedAnalysisResult": ".analyzer",
+    "FrDumpPathNotFoundError": ".analyzer",
+    "TraceAnalyzer": ".analyzer",
+    "run_attribution_pipeline": ".analyzer",
+    "DEFAULT_COMPUTE_TIMEOUT_SECONDS": ".coalescing",
+    "CacheResult": ".coalescing",
+    "CoalescerStats": ".coalescing",
+    "InflightResult": ".coalescing",
+    "LogAnalysisCoalesced": ".coalescing",
+    "RequestCoalescer": ".coalescing",
+    "StatsResult": ".coalescing",
+    "SubmittedResult": ".coalescing",
+    "coalesced_from_cache": ".coalescing",
+    "MAX_JOBS": ".svc.config",
+    "MIN_FILE_SIZE_KB": ".svc.config",
+    "POLL_INTERVAL_SECONDS": ".svc.config",
+    "RESP_ERROR": ".svc.config",
+    "RESP_FILES_ANALYZED": ".svc.config",
+    "RESP_LOG_FILE": ".svc.config",
+    "RESP_LOGS_DIR": ".svc.config",
+    "RESP_MODE": ".svc.config",
+    "RESP_MODULE": ".svc.config",
+    "RESP_RESULT": ".svc.config",
+    "RESP_RESULT_ID": ".svc.config",
+    "RESP_SCHED_RESTARTS": ".svc.config",
+    "RESP_STATE": ".svc.config",
+    "RESP_STATUS": ".svc.config",
+    "RESP_WL_RESTART": ".svc.config",
+    "RESP_WL_RESTART_COUNT": ".svc.config",
+    "STATE_TIMEOUT": ".svc.config",
+    "TTL_MAX_JOB_AGE_SECONDS": ".svc.config",
+    "TTL_PENDING_SECONDS": ".svc.config",
+    "TTL_TERMINATED_SECONDS": ".svc.config",
+    "ErrorCode": ".svc.config",
+    "FileInfo": ".svc.job",
+    "Job": ".svc.job",
+    "JobMode": ".svc.job",
+    "SplitlogTracker": ".svc.splitlog",
+    "LogAnalysisCycleResult": ".svc.types",
+    "LogAnalysisSplitlogResult": ".svc.types",
+    "LogAnalyzerConfig": ".svc.types",
+    "LogAnalyzerError": ".svc.types",
+    "LogAnalyzerFilePreview": ".svc.types",
+    "LogAnalyzerOutcome": ".svc.types",
+    "LogAnalyzerSubmitResult": ".svc.types",
+}
+
+
+def __getattr__(name: str):
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    try:
+        module = import_module(module_name, __name__)
+    except ModuleNotFoundError as exc:
+        reraise_if_missing_attribution_dependency(
+            exc,
+            feature=f"{__name__}.{name}",
+        )
+        raise
+
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals().keys()) + list(__all__))
+
 
 __all__ = [
     # Log + FR orchestration (no LogSage import here)

--- a/src/nvidia_resiliency_ext/attribution/_optional.py
+++ b/src/nvidia_resiliency_ext/attribution/_optional.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for attribution optional dependency messaging."""
+
+from __future__ import annotations
+
+_OPTIONAL_ATTRIBUTION_MODULES = frozenset(
+    {
+        "langchain_openai",
+        "logsage",
+        "mcp",
+        "setproctitle",
+    }
+)
+
+
+def reraise_if_missing_attribution_dependency(exc: ModuleNotFoundError, *, feature: str) -> None:
+    """Raise a clearer error when attribution extras are not installed."""
+    if exc.name not in _OPTIONAL_ATTRIBUTION_MODULES:
+        return
+
+    raise ModuleNotFoundError(
+        f"{feature} requires optional attribution dependencies that are not installed. "
+        "Install them with `pip install nvidia-resiliency-ext[attribution]` "
+        f"(missing module: {exc.name})."
+    ) from exc

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/__init__.py
@@ -1,9 +1,26 @@
 """MCP integration for NVRX Attribution modules."""
 
-from .mcp_client import NVRxMCPClient, create_mcp_client, get_server_command
-from .mcp_server import NVRxMCPServer
-from .registry import AttributionModuleRegistry
-from .transport_errors import is_mcp_connection_error
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+from nvidia_resiliency_ext.attribution._optional import reraise_if_missing_attribution_dependency
+
+if TYPE_CHECKING:
+    from .mcp_client import NVRxMCPClient, create_mcp_client, get_server_command
+    from .mcp_server import NVRxMCPServer
+    from .registry import AttributionModuleRegistry
+    from .transport_errors import is_mcp_connection_error
+
+_EXPORTS = {
+    "NVRxMCPServer": ".mcp_server",
+    "NVRxMCPClient": ".mcp_client",
+    "AttributionModuleRegistry": ".registry",
+    "get_server_command": ".mcp_client",
+    "create_mcp_client": ".mcp_client",
+    "is_mcp_connection_error": ".transport_errors",
+}
 
 __all__ = [
     "NVRxMCPServer",
@@ -13,3 +30,26 @@ __all__ = [
     "create_mcp_client",
     "is_mcp_connection_error",
 ]
+
+
+def __getattr__(name: str):
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    try:
+        module = import_module(module_name, __name__)
+    except ModuleNotFoundError as exc:
+        reraise_if_missing_attribution_dependency(
+            exc,
+            feature=f"{__name__}.{name}",
+        )
+        raise
+
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals().keys()) + list(__all__))

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_client.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_client.py
@@ -15,9 +15,7 @@ from contextlib import AsyncExitStack
 from importlib.resources import files as pkg_files
 from typing import Any, Dict, List
 
-from mcp.client.session import ClientSession
-from mcp.client.stdio import StdioServerParameters, stdio_client
-
+from nvidia_resiliency_ext.attribution._optional import reraise_if_missing_attribution_dependency
 from nvidia_resiliency_ext.attribution.mcp_integration.registry import deserialize_result
 from nvidia_resiliency_ext.attribution.mcp_integration.transport_errors import (
     is_mcp_connection_error,
@@ -108,6 +106,16 @@ class NVRxMCPClient:
     async def __aenter__(self):
         """Async context manager entry."""
         import os
+
+        try:
+            from mcp.client.session import ClientSession
+            from mcp.client.stdio import StdioServerParameters, stdio_client
+        except ModuleNotFoundError as exc:
+            reraise_if_missing_attribution_dependency(
+                exc,
+                feature=f"{type(self).__module__}.{type(self).__name__}.__aenter__",
+            )
+            raise
 
         # Convert server_command list to StdioServerParameters
         logger.info(f"pid: {os.getpid()} is connecting to server")

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/server_launcher.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/server_launcher.py
@@ -22,11 +22,7 @@ import argparse
 import logging
 import sys
 
-from nvidia_resiliency_ext.attribution.mcp_integration.mcp_server import NVRxMCPServer
-from nvidia_resiliency_ext.attribution.mcp_integration.module_definitions import (
-    register_all_modules,
-)
-from nvidia_resiliency_ext.attribution.mcp_integration.registry import global_registry
+from nvidia_resiliency_ext.attribution._optional import reraise_if_missing_attribution_dependency
 
 _PROC_TITLE = "nvrx-mcp-analysis"
 
@@ -47,6 +43,19 @@ logger = logging.getLogger(__name__)
 def main():
     """Main entry point for the MCP server."""
     _set_process_title(_PROC_TITLE)
+
+    try:
+        from nvidia_resiliency_ext.attribution.mcp_integration.mcp_server import NVRxMCPServer
+        from nvidia_resiliency_ext.attribution.mcp_integration.module_definitions import (
+            register_all_modules,
+        )
+        from nvidia_resiliency_ext.attribution.mcp_integration.registry import global_registry
+    except ModuleNotFoundError as exc:
+        reraise_if_missing_attribution_dependency(
+            exc,
+            feature="nvrx-mcp-analysis",
+        )
+        raise
 
     parser = argparse.ArgumentParser(description='Launch NVRX Attribution MCP Server')
     parser.add_argument(

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -25,13 +25,13 @@ import sys
 import threading
 import traceback
 from collections import defaultdict
+from dataclasses import dataclass
 from functools import wraps
 from typing import Any, Callable, Dict, Optional, Union
 from urllib.parse import quote_plus
 
 import defusedxml.ElementTree as ET
 import httpx
-from pydantic import BaseModel
 
 from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
 
@@ -1345,7 +1345,8 @@ class StoragePathHealthCheck:
         return True
 
 
-class AttrSvcResult(BaseModel):
+@dataclass
+class AttrSvcResult:
     result: Any
     status: str = "completed"
 

--- a/tests/attribution/unit/test_api_keys.py
+++ b/tests/attribution/unit/test_api_keys.py
@@ -8,15 +8,17 @@ import sys
 import unittest
 from unittest.mock import patch
 
-if sys.version_info < (3, 10):
-    raise unittest.SkipTest(
-        "Attribution package requires Python 3.10+ (e.g. dataclass(slots=True) in svc.job)."
-    )
+PY310_PLUS = sys.version_info >= (3, 10)
 
-from nvidia_resiliency_ext.attribution.api_keys import load_nvidia_api_key
-from nvidia_resiliency_ext.attribution.combined_log_fr.llm_merge import merge_log_fr_llm
+if PY310_PLUS:
+    from nvidia_resiliency_ext.attribution.api_keys import load_nvidia_api_key
+    from nvidia_resiliency_ext.attribution.combined_log_fr.llm_merge import merge_log_fr_llm
 
 
+@unittest.skipUnless(
+    PY310_PLUS,
+    "Attribution package requires Python 3.10+ (e.g. dataclass(slots=True) in svc.job).",
+)
 class TestLoadNvidiaApiKey(unittest.TestCase):
     def test_reads_and_strips_from_env(self):
         with patch.dict("os.environ", {"NVIDIA_API_KEY": "  sk-test  "}):
@@ -38,6 +40,10 @@ class TestLoadNvidiaApiKey(unittest.TestCase):
             self.assertEqual(load_nvidia_api_key(), "")
 
 
+@unittest.skipUnless(
+    PY310_PLUS,
+    "Attribution package requires Python 3.10+ (e.g. dataclass(slots=True) in svc.job).",
+)
 class TestMergeLogFrLlm(unittest.TestCase):
     def test_raises_when_api_key_empty(self):
         async def run():

--- a/tests/attribution/unit/test_fr_dump_path.py
+++ b/tests/attribution/unit/test_fr_dump_path.py
@@ -7,18 +7,16 @@ import sys
 import tempfile
 import unittest
 
-# isort: off  # SkipTest before attribution import on Python < 3.10
-if sys.version_info < (3, 10):
-    raise unittest.SkipTest("attribution tests require Python 3.10+")
+PY310_PLUS = sys.version_info >= (3, 10)
 
-from nvidia_resiliency_ext.attribution.trace_analyzer.fr_support import (
-    extract_fr_dump_path,
-    fr_path_resolvable_for_collective_analyzer,
-)
-
-# isort: on
+if PY310_PLUS:
+    from nvidia_resiliency_ext.attribution.trace_analyzer.fr_support import (
+        extract_fr_dump_path,
+        fr_path_resolvable_for_collective_analyzer,
+    )
 
 
+@unittest.skipUnless(PY310_PLUS, "attribution tests require Python 3.10+")
 class TestFrDumpPathInference(unittest.TestCase):
     def test_checkpoints_sibling_of_logs(self):
         """Infer <run>/checkpoints when log is under <run>/logs/ and _dump_* files exist."""

--- a/tests/attribution/unit/test_fr_markdown_appendix.py
+++ b/tests/attribution/unit/test_fr_markdown_appendix.py
@@ -4,12 +4,13 @@
 import sys
 import unittest
 
-if sys.version_info < (3, 10):
-    raise unittest.SkipTest("attribution tests require Python 3.10+")
+PY310_PLUS = sys.version_info >= (3, 10)
 
-from nvidia_resiliency_ext.attribution.trace_analyzer.fr_support import fr_markdown_appendix
+if PY310_PLUS:
+    from nvidia_resiliency_ext.attribution.trace_analyzer.fr_support import fr_markdown_appendix
 
 
+@unittest.skipUnless(PY310_PLUS, "attribution tests require Python 3.10+")
 class TestFrMarkdownAppendix(unittest.TestCase):
     def test_no_section_when_only_dump_path(self):
         self.assertEqual(

--- a/tests/attribution/unit/test_mcp_server_command.py
+++ b/tests/attribution/unit/test_mcp_server_command.py
@@ -5,12 +5,13 @@ import sys
 import unittest
 from unittest.mock import patch
 
-if sys.version_info < (3, 10):
-    raise unittest.SkipTest("attribution tests require Python 3.10+")
+PY310_PLUS = sys.version_info >= (3, 10)
 
-from nvidia_resiliency_ext.attribution.mcp_integration.mcp_client import get_server_command
+if PY310_PLUS:
+    from nvidia_resiliency_ext.attribution.mcp_integration.mcp_client import get_server_command
 
 
+@unittest.skipUnless(PY310_PLUS, "attribution tests require Python 3.10+")
 class TestGetServerCommand(unittest.TestCase):
     def test_prefers_nvrx_mcp_analysis_on_path(self):
         with patch(

--- a/tests/attribution/unit/test_optional_dependency_error.py
+++ b/tests/attribution/unit/test_optional_dependency_error.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import unittest
+from unittest.mock import patch
+
+PY310_PLUS = sys.version_info >= (3, 10)
+
+if PY310_PLUS:
+    import nvidia_resiliency_ext.attribution as attribution
+
+
+@unittest.skipUnless(PY310_PLUS, "attribution tests require Python 3.10+")
+class TestOptionalDependencyMessaging(unittest.TestCase):
+    def test_analyzer_missing_optional_dependency_shows_extra_hint(self):
+        with patch(
+            "nvidia_resiliency_ext.attribution.import_module",
+            side_effect=ModuleNotFoundError("No module named 'mcp'", name="mcp"),
+        ):
+            with self.assertRaises(ModuleNotFoundError) as ctx:
+                _ = attribution.Analyzer
+
+        self.assertIn("nvidia-resiliency-ext[attribution]", str(ctx.exception))
+        self.assertIn("missing module: mcp", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/attribution/unit/test_post_backend.py
+++ b/tests/attribution/unit/test_post_backend.py
@@ -6,15 +6,17 @@
 import sys
 import unittest
 
-if sys.version_info < (3, 10):
-    raise unittest.SkipTest(
-        "Importing attribution.postprocessing requires Python 3.10+ (dataclass slots)."
-    )
+PY310_PLUS = sys.version_info >= (3, 10)
 
-from nvidia_resiliency_ext.attribution.postprocessing import post_backend
-from nvidia_resiliency_ext.attribution.postprocessing.post_backend import _nvdataflow_result_ok
+if PY310_PLUS:
+    from nvidia_resiliency_ext.attribution.postprocessing import post_backend
+    from nvidia_resiliency_ext.attribution.postprocessing.post_backend import _nvdataflow_result_ok
 
 
+@unittest.skipUnless(
+    PY310_PLUS,
+    "Importing attribution.postprocessing requires Python 3.10+ (dataclass slots).",
+)
 class TestNvdataflowResultOk(unittest.TestCase):
     def test_bool(self):
         self.assertIs(_nvdataflow_result_ok(True), True)
@@ -30,6 +32,10 @@ class TestNvdataflowResultOk(unittest.TestCase):
         self.assertIs(_nvdataflow_result_ok(1), False)
 
 
+@unittest.skipUnless(
+    PY310_PLUS,
+    "Importing attribution.postprocessing requires Python 3.10+ (dataclass slots).",
+)
 class TestPostWithRetries(unittest.TestCase):
     def tearDown(self) -> None:
         post_backend.set_post_override(None)

--- a/tests/attribution/unit/test_slurm_parser.py
+++ b/tests/attribution/unit/test_slurm_parser.py
@@ -6,12 +6,13 @@
 import sys
 import unittest
 
-if sys.version_info < (3, 10):
-    raise unittest.SkipTest("attribution tests require Python 3.10+")
+PY310_PLUS = sys.version_info >= (3, 10)
 
-from nvidia_resiliency_ext.attribution.svc.slurm_parser import parse_slurm_output
+if PY310_PLUS:
+    from nvidia_resiliency_ext.attribution.svc.slurm_parser import parse_slurm_output
 
 
+@unittest.skipUnless(PY310_PLUS, "attribution tests require Python 3.10+")
 class TestWritingLogsToFallback(unittest.TestCase):
     def test_launch_out_without_start_paths(self):
         content = """\

--- a/tests/attribution/unit/test_splitlog_find.py
+++ b/tests/attribution/unit/test_splitlog_find.py
@@ -8,12 +8,13 @@ import sys
 import tempfile
 import unittest
 
-if sys.version_info < (3, 10):
-    raise unittest.SkipTest("attribution tests require Python 3.10+")
+PY310_PLUS = sys.version_info >= (3, 10)
 
-from nvidia_resiliency_ext.attribution.svc.splitlog import SplitlogTracker
+if PY310_PLUS:
+    from nvidia_resiliency_ext.attribution.svc.splitlog import SplitlogTracker
 
 
+@unittest.skipUnless(PY310_PLUS, "attribution tests require Python 3.10+")
 class TestFindLogFiles(unittest.TestCase):
     def test_slurm_subdir_jobid_dot_pattern(self):
         """Paths like 2058365.0.1.main_workload.log under logs/slurm/."""

--- a/tests/attribution/unit/test_unpack_run_result.py
+++ b/tests/attribution/unit/test_unpack_run_result.py
@@ -4,13 +4,14 @@
 import sys
 import unittest
 
-if sys.version_info < (3, 10):
-    raise unittest.SkipTest("attribution tests require Python 3.10+")
+PY310_PLUS = sys.version_info >= (3, 10)
 
-from nvidia_resiliency_ext.attribution.base import AttributionState
-from nvidia_resiliency_ext.attribution.combined_log_fr.llm_merge import unpack_run_result
+if PY310_PLUS:
+    from nvidia_resiliency_ext.attribution.base import AttributionState
+    from nvidia_resiliency_ext.attribution.combined_log_fr.llm_merge import unpack_run_result
 
 
+@unittest.skipUnless(PY310_PLUS, "attribution tests require Python 3.10+")
 class TestUnpackRunResult(unittest.TestCase):
     def test_log_analyzer_list_of_tuples_joins_text(self):
         """NVRxLogAnalyzer.run_sync returns list[tuple[str, AttributionState]]."""


### PR DESCRIPTION
This PR removes attribution as a hard requirement for nvidia-resiliency-ext. The attribution dependency tree is brings in its own dependency and many downstream consumers (like ft_launcher) do not need runtime log analysis. Making it an optional extra streamlines the default installation and minimizes dependency resolution issues.
https://github.com/NVIDIA/nvidia-resiliency-ext/issues/301
