### PR TITLE
Define the AttributionController boundary for the service path

### DIFF
--- a/services/nvrx_attrsvc/ATTRSVC_SPEC.md
+++ b/services/nvrx_attrsvc/ATTRSVC_SPEC.md
@@ -79,7 +79,7 @@ processed-files ledger (`CACHE_FILE`) — see §3.7. **README.md** for runbooks.
 --------------------------------------------------------------------------------
 
 Two layers: **library** (`nvidia_resiliency_ext.attribution`) and **service**
-(`services/nvrx_attrsvc/` — FastAPI, `Settings`, rate limits, `AttributionService`).
+(`services/nvrx_attrsvc/` — FastAPI, `Settings`, rate limits, `AttributionHttpAdapter`).
 
 | Layer | See |
 |-------|-----|
@@ -97,7 +97,8 @@ Summary:
 - Prefix **`NVRX_ATTRSVC_`** for service settings (see README for exceptions: LLM
   API key, Slack tokens, optional `LLM_API_KEY_FILE` / file paths in `api_keys.py`).
 - **`LLM_API_KEY`** / **`LLM_API_KEY_FILE`**: required for attribution (or default key files);
-  loaded in `config.setup()` after logging — **empty/missing → log error and process exit**. Slack is optional.
+  validated by `AttributionController` at startup — **empty/missing → log error and startup failure**.
+  Slack is optional.
 - LLM-related env vars are optional; unset → library defaults (`LogAnalyzerConfig`).
 - Rate limits: slowapi, `RATE_LIMIT_SUBMIT` / `RATE_LIMIT_ANALYZE` / `RATE_LIMIT_PREVIEW`.
 
@@ -108,7 +109,7 @@ Summary:
 | TTL | `TTL_PENDING_SECONDS`, `TTL_TERMINATED_SECONDS`, `TTL_MAX_JOB_AGE_SECONDS` |
 | Intervals | `POLL_INTERVAL_SECONDS`, `DEFAULT_COMPUTE_TIMEOUT_SECONDS` |
 | Limits | `MAX_JOBS`, `MIN_FILE_SIZE_KB` |
-| Health thresholds | ~20% degraded, ~50% fail (compute / posting error rates in health) |
+| Health thresholds | ~20% degraded, ~50% fail (compute / dataflow error rates in health) |
 
 **3.3 Markers** (mode detection)
 
@@ -144,10 +145,10 @@ Patterns tried in order (scheduler-agnostic where possible): `_(\d+)_date_`,
 --------------------------------------------------------------------------------
 
 **Startup (conceptual)**  
-Load `Settings` → configure logging → **require non-empty LLM API key** → wire
-postprocessing (`configure`, poster, dataflow index, Slack) → construct
-`AttributionService` / **`Analyzer`** → background poll → Uvicorn. Optional cache
-import.
+Load `Settings` → configure logging → construct `AttributionHttpAdapter` /
+**`AttributionController`** / **`Analyzer`**. Controller startup validates the LLM
+API key and wires postprocessing (poster, dataflow index, Slack) before analysis
+begins. Then background poll → Uvicorn. Optional cache import.
 
 **Shutdown**  
 Drain HTTP → stop poll → export cache (if configured) → exit. Job map is not
@@ -193,7 +194,7 @@ mitigates abuse.
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | /healthz | Health (`status`, `issues`); optional `?pretty=true` |
-| GET | /stats | Counters + gauges (library + posting + slack) — **§20** |
+| GET | /stats | Counters + gauges (library + dataflow + slack) — **§20** |
 | GET | /jobs | Paginated job dump (`mode`, `limit`, `offset`) |
 | GET | /print | First 4KB preview (`log_path`) |
 | GET | /inflight | In-flight analyses |
@@ -201,15 +202,14 @@ mitigates abuse.
 | GET | /logs | Analyze / return results (`log_path`, optional `file`, `wl_restart`, `all_files`) |
 
 **GET /healthz**  
-Uses cumulative compute stats (errors + timeouts vs total) and posting failure rate
-when posting is active. Thresholds: ~20% → degraded, ~50% → fail (see service
+Uses cumulative compute stats (errors + timeouts vs total) and dataflow failure rate
+when dataflow posting is active. Thresholds: ~20% → degraded, ~50% → fail (see service
 implementation). Worst issue wins. MCP connectivity may add issues when backend is `mcp`.
 
 **GET /stats**  
 Merges `Analyzer.get_stats()` (coalescer, splitlog folder stats, detection,
-deferred, permission errors, …) with **posting** counters and **Slack** stats.
-**`posting`** holds `total_posts`, `total_successful`, `total_failed`; **`dataflow`**
-is a legacy alias of the same object.
+deferred, permission errors, …) with **dataflow** counters and **Slack** stats.
+**`dataflow`** holds `total_posts`, `total_successful`, `total_failed`.
 
 **POST /logs** body
 
@@ -232,8 +232,8 @@ flowchart TD
     A[GET /logs] --> B[Rate limit: RATE_LIMIT_ANALYZE]
     B --> C[attribution_log_path]
   end
-  subgraph svc["Service layer"]
-    C --> D[AttributionService.analyze_log]
+  subgraph adapter["HTTP adapter"]
+    C --> D[AttributionHttpAdapter.analyze_log]
   end
   subgraph lib["Library: Analyzer"]
     D --> E[analyze: validate path, resolve job mode]
@@ -366,8 +366,9 @@ and inline comments in **`Analyzer`** / `RequestCoalescer`. Do not duplicate her
 - **Library** (`Analyzer.get_stats`): coalescer stats (hits/misses, compute,
   submissions, …), splitlog folder stats under the `splitlog` key, `detection`,
   `deferred`, `permission_errors`, poll gauges, etc. — **exact keys per implementation**.
-- **Service** (`AttributionService.get_stats`): adds **`posting`** (and **`dataflow`**
-  alias), **`slack`** (attempts, successes, failures, user lookup stats when enabled).
+- **Controller/adapter** (`AttributionController.get_stats`, exposed by
+  `AttributionHttpAdapter.get_stats`): adds **`dataflow`** (ES/dataflow post
+  attempts) and **`slack`** (attempts, successes, failures, user lookup stats when enabled).
 
 Refer to live **`GET /stats`** response or OpenAPI for the current JSON shape.
 
@@ -377,9 +378,10 @@ Refer to live **`GET /stats`** response or OpenAPI for the current JSON shape.
 --------------------------------------------------------------------------------
 
 Postprocessing posts results when `DATAFLOW_INDEX` / cluster env configured; Slack
-when `SLACK_BOT_TOKEN` set. Wiring: `config.setup()` → `configure()`. Record build:
-`build_dataflow_record`; backend: `postprocessing/post_backend.py`. Retry behavior
-in implementation.
+when `SLACK_BOT_TOKEN` set or token fallback files are present. Wiring:
+`Settings` → `AttributionControllerConfig` → `AttributionController`. Record build:
+`build_dataflow_record`; backend: `postprocessing/post_backend.py`. Retry behavior in
+implementation.
 
 ================================================================================
                          OPERATIONS & DEVELOPMENT (POINTERS)

--- a/services/nvrx_attrsvc/README.md
+++ b/services/nvrx_attrsvc/README.md
@@ -1,6 +1,6 @@
 # NVRX Attribution Service (nvrx-attrsvc)
 
-FastAPI server that exposes log analysis over HTTP. It wraps the **`nvidia_resiliency_ext.attribution`** library (**`Analyzer`**, coalescing, postprocessing) with pydantic `Settings`, routes, and optional cache persistence.
+FastAPI server that exposes log analysis over HTTP. It wraps the **`nvidia_resiliency_ext.attribution`** library (**`AttributionController`**, **`Analyzer`**, coalescing, postprocessing) with pydantic `Settings`, routes, and rate limits.
 
 ---
 
@@ -8,7 +8,7 @@ FastAPI server that exposes log analysis over HTTP. It wraps the **`nvidia_resil
 
 | | **Library** (`nvidia_resiliency_ext.attribution`) | **This package** (`nvrx_attrsvc`) |
 |---|--------------------------------------------------|-----------------------------------|
-| **Role** | **`Analyzer`** (→ `LogAnalyzer`, pipelines, MCP/lib LogSage, FR analysis, jobs/splitlog) | HTTP API, env-based `Settings`, rate limits, ledger file |
+| **Role** | **`AttributionController`** (config, cache persistence, health/status, dataflow/Slack stats) over **`Analyzer`** (→ `LogAnalyzer`, pipelines, MCP/lib LogSage, FR analysis, jobs/splitlog) | HTTP API, env-based `Settings`, rate limits, ledger file |
 | **Docs** | [`src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md`](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md), [`README.md`](../../src/nvidia_resiliency_ext/attribution/README.md) | This file, [`ATTRSVC_SPEC.md`](ATTRSVC_SPEC.md) |
 
 Do not duplicate library internals here—**ARCHITECTURE.md** is the source of truth for package layout, `LogAnalyzerConfig` / `AnalysisPipelineMode` (default `LOG_AND_TRACE` for this service), MCP vs in-process backends, and analysis flow.
@@ -45,7 +45,7 @@ Environment variables (prefix: `NVRX_ATTRSVC_`):
 | `RATE_LIMIT_ANALYZE` | `60/minute` | Rate limit for GET /logs |
 | `RATE_LIMIT_PREVIEW` | `120/minute` | Rate limit for GET /print |
 
-**LLM / analysis** (optional — unset vars keep library defaults). Use the prefixed names below in the environment or ``.env``; ``AttributionService`` passes them into ``LogSageExecutionConfig`` and the library ``Analyzer`` (LogSage / MCP / merge paths). See **ARCHITECTURE.md §7**.
+**LLM / analysis** (optional — unset vars keep library defaults). Use the prefixed names below in the environment or ``.env``; ``AttributionHttpAdapter`` passes them into ``AttributionControllerConfig``, which wires ``LogSageExecutionConfig`` and the library ``Analyzer`` (LogSage / MCP / merge paths). See **ARCHITECTURE.md §7**.
 
 | Variable (with prefix)          | Description                                                                                                                                                                                                   |
 |---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -67,7 +67,7 @@ Environment variables (prefix: `NVRX_ATTRSVC_`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SLACK_BOT_TOKEN` | `""` | Bot token (empty = try file fallbacks below via `setup()`) |
+| `SLACK_BOT_TOKEN` | `""` | Bot token (empty = controller tries file fallbacks below) |
 | `SLACK_BOT_TOKEN_FILE` | — | Path to a file containing the token (checked before `~/.slack_bot_token` / `~/.slack_token`) |
 | `SLACK_CHANNEL` | `""` | Channel ID or name (e.g. `#trng-alerts`). In `.env`, quote values that start with `#`: `SLACK_CHANNEL="#trng-alerts"` |
 
@@ -232,20 +232,20 @@ For combined deployment with monitor, see `../scripts/nvrx_services.sbatch`
 
 ## Python API
 
-**Embedding the library** (no HTTP): use **`Analyzer`** (or `LogAnalyzer` / `LogAnalyzerConfig` for lower-level control) from `nvidia_resiliency_ext.attribution`. Overview and examples: **[attribution README](../../src/nvidia_resiliency_ext/attribution/README.md)** · **[ARCHITECTURE.md](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md)**.
+**Embedding the library** (no HTTP): use **`AttributionController`** for the service-grade boundary, or **`Analyzer`** / `LogAnalyzer` / `LogAnalyzerConfig` for lower-level control, from `nvidia_resiliency_ext.attribution`. Overview and examples: **[attribution README](../../src/nvidia_resiliency_ext/attribution/README.md)** · **[ARCHITECTURE.md](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md)**.
 
-**In-process service wrapper** (same repo, after `pip install`):
+**In-process HTTP adapter** (same repo, after `pip install`):
 
 ```python
 import asyncio
-from nvrx_attrsvc import AttributionService, setup
+from nvrx_attrsvc import AttributionHttpAdapter, setup
 
 async def main():
     cfg = setup()
-    service = AttributionService(cfg)
+    adapter = AttributionHttpAdapter(cfg)
     
-    result = await service.analyze_log("/path/to/job.log")
-    service.shutdown()
+    result = await adapter.analyze_log("/path/to/job.log")
+    adapter.shutdown()
 
 asyncio.run(main())
 ```
@@ -255,8 +255,8 @@ asyncio.run(main())
 | File | Description |
 |------|-------------|
 | `app.py` | FastAPI routes and middleware |
-| `service.py` | `AttributionService` — wraps **`Analyzer`** |
-| `config.py` | `Settings` (pydantic), `setup()` wires postprocessing (poster via `post_backend.post`, Slack) from cfg |
+| `service.py` | `AttributionHttpAdapter` — wraps **`AttributionController`** |
+| `config.py` | `Settings` (pydantic), `setup()` loads settings and configures logging |
 | `deploy/run_attrsvc.sh` | Run service with logging (background) |
 | `deploy/snapshot_attrsvc.sh` | Periodic endpoint snapshot for debugging |
 | `deploy/Dockerfile` | Docker build instructions |
@@ -273,5 +273,6 @@ asyncio.run(main())
 ## Configuration and postprocessing (summary)
 
 - **Service config** is in `config.py` (`Settings` from env with prefix `NVRX_ATTRSVC_`).
-- **`setup()`** in `config.py` loads settings, configures logging, and wires the library postprocessing singleton via `configure(default_poster=..., cluster_name=..., dataflow_index=..., slack_bot_token=..., slack_channel=...)`.
-- The analyzer calls `post_results()` from the library when it has results; posting and Slack use the values set in `configure()`.
+- **`setup()`** in `config.py` loads settings and configures logging only.
+- **`AttributionHttpAdapter`** translates `Settings` into `AttributionControllerConfig`; **`AttributionController`** validates the LLM API key and wires postprocessing (`cluster_name`, `dataflow_index`, Slack, and the default poster).
+- The analyzer calls `post_results()` from the library when it has results; dataflow and Slack use the values owned by the controller.

--- a/services/nvrx_attrsvc/__init__.py
+++ b/services/nvrx_attrsvc/__init__.py
@@ -13,7 +13,7 @@ from nvidia_resiliency_ext.attribution.coalescing import (
 from .app import create_app
 from .config import Settings, setup
 from .service import (
-    AttributionService,
+    AttributionHttpAdapter,
     LogAnalysisCycleResult,
     LogAnalysisSplitlogResult,
     LogAnalyzerError,
@@ -27,8 +27,8 @@ __all__ = [
     # Configuration
     "Settings",
     "setup",
-    # Core service (for direct Python usage)
-    "AttributionService",
+    # HTTP adapter (for direct Python usage)
+    "AttributionHttpAdapter",
     "LogAnalysisCycleResult",
     "LogAnalysisSplitlogResult",
     "LogAnalyzerError",

--- a/services/nvrx_attrsvc/app.py
+++ b/services/nvrx_attrsvc/app.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""FastAPI HTTP wrapper for AttributionService."""
+"""FastAPI HTTP wrapper for AttributionHttpAdapter."""
 
 import asyncio
 import json
@@ -22,7 +22,7 @@ from slowapi.util import get_remote_address
 from .config import ErrorCode, Settings, setup
 from .routes import PARAM_LOG_PATH, ROUTE_LOGS
 from .service import (
-    AttributionService,
+    AttributionHttpAdapter,
     LogAnalysisCycleResult,
     LogAnalysisSplitlogResult,
     LogAnalyzerError,
@@ -111,24 +111,20 @@ def create_app(cfg: Settings) -> FastAPI:
     """
     Construct and return the FastAPI app for the NVRX Attribution Service.
 
-    This is a thin HTTP wrapper around AttributionService.
+    This is a thin HTTP wrapper around AttributionHttpAdapter.
     """
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        """Startup: set event loop, connect MCP (if used), load cache. Shutdown: save cache and stop service."""
+        """Startup and shutdown for controller-owned runtime dependencies."""
         # Startup
-        app.state.service.set_event_loop(asyncio.get_running_loop())
-        await app.state.service.connect_mcp()
-        if app.state.cache_file:
-            loaded = await app.state.service.load_cache(app.state.cache_file)
-            if loaded > 0:
-                logger.info(f"Restored {loaded} cached results from {app.state.cache_file}")
+        started = await app.state.attribution.start(asyncio.get_running_loop())
+        loaded = started.get("cache_entries_loaded", 0)
+        if loaded > 0:
+            logger.info(f"Restored {loaded} cached results from {cfg.CACHE_FILE}")
         yield
         # Shutdown
-        if app.state.cache_file:
-            await app.state.service.save_cache(app.state.cache_file)
-        await app.state.service.shutdown_async()
+        await app.state.attribution.shutdown_async()
 
     app = FastAPI(
         title="NVRX Attribution Service",
@@ -147,8 +143,7 @@ def create_app(cfg: Settings) -> FastAPI:
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
     # Initialize service in app state (lifespan uses these on startup/shutdown)
-    app.state.service = AttributionService(cfg)
-    app.state.cache_file = cfg.CACHE_FILE
+    app.state.attribution = AttributionHttpAdapter(cfg)
 
     # Global exception handlers to standardize error bodies
     @app.exception_handler(HTTPException)
@@ -198,8 +193,8 @@ def create_app(cfg: Settings) -> FastAPI:
         - "degraded": Some issues but service is functional (20-50% error rate)
         - "fail": Critical issues (>50% error rate)
         """
-        service: AttributionService = request.app.state.service
-        health = await service.get_health()
+        adapter: AttributionHttpAdapter = request.app.state.attribution
+        health = await adapter.get_health()
         return json_response(health, pretty=pretty, indent=indent)
 
     @app.get("/stats")
@@ -211,8 +206,8 @@ def create_app(cfg: Settings) -> FastAPI:
         ),
     ) -> Response:
         """Get cache and request coalescing statistics. See spec Section 20."""
-        service: AttributionService = request.app.state.service
-        stats = await service.get_stats()
+        adapter: AttributionHttpAdapter = request.app.state.attribution
+        stats = await adapter.get_stats()
         return json_response(stats, pretty=pretty, indent=indent)
 
     @app.get("/inflight")
@@ -224,8 +219,8 @@ def create_app(cfg: Settings) -> FastAPI:
         ),
     ) -> Response:
         """Get currently in-flight requests. See spec Section 22."""
-        service: AttributionService = request.app.state.service
-        inflight = await service.get_inflight()
+        adapter: AttributionHttpAdapter = request.app.state.attribution
+        inflight = await adapter.get_inflight()
         return json_response(inflight, pretty=pretty, indent=indent)
 
     @app.get("/jobs")
@@ -237,8 +232,8 @@ def create_app(cfg: Settings) -> FastAPI:
         ),
     ) -> Response:
         """Get all tracked jobs (pending, single-file, and splitlog modes)."""
-        service: AttributionService = request.app.state.service
-        jobs = service.get_all_jobs()
+        adapter: AttributionHttpAdapter = request.app.state.attribution
+        jobs = adapter.get_all_jobs()
         return json_response(jobs, pretty=pretty, indent=indent)
 
     @app.post(
@@ -255,8 +250,8 @@ def create_app(cfg: Settings) -> FastAPI:
         split logging mode is enabled. In split logging mode, the service tracks multiple
         cycles and analyzes log files from the LOGS_DIR folder.
         """
-        service: AttributionService = request.app.state.service
-        result = await service.submit_log(req.log_path, req.user, req.job_id)
+        adapter: AttributionHttpAdapter = request.app.state.attribution
+        result = await adapter.submit_log(req.log_path, req.user, req.job_id)
         if isinstance(result, LogAnalyzerError):
             _raise_error(result)
         return result
@@ -277,8 +272,8 @@ def create_app(cfg: Settings) -> FastAPI:
         log_path: str = Query(..., description="Absolute path to a file under allowed root"),
     ) -> str:
         """Return the first 4KB of a file for preview."""
-        service: AttributionService = request.app.state.service
-        result = service.read_file_preview(log_path)
+        adapter: AttributionHttpAdapter = request.app.state.attribution
+        result = adapter.read_file_preview(log_path)
         if isinstance(result, LogAnalyzerError):
             _raise_error(result)
         return result.content
@@ -325,8 +320,8 @@ def create_app(cfg: Settings) -> FastAPI:
 
         See spec Section 10 and 17 for GET flow details.
         """
-        service: AttributionService = request.app.state.service
-        result = await service.analyze_log(log_path, file, wl_restart)
+        adapter: AttributionHttpAdapter = request.app.state.attribution
+        result = await adapter.analyze_log(log_path, file, wl_restart)
         if isinstance(result, LogAnalyzerError):
             _raise_error(result)
         return result

--- a/services/nvrx_attrsvc/config.py
+++ b/services/nvrx_attrsvc/config.py
@@ -36,10 +36,9 @@ PRINT_PREVIEW_MAX_BYTES = 4096  # Max bytes to return for /print endpoint
 class Settings(BaseSettings):
     """Typed configuration loaded from environment/.env (pydantic-settings v2).
 
-    LLM fields (``NVRX_ATTRSVC_LLM_*``) are passed into
-    :class:`~nvidia_resiliency_ext.attribution.svc.config.LogSageExecutionConfig` when set,
-    then into the library :class:`~nvidia_resiliency_ext.attribution.analyzer.engine.Analyzer` via
-    :class:`~nvrx_attrsvc.service.AttributionService`; unset fields keep library defaults.
+    Attribution fields are translated into
+    :class:`~nvidia_resiliency_ext.attribution.controller.AttributionControllerConfig` by
+    :class:`~nvrx_attrsvc.service.AttributionHttpAdapter`; unset fields keep library defaults.
 
     ``LOG_LEVEL`` sets the root log level, FastAPI ``debug`` (when ``LOG_LEVEL`` is ``DEBUG``), MCP
     subprocess ``--log-level``, and verbosity for in-process MCP client loggers. Allowed values:
@@ -64,7 +63,7 @@ class Settings(BaseSettings):
         default=None, description="Timeout for compute_fn in seconds (None = library default)"
     )
 
-    # LLM settings → LogSageExecutionConfig when set (see AttributionService)
+    # LLM settings -> AttributionControllerConfig when set (see AttributionHttpAdapter)
     LLM_MODEL: str | None = Field(default=DEFAULT_LLM_MODEL, description="LLM model identifier")
     LLM_BASE_URL: str | None = Field(default=DEFAULT_LLM_BASE_URL, description="LLM base url")
     LLM_TEMPERATURE: float | None = Field(
@@ -91,8 +90,9 @@ class Settings(BaseSettings):
     # Slack integration (optional; env vars have no NVRX_ATTRSVC_ prefix)
     SLACK_BOT_TOKEN: str = Field(
         default="",
-        description="Slack bot token; if empty, setup() falls back to load_slack_bot_token() "
-        "(SLACK_BOT_TOKEN_FILE, ~/.slack_bot_token, ~/.slack_token, ~/.config/nvrx/slack_bot_token)",
+        description="Slack bot token; if empty, AttributionController falls back to "
+        "load_slack_bot_token() (SLACK_BOT_TOKEN_FILE, ~/.slack_bot_token, "
+        "~/.slack_token, ~/.config/nvrx/slack_bot_token)",
         validation_alias="SLACK_BOT_TOKEN",
     )
     SLACK_CHANNEL: str = Field(
@@ -237,7 +237,7 @@ def setup() -> Settings:
     """
     Group environment configuration and logging setup for nvrx_attrsvc.
     Returns a configured Settings instance.
-    Also wires postprocessing config (poster, dataflow, Slack) from cfg.
+    Attribution-specific dependency wiring happens in AttributionController.
 
     Field validators handle validation of PORT, LOG_LEVEL, COMPUTE_TIMEOUT,
     ALLOWED_ROOT, CACHE_FILE (when set), and rate limits. See Settings class for details.
@@ -259,32 +259,5 @@ def setup() -> Settings:
     logging.getLogger("mcp").setLevel(_root_lvl)
     logging.getLogger("nvidia_resiliency_ext.attribution.mcp_integration").setLevel(_root_lvl)
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
-
-    from nvidia_resiliency_ext.attribution.api_keys import load_llm_api_key, load_slack_bot_token
-
-    llm_key = load_llm_api_key()
-    if not llm_key:
-        logger.error(
-            "LLM API key not found or empty. Attribution requires a key. Set LLM_API_KEY or "
-            "LLM_API_KEY_FILE, or create ~/.llm_api_key. "
-            "Slack notifications remain optional (SLACK_BOT_TOKEN)."
-        )
-        raise SystemExit(1)
-
-    # Wire postprocessing config (lib singleton)
-    from nvidia_resiliency_ext.attribution.postprocessing import ResultPoster, configure
-    from nvidia_resiliency_ext.attribution.postprocessing.post_backend import post
-
-    slack_token = (cfg.SLACK_BOT_TOKEN or "").strip() or load_slack_bot_token()
-
-    configure(
-        default_poster=ResultPoster(post_fn=post),
-        cluster_name=cfg.CLUSTER_NAME or "",
-        dataflow_index=cfg.DATAFLOW_INDEX or "",
-        slack_bot_token=slack_token,
-        slack_channel=cfg.SLACK_CHANNEL or "",
-    )
-    if slack_token:
-        logger.info(f"Slack notifications enabled for channel: {cfg.SLACK_CHANNEL}")
 
     return cfg

--- a/services/nvrx_attrsvc/service.py
+++ b/services/nvrx_attrsvc/service.py
@@ -1,28 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""HTTP service wrapper for :class:`~nvidia_resiliency_ext.attribution.analyzer.engine.Analyzer`.
+"""HTTP adapter for the attribution controller boundary.
 
-This module provides AttributionService, a thin wrapper around the library
-:class:`~nvidia_resiliency_ext.attribution.analyzer.engine.Analyzer` that adds HTTP-specific concerns like Settings and dataflow posting.
-
-For direct Python usage without HTTP, use :class:`~nvidia_resiliency_ext.attribution.analyzer.engine.Analyzer` directly:
-    from nvidia_resiliency_ext.attribution import Analyzer
+This module keeps FastAPI-facing concerns in ``services/nvrx_attrsvc`` while
+delegating attribution ownership to
+:class:`nvidia_resiliency_ext.attribution.controller.AttributionController`.
 """
 
-import json
+import asyncio
 import logging
-import os
 from typing import Any
 
-from nvidia_resiliency_ext.attribution.analyzer import Analyzer
 from nvidia_resiliency_ext.attribution.coalescing import (
     CacheResult,
     InflightResult,
     SubmittedResult,
 )
-from nvidia_resiliency_ext.attribution.postprocessing import get_posting_stats, get_slack_stats
-from nvidia_resiliency_ext.attribution.svc.config import LogSageExecutionConfig
+from nvidia_resiliency_ext.attribution.controller import (
+    AttributionAnalysisConfig,
+    AttributionCacheConfig,
+    AttributionController,
+    AttributionControllerConfig,
+    AttributionPostprocessingConfig,
+)
 from nvidia_resiliency_ext.attribution.svc.types import (
     LogAnalysisCycleResult,
     LogAnalysisSplitlogResult,
@@ -38,8 +39,8 @@ logger = logging.getLogger(__name__)
 
 # Re-export result types for convenience
 __all__ = [
-    "AttributionService",
-    "LogAnalyzerError",  # Use library error type directly
+    "AttributionHttpAdapter",
+    "LogAnalyzerError",
     "LogAnalysisCycleResult",
     "LogAnalyzerSubmitResult",
     "LogAnalysisSplitlogResult",
@@ -47,205 +48,80 @@ __all__ = [
 ]
 
 
-class AttributionService:
+def _controller_config_from_settings(cfg: Settings) -> AttributionControllerConfig:
+    """Translate HTTP service settings into controller startup config."""
+    return AttributionControllerConfig(
+        allowed_root=cfg.ALLOWED_ROOT,
+        analysis=AttributionAnalysisConfig(
+            engine_backend=cfg.ANALYSIS_BACKEND,
+            mcp_server_log_level=cfg.LOG_LEVEL,
+            llm_model=cfg.LLM_MODEL,
+            llm_base_url=cfg.LLM_BASE_URL,
+            llm_temperature=cfg.LLM_TEMPERATURE,
+            llm_top_p=cfg.LLM_TOP_P,
+            llm_max_tokens=cfg.LLM_MAX_TOKENS,
+        ),
+        cache=AttributionCacheConfig(
+            compute_timeout=cfg.COMPUTE_TIMEOUT,
+            grace_period_seconds=(
+                cfg.CACHE_GRACE_PERIOD_SECONDS if cfg.CACHE_GRACE_PERIOD_SECONDS else None
+            ),
+            cache_file=cfg.CACHE_FILE,
+        ),
+        postprocessing=AttributionPostprocessingConfig(
+            cluster_name=cfg.CLUSTER_NAME,
+            dataflow_index=cfg.DATAFLOW_INDEX,
+            slack_bot_token=(cfg.SLACK_BOT_TOKEN or "").strip() or None,
+            slack_channel=cfg.SLACK_CHANNEL,
+        ),
+    )
+
+
+class AttributionHttpAdapter:
     """
-    HTTP service wrapper for :class:`~nvidia_resiliency_ext.attribution.analyzer.engine.Analyzer`.
+    HTTP adapter facade for :class:`AttributionController`.
 
-    This class wraps the library :class:`~nvidia_resiliency_ext.attribution.analyzer.engine.Analyzer`
-    and adds HTTP-specific concerns like Settings conversion and dataflow posting.
-
-    For direct Python usage without HTTP, use :class:`~nvidia_resiliency_ext.attribution.analyzer.engine.Analyzer` directly:
-        from nvidia_resiliency_ext.attribution import Analyzer
-
-        analyzer = Analyzer(allowed_root="/logs", use_lib_log_analysis=False)
-        result = await analyzer.analyze("/logs/slurm-12345.out")
+    ``AttributionHttpAdapter`` owns Settings conversion and keeps the public service
+    method names stable for FastAPI routes. The controller owns attribution
+    analysis, cache persistence, side-effect stats, and health/status policy.
     """
 
     def __init__(self, cfg: Settings):
         """
-        Initialize the attribution service.
+        Initialize the attribution HTTP adapter.
 
         Args:
             cfg: Application settings (ALLOWED_ROOT must be validated via setup())
         """
         self.cfg = cfg
-
-        coalescing_kwargs: dict[str, Any] = {}
-        if cfg.COMPUTE_TIMEOUT is not None:
-            coalescing_kwargs["compute_timeout"] = cfg.COMPUTE_TIMEOUT
-        if cfg.CACHE_GRACE_PERIOD_SECONDS:
-            coalescing_kwargs["grace_period_seconds"] = cfg.CACHE_GRACE_PERIOD_SECONDS
-
-        use_lib = cfg.ANALYSIS_BACKEND.lower() == "lib"
-        log_sage_kwargs: dict[str, Any] = {
-            "use_lib_log_analysis": use_lib,
-            "mcp_server_log_level": cfg.LOG_LEVEL,
-        }
-        if cfg.LLM_MODEL is not None:
-            log_sage_kwargs["llm_model"] = cfg.LLM_MODEL
-        if cfg.LLM_BASE_URL is not None:
-            log_sage_kwargs["llm_base_url"] = cfg.LLM_BASE_URL
-        if cfg.LLM_TEMPERATURE is not None:
-            log_sage_kwargs["llm_temperature"] = cfg.LLM_TEMPERATURE
-        if cfg.LLM_TOP_P is not None:
-            log_sage_kwargs["llm_top_p"] = cfg.LLM_TOP_P
-        if cfg.LLM_MAX_TOKENS is not None:
-            log_sage_kwargs["llm_max_tokens"] = cfg.LLM_MAX_TOKENS
-        log_sage = LogSageExecutionConfig(**log_sage_kwargs)
-
-        # Create library Analyzer (calls postprocessing.post_results when it has results)
-        self._analyzer = Analyzer(
-            allowed_root=cfg.ALLOWED_ROOT,
-            log_sage=log_sage,
-            **coalescing_kwargs,
-        )
-
-        timeout_str = f"{cfg.COMPUTE_TIMEOUT}s" if cfg.COMPUTE_TIMEOUT else "default"
-        backend_str = cfg.ANALYSIS_BACKEND
-        llm_overrides = [
-            k
-            for k, v in (
-                ("llm_model", cfg.LLM_MODEL),
-                ("llm_base_url", cfg.LLM_BASE_URL),
-                ("llm_temperature", cfg.LLM_TEMPERATURE),
-                ("llm_top_p", cfg.LLM_TOP_P),
-                ("llm_max_tokens", cfg.LLM_MAX_TOKENS),
-            )
-            if v is not None
-        ]
-        llm_str = f", llm_overrides={llm_overrides}" if llm_overrides else ""
-        logger.info(
-            f"Initialized AttributionService with ALLOWED_ROOT={cfg.ALLOWED_ROOT}, "
-            f"compute_timeout={timeout_str}, analysis_backend={backend_str}"
-            f"{llm_str}"
-        )
-        logger.info(
-            "Analyzer LLM wiring: model=%r base_url=%s temperature=%s top_p=%s max_tokens=%s (from LogSageExecutionConfig)",
-            log_sage.llm_model,
-            log_sage.llm_base_url,
-            log_sage.llm_temperature,
-            log_sage.llm_top_p,
-            log_sage.llm_max_tokens,
-        )
+        self._controller = AttributionController(_controller_config_from_settings(cfg))
+        logger.info("Initialized AttributionHttpAdapter")
 
     def shutdown(self) -> None:
-        """Shutdown the service and stop background threads.
-
-        For full shutdown including MCP client cleanup, use shutdown_async() from
-        an async context (e.g. app lifespan).
-        """
-        self._analyzer.shutdown()
-        logger.info("AttributionService shutdown complete")
+        """Shutdown the adapter and stop background threads."""
+        self._controller.shutdown()
+        logger.info("AttributionHttpAdapter shutdown complete")
 
     async def shutdown_async(self) -> None:
-        """Shutdown the service including MCP client. Call from async context (e.g. lifespan)."""
-        await self._analyzer.shutdown_async()
-        logger.info("AttributionService shutdown complete")
+        """Shutdown the adapter including MCP client cleanup."""
+        await self._controller.shutdown_async()
+        logger.info("AttributionHttpAdapter shutdown complete")
 
-    async def save_cache(self, cache_file: str) -> bool:
-        """
-        Save cache to file for persistence across restarts.
+    async def start(self, loop: asyncio.AbstractEventLoop | None = None) -> dict[str, Any]:
+        """Start controller-owned runtime dependencies."""
+        return await self._controller.start(loop)
 
-        Must be awaited so export runs under the coalescer lock (safe during graceful
-        shutdown while other tasks may still finish work).
+    async def save_cache(self, cache_file: str | None = None) -> bool:
+        """Save controller cache to file for persistence across restarts."""
+        return await self._controller.save_cache(cache_file)
 
-        Args:
-            cache_file: Path to save cache JSON
-
-        Returns:
-            True if successful, False otherwise
-        """
-        if not cache_file:
-            return False
-
-        try:
-            entries = await self._analyzer.export_cache()
-            if not entries:
-                logger.debug("No cache entries to save")
-                return True
-
-            # Ensure parent directory exists
-            cache_dir = os.path.dirname(cache_file)
-            if cache_dir:
-                os.makedirs(cache_dir, exist_ok=True)
-
-            # Write atomically using temp file
-            temp_file = f"{cache_file}.tmp"
-            with open(temp_file, "w") as f:
-                json.dump({"version": 1, "entries": entries}, f)
-            os.replace(temp_file, cache_file)
-
-            logger.info(f"Saved {len(entries)} cache entries to {cache_file}")
-            return True
-
-        except Exception as e:
-            logger.warning(f"Failed to save cache to {cache_file}: {e}")
-            return False
-
-    async def load_cache(self, cache_file: str) -> int:
-        """
-        Load cache from file.
-
-        All entries are validated by file (mtime, size) on import.
-        Entries are skipped if file changed, gone, or mtime > 14 days.
-
-        Must be awaited so import runs under the coalescer lock.
-
-        Args:
-            cache_file: Path to cache JSON file
-
-        Returns:
-            Number of entries loaded, or 0 if file doesn't exist or is invalid
-        """
-        if not cache_file or not os.path.exists(cache_file):
-            return 0
-
-        try:
-            with open(cache_file) as f:
-                data = json.load(f)
-
-            # Check version
-            version = data.get("version", 0)
-            if version != 1:
-                logger.warning(f"Unknown cache file version: {version}")
-                return 0
-
-            entries = data.get("entries", [])
-            if not entries:
-                return 0
-
-            imported = await self._analyzer.import_cache(entries)
-            logger.info(f"Loaded {imported} cache entries from {cache_file}")
-            return imported
-
-        except json.JSONDecodeError as e:
-            logger.warning(f"Invalid JSON in cache file {cache_file}: {e}")
-            return 0
-        except Exception as e:
-            logger.warning(f"Failed to load cache from {cache_file}: {e}")
-            return 0
-
-    def set_event_loop(self, loop: Any) -> None:
-        """Set the main event loop for background thread callbacks.
-
-        Args:
-            loop: asyncio.AbstractEventLoop from the main thread
-
-        Call during app startup as soon as the running loop exists. Until then,
-        splitlog fire-and-forget schedules are skipped (logged) rather than raising
-        from the poll thread. See ``Analyzer.set_event_loop()`` for details.
-        """
-        self._analyzer.set_event_loop(loop)
-
-    async def connect_mcp(self) -> None:
-        """Connect the MCP client when using MCP analysis backend. No-op for lib backend."""
-        await self._analyzer.connect_mcp()
+    async def load_cache(self, cache_file: str | None = None) -> int:
+        """Load controller cache from file."""
+        return await self._controller.load_cache(cache_file)
 
     async def check_mcp_health(self, timeout_seconds: float = 5.0) -> tuple[str, str]:
-        """Check MCP backend health. Returns (status, message). See Analyzer.check_mcp_health."""
-        return await self._analyzer.check_mcp_health(timeout_seconds)
-
-    # ─── Delegate to Analyzer ───
+        """Check MCP backend health."""
+        return await self._controller.check_mcp_health(timeout_seconds)
 
     def validate_path(
         self,
@@ -254,8 +130,8 @@ class AttributionService:
         require_regular_file: bool = True,
         reject_empty: bool = False,
     ) -> str | LogAnalyzerError:
-        """Validate and normalize a path. Delegates to Analyzer."""
-        return self._analyzer.validate_path(
+        """Validate and normalize a path."""
+        return self._controller.validate_path(
             user_path,
             require_regular_file=require_regular_file,
             reject_empty=reject_empty,
@@ -267,8 +143,8 @@ class AttributionService:
         user: str = "unknown",
         job_id: str | None = None,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
-        """Submit a log file for analysis tracking (POST /logs)."""
-        return await self._analyzer.submit(log_path, user=user, job_id=job_id)
+        """Submit a log file for analysis tracking."""
+        return await self._controller.submit_log(log_path, user=user, job_id=job_id)
 
     async def analyze_log(
         self,
@@ -276,93 +152,39 @@ class AttributionService:
         file: str | None = None,
         wl_restart: int | None = None,
     ) -> LogAnalysisCycleResult | LogAnalysisSplitlogResult | LogAnalyzerError:
-        """Analyze a log file using LLM (GET /logs).
-
-        Caching: the analyzer's RequestCoalescer caches results per file path.
-        Repeat requests for the same path (any wl_restart) get the cached full
-        result; the analyzer returns the slice for the requested wl_restart.
-        """
-        return await self._analyzer.analyze(log_path, file=file, wl_restart=wl_restart)
+        """Analyze a log file using the configured attribution backend."""
+        return await self._controller.analyze_log(
+            log_path,
+            file=file,
+            wl_restart=wl_restart,
+        )
 
     def read_file_preview(
         self, log_path: str, max_bytes: int = PRINT_PREVIEW_MAX_BYTES
     ) -> LogAnalyzerFilePreview | LogAnalyzerError:
-        """Read the first N bytes of a file for preview (GET /print)."""
-        return self._analyzer.read_file_preview(log_path, max_bytes=max_bytes)
+        """Read the first N bytes of a file for preview."""
+        return self._controller.read_file_preview(log_path, max_bytes=max_bytes)
 
     async def get_stats(self) -> dict[str, Any]:
-        """Get coalescer, folder tracker, posting (ES/dataflow), and Slack statistics."""
-        stats = await self._analyzer.get_stats()
-        ps = get_posting_stats()
-        posting = {
-            "total_posts": ps.total_posts,
-            "total_successful": ps.successful_posts,
-            "total_failed": ps.failed_posts,
-        }
-        stats["posting"] = posting
-        stats["dataflow"] = posting  # legacy alias; same counters as ``posting``
-        # Add Slack stats
-        slack_stats = get_slack_stats()
-        stats["slack"] = {
-            "total_attempts": slack_stats.total_attempts,
-            "total_successful": slack_stats.total_successful,
-            "total_failed": slack_stats.total_failed,
-            "user_lookups": slack_stats.user_lookups,
-            "user_not_found": slack_stats.user_not_found,
-        }
-        return stats
+        """Get controller, cache, posting/dataflow, and Slack statistics."""
+        return await self._controller.get_stats()
 
     async def get_cache(self) -> CacheResult:
         """Get current cache contents."""
-        return await self._analyzer.get_cache()
+        return await self._controller.get_cache()
 
     async def get_inflight(self) -> InflightResult:
         """Get currently in-flight requests."""
-        return await self._analyzer.get_inflight()
+        return await self._controller.get_inflight()
 
     async def get_submitted(self) -> SubmittedResult:
         """Get submitted paths."""
-        return await self._analyzer.get_submitted()
+        return await self._controller.get_submitted()
 
     def get_all_jobs(self) -> dict[str, Any]:
         """Get all tracked jobs."""
-        return self._analyzer.get_all_jobs()
+        return self._controller.get_all_jobs()
 
     async def get_health(self) -> dict[str, Any]:
-        """Get health status based on recent statistics."""
-        posting_stats = get_posting_stats()
-        issues = []
-
-        # MCP backend health (when using MCP)
-        mcp_status, mcp_message = await self.check_mcp_health()
-        if mcp_status == "disconnected":
-            issues.append(f"MCP disconnected: {mcp_message}")
-
-        # Use typed helper so we don't depend on raw stats dict keys
-        compute = await self._analyzer.get_compute_health_metrics()
-        if compute.total > 0:
-            error_rate = (compute.errors + compute.timeouts) / compute.total
-            if error_rate >= 0.5:
-                issues.append(f"high compute error rate: {error_rate:.0%}")
-            elif error_rate >= 0.2:
-                issues.append(f"elevated compute error rate: {error_rate:.0%}")
-
-        # Check dataflow health
-        if posting_stats.total_posts > 0:
-            df_error_rate = posting_stats.failed_posts / posting_stats.total_posts
-            if df_error_rate >= 0.5:
-                issues.append(f"high dataflow failure rate: {df_error_rate:.0%}")
-            elif df_error_rate >= 0.2:
-                issues.append(f"elevated dataflow failure rate: {df_error_rate:.0%}")
-
-        if not issues:
-            status = "ok"
-        elif any("high" in issue for issue in issues):
-            status = "fail"
-        else:
-            status = "degraded"
-
-        result: dict[str, Any] = {"status": status, "issues": issues}
-        if mcp_status != "unused":
-            result["mcp"] = {"status": mcp_status, "message": mcp_message}
-        return result
+        """Get adapter health from controller status."""
+        return await self._controller.status()

--- a/src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md
+++ b/src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md
@@ -116,12 +116,98 @@ flowchart TB
     AP --> CLF
 ```
 
+### 2.4 Proposed attribution controller boundary
+
+The long-term boundary should separate **frontends**, an **AttributionController**, and
+**analysis engines**. Both `ft_launcher` and `nvrx_attrsvc` need attribution, but neither
+should own the full set of attribution internals.
+
+```text
+[ft_launcher | nvrx_attrsvc | future callers]
+        <>
+AttributionController
+        <>
+[MCP tools | in-process analyzers | third-party services]
+```
+
+The **frontend** layer owns caller-specific lifecycle and transport:
+
+- `ft_launcher`: worker monitoring, restart timing, restart budget, and applying the final restart/stop decision.
+- `nvrx_attrsvc`: HTTP routing, FastAPI lifecycle, request/response models, service auth/rate limits, and service health endpoints.
+- Future callers: CLI tools, batch jobs, notebook/debug workflows, or other control planes.
+
+The **AttributionController** owns attribution semantics and state:
+
+- request submission and job tracking
+- path policy / allowed-root enforcement for the deployment
+- request coalescing and cache lifecycle
+- log analysis orchestration
+- FR discovery and FR analysis orchestration
+- result normalization into a caller-stable shape
+- Slack and Elasticsearch/dataflow posting, with idempotency for side effects
+- dry-run behavior and attribution-level status
+
+The controller should have one contract with two deployment modes:
+
+```text
+Embedded mode:
+external client <> nvrx_attrsvc process
+                    └── AttributionController object <> MCP
+
+Hosted mode:
+ft_launcher <> AttributionController process <> MCP
+```
+
+For `nvrx_attrsvc`, the controller can be embedded because the service process already provides
+the process boundary, HTTP lifecycle, and health surface. For `ft_launcher`, the controller should
+be hosted as a separate long-lived process so launcher code does not own attribution state,
+side-effect idempotency, cache, or MCP lifecycle.
+
+Configuration belongs at controller construction or process startup, not as ordinary per-request
+state. The concrete boundary is `AttributionControllerConfig`: path policy plus nested analysis,
+cache, credentials, and postprocessing config. The analysis section uses
+`analysis.engine_backend` (`lib` or `mcp`) for the LogSage/FR execution backend; that is separate
+from whether the controller itself is embedded or hosted as a process. Controller config also
+includes LLM knobs, cache persistence, timeouts, LLM API key policy, Slack,
+Elasticsearch/dataflow, dry-run behavior, and non-secret deployment metadata. Avoid a mutable
+public `configure(...)` API unless dynamic reconfiguration becomes a real requirement.
+
+The controller contract should stay small:
+
+```text
+AttributionController(config)
+  start(...)
+  submit_log(...)
+  analyze_log(...)
+  get_result(...)
+  status(...)
+  shutdown(...)
+```
+
+`status(...)` is operational state, not attribution output. It should report readiness and
+dependency health: `ready` / lifecycle state, sanitized config summary, cache and in-flight counts,
+tracked-job summary, MCP health, Slack/dataflow configured-or-error state, and recent errors.
+
+The **analysis engine** layer owns compute:
+
+- MCP module tools such as `log_analyzer`, `fr_analyzer`, and `log_fr_analyzer`
+- in-process equivalents loaded by the controller when a subprocess boundary is unnecessary
+- future external attribution services or adapters
+
+The key rule is that low-level MCP module tools should not become the owner of the whole
+attribution product surface. MCP is a good process boundary for analysis engines; the controller
+above it should own cache, orchestration, side effects, and policy. If the controller itself is
+implemented using MCP transport, it should expose service-grade methods such as
+`submit_log`, `analyze_log`, `get_result`, and `status` rather than overloading the existing
+`log_analyzer` module tool.
+
 ---
 
 ## 3. Major subsystems
 
 | Area | Responsibility |
 |------|------------------|
+| **`controller.py`** | **`AttributionController`** and nested config dataclasses: frontend-facing attribution boundary; owns startup config, LLM API key validation, cache persistence, health/status policy, postprocessing wiring, dataflow/Slack stats, and delegates analysis to **`Analyzer`**. |
 | **`analyzer/`** | **`Analyzer`** (`engine.py`): path policy, `RequestCoalescer`, `submit` / `analyze`, splitlog branches; delegates heavy lifting to **`LogAnalyzer`**. Re-exports pipeline symbols from `svc.analysis_pipeline` for convenience. |
 | **`log_analyzer/`** | LogSage package surface only: `NVRxLogAnalyzer` implementation plus its minimal `__init__.py` export. It no longer owns orchestration, parsing, splitlog, or config/types modules. |
 | **`svc/`** | Log-side service/orchestration subsystem: **`LogAnalyzer`**, `Job` / `FileInfo`, SLURM parsing, splitlog polling, **`run_attribution_pipeline`** / **`AnalysisPipelineMode`**, `LogAnalyzerConfig` and result dataclasses, path validation, wire keys (`RESP_*`), and LogSage execution config/runtime helpers. |
@@ -267,6 +353,7 @@ attribution/
 ├── base.py
 ├── combined_log_fr/         # CombinedLogFR + merge_log_fr_llm
 ├── coalescing/              # RequestCoalescer, LogAnalysisCoalesced, coalesced_cache
+├── controller.py            # AttributionController boundary and config
 ├── log_analyzer/            # LogAnalyzer, analysis_pipeline, job, splitlog, slurm_parser, nvrx_logsage, types, …
 ├── mcp_integration/         # MCP client/server (see mcp_integration/README.md)
 ├── postprocessing/          # Dataflow record, poster, Slack

--- a/src/nvidia_resiliency_ext/attribution/README.md
+++ b/src/nvidia_resiliency_ext/attribution/README.md
@@ -8,7 +8,8 @@ Install the optional attribution dependency set with:
 pip install 'nvidia-resiliency-ext[attribution]'
 ```
 
-**How it is structured (subsystems, diagrams, `Analyzer` / `LogAnalyzerConfig`, MCP vs in-process LogSage, pipeline modes):**  
+**How it is structured (subsystems, diagrams, `AttributionController`, `Analyzer` / `LogAnalyzerConfig`, MCP vs in-process LogSage, pipeline modes):**
+
 **[ARCHITECTURE.md](./ARCHITECTURE.md)**
 
 The public API is re-exported from `nvidia_resiliency_ext.attribution` (see package `__init__.py`).

--- a/src/nvidia_resiliency_ext/attribution/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/__init__.py
@@ -56,6 +56,14 @@ if TYPE_CHECKING:
         SubmittedResult,
         coalesced_from_cache,
     )
+    from .controller import (
+        AttributionAnalysisConfig,
+        AttributionCacheConfig,
+        AttributionController,
+        AttributionControllerConfig,
+        AttributionCredentialsConfig,
+        AttributionPostprocessingConfig,
+    )
     from .svc.config import (
         MAX_JOBS,
         MIN_FILE_SIZE_KB,
@@ -107,6 +115,12 @@ _EXPORTS = {
     "StatsResult": ".coalescing",
     "SubmittedResult": ".coalescing",
     "coalesced_from_cache": ".coalescing",
+    "AttributionController": ".controller",
+    "AttributionControllerConfig": ".controller",
+    "AttributionAnalysisConfig": ".controller",
+    "AttributionCacheConfig": ".controller",
+    "AttributionCredentialsConfig": ".controller",
+    "AttributionPostprocessingConfig": ".controller",
     "MAX_JOBS": ".svc.config",
     "MIN_FILE_SIZE_KB": ".svc.config",
     "POLL_INTERVAL_SECONDS": ".svc.config",
@@ -184,6 +198,12 @@ __all__ = [
     "LogAnalyzerSubmitResult",
     "LogAnalysisSplitlogResult",
     "LogAnalyzerFilePreview",
+    "AttributionController",
+    "AttributionControllerConfig",
+    "AttributionAnalysisConfig",
+    "AttributionCacheConfig",
+    "AttributionCredentialsConfig",
+    "AttributionPostprocessingConfig",
     # Configuration and error codes
     "ErrorCode",
     "TTL_PENDING_SECONDS",

--- a/src/nvidia_resiliency_ext/attribution/controller.py
+++ b/src/nvidia_resiliency_ext/attribution/controller.py
@@ -1,0 +1,494 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attribution controller boundary.
+
+``AttributionController`` owns attribution lifecycle concerns above the low-level
+``Analyzer``: config translation, cache persistence, service health/status, and
+postprocessing stats. It can be embedded by a service process today and hosted as
+its own process for ft_launcher integration later.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from nvidia_resiliency_ext.attribution.analyzer import Analyzer
+from nvidia_resiliency_ext.attribution.api_keys import load_llm_api_key, load_slack_bot_token
+from nvidia_resiliency_ext.attribution.coalescing import (
+    CacheResult,
+    InflightResult,
+    SubmittedResult,
+)
+from nvidia_resiliency_ext.attribution.postprocessing import ResultPoster
+from nvidia_resiliency_ext.attribution.postprocessing import configure as configure_postprocessing
+from nvidia_resiliency_ext.attribution.postprocessing import get_posting_stats, get_slack_stats
+from nvidia_resiliency_ext.attribution.postprocessing.post_backend import post
+from nvidia_resiliency_ext.attribution.svc.config import LogSageExecutionConfig
+from nvidia_resiliency_ext.attribution.svc.types import (
+    LogAnalysisCycleResult,
+    LogAnalysisSplitlogResult,
+    LogAnalyzerError,
+    LogAnalyzerFilePreview,
+    LogAnalyzerSubmitResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AttributionAnalysisConfig:
+    """Analysis engine configuration."""
+
+    engine_backend: str = "mcp"
+    mcp_server_log_level: str = "INFO"
+    llm_model: str | None = None
+    llm_base_url: str | None = None
+    llm_temperature: float | None = None
+    llm_top_p: float | None = None
+    llm_max_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class AttributionCacheConfig:
+    """Request coalescing and persistence configuration.
+
+    ``cache_file`` is normalized to an absolute, user-expanded path when set so
+    direct controller callers get the same path contract as service Settings.
+    """
+
+    compute_timeout: float | None = None
+    grace_period_seconds: float | None = None
+    cache_file: str = ""
+
+    def __post_init__(self) -> None:
+        cache_file = (self.cache_file or "").strip()
+        if cache_file:
+            cache_file = os.path.abspath(os.path.expanduser(cache_file))
+        object.__setattr__(self, "cache_file", cache_file)
+
+
+@dataclass(frozen=True)
+class AttributionPostprocessingConfig:
+    """Posting and notification configuration for attribution side effects."""
+
+    cluster_name: str = ""
+    dataflow_index: str = ""
+    slack_bot_token: str | None = None
+    slack_channel: str = ""
+    enable_default_poster: bool = True
+
+
+@dataclass(frozen=True)
+class AttributionCredentialsConfig:
+    """Credential policy for attribution engines.
+
+    The current LogSage implementations load the LLM API key via
+    :func:`load_llm_api_key`; the controller validates that policy at startup so
+    callers do not need to know which lower layer will first need the key.
+    """
+
+    require_llm_api_key: bool = True
+
+
+@dataclass(frozen=True)
+class AttributionControllerConfig:
+    """Startup configuration for :class:`AttributionController`.
+
+    Runtime request metadata belongs in ``submit_log`` or ``analyze_log``; this
+    config is the process-level policy and dependency wiring for the controller.
+    """
+
+    allowed_root: str
+    analysis: AttributionAnalysisConfig = field(default_factory=AttributionAnalysisConfig)
+    cache: AttributionCacheConfig = field(default_factory=AttributionCacheConfig)
+    postprocessing: AttributionPostprocessingConfig = field(
+        default_factory=AttributionPostprocessingConfig
+    )
+    credentials: AttributionCredentialsConfig = field(default_factory=AttributionCredentialsConfig)
+
+
+class AttributionController:
+    """Orchestrates attribution across analysis, cache, and side effects.
+
+    The controller exposes the boundary we want callers to depend on. The
+    current implementation delegates analysis to ``Analyzer`` but keeps cache
+    persistence and health/status policy out of the HTTP service wrapper.
+    """
+
+    def __init__(self, config: AttributionControllerConfig):
+        self.config = config
+        self._engine_backend = self._normalize_engine_backend(config.analysis.engine_backend)
+        self._llm_api_key_present = self._validate_llm_api_key()
+        self._slack_configured = self._configure_postprocessing()
+
+        coalescing_kwargs: dict[str, Any] = {}
+        if config.cache.compute_timeout is not None:
+            coalescing_kwargs["compute_timeout"] = config.cache.compute_timeout
+        if config.cache.grace_period_seconds is not None:
+            coalescing_kwargs["grace_period_seconds"] = config.cache.grace_period_seconds
+
+        use_lib = self._engine_backend == "lib"
+        analyzer_engine_kwargs: dict[str, Any] = {
+            "use_lib_log_analysis": use_lib,
+            "mcp_server_log_level": config.analysis.mcp_server_log_level,
+        }
+        if config.analysis.llm_model is not None:
+            analyzer_engine_kwargs["llm_model"] = config.analysis.llm_model
+        if config.analysis.llm_base_url is not None:
+            analyzer_engine_kwargs["llm_base_url"] = config.analysis.llm_base_url
+        if config.analysis.llm_temperature is not None:
+            analyzer_engine_kwargs["llm_temperature"] = config.analysis.llm_temperature
+        if config.analysis.llm_top_p is not None:
+            analyzer_engine_kwargs["llm_top_p"] = config.analysis.llm_top_p
+        if config.analysis.llm_max_tokens is not None:
+            analyzer_engine_kwargs["llm_max_tokens"] = config.analysis.llm_max_tokens
+        analyzer_engine = LogSageExecutionConfig(**analyzer_engine_kwargs)
+
+        self._analyzer = Analyzer(
+            allowed_root=config.allowed_root,
+            log_sage=analyzer_engine,
+            **coalescing_kwargs,
+        )
+
+        timeout_str = (
+            f"{config.cache.compute_timeout}s" if config.cache.compute_timeout else "default"
+        )
+        llm_overrides = [
+            k
+            for k, v in (
+                ("llm_model", config.analysis.llm_model),
+                ("llm_base_url", config.analysis.llm_base_url),
+                ("llm_temperature", config.analysis.llm_temperature),
+                ("llm_top_p", config.analysis.llm_top_p),
+                ("llm_max_tokens", config.analysis.llm_max_tokens),
+            )
+            if v is not None
+        ]
+        llm_str = f", llm_overrides={llm_overrides}" if llm_overrides else ""
+        logger.info(
+            "Initialized AttributionController with allowed_root=%s, compute_timeout=%s, "
+            "analysis_engine_backend=%s%s",
+            config.allowed_root,
+            timeout_str,
+            self._engine_backend,
+            llm_str,
+        )
+        logger.info(
+            "Analyzer engine LLM wiring: model=%r base_url=%s temperature=%s top_p=%s "
+            "max_tokens=%s",
+            analyzer_engine.llm_model,
+            analyzer_engine.llm_base_url,
+            analyzer_engine.llm_temperature,
+            analyzer_engine.llm_top_p,
+            analyzer_engine.llm_max_tokens,
+        )
+
+    def shutdown(self) -> None:
+        """Shutdown the controller and stop background threads."""
+        self._analyzer.shutdown()
+        logger.info("AttributionController shutdown complete")
+
+    async def shutdown_async(self) -> None:
+        """Shutdown the controller including MCP client cleanup."""
+        await self.save_cache()
+        await self._analyzer.shutdown_async()
+        logger.info("AttributionController shutdown complete")
+
+    async def start(self, loop: asyncio.AbstractEventLoop | None = None) -> dict[str, Any]:
+        """Start controller-owned runtime dependencies.
+
+        The caller provides the process event loop when one exists; the
+        controller decides which internal dependencies need startup work.
+        """
+        if loop is not None:
+            self._analyzer.set_event_loop(loop)
+        await self._connect_mcp()
+        loaded = await self.load_cache()
+        return {"cache_entries_loaded": loaded}
+
+    async def save_cache(self, cache_file: str | None = None) -> bool:
+        """Persist the analyzer cache using the controller cache-file format."""
+        cache_file = cache_file if cache_file is not None else self.config.cache.cache_file
+        if not cache_file:
+            return False
+
+        try:
+            entries = await self._analyzer.export_cache()
+            if not entries:
+                logger.debug("No cache entries to save")
+                return True
+
+            cache_dir = os.path.dirname(cache_file)
+            if cache_dir:
+                os.makedirs(cache_dir, exist_ok=True)
+
+            temp_file = f"{cache_file}.tmp"
+            with open(temp_file, "w") as f:
+                json.dump({"version": 1, "entries": entries}, f)
+            os.replace(temp_file, cache_file)
+
+            logger.info("Saved %d cache entries to %s", len(entries), cache_file)
+            return True
+
+        except Exception as e:
+            logger.warning("Failed to save cache to %s: %s", cache_file, e)
+            return False
+
+    async def load_cache(self, cache_file: str | None = None) -> int:
+        """Load persisted cache entries into the analyzer cache."""
+        cache_file = cache_file if cache_file is not None else self.config.cache.cache_file
+        if not cache_file or not os.path.exists(cache_file):
+            return 0
+
+        try:
+            with open(cache_file) as f:
+                data = json.load(f)
+
+            version = data.get("version", 0)
+            if version != 1:
+                logger.warning("Unknown cache file version: %s", version)
+                return 0
+
+            entries = data.get("entries", [])
+            if not entries:
+                return 0
+
+            imported = await self._analyzer.import_cache(entries)
+            logger.info("Loaded %d cache entries from %s", imported, cache_file)
+            return imported
+
+        except json.JSONDecodeError as e:
+            logger.warning("Invalid JSON in cache file %s: %s", cache_file, e)
+            return 0
+        except Exception as e:
+            logger.warning("Failed to load cache from %s: %s", cache_file, e)
+            return 0
+
+    async def _connect_mcp(self) -> None:
+        """Connect internal MCP dependencies when the analysis engine needs them."""
+        await self._analyzer.connect_mcp()
+
+    async def check_mcp_health(self, timeout_seconds: float = 5.0) -> tuple[str, str]:
+        """Check MCP backend health. Returns ``(status, message)``."""
+        return await self._analyzer.check_mcp_health(timeout_seconds)
+
+    def validate_path(
+        self,
+        user_path: str,
+        *,
+        require_regular_file: bool = True,
+        reject_empty: bool = False,
+    ) -> str | LogAnalyzerError:
+        """Validate and normalize a path under the configured root."""
+        return self._analyzer.validate_path(
+            user_path,
+            require_regular_file=require_regular_file,
+            reject_empty=reject_empty,
+        )
+
+    async def submit_log(
+        self,
+        log_path: str,
+        user: str = "unknown",
+        job_id: str | None = None,
+    ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
+        """Submit a log file for attribution tracking."""
+        return await self._analyzer.submit(log_path, user=user, job_id=job_id)
+
+    async def analyze_log(
+        self,
+        log_path: str,
+        file: str | None = None,
+        wl_restart: int | None = None,
+    ) -> LogAnalysisCycleResult | LogAnalysisSplitlogResult | LogAnalyzerError:
+        """Analyze a log file and return the attribution result."""
+        return await self._analyzer.analyze(log_path, file=file, wl_restart=wl_restart)
+
+    def read_file_preview(
+        self, log_path: str, max_bytes: int = 4096
+    ) -> LogAnalyzerFilePreview | LogAnalyzerError:
+        """Read the first ``max_bytes`` bytes of a log file."""
+        return self._analyzer.read_file_preview(log_path, max_bytes=max_bytes)
+
+    async def get_stats(self) -> dict[str, Any]:
+        """Get analyzer, cache, dataflow, and Slack statistics."""
+        stats = await self._analyzer.get_stats()
+        posting_stats = get_posting_stats()
+        stats["dataflow"] = {
+            "total_posts": posting_stats.total_posts,
+            "total_successful": posting_stats.successful_posts,
+            "total_failed": posting_stats.failed_posts,
+        }
+
+        slack_stats = get_slack_stats()
+        stats["slack"] = {
+            "total_attempts": slack_stats.total_attempts,
+            "total_successful": slack_stats.total_successful,
+            "total_failed": slack_stats.total_failed,
+            "user_lookups": slack_stats.user_lookups,
+            "user_not_found": slack_stats.user_not_found,
+        }
+        return stats
+
+    async def get_cache(self) -> CacheResult:
+        """Get current cache contents."""
+        return await self._analyzer.get_cache()
+
+    async def get_inflight(self) -> InflightResult:
+        """Get currently in-flight requests."""
+        return await self._analyzer.get_inflight()
+
+    async def get_submitted(self) -> SubmittedResult:
+        """Get submitted paths."""
+        return await self._analyzer.get_submitted()
+
+    def get_all_jobs(self) -> dict[str, Any]:
+        """Get all tracked jobs."""
+        return self._analyzer.get_all_jobs()
+
+    async def status(self) -> dict[str, Any]:
+        """Get controller readiness/dependency health, not an attribution result."""
+        posting_stats = get_posting_stats()
+        issues: list[str] = []
+
+        mcp_status, mcp_message = await self.check_mcp_health()
+        if mcp_status == "disconnected":
+            issues.append(f"MCP disconnected: {mcp_message}")
+
+        compute = await self._analyzer.get_compute_health_metrics()
+        if compute.total > 0:
+            error_rate = (compute.errors + compute.timeouts) / compute.total
+            if error_rate >= 0.5:
+                issues.append(f"high compute error rate: {error_rate:.0%}")
+            elif error_rate >= 0.2:
+                issues.append(f"elevated compute error rate: {error_rate:.0%}")
+
+        if posting_stats.total_posts > 0:
+            df_error_rate = posting_stats.failed_posts / posting_stats.total_posts
+            if df_error_rate >= 0.5:
+                issues.append(f"high dataflow failure rate: {df_error_rate:.0%}")
+            elif df_error_rate >= 0.2:
+                issues.append(f"elevated dataflow failure rate: {df_error_rate:.0%}")
+
+        if not issues:
+            status = "ok"
+        elif any("high" in issue for issue in issues):
+            status = "fail"
+        else:
+            status = "degraded"
+
+        result: dict[str, Any] = {"status": status, "issues": issues}
+        if mcp_status != "unused":
+            result["mcp"] = {"status": mcp_status, "message": mcp_message}
+        cache = await self.get_cache()
+        in_flight = await self.get_inflight()
+        submitted = await self.get_submitted()
+        jobs = self.get_all_jobs()
+        result["controller"] = {
+            "ready": status != "fail",
+            "config": self._status_config_summary(),
+            "cache": {
+                "count": cache.get("count", 0),
+            },
+            "in_flight": {
+                "count": in_flight.get("count", 0),
+            },
+            "submitted": {
+                "count": submitted.get("count", 0),
+            },
+            "jobs": {
+                mode: payload.get("count", 0)
+                for mode, payload in jobs.items()
+                if isinstance(payload, dict)
+            },
+        }
+        return result
+
+    async def get_health(self) -> dict[str, Any]:
+        """Compatibility alias for callers that use service-style health naming."""
+        return await self.status()
+
+    def _status_config_summary(self) -> dict[str, Any]:
+        """Return non-secret controller config for status payloads."""
+        llm_overrides = [
+            k
+            for k, v in (
+                ("llm_model", self.config.analysis.llm_model),
+                ("llm_base_url", self.config.analysis.llm_base_url),
+                ("llm_temperature", self.config.analysis.llm_temperature),
+                ("llm_top_p", self.config.analysis.llm_top_p),
+                ("llm_max_tokens", self.config.analysis.llm_max_tokens),
+            )
+            if v is not None
+        ]
+        return {
+            "analysis": {
+                "engine_backend": self._engine_backend,
+                "mcp_server_log_level": self.config.analysis.mcp_server_log_level,
+                "llm_overrides": llm_overrides,
+                "llm_api_key_present": self._llm_api_key_present,
+            },
+            "cache": {
+                "compute_timeout": self.config.cache.compute_timeout,
+                "grace_period_seconds": self.config.cache.grace_period_seconds,
+                "persistence_enabled": bool(self.config.cache.cache_file),
+            },
+            "postprocessing": {
+                "cluster_name": self.config.postprocessing.cluster_name,
+                "dataflow_index": self.config.postprocessing.dataflow_index,
+                "dataflow_enabled": bool(self.config.postprocessing.dataflow_index),
+                "slack_channel": self.config.postprocessing.slack_channel,
+                "slack_enabled": self._slack_configured,
+            },
+        }
+
+    def _validate_llm_api_key(self) -> bool:
+        if not self.config.credentials.require_llm_api_key:
+            return bool(load_llm_api_key())
+        llm_key = load_llm_api_key()
+        if llm_key:
+            return True
+        logger.error(
+            "LLM API key not found or empty. Attribution requires a key. Set LLM_API_KEY or "
+            "LLM_API_KEY_FILE, or create ~/.llm_api_key. Slack notifications remain optional."
+        )
+        raise RuntimeError("LLM API key not found or empty")
+
+    def _configure_postprocessing(self) -> bool:
+        cfg = self.config.postprocessing
+        slack_token = cfg.slack_bot_token
+        if slack_token is None:
+            slack_token = load_slack_bot_token()
+        slack_token = (slack_token or "").strip()
+        slack_channel = (cfg.slack_channel or "").strip()
+
+        poster = ResultPoster(post_fn=post) if cfg.enable_default_poster else ResultPoster()
+        slack_enabled = bool(slack_token and slack_channel)
+        configure_postprocessing(
+            default_poster=poster,
+            cluster_name=cfg.cluster_name or "",
+            dataflow_index=cfg.dataflow_index or "",
+            slack_bot_token=slack_token,
+            slack_channel=slack_channel,
+        )
+        if slack_enabled:
+            logger.info(
+                "Slack notifications enabled for channel: %s",
+                slack_channel,
+            )
+        return slack_enabled
+
+    @staticmethod
+    def _normalize_engine_backend(engine_backend: str) -> str:
+        normalized = engine_backend.strip().lower()
+        if normalized not in {"lib", "mcp"}:
+            raise ValueError(
+                "analysis.engine_backend must be 'lib' or 'mcp', " f"got {engine_backend!r}"
+            )
+        return normalized


### PR DESCRIPTION
Define the AttributionController boundary and introduce the HTTP adapter for the service path.

Frontend adapters:
- AttributionHttpAdapter: FastAPI / nvrx_attrsvc transport
- Future AttributionLocalAdapter: local process endpoint for ft_launcher

Core:
- AttributionController: config, cache, postprocessing, health/status, and analysis lifecycle

This keeps attribution ownership out of ft_launcher. The previous boundary was effectively at the analysis/MCP layer, which still required ft_launcher to understand attribution concerns such as orchestration, postprocessing, cache lifecycle, and backend startup. With this boundary, ft_launcher can talk to a controller endpoint, while the controller owns attribution state, side effects, and analysis engine lifecycle.

From a deployment perspective, we can either use nvrx_attrsvc as a local HTTP endpoint or expose AttributionController through a local adapter such as Unix domain socket, gRPC, or another local transport.
Also note that AttributionController can be directly invoked inline in the same process ie ft_launcher. 