### PR TITLE
feat: Added ft_launcher managed attrsvc

### DIFF
--- a/build.py
+++ b/build.py
@@ -165,6 +165,20 @@ def _compile_protos(proto_dir, proto_filenames):
 
 
 def build(setup_kwargs):
+    # ``pyproject.toml`` installs ``services/nvrx_attrsvc`` under the
+    # ``nvidia_resiliency_ext.attribution`` namespace via Poetry's package
+    # ``to`` target. The generated setuptools build path does not understand
+    # that target and would otherwise also emit a top-level ``nvrx_attrsvc``.
+    packages = setup_kwargs.get("packages")
+    if packages:
+        setup_kwargs["packages"] = [
+            pkg for pkg in packages if pkg != "nvrx_attrsvc" and not pkg.startswith("nvrx_attrsvc.")
+        ]
+    for package_data_key in ("package_data", "exclude_package_data"):
+        package_data = setup_kwargs.get(package_data_key)
+        if isinstance(package_data, dict):
+            package_data.pop("nvrx_attrsvc", None)
+
     # Generate gRPC Python files from .proto files
     proto_dir = os.path.join("src", "nvidia_resiliency_ext", "shared_utils", "proto")
     proto_files = [

--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -112,30 +112,64 @@ Validation behavior:
 Attribution service integration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Enable artifact analysis (e.g., logs) during rendezvous health checks by pointing to a running attribution service.
-The feature is enabled by specifying both host and port.
+Per-cycle application logs do not enable attribution by themselves. To enable attribution, set
+``--ft-attribution-endpoint``. The endpoint value ``localhost`` makes ``ft_launcher`` run the
+attribution service on the TCPStore host; other endpoints are treated as externally managed
+attribution services.
+External endpoints may use schemes such as ``http://``, ``grpc://``, or ``unix://``. The current
+in-job attribution client submits logs over HTTP(S); non-HTTP endpoint strings are preserved but do
+not add a new transport implementation.
+If ``--ft-attribution-endpoint`` is set, ``--ft-per-cycle-applog-prefix`` is required because the
+attribution service analyzes the per-cycle application logs.
+
+The service code is included in the NVRx wheel, but the service dependencies are optional.
+Install the wheel with the ``attribution`` extra before running a launcher-managed attribution
+service:
+
+.. code-block:: bash
+
+   python -m pip install 'nvidia_resiliency_ext-<version>-<tags>.whl[attribution]'
+
+Plain ``python -m pip install nvidia_resiliency_ext-*.whl`` does not install the attribution
+service dependencies.
 
 * CLI:
 
-  - ``--ft-attrsvc-host <HOST>`` (alias: ``--ft_attrsvc_host``)
-  - ``--ft-attrsvc-port <PORT>`` (alias: ``--ft_attrsvc_port``)
+  - ``--ft-attribution-endpoint <ENDPOINT>`` (alias: ``--ft_attribution_endpoint``), default disabled
+  - ``--ft-attribution-llm-api-key-file <PATH>`` (alias: ``--ft_attribution_llm_api_key_file``)
+  - ``--ft-attribution-llm-base-url <URL>`` (alias: ``--ft_attribution_llm_base_url``)
+  - ``--ft-attribution-llm-model <MODEL>`` (alias: ``--ft_attribution_llm_model``)
+  - ``--ft-attribution-startup-timeout <SECONDS>`` (alias: ``--ft_attribution_startup_timeout``), default ``20``
+
+  The managed attribution app-log directory is derived from
+  ``dirname(realpath(--ft-per-cycle-applog-prefix))``. Its stdout/stderr log is derived
+  from ``--ft-per-cycle-applog-prefix`` as ``*_attribution.log``. The managed service listens on
+  ``127.0.0.1:50050`` and is exposed to the in-job client as ``http://localhost:50050``.
+
+  The managed attribution API key must come from ``--ft-attribution-llm-api-key-file`` or inherited
+  ``LLM_API_KEY_FILE``. If neither points to a readable file, the TCPStore-host launcher fails
+  before starting the attribution service.
 
   Example:
 
   .. code-block:: bash
 
      ft_launcher \
-       --ft-attrsvc-host 127.0.0.1 \
-       --ft-attrsvc-port 8000 \
+       --ft-per-cycle-applog-prefix /lustre/job123/train.log \
+       --ft-attribution-endpoint localhost \
+       --ft-attribution-llm-api-key-file /secure/llm_api_key \
+       --ft-attribution-llm-base-url https://integrate.api.nvidia.com/v1 \
+       --ft-attribution-llm-model nvidia/nemotron-3-super-120b-a12b \
        train.py
 
-* YAML: under the ``fault_tolerance`` section
+  To use an externally managed attribution service instead, specify an explicit endpoint:
 
-  .. code-block:: yaml
+  .. code-block:: bash
 
-     fault_tolerance:
-       attrsvc_host: "127.0.0.1"
-       attrsvc_port: 8000
+     ft_launcher \
+       --ft-per-cycle-applog-prefix /lustre/job123/train.log \
+       --ft-attribution-endpoint http://attribution.service.internal:8000 \
+       train.py
 
 GPU Memory Reclaim
 ^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 packages = [
     { include = "nvidia_resiliency_ext", from = "src" },
+    { include = "nvrx_attrsvc", from = "services", to = "nvidia_resiliency_ext/attribution" },
 ]
 
 exclude = [
@@ -52,6 +53,13 @@ langchain-openai = { version = ">=0.3.0", optional = true }
 mcp = { version = ">=1.15.0", optional = true }
 setproctitle = { version = ">=1.3.0", optional = true }
 logsage = { version = ">=0.1.7", optional = true }
+fastapi = { version = ">=0.100.0", optional = true }
+uvicorn = { version = ">=0.20.0", extras = ["standard"], optional = true }
+pydantic = { version = ">=2.0.0", optional = true }
+pydantic-settings = { version = ">=2.0.0", optional = true }
+slowapi = { version = ">=0.1.9", optional = true }
+slack-bolt = { version = ">=1.23.0", optional = true }
+slack-sdk = { version = ">=3.35.0", optional = true }
 grpcio = "^1.76.0"
 grpcio-tools = "^1.76.0"
 protobuf = ">=4.22.0"
@@ -59,9 +67,22 @@ protobuf = ">=4.22.0"
 [tool.poetry.scripts]
 ft_launcher = "nvidia_resiliency_ext.fault_tolerance.launcher:main"
 nvrx-mcp-analysis = "nvidia_resiliency_ext.attribution.mcp_integration.server_launcher:main"
+nvrx-attrsvc = "nvidia_resiliency_ext.attribution.nvrx_attrsvc.app:main"
 
 [tool.poetry.extras]
-attribution = ["langchain-openai", "logsage", "mcp", "setproctitle"]
+attribution = [
+    "langchain-openai",
+    "logsage",
+    "mcp",
+    "setproctitle",
+    "fastapi",
+    "uvicorn",
+    "pydantic",
+    "pydantic-settings",
+    "slowapi",
+    "slack-bolt",
+    "slack-sdk",
+]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lifecycle management for launcher-managed attribution service."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import shutil
+import subprocess  # nosec B404
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
+from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
+
+logger = logging.getLogger(LogConfig.name)
+
+DEFAULT_ATTRIBUTION_PORT = 50050
+DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT = 20.0
+_ATTRIBUTION_STOP_TIMEOUT = 5.0
+_ATTRIBUTION_READY_POLL_INTERVAL = 0.5
+
+
+@dataclass(frozen=True)
+class AttributionEndpoint:
+    """Endpoint used by the in-launcher attribution client."""
+
+    endpoint: str
+
+
+@dataclass(frozen=True)
+class AttributionConfig:
+    """Resolved launcher-managed attribution service configuration."""
+
+    endpoint: Optional[str]
+    applog_dir: Optional[str]
+    log_file: Optional[str]
+    startup_timeout: float
+    llm_api_key_file: Optional[str] = None
+    llm_base_url: Optional[str] = None
+    llm_model: Optional[str] = None
+    analysis_backend: Optional[str] = None
+    compute_timeout: Optional[float] = None
+    log_level: Optional[str] = None
+
+    @property
+    def is_enabled(self) -> bool:
+        return self.endpoint is not None
+
+    @property
+    def is_managed(self) -> bool:
+        if not self.is_enabled:
+            return False
+        assert self.endpoint is not None
+        return is_managed_attribution_endpoint(self.endpoint)
+
+    @property
+    def client_endpoint(self) -> AttributionEndpoint:
+        if not self.is_enabled:
+            raise ValueError("attribution endpoint requested while attribution service is disabled")
+        assert self.endpoint is not None
+        if self.is_managed:
+            return AttributionEndpoint(endpoint=_managed_attribution_client_endpoint())
+        return AttributionEndpoint(endpoint=self.endpoint)
+
+    @classmethod
+    def from_args(
+        cls,
+        args: Any,
+        base_log_file: str,
+        ft_cfg: FaultToleranceConfig,
+    ) -> "AttributionConfig":
+        endpoint = getattr(args, "ft_attribution_endpoint", None)
+        if endpoint is None:
+            endpoint = ft_cfg.attribution_endpoint
+        if endpoint is not None:
+            endpoint = str(endpoint).strip() or None
+        if endpoint is not None:
+            _validate_attribution_endpoint(endpoint)
+
+        startup_timeout = getattr(args, "ft_attribution_startup_timeout", None)
+        if startup_timeout is None:
+            startup_timeout = DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT
+        startup_timeout = float(startup_timeout)
+        if startup_timeout <= 0:
+            raise ValueError("--ft-attribution-startup-timeout must be positive")
+
+        if endpoint is None:
+            return cls(
+                endpoint=None,
+                applog_dir=None,
+                log_file=None,
+                startup_timeout=startup_timeout,
+                llm_api_key_file=getattr(args, "ft_attribution_llm_api_key_file", None),
+                llm_base_url=getattr(args, "ft_attribution_llm_base_url", None),
+                llm_model=getattr(args, "ft_attribution_llm_model", None),
+                analysis_backend=getattr(args, "ft_attribution_analysis_backend", None),
+                compute_timeout=getattr(args, "ft_attribution_compute_timeout", None),
+                log_level=getattr(args, "ft_attribution_log_level", None),
+            )
+
+        applog_dir = os.path.dirname(os.path.realpath(os.path.abspath(base_log_file)))
+        os.makedirs(applog_dir, exist_ok=True)
+        _validate_existing_dir(applog_dir, "derived attribution applog_dir")
+        base_real = os.path.realpath(os.path.abspath(base_log_file))
+        if os.path.commonpath([applog_dir, base_real]) != applog_dir:
+            raise ValueError(
+                f"derived attribution applog_dir must contain --ft-per-cycle-applog-prefix: "
+                f"{applog_dir!r} does not contain {base_real!r}"
+            )
+
+        log_file = _attribution_log_path(base_log_file)
+        log_file = os.path.realpath(os.path.abspath(os.path.expanduser(log_file)))
+        log_parent = os.path.dirname(log_file) or "."
+        os.makedirs(log_parent, exist_ok=True)
+
+        return cls(
+            endpoint=endpoint,
+            applog_dir=applog_dir,
+            log_file=log_file,
+            startup_timeout=startup_timeout,
+            llm_api_key_file=getattr(args, "ft_attribution_llm_api_key_file", None),
+            llm_base_url=getattr(args, "ft_attribution_llm_base_url", None),
+            llm_model=getattr(args, "ft_attribution_llm_model", None),
+            analysis_backend=getattr(args, "ft_attribution_analysis_backend", None),
+            compute_timeout=getattr(args, "ft_attribution_compute_timeout", None),
+            log_level=getattr(args, "ft_attribution_log_level", None),
+        )
+
+
+class AttributionManager:
+    """Start and stop a job-local attribution service process when this launcher owns it."""
+
+    def __init__(self, cfg: AttributionConfig, *, is_store_host: bool):
+        self.cfg = cfg
+        self.is_store_host = is_store_host
+        self.process: Optional[subprocess.Popen] = None
+
+    def start_if_needed(self) -> Optional[AttributionEndpoint]:
+        if not self.cfg.is_enabled:
+            return None
+
+        if not self.cfg.is_managed:
+            logger.debug(
+                "Using externally managed attribution service at %s",
+                self.cfg.endpoint,
+            )
+            return self.cfg.client_endpoint
+
+        if not self.is_store_host:
+            return None
+
+        assert self.cfg.applog_dir is not None
+        assert self.cfg.log_file is not None
+        api_key_file = self._resolve_api_key_file()
+        env = self._child_env(api_key_file)
+        cmd = _attribution_command()
+
+        logger.info(
+            "Starting managed attribution service on localhost:%s "
+            "(applog_dir=%s, log_file=%s, startup_timeout=%.1fs)",
+            DEFAULT_ATTRIBUTION_PORT,
+            self.cfg.applog_dir,
+            self.cfg.log_file,
+            self.cfg.startup_timeout,
+        )
+
+        log_fd = open(self.cfg.log_file, "w")
+        try:
+            self.process = subprocess.Popen(  # nosec B603
+                cmd,
+                stdout=log_fd,
+                stderr=subprocess.STDOUT,
+                env=env,
+                shell=False,
+            )
+        finally:
+            log_fd.close()
+
+        try:
+            self._wait_until_ready()
+        except Exception:
+            self.stop()
+            raise
+
+        logger.info(
+            "Managed attribution service is ready: PID=%s endpoint=http://localhost:%s",
+            self.process.pid if self.process else None,
+            DEFAULT_ATTRIBUTION_PORT,
+        )
+        return self.cfg.client_endpoint
+
+    def stop(self) -> None:
+        proc = self.process
+        if proc is None:
+            return
+        if proc.poll() is not None:
+            logger.info(
+                "Managed attribution service PID=%s already exited with returncode=%s",
+                proc.pid,
+                proc.returncode,
+            )
+            self.process = None
+            return
+
+        logger.info("Sending SIGTERM to managed attribution service PID=%s", proc.pid)
+        with contextlib.suppress(Exception):
+            proc.terminate()
+        try:
+            proc.wait(timeout=_ATTRIBUTION_STOP_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Managed attribution service PID=%s did not exit within %.0fs; killing",
+                proc.pid,
+                _ATTRIBUTION_STOP_TIMEOUT,
+            )
+            with contextlib.suppress(Exception):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                proc.wait()
+        logger.info(
+            "Managed attribution service PID=%s finished with returncode=%s",
+            proc.pid,
+            proc.returncode,
+        )
+        self.process = None
+
+    def _resolve_api_key_file(self) -> str:
+        raw = self.cfg.llm_api_key_file or os.getenv("LLM_API_KEY_FILE")
+        if not raw:
+            raise ValueError(
+                "managed attribution service requires "
+                "--ft-attribution-llm-api-key-file or LLM_API_KEY_FILE"
+            )
+        path = os.path.realpath(os.path.abspath(os.path.expanduser(raw)))
+        if not os.path.isfile(path):
+            raise ValueError(f"managed attribution service LLM API key file is not a file: {path}")
+        if not os.access(path, os.R_OK):
+            raise ValueError(
+                f"managed attribution service LLM API key file is not readable: {path}"
+            )
+        return path
+
+    def _child_env(self, api_key_file: str) -> dict[str, str]:
+        assert self.cfg.applog_dir is not None
+        env = os.environ.copy()
+        services_dir = _repo_services_dir()
+        if services_dir is not None:
+            _prepend_env_path(env, "PYTHONPATH", str(services_dir))
+        env["LLM_API_KEY_FILE"] = api_key_file
+        # nvrx-attrsvc owns the service-side environment variable contract.
+        env["NVRX_ATTRSVC_HOST"] = "127.0.0.1"
+        env["NVRX_ATTRSVC_PORT"] = str(DEFAULT_ATTRIBUTION_PORT)
+        env["NVRX_ATTRSVC_ALLOWED_ROOT"] = self.cfg.applog_dir
+        _set_if_not_none(env, "NVRX_ATTRSVC_LLM_BASE_URL", self.cfg.llm_base_url)
+        _set_if_not_none(env, "NVRX_ATTRSVC_LLM_MODEL", self.cfg.llm_model)
+        _set_if_not_none(env, "NVRX_ATTRSVC_ANALYSIS_BACKEND", self.cfg.analysis_backend)
+        _set_if_not_none(env, "NVRX_ATTRSVC_COMPUTE_TIMEOUT", self.cfg.compute_timeout)
+        _set_if_not_none(env, "NVRX_ATTRSVC_LOG_LEVEL", self.cfg.log_level)
+        return env
+
+    def _wait_until_ready(self) -> None:
+        assert self.process is not None
+        deadline = time.monotonic() + self.cfg.startup_timeout
+        url = f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}/healthz"
+        last_error = "not probed"
+
+        while time.monotonic() < deadline:
+            rc = self.process.poll()
+            if rc is not None:
+                raise RuntimeError(
+                    f"managed attribution service exited before becoming ready "
+                    f"(returncode={rc}, log_file={self.cfg.log_file})"
+                )
+            try:
+                with urllib.request.urlopen(url, timeout=1.0) as resp:  # nosec B310
+                    if 200 <= resp.status < 300:
+                        return
+                    last_error = f"HTTP status {resp.status}"
+            except urllib.error.HTTPError as exc:
+                last_error = f"HTTP status {exc.code}: {exc.reason}"
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+            time.sleep(_ATTRIBUTION_READY_POLL_INTERVAL)
+
+        raise TimeoutError(
+            f"managed attribution service did not become ready within "
+            f"{self.cfg.startup_timeout:.1f}s "
+            f"at {url} (last_error={last_error}, log_file={self.cfg.log_file})"
+        )
+
+
+def is_managed_attribution_endpoint(endpoint: str) -> bool:
+    return endpoint.strip().lower() == "localhost"
+
+
+def _managed_attribution_client_endpoint() -> str:
+    return f"http://localhost:{DEFAULT_ATTRIBUTION_PORT}"
+
+
+def _attribution_command() -> list[str]:
+    exe = shutil.which("nvrx-attrsvc")
+    if exe:
+        return [exe]
+    return [
+        sys.executable,
+        "-c",
+        "from nvidia_resiliency_ext.attribution.nvrx_attrsvc.app import main; main()",
+    ]
+
+
+def _attribution_log_path(base_log_file: str) -> str:
+    if base_log_file.endswith(".log"):
+        return base_log_file[:-4] + "_attribution.log"
+    return base_log_file + "_attribution.log"
+
+
+def _validate_attribution_endpoint(endpoint: str) -> None:
+    hostname = _endpoint_hostname(endpoint)
+    if (hostname or endpoint).strip().lower() in {"0.0.0.0", "::", "[::]"}:
+        raise ValueError(
+            "--ft-attribution-endpoint must not be a bind-all address. "
+            "Use localhost for launcher-managed attribution, or use a routable "
+            "endpoint for an externally managed attribution service."
+        )
+
+
+def _endpoint_hostname(endpoint: str) -> Optional[str]:
+    parsed = urlparse(endpoint)
+    if parsed.scheme:
+        return parsed.hostname
+    value = endpoint.strip()
+    if value.startswith("[") and "]" in value:
+        return value[1 : value.index("]")]
+    if value.count(":") == 1:
+        return value.rsplit(":", 1)[0]
+    return value
+
+
+def _validate_existing_dir(path: str, name: str) -> None:
+    if not os.path.isdir(path):
+        raise ValueError(f"{name} must be an existing directory, got {path}")
+    if not os.access(path, os.R_OK | os.X_OK):
+        raise ValueError(f"{name} must be readable/searchable, got {path}")
+
+
+def _repo_services_dir() -> Optional[Path]:
+    for parent in Path(__file__).resolve().parents:
+        services_dir = parent / "services"
+        if (services_dir / "nvrx_attrsvc" / "app.py").is_file():
+            return services_dir
+    return None
+
+
+def _prepend_env_path(env: dict[str, str], key: str, path: str) -> None:
+    existing = env.get(key)
+    if existing:
+        parts = existing.split(os.pathsep)
+        if path in parts:
+            return
+        env[key] = os.pathsep.join([path, existing])
+    else:
+        env[key] = path
+
+
+def _set_if_not_none(env: dict[str, str], key: str, value: Any) -> None:
+    if value is not None:
+        env[key] = str(value)

--- a/src/nvidia_resiliency_ext/fault_tolerance/config.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/config.py
@@ -95,9 +95,8 @@ class FaultToleranceConfig:
       out-of-section timeouts. The first N iterations (relative to cycle start) are excluded from
       timeout monitoring as they can be significantly slower than steady-state iterations.
       Default: 5. Can be overridden by workload (e.g., Megatron-LM via init_workload_monitoring).
-    * Attribution service (optional):
-      - `attrsvc_host` [str] hostname/IP of the attribution service
-      - `attrsvc_port` [int] port of the attribution service
+    * Attribution service (optional, disabled unless `attribution_endpoint` is set):
+      - `attribution_endpoint` [str] endpoint of the attribution service
 
     * `cycle_info_dir` [str|None] Full path to the NVRx cycle info directory (e.g.
       <base>/nvrx/). If set, the TCPStore host writes cycle info JSON files and the
@@ -145,8 +144,7 @@ class FaultToleranceConfig:
         5  # Number of warmup iterations before monitoring step section and out-of-section timeouts
     )
     # Attribution service configuration (optional)
-    attrsvc_host: Optional[str] = None
-    attrsvc_port: Optional[int] = None
+    attribution_endpoint: Optional[str] = None
 
     # NVRx cycle info: base directory for cycle_info JSON files
     cycle_info_dir: Optional[str] = None

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -1734,8 +1734,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         enable_dist_storage_healthcheck: bool = False,
         link_state_path_template: Optional[str] = None,
         storage_healthcheck_paths: Optional[list] = None,
-        attrsvc_host: Optional[str] = None,
-        attrsvc_port: Optional[int] = None,
+        attribution_endpoint: Optional[str] = None,
     ):
         """Create a new :py:class:`FtRendezvousBarrierHandler`.
 
@@ -1766,10 +1765,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
                 Template path for NIC link state files.
             storage_healthcheck_paths:
                 List of storage paths to check for health.
-            attrsvc_host:
-                Hostname or IP address of the attribution service.
-            attrsvc_port:
-                Port number of the attribution service.
+            attribution_endpoint:
+                Endpoint of the attribution service.
         """
         # We associate each handler instance with a unique node descriptor.
         node = cls._node_desc_generator.generate(local_addr)
@@ -1795,8 +1792,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             enable_dist_storage_healthcheck=enable_dist_storage_healthcheck,
             link_state_path_template=link_state_path_template,
             storage_healthcheck_paths=storage_healthcheck_paths,
-            attrsvc_host=attrsvc_host,
-            attrsvc_port=attrsvc_port,
+            attribution_endpoint=attribution_endpoint,
         )
 
     def __init__(
@@ -1810,8 +1806,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         enable_dist_storage_healthcheck: bool = False,
         link_state_path_template: Optional[str] = None,
         storage_healthcheck_paths: Optional[list] = None,
-        attrsvc_host: Optional[str] = None,
-        attrsvc_port: Optional[int] = None,
+        attribution_endpoint: Optional[str] = None,
     ) -> None:
         if not settings.run_id:
             raise ValueError("The run id must be a non-empty string.")
@@ -1873,13 +1868,10 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         )
 
         # Attribution service client (optional, only on master node)
-        if is_store_host and attrsvc_host and attrsvc_port is not None:
-            self._attr_service = AttributionService(
-                host=attrsvc_host,
-                port=int(attrsvc_port),
-            )
+        if is_store_host and attribution_endpoint:
+            self._attribution_service = AttributionService(endpoint=attribution_endpoint)
         else:
-            self._attr_service = None
+            self._attribution_service = None
 
     @property
     def _rendezvous_round(self) -> int:
@@ -2028,8 +2020,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
 
         # Perform optional log analysis (non-fatal)
         # Note: _submit_log() was already called from launcher before workers started
-        if self._attr_service is not None:
-            self._attr_service()
+        if self._attribution_service is not None:
+            self._attribution_service()
 
         # Perform Node health check (external service if available)
         _nodehealth_checker = get_node_health_check()
@@ -2384,8 +2376,7 @@ def create_handler(
         )
         storage_healthcheck_paths = params.config.get('storage_healthcheck_paths', None)
         link_state_path_template = params.config.get('link_state_path_template', None)
-        attrsvc_host = params.config.get('attrsvc_host', None)
-        attrsvc_port = params.config.get('attrsvc_port', None)
+        attribution_endpoint = params.config.get('attribution_endpoint', None)
 
         return FtRendezvousBarrierHandler.from_backend(
             params.run_id,
@@ -2402,8 +2393,7 @@ def create_handler(
             enable_dist_storage_healthcheck=enable_dist_storage_healthcheck,
             link_state_path_template=link_state_path_template,
             storage_healthcheck_paths=storage_healthcheck_paths,
-            attrsvc_host=attrsvc_host,
-            attrsvc_port=attrsvc_port,
+            attribution_endpoint=attribution_endpoint,
         )
     except Exception as e:
         construct_and_record_rdzv_event(

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -69,6 +69,12 @@ from torch.distributed.elastic.rendezvous.utils import (
 )
 from torch.distributed.elastic.utils import macros
 
+from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
+    DEFAULT_ATTRIBUTION_PORT,
+    DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT,
+    AttributionConfig,
+    AttributionManager,
+)
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
 from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import CycleInfoWriter, utc_iso_now
 from nvidia_resiliency_ext.fault_tolerance.data import (
@@ -119,6 +125,7 @@ _NODE_HEALTH_CHECK_INSTANCE: Optional[NodeHealthCheck] = None
 # Populated on TCP store host when gRPC log aggregation is enabled: root-only [Popen] or
 # [root, leaf0, ..., leaf_{N-1}] when ft_log_aggregator_count > 1.
 _GRPC_SERVER_PROCESSES: List[subprocess.Popen] = []
+_ATTRIBUTION_MANAGER: Optional[AttributionManager] = None
 
 def init_node_health_check(endpoint: Optional[str]) -> None:
     global _NODE_HEALTH_CHECK_INSTANCE
@@ -1021,11 +1028,11 @@ class LocalElasticAgent(SimpleElasticAgent):
         # Submit current cycle's log to attribution service (master node only, before workers start)
         if (
             self._is_store_host
-            and self._rdzv_handler._attr_service is not None
+            and self._rdzv_handler._attribution_service is not None
             and hasattr(self._logs_specs, 'get_cycle_log_file')
         ):
             cycle_log_file = self._logs_specs.get_cycle_log_file(current_cycle)
-            self._rdzv_handler._attr_service._submit_log(cycle_log_file)
+            self._rdzv_handler._attribution_service._submit_log(cycle_log_file)
 
         # Write NVRx cycle info and set env for workload
         current_cycle_info_path = self._write_cycle_start_info(current_cycle)
@@ -1666,8 +1673,8 @@ def launch_agent(
         # permanent-close signaling; it cannot keep the store alive after process exit.
         if is_store_host:
             # Trigger attribution service analysis for final cycle
-            if agent._rdzv_handler._attr_service is not None:
-                agent._rdzv_handler._attr_service()
+            if agent._rdzv_handler._attribution_service is not None:
+                agent._rdzv_handler._attribution_service()
 
             # No ordering required between cycle_info_writer and rendezvous: the writer
             # is independent I/O. Run grace-period wait and writer shutdown in parallel
@@ -2069,7 +2076,10 @@ utility
 
 def get_args_parser() -> ArgumentParser:
     """Parse the command line options."""
-    parser = ArgumentParser(description="Torch Distributed Elastic Training Launcher")
+    parser = ArgumentParser(
+        description="Torch Distributed Elastic Training Launcher",
+        allow_abbrev=False,
+    )
 
     #
     # Worker/node size related arguments.
@@ -2732,22 +2742,85 @@ def get_args_parser() -> ArgumentParser:
         "format and log the traceback, and use os._exit() to exit the process reliably. Default: False.",
     )
 
-    # Attribution service configuration (optional)
+    # Attribution service configuration. Disabled by default. The literal
+    # endpoint "localhost" means ft_launcher manages the attribution service on
+    # the TCPStore host; other endpoints are treated as external services.
     parser.add_argument(
-        "--ft-attrsvc-host",
-        "--ft_attrsvc_host",
+        "--ft-attribution-endpoint",
+        "--ft_attribution_endpoint",
         type=str,
         default=None,
-        dest="ft_attrsvc_host",
-        help="Hostname or IP for the attribution service (e.g., 127.0.0.1).",
+        dest="ft_attribution_endpoint",
+        help=(
+            "Endpoint for the attribution service. Default: disabled. "
+            "Set to localhost to let ft_launcher manage nvrx-attrsvc on the TCPStore host. "
+            "Use an explicit endpoint such as http://host:port, grpc://host:port, "
+            "or unix:///path/to/socket for an externally managed attribution service."
+        ),
     )
     parser.add_argument(
-        "--ft-attrsvc-port",
-        "--ft_attrsvc_port",
-        type=int,
+        "--ft-attribution-startup-timeout",
+        "--ft_attribution_startup_timeout",
+        type=float,
+        default=DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT,
+        dest="ft_attribution_startup_timeout",
+        help=(
+            "Seconds to wait for launcher-managed attribution service /healthz readiness. "
+            f"Default: {DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT}."
+        ),
+    )
+    parser.add_argument(
+        "--ft-attribution-llm-api-key-file",
+        "--ft_attribution_llm_api_key_file",
+        type=str,
         default=None,
-        dest="ft_attrsvc_port",
-        help="Port for the attribution service (e.g., 8000).",
+        dest="ft_attribution_llm_api_key_file",
+        help=(
+            "Path to the LLM API key file for launcher-managed attribution service. "
+            "If unset, LLM_API_KEY_FILE from the launcher environment is used."
+        ),
+    )
+    parser.add_argument(
+        "--ft-attribution-llm-base-url",
+        "--ft_attribution_llm_base_url",
+        type=str,
+        default=None,
+        dest="ft_attribution_llm_base_url",
+        help="LLM base URL for launcher-managed attribution service.",
+    )
+    parser.add_argument(
+        "--ft-attribution-llm-model",
+        "--ft_attribution_llm_model",
+        type=str,
+        default=None,
+        dest="ft_attribution_llm_model",
+        help="LLM model identifier for launcher-managed attribution service.",
+    )
+    parser.add_argument(
+        "--ft-attribution-analysis-backend",
+        "--ft_attribution_analysis_backend",
+        type=str,
+        default=None,
+        dest="ft_attribution_analysis_backend",
+        choices=("mcp", "lib"),
+        help="Analysis backend for launcher-managed attribution service: mcp or lib.",
+    )
+    parser.add_argument(
+        "--ft-attribution-compute-timeout",
+        "--ft_attribution_compute_timeout",
+        type=float,
+        default=None,
+        dest="ft_attribution_compute_timeout",
+        help="Analysis compute timeout in seconds for launcher-managed attribution service.",
+    )
+    parser.add_argument(
+        "--ft-attribution-log-level",
+        "--ft_attribution_log_level",
+        type=str.upper,
+        default=None,
+        dest="ft_attribution_log_level",
+        choices=("DEBUG", "INFO", "WARNING"),
+        help="Log level for launcher-managed attribution service.",
     )
 
     parser.add_argument(
@@ -3002,6 +3075,28 @@ def _validate_args(args: Any) -> None:
             "--ft-nvrx-logfile cannot be used when NVRX_NODE_LOCAL_TMPDIR is set."
         )
 
+
+def _resolve_attribution_endpoint(args: Any, fault_tol_cfg: FaultToleranceConfig) -> Optional[str]:
+    endpoint = getattr(args, "ft_attribution_endpoint", None)
+    if endpoint is None:
+        endpoint = fault_tol_cfg.attribution_endpoint
+    if endpoint is not None:
+        endpoint = str(endpoint).strip() or None
+    return endpoint
+
+
+def _validate_attribution_requires_per_cycle_applog(
+    args: Any, fault_tol_cfg: FaultToleranceConfig
+) -> None:
+    if _resolve_attribution_endpoint(args, fault_tol_cfg) and not getattr(
+        args, "ft_per_cycle_applog_prefix", None
+    ):
+        raise ValueError(
+            "--ft-attribution-endpoint requires --ft-per-cycle-applog-prefix to be specified. "
+            "Attribution service needs per-cycle application logs as analysis input."
+        )
+
+
 def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -> Tuple[LaunchConfig, Union[Callable, str], List[str]]:
     # If ``args`` not passed, defaults to ``sys.argv[:1]``
     _validate_args(args)
@@ -3070,6 +3165,7 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
 
 
     fault_tol_cfg = FaultToleranceConfig.from_args(args)
+    _validate_attribution_requires_per_cycle_applog(args, fault_tol_cfg)
 
     # Pass segment-related configs to rendezvous config
     rdzv_configs['segment'] = fault_tol_cfg.segment
@@ -3081,11 +3177,6 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
     # Pass enable_nic_healthcheck and link_state_path_template from fault tolerance config to rendezvous config
     rdzv_configs['enable_nic_healthcheck'] = fault_tol_cfg.enable_nic_healthcheck
     rdzv_configs['link_state_path_template'] = fault_tol_cfg.link_state_path_template
-    # Pass attribution service configuration if provided
-    if getattr(fault_tol_cfg, 'attrsvc_host', None):
-        rdzv_configs['attrsvc_host'] = fault_tol_cfg.attrsvc_host
-    if getattr(fault_tol_cfg, 'attrsvc_port', None) is not None:
-        rdzv_configs['attrsvc_port'] = int(fault_tol_cfg.attrsvc_port)
     # Pass distributed storage health check configuration
     cli_dist_storage = getattr(args, 'ft_enable_dist_storage_healthcheck', None)
     if cli_dist_storage is not None:
@@ -3158,13 +3249,36 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
                 "Using PipeBasedLogsSpecs automatically."
             )
 
+        rdzv_endpoint_host = parse_rendezvous_endpoint(rdzv_endpoint, default_port=-1)[0]
+        host, _ = parse_rendezvous_endpoint(rdzv_endpoint, default_port=0)
+        is_tcp_store_host = _matches_machine_hostname(host)
+
         # Configure gRPC if enabled
         grpc_server_address = None
         node_id = None
+        log_funnel_ports = None
 
         if getattr(args, 'ft_enable_log_server', False):
-            rdzv_endpoint_host = parse_rendezvous_endpoint(args.rdzv_endpoint, default_port=-1)[0]
             log_funnel_ports = LogFunnelPorts.from_launcher_args(args)
+
+        attribution_cfg = AttributionConfig.from_args(args, base_log_file, fault_tol_cfg)
+        if log_funnel_ports is not None and attribution_cfg.is_managed:
+            _validate_managed_attribution_listen_port_not_in_log_funnel(
+                DEFAULT_ATTRIBUTION_PORT, log_funnel_ports
+            )
+
+        attribution_manager = AttributionManager(
+            attribution_cfg,
+            is_store_host=is_tcp_store_host,
+        )
+        global _ATTRIBUTION_MANAGER
+        _ATTRIBUTION_MANAGER = attribution_manager
+        attribution_endpoint = attribution_manager.start_if_needed()
+        if attribution_endpoint is not None:
+            rdzv_configs['attribution_endpoint'] = attribution_endpoint.endpoint
+
+        if getattr(args, 'ft_enable_log_server', False):
+            assert log_funnel_ports is not None
             grpc_port = log_funnel_ports.client_connect_port()
 
             # Node ID: hostname + PID for uniqueness in simulated multi-launcher environments
@@ -3175,9 +3289,6 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
             # CRITICAL: Start gRPC server BEFORE creating PipeBasedLogsSpecs
             # If we're the TCP store host and server fails to start, we need to know
             # NOW before we configure logging to use gRPC (chicken-and-egg problem)
-            host, _ = parse_rendezvous_endpoint(args.rdzv_endpoint, default_port=0)
-            is_tcp_store_host = _matches_machine_hostname(host)
-
             if is_tcp_store_host:
                 grpc_server_address = f"localhost:{grpc_port}"
 
@@ -3373,6 +3484,26 @@ class LogFunnelPorts:
             return self.base_port
         shard = get_log_aggregator_shard_index(self.first_level_count)
         return self.leaf_listen_port(shard)
+
+    def listen_ports(self) -> Set[int]:
+        """All TCP ports bound by the log funnel on the TCPStore host."""
+        if not self.uses_two_level:
+            return {self.base_port}
+        return set(range(self.base_port, self.base_port + self.first_level_count + 1))
+
+
+def _validate_managed_attribution_listen_port_not_in_log_funnel(
+    managed_port: int, funnel_ports: LogFunnelPorts
+) -> None:
+    log_ports = funnel_ports.listen_ports()
+    if managed_port in log_ports:
+        sorted_ports = sorted(log_ports)
+        raise ValueError(
+            "launcher-managed attribution service port overlaps the gRPC log funnel port range: "
+            f"managed_attrsvc_listen_port={managed_port}, log_funnel_ports={sorted_ports}. "
+            "Use --ft-attribution-endpoint with an external service or use "
+            "--ft-log-server-port to choose a non-overlapping log funnel port."
+        )
 
 
 # Listen on all interfaces so peer training nodes can reach the log funnel on the TCP store host.
@@ -3648,7 +3779,7 @@ def main(args=None):
     finally:
         # Clean up gRPC server AFTER all logging is done
         # (logging cleanup already happened in run()'s finally block)
-        global _GRPC_SERVER_PROCESSES
+        global _GRPC_SERVER_PROCESSES, _ATTRIBUTION_MANAGER
         if _GRPC_SERVER_PROCESSES:
             grpc_graceful_shutdown_timeout = float(
                 getattr(args, 'ft_log_server_graceful_shutdown_timeout', 60.0)
@@ -3699,6 +3830,10 @@ def main(args=None):
                 rc = getattr(p, "returncode", None)
                 logger.info(f"gRPC log subprocess PID={p.pid} finished with returncode={rc}")
             _GRPC_SERVER_PROCESSES.clear()
+
+        if _ATTRIBUTION_MANAGER is not None:
+            _ATTRIBUTION_MANAGER.stop()
+            _ATTRIBUTION_MANAGER = None
 
     sys.exit(exit_code)
 

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -1361,11 +1361,10 @@ class AttributionService:
 
     def __init__(
         self,
-        host: str,
-        port: int,
+        endpoint: str,
     ):
-        self.host = host
-        self.port = port
+        self.endpoint = endpoint.rstrip("/")
+        self._unsupported_transport_warned = False
         # Track the most recent log_path we submitted
         self._last_submitted: Optional[str] = None
 
@@ -1398,9 +1397,12 @@ class AttributionService:
 
     def _do_submit_log(self, log_path: str) -> None:
         """Perform the actual POST request (runs in background thread)."""
+        base_url = self._http_base_url()
+        if base_url is None:
+            return
         try:
             with httpx.Client(timeout=10.0) as client:
-                url = f"http://{self.host}:{self.port}/logs"
+                url = f"{base_url}/logs"
                 logger.debug("AttributionService POST: %s (log_path=%s)", url, log_path)
                 client.post(
                     url,
@@ -1416,10 +1418,13 @@ class AttributionService:
         """
         Get analysis results for a previously submitted log file via GET.
         """
+        base_url = self._http_base_url()
+        if base_url is None:
+            return
         try:
             with httpx.Client(timeout=60.0) as client:
                 q_path = quote_plus(log_path)
-                url = f"http://{self.host}:{self.port}/logs?log_path={q_path}"
+                url = f"{base_url}/logs?log_path={q_path}"
                 logger.debug("AttributionService GET: %s (log_path=%s)", url, log_path)
                 resp = client.get(url, headers={"accept": "application/json"})
                 if resp.status_code == 200:
@@ -1441,3 +1446,15 @@ class AttributionService:
             logger.warning(
                 "AttributionService GET %s failed: %s: %s", log_path, type(e).__name__, e
             )
+
+    def _http_base_url(self) -> Optional[str]:
+        if self.endpoint.startswith(("http://", "https://")):
+            return self.endpoint
+        if not self._unsupported_transport_warned:
+            logger.warning(
+                "AttributionService endpoint uses a non-HTTP transport that is not "
+                "implemented by the in-job client: %s",
+                self.endpoint,
+            )
+            self._unsupported_transport_warned = True
+        return None

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
+    DEFAULT_ATTRIBUTION_PORT,
+    AttributionConfig,
+    AttributionManager,
+    _repo_services_dir,
+)
+from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
+
+
+def _args(**overrides):
+    defaults = {
+        "ft_attribution_endpoint": None,
+        "ft_attribution_startup_timeout": 20.0,
+        "ft_attribution_llm_api_key_file": None,
+        "ft_attribution_llm_base_url": None,
+        "ft_attribution_llm_model": None,
+        "ft_attribution_analysis_backend": None,
+        "ft_attribution_compute_timeout": None,
+        "ft_attribution_log_level": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class _FakeProcess:
+    def __init__(self, returncode=None):
+        self.returncode = returncode
+        self.pid = 123
+
+    def poll(self):
+        return self.returncode
+
+
+class _FakeResponse:
+    def __init__(self, status):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _managed_cfg(tmp_path, *, startup_timeout=1.0):
+    return AttributionConfig.from_args(
+        _args(
+            ft_attribution_endpoint="localhost",
+            ft_attribution_startup_timeout=startup_timeout,
+        ),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(),
+    )
+
+
+def test_attribution_default_is_disabled_and_does_not_start(tmp_path, monkeypatch):
+    base_log = tmp_path / "logs" / "train.log"
+    cfg = AttributionConfig.from_args(_args(), str(base_log), FaultToleranceConfig())
+
+    assert cfg.endpoint is None
+    assert cfg.applog_dir is None
+    assert cfg.log_file is None
+    assert not cfg.is_enabled
+    assert not cfg.is_managed
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError("Popen should not be called when attribution service is disabled")
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.subprocess.Popen",
+        fail_popen,
+    )
+
+    endpoint = AttributionManager(cfg, is_store_host=True).start_if_needed()
+
+    assert endpoint is None
+
+
+def test_managed_attribution_config_derives_applog_dir_and_log_file(tmp_path):
+    base_log = tmp_path / "logs" / "train.log"
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"), str(base_log), FaultToleranceConfig()
+    )
+
+    assert cfg.endpoint == "localhost"
+    assert cfg.client_endpoint.endpoint == f"http://localhost:{DEFAULT_ATTRIBUTION_PORT}"
+    assert cfg.applog_dir == str(tmp_path / "logs")
+    assert cfg.log_file == str(tmp_path / "logs" / "train_attribution.log")
+    assert cfg.is_enabled
+    assert cfg.is_managed
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ["0.0.0.0", "::", "[::]", "http://0.0.0.0:50050", "grpc://[::]:50050"],
+)
+def test_attribution_endpoint_rejects_bind_all_addresses(tmp_path, endpoint):
+    with pytest.raises(ValueError, match="bind-all address"):
+        AttributionConfig.from_args(
+            _args(ft_attribution_endpoint=endpoint),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(),
+        )
+
+
+def test_attribution_endpoint_localhost_is_managed(tmp_path):
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(),
+    )
+
+    assert cfg.endpoint == "localhost"
+    assert cfg.is_managed
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://attribution.external:50123",
+        "grpc://attribution.external:50123",
+        "unix:///tmp/a.sock",
+    ],
+)
+def test_attribution_endpoint_external_strings_are_not_managed(tmp_path, endpoint):
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint=endpoint),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(),
+    )
+
+    assert cfg.endpoint == endpoint
+    assert cfg.client_endpoint.endpoint == endpoint
+    assert cfg.is_enabled
+    assert not cfg.is_managed
+
+
+def test_attribution_config_maps_launcher_args(tmp_path):
+    api_key_file = tmp_path / "key"
+    api_key_file.write_text("secret")
+    applog_dir = tmp_path / "allowed"
+    applog_dir.mkdir()
+    base_log = applog_dir / "train.log"
+
+    cfg = AttributionConfig.from_args(
+        _args(
+            ft_attribution_endpoint="localhost",
+            ft_attribution_llm_api_key_file=str(api_key_file),
+            ft_attribution_llm_base_url="https://llm.example/v1",
+            ft_attribution_llm_model="model-a",
+            ft_attribution_analysis_backend="lib",
+            ft_attribution_compute_timeout=12.5,
+            ft_attribution_log_level="DEBUG",
+        ),
+        str(base_log),
+        FaultToleranceConfig(),
+    )
+
+    env = AttributionManager(cfg, is_store_host=True)._child_env(str(api_key_file))
+    assert env["LLM_API_KEY_FILE"] == str(api_key_file)
+    assert env["NVRX_ATTRSVC_ALLOWED_ROOT"] == str(applog_dir)
+    assert env["NVRX_ATTRSVC_PORT"] == str(DEFAULT_ATTRIBUTION_PORT)
+    assert env["NVRX_ATTRSVC_LLM_BASE_URL"] == "https://llm.example/v1"
+    assert env["NVRX_ATTRSVC_LLM_MODEL"] == "model-a"
+    assert env["NVRX_ATTRSVC_ANALYSIS_BACKEND"] == "lib"
+    assert env["NVRX_ATTRSVC_COMPUTE_TIMEOUT"] == "12.5"
+    assert env["NVRX_ATTRSVC_LOG_LEVEL"] == "DEBUG"
+
+
+def test_child_env_prepends_repo_services_to_pythonpath(tmp_path, monkeypatch):
+    api_key_file = tmp_path / "key"
+    api_key_file.write_text("secret")
+    base_log = tmp_path / "train.log"
+    monkeypatch.setenv("PYTHONPATH", "/existing")
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"),
+        str(base_log),
+        FaultToleranceConfig(),
+    )
+
+    env = AttributionManager(cfg, is_store_host=True)._child_env(str(api_key_file))
+
+    pythonpath = env["PYTHONPATH"].split(os.pathsep)
+    services_dir = _repo_services_dir()
+    if services_dir is not None:
+        assert pythonpath[0] == str(services_dir)
+        assert os.path.isfile(os.path.join(pythonpath[0], "nvrx_attrsvc", "app.py"))
+        assert pythonpath[1] == "/existing"
+    else:
+        assert pythonpath == ["/existing"]
+
+
+def test_managed_attribution_requires_api_key_file_before_popen(tmp_path, monkeypatch):
+    base_log = tmp_path / "train.log"
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"), str(base_log), FaultToleranceConfig()
+    )
+    manager = AttributionManager(cfg, is_store_host=True)
+    monkeypatch.delenv("LLM_API_KEY_FILE", raising=False)
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError("Popen should not be called without an API key file")
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.subprocess.Popen",
+        fail_popen,
+    )
+
+    with pytest.raises(ValueError, match="LLM_API_KEY_FILE"):
+        manager.start_if_needed()
+
+
+def test_external_attribution_does_not_require_key_or_start_process(tmp_path, monkeypatch):
+    base_log = tmp_path / "train.log"
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="http://attribution.external:50123"),
+        str(base_log),
+        FaultToleranceConfig(),
+    )
+    manager = AttributionManager(cfg, is_store_host=True)
+    monkeypatch.delenv("LLM_API_KEY_FILE", raising=False)
+
+    def fail_popen(*args, **kwargs):
+        raise AssertionError("Popen should not be called for external attribution")
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.subprocess.Popen",
+        fail_popen,
+    )
+
+    endpoint = manager.start_if_needed()
+
+    assert endpoint is not None
+    assert endpoint.endpoint == "http://attribution.external:50123"
+
+
+def test_wait_until_ready_accepts_2xx_health_response(tmp_path, monkeypatch):
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=True)
+    manager.process = _FakeProcess()
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeResponse(200),
+    )
+
+    manager._wait_until_ready()
+
+
+def test_wait_until_ready_rejects_4xx_health_response(tmp_path, monkeypatch):
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=True)
+    manager.process = _FakeProcess()
+    monotonic_values = iter([0.0, 0.0, 2.0])
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeResponse(404),
+    )
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.time.sleep",
+        lambda _seconds: None,
+    )
+
+    with pytest.raises(TimeoutError, match="HTTP status 404"):
+        manager._wait_until_ready()
+
+
+def test_wait_until_ready_raises_when_process_exits_early(tmp_path):
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=True)
+    manager.process = _FakeProcess(returncode=1)
+
+    with pytest.raises(RuntimeError, match="returncode=1"):
+        manager._wait_until_ready()

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -28,6 +28,7 @@ These tests focus on:
 
 import multiprocessing
 import os
+import queue
 import signal
 import socket
 import threading
@@ -124,10 +125,10 @@ def _run_rendezvous_processes(
     join_timeout_seconds=15.0,
     process_timeout=PROCESS_JOIN_TIMEOUT_SECS,
 ):
-    """Run min_nodes participants in separate (fork) processes; return (store, results, errors).
+    """Run min_nodes participants in separate processes; return (store, results, errors).
 
     Main process holds the master TCPStore so callers can inspect keys after (e.g. for
-    test_barrier_keys_cleared_after_acknowledgment). Uses fork for faster process start.
+    test_barrier_keys_cleared_after_acknowledgment).
     """
     from .utils import find_free_port
 
@@ -139,9 +140,12 @@ def _run_rendezvous_processes(
         is_master=True,
         wait_for_workers=False,
     )
-    result_queue = multiprocessing.Queue()
-    ctx = multiprocessing.get_context("fork")
+    # Avoid forking after the master TCPStore is created. TCPStore owns native
+    # background state, and inheriting it into children can leave CI workers hung.
+    ctx = multiprocessing.get_context("spawn")
+    result_queue = ctx.Queue()
     procs = []
+    proc_participant_ids = {}
     for i in range(min_nodes):
         p = ctx.Process(
             target=_run_participant_process,
@@ -160,14 +164,69 @@ def _run_rendezvous_processes(
         )
         p.start()
         procs.append(p)
-    for p in procs:
-        p.join(timeout=process_timeout)
+        proc_participant_ids[p.pid] = i
     results = []
     errors = []
-    for _ in range(min_nodes):
+
+    def drain_results():
+        while len(results) + len(errors) < min_nodes:
+            try:
+                item = result_queue.get_nowait()
+            except queue.Empty:
+                break
+            participant_id, rank, total, exc = item
+            if exc is None:
+                results.append((participant_id, rank, total))
+            else:
+                errors.append((participant_id, exc))
+
+    deadline = time.monotonic() + process_timeout
+    while time.monotonic() < deadline:
+        drain_results()
+        alive = [p for p in procs if p.is_alive()]
+        if not alive:
+            break
+        for p in alive:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            p.join(timeout=min(0.1, remaining))
+
+    drain_results()
+    for p in procs:
+        if p.is_alive():
+            participant_id = proc_participant_ids.get(p.pid, "unknown")
+            p.terminate()
+            p.join(timeout=5)
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=5)
+            errors.append(
+                (
+                    participant_id,
+                    TimeoutError(
+                        f"participant process {p.pid} did not exit within " f"{process_timeout}s"
+                    ),
+                )
+            )
+        elif p.exitcode not in (0, None):
+            participant_id = proc_participant_ids.get(p.pid, "unknown")
+            reported = {item[0] for item in results} | {item[0] for item in errors}
+            if participant_id not in reported:
+                errors.append(
+                    (
+                        participant_id,
+                        RuntimeError(
+                            f"participant process {p.pid} exited with code "
+                            f"{p.exitcode} without reporting a result"
+                        ),
+                    )
+                )
+
+    while len(results) + len(errors) < min_nodes:
         try:
             item = result_queue.get(timeout=1)
-        except Exception:
+        except queue.Empty:
             break
         participant_id, rank, total, exc = item
         if exc is None:
@@ -611,7 +670,7 @@ class Step2CompletionTest(BaseRendezvousTest):
     def test_step2_completion_on_max_nodes(self):
         """Test that Step 2 completes immediately when max_nodes is reached.
 
-        Runs participants in separate processes (fork) to avoid shared-store contention.
+        Runs participants in separate processes to avoid shared-store contention.
         """
         min_nodes = 2
         max_nodes = 3
@@ -635,7 +694,7 @@ class Step2CompletionTest(BaseRendezvousTest):
     def test_step2_completion_on_min_nodes_with_segment_check(self):
         """Test that Step 2 completes when min_nodes is reached and segment constraint is satisfied.
 
-        Runs participants in separate processes (fork) to avoid shared-store contention.
+        Runs participants in separate processes to avoid shared-store contention.
         """
         min_nodes = 2
         max_nodes = 4
@@ -661,7 +720,7 @@ class Step2CompletionTest(BaseRendezvousTest):
     def test_step2_late_arrival_sees_completion_key(self):
         """Test that rendezvous completes correctly when all participants arrive quickly.
 
-        Runs participants in separate processes (fork) to avoid shared-store contention.
+        Runs participants in separate processes to avoid shared-store contention.
         Each must see the completion key and get a rank.
         """
         min_nodes = 3
@@ -937,7 +996,7 @@ class StoreHostBehaviorTest(BaseRendezvousTest):
     def test_rank_assignment_with_arrival_order(self):
         """Test that store host assigns ranks to all participants.
 
-        Runs participants in separate processes (fork) to avoid shared-store contention.
+        Runs participants in separate processes to avoid shared-store contention.
         """
         min_nodes = 3
         max_nodes = 3
@@ -965,7 +1024,7 @@ class StoreHostBehaviorTest(BaseRendezvousTest):
     def test_non_store_host_waits_for_ranks(self):
         """Test that non-store host participants wait for rank assignment.
 
-        Runs participants in separate processes (fork) so each has its own store
+        Runs participants in separate processes so each has its own store
         connection; avoids shared-store contention that can hang with threads.
         """
         min_nodes = 2
@@ -1969,7 +2028,7 @@ class AcknowledgmentPhaseTest(BaseRendezvousTest):
     def test_all_participants_acknowledge(self):
         """Test that all participants acknowledge completion.
 
-        Runs participants in separate processes (fork) so each has its own store
+        Runs participants in separate processes so each has its own store
         connection; avoids shared-store contention that can hang with threads.
         """
         min_nodes = 3
@@ -2004,7 +2063,7 @@ class AcknowledgmentPhaseTest(BaseRendezvousTest):
         join_count_{N+1} does not exist during training, so num_nodes_waiting() returns 0.
         Round N keys persist with correct values — the per-round naming makes them harmless.
 
-        Runs participants in separate processes (fork) so each has its own store
+        Runs participants in separate processes so each has its own store
         connection; avoids shared-store contention that can hang with threads.
         """
         min_nodes = 2

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -727,6 +727,92 @@ def test_ft_log_aggregator_count_rejects_negative():
         _validate_args(args)
 
 
+def test_cli_attribution_endpoint_requires_per_cycle_applog():
+    from nvidia_resiliency_ext.fault_tolerance.launcher import (
+        _validate_attribution_requires_per_cycle_applog,
+        get_args_parser,
+    )
+
+    parser = get_args_parser()
+    args = parser.parse_args(['--ft-attribution-endpoint', 'localhost', 'train.py'])
+
+    with pytest.raises(ValueError, match='--ft-attribution-endpoint requires'):
+        _validate_attribution_requires_per_cycle_applog(args, FaultToleranceConfig())
+
+
+def test_yaml_attribution_endpoint_requires_per_cycle_applog():
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance.launcher import (
+        _validate_attribution_requires_per_cycle_applog,
+    )
+
+    args = SimpleNamespace(ft_attribution_endpoint=None, ft_per_cycle_applog_prefix=None)
+    cfg = FaultToleranceConfig(attribution_endpoint='localhost')
+
+    with pytest.raises(ValueError, match='--ft-attribution-endpoint requires'):
+        _validate_attribution_requires_per_cycle_applog(args, cfg)
+
+
+def test_per_cycle_applog_without_attribution_is_valid():
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance.launcher import (
+        _validate_attribution_requires_per_cycle_applog,
+    )
+
+    args = SimpleNamespace(
+        ft_attribution_endpoint=None,
+        ft_per_cycle_applog_prefix='/tmp/train.log',
+    )
+
+    _validate_attribution_requires_per_cycle_applog(args, FaultToleranceConfig())
+
+
+def test_attribution_endpoint_with_per_cycle_applog_is_valid():
+    from nvidia_resiliency_ext.fault_tolerance.launcher import (
+        _validate_attribution_requires_per_cycle_applog,
+        get_args_parser,
+    )
+
+    parser = get_args_parser()
+    args = parser.parse_args(
+        [
+            '--ft-per-cycle-applog-prefix',
+            '/tmp/train.log',
+            '--ft-attribution-endpoint',
+            'localhost',
+            'train.py',
+        ]
+    )
+
+    _validate_attribution_requires_per_cycle_applog(args, FaultToleranceConfig())
+
+
+@pytest.mark.parametrize(
+    "removed_option",
+    [
+        "--ft-attribution-applog-dir",
+        "--ft_attribution_applog_dir",
+        "--ft-attribution-log",
+        "--ft_attribution_log",
+        "--ft-attribution-cache-file",
+        "--ft_attribution_cache_file",
+        "--ft-attribution-host",
+        "--ft_attribution_host",
+        "--ft-attribution-port",
+        "--ft_attribution_port",
+    ],
+)
+def test_removed_attribution_options_are_rejected(removed_option):
+    from nvidia_resiliency_ext.fault_tolerance.launcher import get_args_parser
+
+    parser = get_args_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([removed_option, "DEBUG", "train.py"])
+
+
 def test_log_funnel_ports_from_launcher_args_auto():
     from types import SimpleNamespace
 
@@ -759,3 +845,17 @@ def test_log_funnel_ports_from_launcher_args_rejects_negative():
         LogFunnelPorts.from_launcher_args(
             SimpleNamespace(ft_log_server_port=50051, ft_log_aggregator_count=-1, nnodes="100")
         )
+
+
+def test_managed_attribution_listen_port_rejects_log_funnel_overlap():
+    from nvidia_resiliency_ext.fault_tolerance.launcher import (
+        LogFunnelPorts,
+        _validate_managed_attribution_listen_port_not_in_log_funnel,
+    )
+
+    funnel_ports = LogFunnelPorts(base_port=50051, first_level_count=3)
+
+    with pytest.raises(ValueError, match="overlaps"):
+        _validate_managed_attribution_listen_port_not_in_log_funnel(50053, funnel_ports)
+
+    _validate_managed_attribution_listen_port_not_in_log_funnel(50050, funnel_ports)

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -20,6 +20,7 @@ import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
 from nvidia_resiliency_ext.shared_utils.health_check import (
+    AttributionService,
     NicHealthCheck,
     NVLHealthCheck,
     PciMixin,
@@ -547,6 +548,30 @@ class TestNVLHealthCheck(unittest.TestCase):
                 result = checker._perform_health_check()
                 self.assertTrue(result)
                 mock_check.assert_called_once_with(0)
+
+
+class TestAttributionService(unittest.TestCase):
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_http_endpoint_posts_to_logs_route(self, mock_client):
+        client = mock_client.return_value.__enter__.return_value
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        service._do_submit_log("/tmp/train.log")
+
+        client.post.assert_called_once_with(
+            "http://attr.example:8000/logs",
+            json={"log_path": "/tmp/train.log"},
+            headers={"accept": "application/json"},
+        )
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_non_http_endpoint_does_not_create_http_client(self, mock_client):
+        service = AttributionService(endpoint="grpc://attr.example:50050")
+
+        service._do_submit_log("/tmp/train.log")
+
+        mock_client.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support ft_launcher to manage the attribution process life cycle.

Default the attribution service launcher path to disabled unless --ft-attrsvc-host is set, and require per-cycle application logs when the service is enabled. Add managed attrsvc lifecycle handling, startup validation, port-overlap checks, cleanup, and focused unit coverage.

Package nvrx_attrsvc and nvrx_smonsvc in the main NVRx wheel while keeping their service dependencies behind the existing attribution extra. Plain wheel installs remain dependency-clean; users opt into the service stack with nvidia_resiliency_ext-*.whl[attribution]. Add service entrypoint wrappers that report a clear install hint when optional dependencies are missing.