### PR TITLE
Auto-select log aggregation tier.

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -2286,12 +2286,14 @@ def get_args_parser() -> ArgumentParser:
         "--ft_log_aggregator_count",
         action=env,
         type=int,
-        default=2,
+        default=0,
         dest="ft_log_aggregator_count",
-        help="Number of first-level gRPC log aggregators (default 2). "
-        "When 1: single root server listens on --ft-log-server-port (legacy). "
-        "When N>1: N leaf servers on ports [P, P+1, ..., P+N-1] and one root on P+N "
-        "(P = --ft-log-server-port). Clients pick leaf via infra_rank %% N. "
+        help="Number of first-level gRPC log aggregators. "
+        "0 (default): auto — single root server for up to 1536 nodes, "
+        "adds leaf servers beyond that (one per 1536 nodes). "
+        "1: single root server (legacy). "
+        "N>1: N leaf servers on ports [P, P+1, ..., P+N-1] and one root on P+N "
+        "(P = --ft-log-server-port). "
         "Open TCP ports P through P+N on the TCP store host. "
         "Each node picks a leaf from SLURM array/procid when set, else from hostname.",
     )
@@ -2980,10 +2982,10 @@ def _validate_slurm_single_launcher_per_node() -> None:
 
 def _validate_args(args: Any) -> None:
     """Centralized validation of CLI args (cross-flag consistency). Raises ValueError if invalid."""
-    n_log_agg = int(getattr(args, "ft_log_aggregator_count", 2))
-    if n_log_agg < 1:
+    n_log_agg = int(getattr(args, "ft_log_aggregator_count", 0))
+    if n_log_agg < 0:
         raise ValueError(
-            f"--ft-log-aggregator-count must be >= 1, got {n_log_agg}"
+            f"--ft-log-aggregator-count must be >= 0 (0 = auto), got {n_log_agg}"
         )
     _validate_slurm_single_launcher_per_node()
     if getattr(args, "ft_cycle_info_dir", None) and not getattr(args, "ft_per_cycle_applog_prefix", None):
@@ -3294,6 +3296,9 @@ def _grpc_log_path(base_log_file: str, suffix: str) -> str:
     return base_log_file + suffix
 
 
+_LOG_FUNNEL_NODES_PER_LEAF = 1536  # max nodes per single log server (≈6K GPU at 4 GPUs/node)
+
+
 @dataclass(frozen=True)
 class LogFunnelPorts:
     """Port assignments for the gRPC log funnel (single root vs N leaves + root).
@@ -3327,7 +3332,16 @@ class LogFunnelPorts:
     @classmethod
     def from_launcher_args(cls, args: Any) -> "LogFunnelPorts":
         base = int(getattr(args, "ft_log_server_port", 50051))
-        n = int(getattr(args, "ft_log_aggregator_count", 2))
+        n = int(getattr(args, "ft_log_aggregator_count", 0))
+        if n == 0:
+            _, max_nodes = parse_min_max_nnodes(getattr(args, "nnodes", "1"))
+            n = max(1, (max_nodes + _LOG_FUNNEL_NODES_PER_LEAF - 1) // _LOG_FUNNEL_NODES_PER_LEAF)
+            if n > 16:
+                logger.warning(
+                    f"Auto log aggregator count is {n} (max_nodes={max_nodes}); "
+                    f"head node will run {n} leaf processes (~{n * 50} MB extra RSS). "
+                    f"Override with --ft-log-aggregator-count if needed."
+                )
         if n < 1:
             raise ValueError(f"ft_log_aggregator_count must be >= 1, got {n}")
         return cls(base_port=base, first_level_count=n)
@@ -3421,7 +3435,7 @@ def _start_grpc_log_servers(
         root_port = funnel_ports.root_listen_port
         n = funnel_ports.first_level_count
         root_workers = max(n + 10, 32)
-        per_leaf = max(100, (max_nodes + n - 1) // n + 10)
+        per_leaf = max(100, (max_nodes + n - 1) // n + 100)
         raw_leaf_chunks = int(getattr(args, 'ft_log_leaf_max_queue_chunks', -1))
         if raw_leaf_chunks < 0:
             max_queue = min(1_000_000, max(16_384, per_leaf * 256))

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -614,132 +614,121 @@ class RaceConditionTest(BaseRendezvousTest):
         miss the snapshot detect UNASSIGNED via the embedded round number in rank_key and
         loop to the next round.
         """
+        from .utils import find_free_port
+
         min_nodes = 2
         max_nodes = 4
-        segment_check_interval = _test_segment_check_interval()  # Short timeout for testing
+        segment_check_interval = _test_segment_check_interval()
 
-        results = []
-        errors = []
+        # Use separate forked processes (each with its own TCPStore connection) to avoid
+        # shared-socket mutex deadlock that occurs when threads share one TCPStore object.
+        # multiprocessing.Event crosses fork boundaries via OS semaphores.
+        host_addr = "127.0.0.1"
+        server_port = find_free_port(host_addr)
+        server_store = TCPStore(host_addr, server_port, is_master=True, wait_for_workers=False)
 
-        # Create a synchronization event to control timing
-        import threading as th
+        ctx = multiprocessing.get_context("fork")
+        ack_check_event = ctx.Event()
+        result_queue = ctx.Queue()
+        run_id = self.run_id
 
-        ack_check_event = th.Event()
-        late_arrival_done = th.Event()
+        def host_fn():
+            store = TCPStore(host_addr, server_port, is_master=False, wait_for_workers=False)
+            state = _RendezvousBarrierState(store=store, run_id=run_id, is_store_host=True)
+            node = _NodeDescGenerator().generate()
+            original_assign = state.assign_group_ranks
 
-        def store_host_thread():
-            """Store host that signals when it's checking acknowledgments."""
-            state = _RendezvousBarrierState(
-                store=self.store,
-                run_id=self.run_id,
-                is_store_host=True,
-            )
+            def instrumented_assign(*args, **kwargs):
+                ack_check_event.set()
+                time.sleep(0.02)
+                return original_assign(*args, **kwargs)
+
+            state.assign_group_ranks = instrumented_assign
             try:
-                node = self.node_desc_gen.generate()
-
-                # Monkey-patch to inject synchronization point
-                original_assign = state.assign_group_ranks
-
-                def instrumented_assign(*args, **kwargs):
-                    # Signal that we're about to check/assign (after ack check)
-                    ack_check_event.set()
-                    # Give late arrival a chance to join in the critical window
-                    time.sleep(0.02)  # Minimal delay to test race condition
-                    return original_assign(*args, **kwargs)
-
-                state.assign_group_ranks = instrumented_assign
-
-                # Rendezvous completes when segment constraint is met
                 rank, total = state.perform_rendezvous(
                     node, min_nodes, max_nodes, segment_check_interval
                 )
-                results.append(('host', rank, total))
+                result_queue.put(('host', rank, total, None))
             except Exception as e:
-                errors.append(('host', e))
+                result_queue.put(('host', None, None, e))
 
-        def regular_participant_thread():
-            """Regular participant."""
-            state = _RendezvousBarrierState(
-                store=self.store,
-                run_id=self.run_id,
-                is_store_host=False,
-            )
+        def regular_fn():
+            store = TCPStore(host_addr, server_port, is_master=False, wait_for_workers=False)
+            state = _RendezvousBarrierState(store=store, run_id=run_id, is_store_host=False)
+            node = _NodeDescGenerator().generate()
             try:
-                node = self.node_desc_gen.generate()
-                # Test subsequent rendezvous behavior (not first rendezvous)
                 rank, total = state.perform_rendezvous(
                     node, min_nodes, max_nodes, segment_check_interval
                 )
-                results.append(('regular', rank, total))
+                result_queue.put(('regular', rank, total, None))
             except Exception as e:
-                errors.append(('regular', e))
+                result_queue.put(('regular', None, None, e))
 
-        def late_arrival_thread():
-            """Late arrival that joins after ack check but before key clear."""
-            # Wait for the ack check to happen
+        def late_arrival_fn():
             ack_check_event.wait(timeout=10)
-
+            store = TCPStore(host_addr, server_port, is_master=False, wait_for_workers=False)
             state = _RendezvousBarrierState(
-                store=self.store,
-                run_id=self.run_id,
+                store=store,
+                run_id=run_id,
                 is_store_host=False,
                 join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
             )
+            node = _NodeDescGenerator().generate()
             try:
-                node = self.node_desc_gen.generate()
-                # Test subsequent rendezvous behavior (not first rendezvous)
                 rank, total = state.perform_rendezvous(
                     node, min_nodes, max_nodes, segment_check_interval
                 )
-                results.append(('late', rank, total))
+                result_queue.put(('late', rank, total, None))
             except Exception as e:
-                errors.append(('late', e))
-            finally:
-                late_arrival_done.set()
+                result_queue.put(('late', None, None, e))
 
-        # Start regular participants
-        t_host = th.Thread(target=store_host_thread)
-        t_regular = th.Thread(target=regular_participant_thread)
-        t_late = th.Thread(target=late_arrival_thread)
+        p_host = ctx.Process(target=host_fn)
+        p_regular = ctx.Process(target=regular_fn)
+        p_late = ctx.Process(target=late_arrival_fn)
 
-        t_host.start()
-        t_regular.start()
-        t_late.start()
+        p_host.start()
+        p_regular.start()
+        p_late.start()
 
         join_timeout = 15
-        t_host.join(timeout=join_timeout)
-        t_regular.join(timeout=join_timeout)
-        self.assertFalse(t_host.is_alive(), f"Host thread did not terminate within {join_timeout}s")
+        p_host.join(timeout=join_timeout)
+        p_regular.join(timeout=join_timeout)
         self.assertFalse(
-            t_regular.is_alive(),
-            f"Regular participant thread did not terminate within {join_timeout}s",
+            p_host.is_alive(), f"Host process did not terminate within {join_timeout}s"
+        )
+        self.assertFalse(
+            p_regular.is_alive(),
+            f"Regular participant process did not terminate within {join_timeout}s",
         )
 
         # Late arrival can be stuck in Step 0 (_wait_for_rendezvous_open): it sees
         # round_done_0=1 (round 0 complete) and waits for round_done_1 to appear.
         # Unblock it by setting round_done_1=0 so it proceeds to Step 2,
         # then hits join_timeout_seconds and raises RendezvousTimeoutError.
-        unblock_state = _RendezvousBarrierState(
-            store=self.store,
-            run_id=self.run_id,
-            is_store_host=False,
-            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
-        )
-        round1_done_key = f"{unblock_state.prefix}:round_done_1"
-        self.store.set(round1_done_key, "0".encode("utf-8"))
+        prefix = f"ft_rendezvous_barrier:{run_id}"
+        round1_done_key = f"{prefix}:round_done_1"
+        server_store.set(round1_done_key, "0".encode("utf-8"))
 
-        t_late.join(timeout=join_timeout)
+        p_late.join(timeout=join_timeout)
         self.assertFalse(
-            t_late.is_alive(), f"Late arrival thread did not terminate within {join_timeout}s"
+            p_late.is_alive(), f"Late arrival process did not terminate within {join_timeout}s"
         )
 
-        # Check results
-        # The late arrival should either:
-        # 1. Be included in the current round if it joined before snapshot, OR
-        # 2. Timeout/restart if it missed the window
-        # Both behaviors are acceptable as long as no deadlock occurs
+        # Collect results from the queue
+        results = []
+        errors = []
+        while not result_queue.empty():
+            try:
+                name, rank, total, exc = result_queue.get_nowait()
+                if exc is None:
+                    results.append((name, rank, total))
+                else:
+                    errors.append((name, exc))
+            except Exception:
+                break
 
-        # At minimum, the first 2 participants should complete
+        # The late arrival should either be included in round 0 (if it joined before the
+        # snapshot) or timeout in round 1. Either is acceptable — no deadlock is the goal.
         successful_results = [r for r in results if r is not None]
         self.assertGreaterEqual(
             len(successful_results), min_nodes, "At least min_nodes should complete successfully"

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -718,22 +718,44 @@ class TestHandleRestartDecision(unittest.TestCase):
         self.assertFalse(hasattr(legacy_rdzv, '_barrier_state'))
 
 
-def test_ft_log_aggregator_count_rejects_non_positive():
+def test_ft_log_aggregator_count_rejects_negative():
     from nvidia_resiliency_ext.fault_tolerance.launcher import _validate_args, get_args_parser
 
     parser = get_args_parser()
-    for bad in ('0', '-1'):
-        args = parser.parse_args(['--ft-log-aggregator-count', bad, 'train.py'])
-        with pytest.raises(ValueError, match='--ft-log-aggregator-count'):
-            _validate_args(args)
+    args = parser.parse_args(['--ft-log-aggregator-count', '-1', 'train.py'])
+    with pytest.raises(ValueError, match='--ft-log-aggregator-count'):
+        _validate_args(args)
 
 
-def test_log_funnel_ports_from_launcher_args_rejects_non_positive_aggregator_count():
+def test_log_funnel_ports_from_launcher_args_auto():
     from types import SimpleNamespace
 
     from nvidia_resiliency_ext.fault_tolerance.launcher import LogFunnelPorts
 
-    with pytest.raises(ValueError, match='>= 1'):
+    # 0 = auto: single-level for small jobs, two-level for large jobs
+    cases = [
+        ("1", 1),
+        ("1536", 1),
+        ("1537", 2),
+        ("3072", 2),
+        ("3073", 3),
+        ("4608", 3),
+    ]
+    for nnodes, expected_n in cases:
+        ports = LogFunnelPorts.from_launcher_args(
+            SimpleNamespace(ft_log_server_port=50051, ft_log_aggregator_count=0, nnodes=nnodes)
+        )
+        assert (
+            ports.first_level_count == expected_n
+        ), f"nnodes={nnodes}: expected n={expected_n}, got {ports.first_level_count}"
+
+
+def test_log_funnel_ports_from_launcher_args_rejects_negative():
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance.launcher import LogFunnelPorts
+
+    with pytest.raises(ValueError):
         LogFunnelPorts.from_launcher_args(
-            SimpleNamespace(ft_log_server_port=50051, ft_log_aggregator_count=0)
+            SimpleNamespace(ft_log_server_port=50051, ft_log_aggregator_count=-1, nnodes="100")
         )


### PR DESCRIPTION
Default --ft-log-aggregator-count to 0 (auto): single root server for ≤1536 nodes, one leaf per 1536 nodes beyond that. Eliminates manual tuning for most jobs.

Increase per_leaf worker headroom from +10 to +100 to absorb load imbalance when SLURM_PROCID sharding groups multiple ranks per physical node onto the same leaf.