### PR TITLE
Expose attrsvc restart recommendations

### DIFF
--- a/services/attrsvc/ATTRSVC_SPEC.md
+++ b/services/attrsvc/ATTRSVC_SPEC.md
@@ -223,6 +223,10 @@ Response: `{ "mode": "pending" | "single" | "splitlog" }`.
 Returns single-file or splitlog-shaped JSON; optional `file` selects a file in
 splitlog mode; `wl_restart` selects a chunk; `all_files` returns completed files.
 Exact fields match library serializers — see **`types.py`** and OpenAPI **`/docs`**.
+Responses include a normalized `recommendation` object:
+`{ "action": "STOP" | "RESTART" | "CONTINUE" | "UNKNOWN" | "TIMEOUT", "reason": str,
+"source": str }`. Clients should branch on `recommendation.action`; raw backend
+output remains under `result` for debugging and backward compatibility.
 
 **6.1 GET /logs — processing flow (implementation)**
 

--- a/services/attrsvc/README.md
+++ b/services/attrsvc/README.md
@@ -171,30 +171,44 @@ All success responses use HTTP 200. Interpret outcome from the response body onl
 |-------|------|-------------|
 | `result` | object | **Inner result** from the analysis pipeline (see below). |
 | `status` | string | Always `"completed"` (request completed). |
+| `recommendation` | object | Normalized client contract for restart/stop decisions. |
 | `wl_restart` | int | Which workload cycle this result is for (0 when returning all). |
 | `wl_restart_count` | int \| null | Total workload cycles in the file (single-file; null if N/A). |
 | `mode` | string | Only for splitlog: `"splitlog"`. |
 | `sched_restarts` | int | Only for splitlog. |
 | `log_file` | string | Only for splitlog: path to the analyzed log file. |
 
-**Inner `result` object** — client should branch on `result.state`:
+**`recommendation` object** — clients should branch on this field:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `action` | string | One of `"STOP"` \| `"RESTART"` \| `"CONTINUE"` \| `"UNKNOWN"` \| `"TIMEOUT"`. |
+| `reason` | string | Human-readable summary or backend reason. |
+| `source` | string | Backend/module that produced the recommendation, e.g. `"log_analyzer"`. |
+
+`"STOP"` means the client should not restart immediately. `"RESTART"` means
+the client may restart a failed run. `"CONTINUE"` means no stop/restart
+intervention is recommended. `"UNKNOWN"` and `"TIMEOUT"` are not actionable stop
+signals.
+
+**Inner `result` object** — raw backend result, retained for debugging:
 
 | Field | Type | When | Description |
 |-------|------|------|-------------|
 | `module` | string | Always | e.g. `"log_analyzer"`. |
-| `state` | string | Always | **Drives client decision: continue or stop.** One of `"timeout"` \| `"CONTINUE"` \| `"STOP"`. See below. |
+| `state` | string | Always | Raw backend state, e.g. `"timeout"` \| `"CONTINUE"` \| `"STOP"`. |
 | `result` | array | Always | Attribution items (one per cycle). Empty when `state === "timeout"`. |
 | `error` | string | When `state === "timeout"` | Human-readable timeout message. |
 
 Other fields (e.g. `result_id`, `resource_uri`) may be present.
 
-**`result.state` — how the client should use it:**
+**Raw `result.state`:**
 
 1. **`"timeout"`** — Analysis did not complete. Use `result.error` for the message; do not treat as a successful attribution. Do not use `result.state` for a continue/stop decision.
-2. **`"CONTINUE"`** — Analysis succeeded; attribution suggests it is safe to continue (e.g. resume/restart the job).
+2. **`"CONTINUE"`** — Backend state for non-stop output. Use `recommendation.action`, which may be `"RESTART"` or `"CONTINUE"` depending on the raw backend text.
 3. **`"STOP"`** — Analysis succeeded; attribution suggests **do not** continue (e.g. do not restart immediately; user intervention or different action required).
 
-The client should branch on `result.state` to decide whether to continue or stop the workflow, and to choose between `result.error` (timeout) and `result.result` (attribution text).
+Clients should use `recommendation.action` for restart/stop decisions.
 
 **Type note:** `state` is a string in JSON for compatibility. The set of values is fixed; clients may treat it as an enum (e.g. in OpenAPI schema or client code: `"timeout" | "CONTINUE" | "STOP"`).
 

--- a/services/smonsvc/README.md
+++ b/services/smonsvc/README.md
@@ -89,8 +89,8 @@ When `PORT` is set, the monitor exposes an HTTP server:
 
 - **SlurmJobMonitor**: Main loop; every `INTERVAL` seconds polls SLURM, updates in-memory job state, submits new logs to attrsvc via **AttrsvcClient**, and fetches results for completed submissions.
 - **SlurmClient**: Runs `squeue` (running/completing jobs), `scontrol` (output paths), `sacct` (batch path lookup); handles array and het job IDs.
-- **AttrsvcClient**: HTTP client with retries and rate limiting; POST `/logs` to submit, GET `/logs/result` to fetch attribution results, GET `/stats` for status.
-- **job_handlers**: Layer that interacts with nvrx-attrsvc: `submit_log()` and `fetch_results()` use **AttrsvcClient** (POST/GET), then update **MonitorState** and per-job flags from responses.
+- **AttrsvcClient**: HTTP client with retries and rate limiting; POST `/logs` to submit, GET `/logs` to fetch attribution results, GET `/stats` for status.
+- **job_handlers**: Layer that interacts with nvrx-attrsvc: `submit_log()` and `fetch_results()` use **AttrsvcClient** (POST/GET), then update **MonitorState** and summarize `recommendation` from responses.
 - **StatusServer**: Optional HTTP server (when `PORT` is set) serving `/healthz`, `/stats`, `/jobs` from **MonitorState**; can optionally proxy attrsvc `/stats`.
 
 ### SLURM Job ID Handling

--- a/services/tests/test_smonsvc_attrsvc_client.py
+++ b/services/tests/test_smonsvc_attrsvc_client.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import stat
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -138,5 +139,153 @@ def test_request_with_retry_uses_relative_logs_route(mock_httpx):
         on_client_error=MagicMock(),
     )
 
-    client.get.assert_called_once_with("/logs", params={"log_path": "/tmp/job.log"})
+    client.get.assert_called_once_with(
+        "/logs",
+        params={"log_path": "/tmp/job.log"},
+        headers={"accept": "application/json"},
+    )
     on_success.assert_called_once_with(response)
+
+
+@patch("nvidia_resiliency_ext.services.smonsvc.attrsvc_client.httpx")
+def test_not_readable_403_warns_by_default(mock_httpx, caplog):
+    response = MagicMock()
+    response.status_code = 403
+    response.json.return_value = {
+        "error_code": "errorcode.not_readable",
+        "message": "permission denied",
+        "details": None,
+    }
+    client = MagicMock()
+    client.post.return_value = response
+    mock_httpx.Client.return_value = client
+    on_client_error = MagicMock()
+
+    attrsvc = AttrsvcClient("unix:///tmp/nvrx-attrsvc.sock", request_throttle=0)
+    with caplog.at_level(
+        logging.WARNING,
+        logger="nvidia_resiliency_ext.services.smonsvc.attrsvc_client",
+    ):
+        attrsvc.request_with_retry(
+            "POST",
+            job_id="123",
+            log_path="/tmp/job.log",
+            on_success=MagicMock(),
+            on_client_error=on_client_error,
+        )
+
+    assert "[123] POST failed (403)" in caplog.text
+    on_client_error.assert_called_once()
+
+
+@patch("nvidia_resiliency_ext.services.smonsvc.attrsvc_client.httpx")
+def test_not_readable_403_logs_at_debug_when_expected(mock_httpx, caplog):
+    response = MagicMock()
+    response.status_code = 403
+    response.json.return_value = {
+        "error_code": "errorcode.not_readable",
+        "message": "permission denied",
+        "details": None,
+    }
+    client = MagicMock()
+    client.post.return_value = response
+    mock_httpx.Client.return_value = client
+    on_client_error = MagicMock()
+
+    attrsvc = AttrsvcClient(
+        "unix:///tmp/nvrx-attrsvc.sock",
+        request_throttle=0,
+        permission_denied_is_expected=True,
+    )
+    with caplog.at_level(
+        logging.DEBUG,
+        logger="nvidia_resiliency_ext.services.smonsvc.attrsvc_client",
+    ):
+        attrsvc.request_with_retry(
+            "POST",
+            job_id="123",
+            log_path="/tmp/job.log",
+            on_success=MagicMock(),
+            on_client_error=on_client_error,
+        )
+
+    matching_records = [
+        record for record in caplog.records if "[123] POST failed (403)" in record.message
+    ]
+    assert matching_records
+    assert {record.levelno for record in matching_records} == {logging.DEBUG}
+    on_client_error.assert_called_once()
+
+
+@patch("nvidia_resiliency_ext.services.smonsvc.attrsvc_client.httpx")
+def test_non_json_client_error_still_calls_error_callback(mock_httpx, caplog):
+    response = MagicMock()
+    response.status_code = 403
+    response.json.side_effect = ValueError("not json")
+    response.text = "<html>forbidden</html>"
+    client = MagicMock()
+    client.post.return_value = response
+    mock_httpx.Client.return_value = client
+    on_client_error = MagicMock()
+
+    attrsvc = AttrsvcClient(
+        "unix:///tmp/nvrx-attrsvc.sock",
+        request_throttle=0,
+        permission_denied_is_expected=True,
+    )
+    with caplog.at_level(
+        logging.WARNING,
+        logger="nvidia_resiliency_ext.services.smonsvc.attrsvc_client",
+    ):
+        attrsvc.request_with_retry(
+            "POST",
+            job_id="123",
+            log_path="/tmp/job.log",
+            on_success=MagicMock(),
+            on_client_error=on_client_error,
+        )
+
+    assert "[123] POST failed (403): <html>forbidden</html>" in caplog.text
+    on_client_error.assert_called_once_with("<html>forbidden</html>")
+
+
+@patch("nvidia_resiliency_ext.services.smonsvc.attrsvc_client.httpx")
+def test_expected_client_errors_are_sampled(mock_httpx, caplog):
+    response = MagicMock()
+    response.status_code = 403
+    response.json.return_value = {
+        "error_code": "errorcode.not_readable",
+        "message": "permission denied",
+        "details": None,
+    }
+    client = MagicMock()
+    client.post.return_value = response
+    mock_httpx.Client.return_value = client
+    on_client_error = MagicMock()
+
+    attrsvc = AttrsvcClient(
+        "unix:///tmp/nvrx-attrsvc.sock",
+        request_throttle=0,
+        permission_denied_is_expected=True,
+    )
+    with caplog.at_level(
+        logging.DEBUG,
+        logger="nvidia_resiliency_ext.services.smonsvc.attrsvc_client",
+    ):
+        for idx in range(6):
+            attrsvc.request_with_retry(
+                "POST",
+                job_id=str(123 + idx),
+                log_path="/tmp/job.log",
+                on_success=MagicMock(),
+                on_client_error=on_client_error,
+            )
+
+    matching_records = [
+        record
+        for record in caplog.records
+        if "POST failed (403)" in record.message
+        and "expected client error count=" in record.message
+    ]
+    assert len(matching_records) == 5
+    assert on_client_error.call_count == 6

--- a/services/tests/test_smonsvc_job_handlers.py
+++ b/services/tests/test_smonsvc_job_handlers.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from nvidia_resiliency_ext.services.smonsvc.job_handlers import log_attribution_result
+
+
+def _job():
+    return SimpleNamespace(job_id="123")
+
+
+def test_log_attribution_result_uses_recommendation_over_raw_state(capsys):
+    response = {
+        "recommendation": {
+            "action": "RESTART",
+            "reason": "safe to restart failed run",
+            "source": "log_analyzer",
+        },
+        "result": {
+            "module": "log_analyzer",
+            "state": "STOP",
+            "result_id": "abcdef0123456789",
+            "result": ["raw backend text"],
+        },
+    }
+
+    log_attribution_result(_job(), "/tmp/job.log", response)
+
+    output = capsys.readouterr().out
+    assert "Recommendation: RESTART" in output
+    assert "Reason: safe to restart failed run" in output
+    assert "State:" not in output
+
+
+def test_log_attribution_result_uses_recommendation_for_timeout(capsys):
+    response = {
+        "recommendation": {
+            "action": "TIMEOUT",
+            "reason": "LLM analysis timed out",
+            "source": "log_analyzer",
+        },
+        "result": {
+            "module": "log_analyzer",
+            "state": "CONTINUE",
+            "result": [],
+        },
+    }
+
+    log_attribution_result(_job(), "/tmp/job.log", response)
+
+    output = capsys.readouterr().out
+    assert "Attribution timeout" in output
+    assert "Recommendation: TIMEOUT" in output
+    assert "Reason: LLM analysis timed out" in output
+    assert "State:" not in output

--- a/src/nvidia_resiliency_ext/attribution/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/__init__.py
@@ -64,6 +64,11 @@ if TYPE_CHECKING:
         AttributionCredentialsConfig,
         AttributionPostprocessingConfig,
     )
+    from .orchestration.client_response import (
+        AttrSvcResult,
+        parse_attrsvc_response,
+        recommendation_should_stop,
+    )
     from .orchestration.config import (
         MAX_JOBS,
         MIN_FILE_SIZE_KB,
@@ -90,6 +95,7 @@ if TYPE_CHECKING:
     from .orchestration.job import FileInfo, Job, JobMode
     from .orchestration.splitlog import SplitlogTracker
     from .orchestration.types import (
+        AttributionRecommendation,
         LogAnalysisCycleResult,
         LogAnalysisSplitlogResult,
         LogAnalyzerConfig,
@@ -142,10 +148,14 @@ _EXPORTS = {
     "TTL_PENDING_SECONDS": ".orchestration.config",
     "TTL_TERMINATED_SECONDS": ".orchestration.config",
     "ErrorCode": ".orchestration.config",
+    "AttrSvcResult": ".orchestration.client_response",
+    "parse_attrsvc_response": ".orchestration.client_response",
+    "recommendation_should_stop": ".orchestration.client_response",
     "FileInfo": ".orchestration.job",
     "Job": ".orchestration.job",
     "JobMode": ".orchestration.job",
     "SplitlogTracker": ".orchestration.splitlog",
+    "AttributionRecommendation": ".orchestration.types",
     "LogAnalysisCycleResult": ".orchestration.types",
     "LogAnalysisSplitlogResult": ".orchestration.types",
     "LogAnalyzerConfig": ".orchestration.types",
@@ -192,6 +202,10 @@ __all__ = [
     "Analyzer",
     "TraceAnalyzer",
     "LogAnalyzerConfig",
+    "AttributionRecommendation",
+    "AttrSvcResult",
+    "parse_attrsvc_response",
+    "recommendation_should_stop",
     "LogAnalyzerError",
     "LogAnalyzerOutcome",
     "LogAnalysisCycleResult",

--- a/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
+++ b/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
@@ -48,6 +48,7 @@ from nvidia_resiliency_ext.attribution.orchestration.analysis_pipeline import (
 )
 from nvidia_resiliency_ext.attribution.orchestration.config import ErrorCode, LogSageExecutionConfig
 from nvidia_resiliency_ext.attribution.orchestration.job import Job, JobMode
+from nvidia_resiliency_ext.attribution.orchestration.llm_output import attribution_recommendation
 from nvidia_resiliency_ext.attribution.orchestration.log_analyzer import LogAnalyzer
 from nvidia_resiliency_ext.attribution.orchestration.types import (
     LogAnalysisCycleResult,
@@ -357,6 +358,13 @@ class Analyzer:
                     fr_dump_path=fr_dump,
                     fr_analysis=fr_analysis,
                     llm_merged_summary=llm_merged,
+                    recommendation=attribution_recommendation(
+                        {
+                            "state": "no_log",
+                            "result": [],
+                            "module": "fr_only",
+                        }
+                    ),
                 )
             # LLM returns multiple results per file (one per workload cycle); support wl_restart to select one
             results_list = (
@@ -380,6 +388,7 @@ class Analyzer:
                     fr_dump_path=fr_dump,
                     fr_analysis=fr_analysis,
                     llm_merged_summary=llm_merged,
+                    recommendation=attribution_recommendation(single_result),
                 )
             # No wl_restart: return full result (all cycles) with count so client can iterate
             return LogAnalysisCycleResult(
@@ -390,6 +399,7 @@ class Analyzer:
                 fr_dump_path=fr_dump,
                 fr_analysis=fr_analysis,
                 llm_merged_summary=llm_merged,
+                recommendation=attribution_recommendation(log_result),
             )
         except FrDumpPathNotFoundError as e:
             return LogAnalyzerError(
@@ -499,6 +509,7 @@ class Analyzer:
             fr_dump_path=fr_dump,
             fr_analysis=fr_analysis,
             llm_merged_summary=bundle.llm_merged_summary,
+            recommendation=attribution_recommendation(result),
         )
 
     def _sync_analyze_via_coalescer(

--- a/src/nvidia_resiliency_ext/attribution/orchestration/client_response.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/client_response.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Client-side helpers for attrsvc response payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .config import (
+    RESP_LOG_FILE,
+    RESP_MODE,
+    RESP_MODULE,
+    RESP_RESULT,
+    RESP_RESULT_ID,
+    RESP_SCHED_RESTARTS,
+    RESP_STATUS,
+    RESP_WL_RESTART,
+)
+from .llm_output import attribution_recommendation
+from .types import (
+    RECOMMENDATION_CONTINUE,
+    RECOMMENDATION_RESTART,
+    RECOMMENDATION_STOP,
+    RECOMMENDATION_TIMEOUT,
+    RECOMMENDATION_UNKNOWN,
+    AttributionRecommendation,
+)
+
+_VALID_RECOMMENDATION_ACTIONS = {
+    RECOMMENDATION_STOP,
+    RECOMMENDATION_RESTART,
+    RECOMMENDATION_CONTINUE,
+    RECOMMENDATION_UNKNOWN,
+    RECOMMENDATION_TIMEOUT,
+}
+_SPLITLOG_MODE = "splitlog"
+
+
+@dataclass(frozen=True)
+class AttrSvcResult:
+    """Normalized view of an attrsvc ``GET /logs`` response."""
+
+    result: Any
+    status: str = "completed"
+    log_path: str | None = None
+    recommendation: AttributionRecommendation = field(default_factory=AttributionRecommendation)
+    should_stop: bool = False
+    mode: str = "single"
+    analyzed_log_file: str = ""
+    wl_restart: Any = None
+    sched_restarts: Any = None
+
+    @property
+    def recommendation_reason(self) -> str:
+        """Convenience alias for callers that only need the recommendation reason."""
+        return self.recommendation.reason
+
+    @property
+    def module(self) -> str:
+        """Raw backend module for the analyzed result, e.g. ``log_analyzer`` or ``fr_only``."""
+        return _result_string(self.result, RESP_MODULE)
+
+    @property
+    def result_id(self) -> str:
+        return _result_string(self.result, RESP_RESULT_ID)
+
+    def result_id_preview(self, max_chars: int = 16) -> str:
+        if len(self.result_id) > max_chars:
+            return f"{self.result_id[:max_chars]}..."
+        return self.result_id
+
+    def attribution_preview(self, max_chars: int = 200) -> str:
+        attribution_result = (
+            self.result.get(RESP_RESULT, "") if isinstance(self.result, dict) else ""
+        )
+        if isinstance(attribution_result, list):
+            text = " | ".join(str(item) for item in attribution_result)
+        else:
+            text = str(attribution_result) if attribution_result else ""
+        if len(text) > max_chars:
+            return f"{text[:max_chars]}..."
+        return text
+
+    def format_summary(self, *, prefix: str = "", preview_chars: int = 200) -> str:
+        """Return a multi-line summary suitable for smon logs/stdout."""
+        action = self.recommendation.action
+        reason = self.recommendation.reason
+        if action == RECOMMENDATION_TIMEOUT and not reason:
+            reason = "Attribution analysis timed out"
+
+        title = "Attribution timeout" if action == RECOMMENDATION_TIMEOUT else "Attribution result"
+        lines = [f"{prefix}{title}:"]
+        if self.mode == _SPLITLOG_MODE:
+            lines.append(
+                f"  Mode: {_SPLITLOG_MODE} (wl_restart {self.wl_restart}/{self.sched_restarts})"
+            )
+            if self.log_path:
+                lines.append(f"  Slurm output: {self.log_path}")
+            if self.analyzed_log_file:
+                lines.append(f"  Analyzed log: {self.analyzed_log_file}")
+        elif self.log_path:
+            lines.append(f"  Log: {self.log_path}")
+
+        if self.module:
+            lines.append(f"  Module: {self.module}")
+        if self.result_id:
+            lines.append(f"  Result ID: {self.result_id_preview()}")
+        lines.append(f"  Recommendation: {action}")
+        if reason:
+            lines.append(f"  Reason: {reason}")
+        if self.recommendation.source and self.recommendation.source != self.module:
+            lines.append(f"  Recommendation source: {self.recommendation.source}")
+        if action != RECOMMENDATION_TIMEOUT:
+            lines.append(f"  Attribution: {self.attribution_preview(preview_chars)}")
+        return "\n".join(lines)
+
+    def format_log_message(self, *, preview_chars: int = 200) -> str:
+        """Return a compact one-line summary suitable for launcher logs."""
+        path = f" for {self.log_path}" if self.log_path else ""
+        return (
+            f"AttrSvcResult{path}: status={self.status} "
+            f"recommendation={self.recommendation.action} "
+            f"reason={self.recommendation_reason} "
+            f"should_stop={self.should_stop} "
+            f"result preview: {self.attribution_preview(preview_chars)}"
+        )
+
+
+def parse_attrsvc_response(payload: Any, *, log_path: str | None = None) -> AttrSvcResult:
+    """Parse attrsvc response JSON into a stable client contract.
+
+    Callers should use ``recommendation`` and ``should_stop`` instead of peeking at
+    backend-specific fields under ``result``.
+    """
+    body = payload if isinstance(payload, dict) else {}
+    result = body.get(RESP_RESULT, payload)
+    status = _string_value(body.get(RESP_STATUS)) or "completed"
+    recommendation = _standard_recommendation(body.get("recommendation"))
+    if recommendation is None:
+        recommendation = attribution_recommendation(result)
+
+    return AttrSvcResult(
+        result=result,
+        status=status,
+        log_path=log_path,
+        recommendation=recommendation,
+        should_stop=recommendation_should_stop(recommendation),
+        mode=_string_value(body.get(RESP_MODE)) or "single",
+        analyzed_log_file=_string_value(body.get(RESP_LOG_FILE)),
+        wl_restart=body.get(RESP_WL_RESTART),
+        sched_restarts=body.get(RESP_SCHED_RESTARTS),
+    )
+
+
+def recommendation_should_stop(recommendation: AttributionRecommendation) -> bool:
+    """Return whether a normalized recommendation is a stop signal."""
+    return recommendation.action == RECOMMENDATION_STOP
+
+
+def _string_value(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _result_string(result: Any, key: str) -> str:
+    if not isinstance(result, dict):
+        return ""
+    return _string_value(result.get(key))
+
+
+def _standard_recommendation(payload: Any) -> AttributionRecommendation | None:
+    if not isinstance(payload, dict):
+        return None
+
+    action = _string_value(payload.get("action")).strip().upper()
+    if action not in _VALID_RECOMMENDATION_ACTIONS:
+        action = RECOMMENDATION_UNKNOWN
+
+    return AttributionRecommendation(
+        action=action,
+        reason=_string_value(payload.get("reason")),
+        source=_string_value(payload.get("source")),
+    )

--- a/src/nvidia_resiliency_ext/attribution/orchestration/http_api.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/http_api.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared attrsvc HTTP route names and client-side request helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Logs endpoint path
+ROUTE_LOGS = "/logs"
+ROUTE_HEALTHZ = "/healthz"
+
+# POST /logs body and GET /logs query parameter names
+PARAM_LOG_PATH = "log_path"
+PARAM_USER = "user"
+PARAM_JOB_ID = "job_id"
+
+# GET /logs optional query parameters (splitlog mode)
+PARAM_FILE = "file"
+PARAM_WL_RESTART = "wl_restart"
+
+ACCEPT_JSON_HEADERS = {"accept": "application/json"}
+
+
+def log_submit_payload(
+    log_path: str,
+    *,
+    user: str | None = None,
+    job_id: str | None = None,
+) -> dict[str, str]:
+    """Build the JSON body for ``POST /logs``."""
+    payload = {PARAM_LOG_PATH: log_path}
+    if user is not None:
+        payload[PARAM_USER] = user
+    if job_id is not None:
+        payload[PARAM_JOB_ID] = job_id
+    return payload
+
+
+def log_result_params(
+    log_path: str,
+    *,
+    file: str | None = None,
+    wl_restart: int | None = None,
+) -> dict[str, Any]:
+    """Build query params for ``GET /logs``."""
+    params: dict[str, Any] = {PARAM_LOG_PATH: log_path}
+    if file is not None:
+        params[PARAM_FILE] = file
+    if wl_restart is not None:
+        params[PARAM_WL_RESTART] = wl_restart
+    return params
+
+
+def post_log(
+    client: Any,
+    log_path: str,
+    *,
+    user: str | None = None,
+    job_id: str | None = None,
+) -> Any:
+    """Submit a log to attrsvc with an existing HTTP client."""
+    return client.post(
+        ROUTE_LOGS,
+        json=log_submit_payload(log_path, user=user, job_id=job_id),
+        headers=ACCEPT_JSON_HEADERS,
+    )
+
+
+def get_log_response(
+    client: Any,
+    log_path: str,
+    *,
+    file: str | None = None,
+    wl_restart: int | None = None,
+) -> Any:
+    """Fetch a log-analysis response from attrsvc with an existing HTTP client."""
+    return client.get(
+        ROUTE_LOGS,
+        params=log_result_params(log_path, file=file, wl_restart=wl_restart),
+        headers=ACCEPT_JSON_HEADERS,
+    )

--- a/src/nvidia_resiliency_ext/attribution/orchestration/llm_output.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/llm_output.py
@@ -9,7 +9,7 @@ validation and MCP/lib result shaping) because LLM output handling is a distinct
 Path-derived job/cycle ids live in :mod:`nvidia_resiliency_ext.attribution.orchestration.log_path_metadata`.
 
 - :func:`parse_llm_response` / :class:`ParsedLLMResponse` — structured fields from raw LLM text
-- :func:`attribution_no_restart` — decision helper on attribution dicts
+- :func:`attribution_recommendation` — decision helper
 - :func:`log_fields_for_dataflow_record` — keys merged in :mod:`~nvidia_resiliency_ext.attribution.postprocessing.pipeline`
 """
 
@@ -20,51 +20,139 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Optional
 
+from .config import RESP_ERROR, RESP_MODULE, RESP_RESULT, RESP_STATE, STATE_TIMEOUT
 from .log_path_metadata import JobMetadata
+from .types import (
+    RECOMMENDATION_CONTINUE,
+    RECOMMENDATION_RESTART,
+    RECOMMENDATION_STOP,
+    RECOMMENDATION_TIMEOUT,
+    RECOMMENDATION_UNKNOWN,
+    AttributionRecommendation,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def attribution_no_restart(attr_result: Optional[Dict[str, Any]]) -> bool:
-    """Whether attribution recommends do not restart (stop).
+def attribution_recommendation(attr_result: Optional[Dict[str, Any]]) -> AttributionRecommendation:
+    """Normalize backend-specific log-analysis output.
 
-    Call on the raw result from log analysis or an attribution service (or None if unavailable).
-    True = stop; False = restart or no usable result (skip).
-
-    Handles result shapes: state STOP/CONTINUE/RESTART, or strings containing
-    ``STOP - DONT RESTART`` / ``RESTART IMMEDIATE``.
+    This function expects the inner analysis result, e.g. ``{"state": ..., "result": ...}``.
+    Full attrsvc HTTP response bodies are parsed by ``parse_attrsvc_response``.
     """
     if attr_result is None or not isinstance(attr_result, dict):
-        return False
-    state = attr_result.get("state")
-    if state == "STOP":
-        return True
-    if state in ("CONTINUE", "RESTART"):
-        return False
-    nested = attr_result.get("result")
-    if isinstance(nested, dict):
-        nested_state = nested.get("state")
-        if nested_state == "STOP":
-            return True
-        if nested_state in ("CONTINUE", "RESTART"):
-            return False
-    if isinstance(nested, (list, tuple)) and nested:
-        first = nested[0]
-        s = first if isinstance(first, str) else str(first)
-        if "STOP" in s and "RESTART" not in s.split("STOP")[0]:
-            return True
-        if "RESTART" in s:
-            return False
-    s = str(attr_result)
-    logger.warning(
-        "attribution_no_restart: falling through to string matching on result: %s",
-        s[:200] + ("..." if len(s) > 200 else ""),
+        return AttributionRecommendation(reason="missing attribution result")
+
+    state = _extract_state(attr_result)
+    source = _extract_source(attr_result)
+    reason = _extract_reason(attr_result)
+    state_action = _action_from_state(state)
+    known_unknown_reason = _known_unknown_reason(state, source)
+
+    if reason:
+        text_action = _action_from_text(reason)
+        action = text_action if text_action != RECOMMENDATION_UNKNOWN else state_action
+    elif state_action != RECOMMENDATION_UNKNOWN:
+        action = state_action
+    elif known_unknown_reason:
+        action = RECOMMENDATION_UNKNOWN
+        reason = known_unknown_reason
+    else:
+        result_text = str(attr_result)
+        logger.warning(
+            "attribution_recommendation: falling through to string matching on result: %s",
+            result_text[:200] + ("..." if len(result_text) > 200 else ""),
+        )
+        action = _action_from_text(result_text)
+
+    if not reason and state:
+        reason = f"state={state}"
+
+    return AttributionRecommendation(
+        action=action,
+        reason=reason,
+        source=source,
     )
-    if "STOP" in s and "DONT RESTART" in s:
-        return True
-    if "RESTART" in s and "IMMEDIATE" in s:
-        return False
-    return False
+
+
+def _known_unknown_reason(state: Optional[str], source: str) -> str:
+    if source == "fr_only" and state == "no_log":
+        return "no_log"
+    return ""
+
+
+def _extract_state(attr_result: Dict[str, Any]) -> Optional[str]:
+    for candidate in (attr_result, attr_result.get(RESP_RESULT)):
+        if isinstance(candidate, dict):
+            state = candidate.get(RESP_STATE)
+            if isinstance(state, str) and state.strip():
+                return state.strip()
+    return None
+
+
+def _extract_source(attr_result: Dict[str, Any]) -> str:
+    for candidate in (attr_result, attr_result.get(RESP_RESULT)):
+        if isinstance(candidate, dict):
+            module = candidate.get(RESP_MODULE)
+            if isinstance(module, str) and module.strip():
+                return module.strip()
+    return ""
+
+
+def _extract_reason(attr_result: Dict[str, Any]) -> str:
+    error = attr_result.get(RESP_ERROR)
+    if isinstance(error, str) and error:
+        return error
+
+    nested = attr_result.get(RESP_RESULT)
+    if isinstance(nested, dict):
+        nested_error = nested.get(RESP_ERROR)
+        if isinstance(nested_error, str) and nested_error:
+            return nested_error
+        nested = nested.get(RESP_RESULT)
+
+    return _reason_text(nested)
+
+
+def _reason_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            text = _reason_text(item)
+            if text:
+                return text
+    return ""
+
+
+def _action_from_state(state: Optional[str]) -> str:
+    if not isinstance(state, str):
+        return RECOMMENDATION_UNKNOWN
+    normalized = _normalize_action(state)
+    if normalized == RECOMMENDATION_STOP:
+        return RECOMMENDATION_STOP
+    if normalized == RECOMMENDATION_RESTART:
+        return RECOMMENDATION_RESTART
+    if normalized == RECOMMENDATION_CONTINUE:
+        return RECOMMENDATION_CONTINUE
+    if normalized == STATE_TIMEOUT.upper():
+        return RECOMMENDATION_TIMEOUT
+    return RECOMMENDATION_UNKNOWN
+
+
+def _normalize_action(action: Any) -> str:
+    return action.strip().upper() if isinstance(action, str) and action.strip() else ""
+
+
+def _action_from_text(text: str) -> str:
+    normalized = text.upper()
+    if "STOP" in normalized and "RESTART" not in normalized.split("STOP", 1)[0]:
+        return RECOMMENDATION_STOP
+    if "RESTART" in normalized and "IMMEDIATE" in normalized:
+        return RECOMMENDATION_RESTART
+    if "ERRORS NOT FOUND" in normalized or "NO LOGS" in normalized:
+        return RECOMMENDATION_CONTINUE
+    return RECOMMENDATION_UNKNOWN
 
 
 @dataclass

--- a/src/nvidia_resiliency_ext/attribution/orchestration/runner.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/runner.py
@@ -177,7 +177,7 @@ def ensure_analyzer_ready(
 
 
 def _raw_to_result_dict(raw: Any) -> Optional[Dict[str, Any]]:
-    """Convert controller result to the dict shape used by attribution_no_restart."""
+    """Convert controller result to the inner attribution result dict."""
     if hasattr(raw, "result"):
         r = getattr(raw, "result", None)
         return r if isinstance(r, dict) else None

--- a/src/nvidia_resiliency_ext/attribution/orchestration/types.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/types.py
@@ -11,7 +11,7 @@ is configured on :class:`~nvidia_resiliency_ext.attribution.analyzer.engine.Anal
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from .analysis_pipeline import AnalysisPipelineMode
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
 from nvidia_resiliency_ext.attribution.trace_analyzer import FRAnalysisResult
 
 from .job import JobMode
+
+RECOMMENDATION_STOP = "STOP"
+RECOMMENDATION_RESTART = "RESTART"
+RECOMMENDATION_CONTINUE = "CONTINUE"
+RECOMMENDATION_UNKNOWN = "UNKNOWN"
+RECOMMENDATION_TIMEOUT = "TIMEOUT"
 
 
 @dataclass
@@ -77,6 +83,20 @@ class LogAnalyzerError:
 
 
 @dataclass
+class AttributionRecommendation:
+    """Normalized client-facing restart/stop recommendation.
+
+    ``UNKNOWN`` means attribution completed without a usable action, for example
+    missing results, FR-only ``no_log`` output, invalid recommendation payloads,
+    or an unrecognized backend result shape.
+    """
+
+    action: str = RECOMMENDATION_UNKNOWN
+    reason: str = ""
+    source: str = ""
+
+
+@dataclass
 class LogAnalysisCycleResult:
     """Single-file mode: one row per workload cycle (``wl_restart``) after orchestrated analysis."""
 
@@ -87,6 +107,7 @@ class LogAnalysisCycleResult:
     fr_dump_path: Optional[str] = None
     fr_analysis: Optional[FRAnalysisResult] = None
     llm_merged_summary: Optional[str] = None
+    recommendation: AttributionRecommendation = field(default_factory=AttributionRecommendation)
 
 
 @dataclass
@@ -114,6 +135,7 @@ class LogAnalysisSplitlogResult:
     fr_dump_path: Optional[str] = None
     fr_analysis: Optional[FRAnalysisResult] = None
     llm_merged_summary: Optional[str] = None
+    recommendation: AttributionRecommendation = field(default_factory=AttributionRecommendation)
 
 
 @dataclass

--- a/src/nvidia_resiliency_ext/services/attrsvc/__init__.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/__init__.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from .config import Settings, setup
     from .service import (
         AttributionHttpAdapter,
+        AttributionRecommendation,
         LogAnalysisCycleResult,
         LogAnalysisSplitlogResult,
         LogAnalyzerError,
@@ -39,6 +40,7 @@ _EXPORTS = {
     "Settings": ".config",
     "setup": ".config",
     "AttributionHttpAdapter": ".service",
+    "AttributionRecommendation": ".service",
     "LogAnalysisCycleResult": ".service",
     "LogAnalysisSplitlogResult": ".service",
     "LogAnalyzerError": ".service",
@@ -82,6 +84,7 @@ __all__ = [
     "setup",
     # HTTP adapter (for direct Python usage)
     "AttributionHttpAdapter",
+    "AttributionRecommendation",
     "LogAnalysisCycleResult",
     "LogAnalysisSplitlogResult",
     "LogAnalyzerError",

--- a/src/nvidia_resiliency_ext/services/attrsvc/routes.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/routes.py
@@ -1,20 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""HTTP API route and parameter names for nvidia_resiliency_ext.services.attrsvc.
+"""HTTP API route and parameter names for nvidia_resiliency_ext.services.attrsvc."""
 
-Result/mode constants (RESP_*, STATE_*, mode values) live in the library:
-  nvidia_resiliency_ext.attribution (JobMode, RESP_*, STATE_TIMEOUT)
-"""
+from nvidia_resiliency_ext.attribution.orchestration.http_api import (
+    PARAM_FILE,
+    PARAM_JOB_ID,
+    PARAM_LOG_PATH,
+    PARAM_USER,
+    PARAM_WL_RESTART,
+    ROUTE_LOGS,
+)
 
-# Logs endpoint path
-ROUTE_LOGS = "/logs"
-
-# POST /logs body and GET /logs query parameter names
-PARAM_LOG_PATH = "log_path"
-PARAM_USER = "user"
-PARAM_JOB_ID = "job_id"
-
-# GET /logs optional query parameters (splitlog mode)
-PARAM_FILE = "file"
-PARAM_WL_RESTART = "wl_restart"
+__all__ = [
+    "PARAM_FILE",
+    "PARAM_JOB_ID",
+    "PARAM_LOG_PATH",
+    "PARAM_USER",
+    "PARAM_WL_RESTART",
+    "ROUTE_LOGS",
+]

--- a/src/nvidia_resiliency_ext/services/attrsvc/service.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/service.py
@@ -25,6 +25,7 @@ from nvidia_resiliency_ext.attribution.controller import (
     AttributionPostprocessingConfig,
 )
 from nvidia_resiliency_ext.attribution.orchestration.types import (
+    AttributionRecommendation,
     LogAnalysisCycleResult,
     LogAnalysisSplitlogResult,
     LogAnalyzerError,
@@ -40,6 +41,7 @@ logger = logging.getLogger(__name__)
 # Re-export result types for convenience
 __all__ = [
     "AttributionHttpAdapter",
+    "AttributionRecommendation",
     "LogAnalyzerError",
     "LogAnalysisCycleResult",
     "LogAnalyzerSubmitResult",

--- a/src/nvidia_resiliency_ext/services/smonsvc/__init__.py
+++ b/src/nvidia_resiliency_ext/services/smonsvc/__init__.py
@@ -8,8 +8,14 @@ A standalone program that monitors SLURM jobs and integrates with the
 nvrx-attrsvc attribution service for log analysis.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .models import JobState, MonitorState, SlurmJob
-from .monitor import SlurmJobMonitor
+
+if TYPE_CHECKING:
+    from .monitor import SlurmJobMonitor
 
 __all__ = [
     "SlurmJobMonitor",
@@ -17,3 +23,11 @@ __all__ = [
     "JobState",
     "MonitorState",
 ]
+
+
+def __getattr__(name: str):
+    if name == "SlurmJobMonitor":
+        from .monitor import SlurmJobMonitor
+
+        return SlurmJobMonitor
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/nvidia_resiliency_ext/services/smonsvc/attrsvc_client.py
+++ b/src/nvidia_resiliency_ext/services/smonsvc/attrsvc_client.py
@@ -15,15 +15,20 @@ try:
 except ImportError:
     httpx = None  # type: ignore
 
-from nvidia_resiliency_ext.services.attrsvc.routes import (
-    PARAM_JOB_ID,
-    PARAM_LOG_PATH,
-    PARAM_USER,
-    PARAM_WL_RESTART,
-    ROUTE_LOGS,
+from nvidia_resiliency_ext.attribution.orchestration.http_api import (
+    ROUTE_HEALTHZ,
+    get_log_response,
+    post_log,
 )
 
 logger = logging.getLogger(__name__)
+
+_EXPECTED_CLIENT_ERROR_CODES = {
+    "errorcode.not_readable",
+    "not_readable",
+    "errorcode.logs_dir_not_readable",
+    "logs_dir_not_readable",
+}
 
 
 @dataclass(frozen=True)
@@ -74,6 +79,29 @@ def _parse_attrsvc_endpoint(endpoint: str) -> _AttrsvcEndpoint:
     return _AttrsvcEndpoint(base_url=value.rstrip("/"), display_url=value.rstrip("/"))
 
 
+def _is_expected_client_error(
+    status_code: int,
+    error_detail: object,
+    *,
+    permission_denied_is_expected: bool = False,
+) -> bool:
+    if status_code == 400:
+        return True
+    if (
+        not permission_denied_is_expected
+        or status_code != 403
+        or not isinstance(error_detail, dict)
+    ):
+        return False
+    return _client_error_code(error_detail) in _EXPECTED_CLIENT_ERROR_CODES
+
+
+def _client_error_code(error_detail: object) -> str:
+    if not isinstance(error_detail, dict):
+        return ""
+    return str(error_detail.get("error_code", "")).lower()
+
+
 class AttrsvcClient:
     """
     HTTP client for interacting with the attribution service (attrsvc).
@@ -99,6 +127,7 @@ class AttrsvcClient:
         rate_limit_max_delay: float = DEFAULT_RATE_LIMIT_MAX_DELAY,
         request_throttle: float = DEFAULT_REQUEST_THROTTLE,
         on_rate_limited: Callable[[], None] | None = None,
+        permission_denied_is_expected: bool = False,
     ):
         """
         Initialize the attribution service client.
@@ -113,6 +142,10 @@ class AttrsvcClient:
             rate_limit_max_delay: Maximum delay for rate limiting
             request_throttle: Delay between successful requests to prevent rate limiting
             on_rate_limited: Optional callback when rate limited (for stats tracking)
+            permission_denied_is_expected: Treat attrsvc not_readable/logs_dir_not_readable 403s
+                as expected. This is useful for standalone all-users smonsvc deployments where
+                attrsvc may not be able to read every user's logs. Keep False for co-deployed
+                same-user paths where ft_launcher creates the log and attrsvc should have access.
         """
         if httpx is None:
             raise ImportError("httpx is required. Install with: pip install httpx")
@@ -126,6 +159,7 @@ class AttrsvcClient:
         self._rate_limit_max_delay = rate_limit_max_delay
         self._request_throttle = request_throttle
         self._on_rate_limited = on_rate_limited
+        self._permission_denied_is_expected = permission_denied_is_expected
         if self._endpoint.uds_path:
             transport = httpx.HTTPTransport(uds=self._endpoint.uds_path)
             self._client = httpx.Client(
@@ -139,6 +173,7 @@ class AttrsvcClient:
         # Health check cache to avoid blocking HTTP calls on every /healthz request
         self._health_cache: tuple[bool, float] | None = None
         self._health_cache_ttl = 60.0  # seconds
+        self._expected_client_error_counts: dict[tuple[str, int, str], int] = {}
 
     def close(self) -> None:
         """Close the HTTP client."""
@@ -175,7 +210,7 @@ class AttrsvcClient:
         if self._client is not None:
             response = None
             try:
-                response = self._client.get("/healthz", timeout=5.0)
+                response = self._client.get(ROUTE_HEALTHZ, timeout=5.0)
                 is_healthy = response.status_code < 500
             except Exception:
                 pass
@@ -184,6 +219,24 @@ class AttrsvcClient:
                     response.close()
         self._health_cache = (is_healthy, now)
         return is_healthy
+
+    def _log_expected_client_error(
+        self,
+        method: str,
+        job_id: str,
+        status_code: int,
+        error_detail: object,
+        error_msg: object,
+    ) -> None:
+        error_code = _client_error_code(error_detail)
+        key = (method, status_code, error_code)
+        count = self._expected_client_error_counts.get(key, 0) + 1
+        self._expected_client_error_counts[key] = count
+        if count <= 5 or count % 100 == 0:
+            logger.debug(
+                f"[{job_id}] {method} failed ({status_code}): {error_msg} "
+                f"(expected client error count={count})"
+            )
 
     def request_with_retry(
         self,
@@ -213,22 +266,17 @@ class AttrsvcClient:
             response = None
             try:
                 if method == "POST":
-                    response = self._client.post(
-                        ROUTE_LOGS,
-                        json={
-                            PARAM_LOG_PATH: log_path,
-                            PARAM_USER: user,
-                            PARAM_JOB_ID: job_id,
-                        },
-                        headers={"accept": "application/json"},
+                    response = post_log(
+                        self._client,
+                        log_path,
+                        user=user,
+                        job_id=job_id,
                     )
                 else:  # GET
-                    params = {PARAM_LOG_PATH: log_path}
-                    if cycle is not None:
-                        params[PARAM_WL_RESTART] = cycle
-                    response = self._client.get(
-                        ROUTE_LOGS,
-                        params=params,
+                    response = get_log_response(
+                        self._client,
+                        log_path,
+                        wl_restart=cycle,
                     )
 
                 if response.status_code == 200:
@@ -276,6 +324,7 @@ class AttrsvcClient:
                     return
                 else:
                     # Client error - permanent failure
+                    error_detail: object = {}
                     try:
                         error_detail = response.json()
                         if isinstance(error_detail, dict):
@@ -289,10 +338,20 @@ class AttrsvcClient:
                     # - NOT_REGULAR: path is symlink or directory
                     # - EMPTY_FILE: file just created, not yet written
                     # These resolve on the next poll cycle, so log at debug.
-                    # Other 4xx errors (401, 403, 422) indicate real problems.
-                    if response.status_code == 400:
-                        logger.debug(
-                            f"[{job_id}] {method} failed ({response.status_code}): {error_msg}"
+                    # Permission-denied 403s are expected only for standalone
+                    # all-users monitor deployments; co-deployed same-user
+                    # attrsvc paths should be able to read ft_launcher logs.
+                    if _is_expected_client_error(
+                        response.status_code,
+                        error_detail,
+                        permission_denied_is_expected=self._permission_denied_is_expected,
+                    ):
+                        self._log_expected_client_error(
+                            method,
+                            job_id,
+                            response.status_code,
+                            error_detail,
+                            error_msg,
                         )
                     else:
                         logger.warning(

--- a/src/nvidia_resiliency_ext/services/smonsvc/job_handlers.py
+++ b/src/nvidia_resiliency_ext/services/smonsvc/job_handlers.py
@@ -7,20 +7,16 @@ import logging
 from typing import TYPE_CHECKING
 
 from nvidia_resiliency_ext.attribution import (
-    RESP_ERROR,
     RESP_FILES_ANALYZED,
-    RESP_LOG_FILE,
     RESP_LOGS_DIR,
     RESP_MODE,
     RESP_MODULE,
     RESP_RESULT,
-    RESP_RESULT_ID,
     RESP_SCHED_RESTARTS,
-    RESP_STATE,
-    RESP_WL_RESTART,
-    STATE_TIMEOUT,
     JobMode,
+    parse_attrsvc_response,
 )
+from nvidia_resiliency_ext.attribution.orchestration.types import RECOMMENDATION_TIMEOUT
 
 if TYPE_CHECKING:
     from .attrsvc_client import AttrsvcClient
@@ -162,12 +158,6 @@ def log_attribution_result(job: "SlurmJob", log_path: str, response: dict) -> No
     try:
         logger.debug(f"[{job.job_id}] Raw response: {response}")
 
-        # Check for splitlog mode response
-        mode = response.get(RESP_MODE, JobMode.SINGLE.value)
-        wl_restart = response.get(RESP_WL_RESTART)
-        sched_restarts = response.get(RESP_SCHED_RESTARTS)
-        analyzed_log_file = response.get(RESP_LOG_FILE, "")
-
         inner = response.get(RESP_RESULT, response)
 
         if not inner or not inner.get(RESP_MODULE):
@@ -176,49 +166,16 @@ def log_attribution_result(job: "SlurmJob", log_path: str, response: dict) -> No
             )
             return
 
-        module = inner.get(RESP_MODULE)
-        state = inner.get(RESP_STATE, "")
+        parsed = parse_attrsvc_response(response, log_path=log_path)
+        action = parsed.recommendation.action
 
-        # Handle timeout results specially
-        if state == STATE_TIMEOUT:
-            error_msg = inner.get(RESP_ERROR, "LLM analysis timed out")
-            logger.warning(f"[{job.job_id}] Attribution timeout: {error_msg}")
-            print(
-                f"[{job.job_id}] Attribution timeout:\n"
-                f"  Log: {log_path}\n"
-                f"  Error: {error_msg}",
-                flush=True,
-            )
+        if action == RECOMMENDATION_TIMEOUT:
+            timeout_reason = parsed.recommendation_reason or "Attribution analysis timed out"
+            logger.warning(f"[{job.job_id}] Attribution timeout: {timeout_reason}")
+            print(parsed.format_summary(prefix=f"[{job.job_id}] "), flush=True)
             return
 
-        raw_result_id = inner.get(RESP_RESULT_ID, "")
-        result_id = raw_result_id[:16] + "..." if len(raw_result_id) > 16 else raw_result_id
-
-        attribution_result = inner.get(RESP_RESULT, "")
-        if isinstance(attribution_result, list):
-            attribution_text = " | ".join(str(item) for item in attribution_result)
-        else:
-            attribution_text = str(attribution_result) if attribution_result else ""
-
-        if len(attribution_text) > 200:
-            attribution_text = attribution_text[:200] + "..."
-
-        # Build output message
-        lines = [f"[{job.job_id}] Attribution result:"]
-        if mode == JobMode.SPLITLOG.value:
-            lines.append(
-                f"  Mode: {JobMode.SPLITLOG.value} (wl_restart {wl_restart}/{sched_restarts})"
-            )
-            lines.append(f"  Slurm output: {log_path}")
-            lines.append(f"  Analyzed log: {analyzed_log_file}")
-        else:
-            lines.append(f"  Log: {log_path}")
-        lines.append(f"  Module: {module}")
-        lines.append(f"  Result ID: {result_id}")
-        lines.append(f"  State: {state}")
-        lines.append(f"  Attribution: {attribution_text}")
-
-        print("\n".join(lines), flush=True)
+        print(parsed.format_summary(prefix=f"[{job.job_id}] "), flush=True)
 
     except Exception as e:
         logger.warning(f"[{job.job_id}] Could not parse attribution result: {e}")

--- a/src/nvidia_resiliency_ext/services/smonsvc/monitor.py
+++ b/src/nvidia_resiliency_ext/services/smonsvc/monitor.py
@@ -90,6 +90,7 @@ class SlurmJobMonitor:
             rate_limit_max_delay=self.HTTP_RATE_LIMIT_MAX_DELAY,
             request_throttle=self.HTTP_REQUEST_THROTTLE,
             on_rate_limited=self._on_rate_limited,
+            permission_denied_is_expected=all_users,
         )
 
         # SLURM client for subprocess calls

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -25,14 +25,18 @@ import sys
 import threading
 import traceback
 from collections import defaultdict
-from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Union
-from urllib.parse import quote_plus
+from typing import Callable, Dict, Optional, Union
 
 import defusedxml.ElementTree as ET
 import httpx
 
+from nvidia_resiliency_ext.attribution import parse_attrsvc_response
+from nvidia_resiliency_ext.attribution.orchestration.http_api import (
+    ROUTE_LOGS,
+    get_log_response,
+    post_log,
+)
 from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
 
 # Get the nvrx logger
@@ -1345,12 +1349,6 @@ class StoragePathHealthCheck:
         return True
 
 
-@dataclass
-class AttrSvcResult:
-    result: Any
-    status: str = "completed"
-
-
 class AttributionService:
     """
     Client that queries an external attribution service to analyze artifacts (e.g., logs).
@@ -1383,6 +1381,14 @@ class AttributionService:
                 daemon=True,
             ).start()
 
+    def get_last_result(self) -> Optional[bool]:
+        """Synchronously fetch whether attribution recommends stopping the last log."""
+        log_path = self._last_submitted
+        if not log_path:
+            logger.debug("AttributionService GET skipped: no submitted log path")
+            return None
+        return self._get_results(log_path)
+
     def _submit_log(self, log_path: str) -> None:
         """
         Submit a log file for analysis via POST.
@@ -1401,51 +1407,42 @@ class AttributionService:
         if base_url is None:
             return
         try:
-            with httpx.Client(timeout=10.0) as client:
-                url = f"{base_url}/logs"
+            with httpx.Client(base_url=base_url, timeout=10.0) as client:
+                url = f"{base_url}{ROUTE_LOGS}"
                 logger.debug("AttributionService POST: %s (log_path=%s)", url, log_path)
-                client.post(
-                    url,
-                    json={"log_path": log_path},
-                    headers={"accept": "application/json"},
-                )
+                post_log(client, log_path)
         except Exception as e:
             logger.warning(
                 "AttributionService POST %s failed: %s: %s", log_path, type(e).__name__, e
             )
 
-    def _get_results(self, log_path: str) -> None:
+    def _get_results(self, log_path: str) -> Optional[bool]:
         """
-        Get analysis results for a previously submitted log file via GET.
+        Get the stop decision for a previously submitted log file via GET.
         """
         base_url = self._http_base_url()
         if base_url is None:
-            return
+            return None
         try:
-            with httpx.Client(timeout=60.0) as client:
-                q_path = quote_plus(log_path)
-                url = f"{base_url}/logs?log_path={q_path}"
+            with httpx.Client(base_url=base_url, timeout=60.0) as client:
+                url = f"{base_url}{ROUTE_LOGS}"
                 logger.debug("AttributionService GET: %s (log_path=%s)", url, log_path)
-                resp = client.get(url, headers={"accept": "application/json"})
+                resp = get_log_response(client, log_path)
                 if resp.status_code == 200:
                     payload = resp.json() if resp.text else {}
-                    result = payload.get("result", payload)
-                    status = payload.get("status", "completed")
-                    attrsvc_result = AttrSvcResult(result=result, status=status)
-                    logger.info("AttrSvcResult for %s: status=%s", log_path, attrsvc_result.status)
-                    logger.info(
-                        "AttrSvcResult for %s: result preview: %s",
-                        log_path,
-                        str(attrsvc_result.result)[:200],
-                    )
+                    attrsvc_result = parse_attrsvc_response(payload, log_path=log_path)
+                    logger.info(attrsvc_result.format_log_message())
+                    return attrsvc_result.should_stop
                 else:
                     logger.warning(
                         "AttributionService GET for %s returned %d", log_path, resp.status_code
                     )
+                    return None
         except Exception as e:
             logger.warning(
                 "AttributionService GET %s failed: %s: %s", log_path, type(e).__name__, e
             )
+            return None
 
     def _http_base_url(self) -> Optional[str]:
         if self.endpoint.startswith(("http://", "https://")):

--- a/tests/attribution/unit/test_client_response.py
+++ b/tests/attribution/unit/test_client_response.py
@@ -1,0 +1,140 @@
+from nvidia_resiliency_ext.attribution import AttrSvcResult, parse_attrsvc_response
+
+
+def test_parse_attrsvc_response_uses_standard_recommendation():
+    parsed = parse_attrsvc_response(
+        {
+            "status": "completed",
+            "recommendation": {
+                "action": "STOP",
+                "reason": "standard stop",
+                "source": "log_analyzer",
+            },
+            "result": {
+                "module": "log_analyzer",
+                "state": "CONTINUE",
+                "result": ["raw backend payload"],
+            },
+        }
+    )
+
+    assert parsed.status == "completed"
+    assert isinstance(parsed, AttrSvcResult)
+    assert parsed.result["state"] == "CONTINUE"
+    assert parsed.recommendation.action == "STOP"
+    assert parsed.recommendation.reason == "standard stop"
+    assert parsed.recommendation.source == "log_analyzer"
+    assert parsed.should_stop is True
+
+
+def test_parse_attrsvc_response_falls_back_to_raw_result():
+    parsed = parse_attrsvc_response(
+        {
+            "result": {
+                "module": "log_analyzer",
+                "state": "CONTINUE",
+                "result": ["RESTART IMMEDIATE"],
+            },
+        }
+    )
+
+    assert parsed.status == "completed"
+    assert parsed.recommendation.action == "RESTART"
+    assert parsed.recommendation.reason == "RESTART IMMEDIATE"
+    assert parsed.should_stop is False
+
+
+def test_parse_attrsvc_response_fallback_uses_inner_result_only():
+    parsed = parse_attrsvc_response(
+        {
+            "status": "completed",
+            "state": "STOP",
+            "result": {
+                "module": "log_analyzer",
+                "state": "CONTINUE",
+                "result": ["ERRORS NOT FOUND"],
+            },
+        }
+    )
+
+    assert parsed.recommendation.action == "CONTINUE"
+    assert parsed.recommendation.reason == "ERRORS NOT FOUND"
+    assert parsed.should_stop is False
+
+
+def test_parse_attrsvc_response_keeps_client_log_path():
+    parsed = parse_attrsvc_response(
+        {
+            "status": "completed",
+            "recommendation": {
+                "action": "CONTINUE",
+                "reason": "no terminal issue",
+                "source": "log_analyzer",
+            },
+            "result": {"module": "log_analyzer"},
+        },
+        log_path="/tmp/train.log",
+    )
+
+    assert parsed.log_path == "/tmp/train.log"
+    assert parsed.recommendation_reason == "no terminal issue"
+
+
+def test_attrsvc_result_formats_smon_summary():
+    parsed = parse_attrsvc_response(
+        {
+            "status": "completed",
+            "mode": "splitlog",
+            "log_file": "/tmp/cycle-0.log",
+            "wl_restart": 0,
+            "sched_restarts": 2,
+            "recommendation": {
+                "action": "RESTART",
+                "reason": "safe to restart",
+                "source": "log_analyzer",
+            },
+            "result": {
+                "module": "log_analyzer",
+                "result_id": "abcdef0123456789",
+                "result": ["RESTART IMMEDIATE", "details"],
+            },
+        },
+        log_path="/tmp/slurm.out",
+    )
+
+    summary = parsed.format_summary(prefix="[123] ")
+
+    assert "[123] Attribution result:" in summary
+    assert "Mode: splitlog (wl_restart 0/2)" in summary
+    assert "Slurm output: /tmp/slurm.out" in summary
+    assert "Analyzed log: /tmp/cycle-0.log" in summary
+    assert "Result ID: abcdef0123456789" in summary
+    assert "Recommendation: RESTART" in summary
+    assert "Reason: safe to restart" in summary
+    assert "Attribution: RESTART IMMEDIATE | details" in summary
+
+
+def test_attrsvc_result_formats_launcher_log_message():
+    parsed = parse_attrsvc_response(
+        {
+            "status": "completed",
+            "recommendation": {
+                "action": "CONTINUE",
+                "reason": "training cycle still running",
+                "source": "log_analyzer",
+            },
+            "result": {
+                "module": "log_analyzer",
+                "result": ["ERRORS NOT FOUND"],
+            },
+        },
+        log_path="/tmp/train.log",
+    )
+
+    message = parsed.format_log_message()
+
+    assert message == (
+        "AttrSvcResult for /tmp/train.log: status=completed "
+        "recommendation=CONTINUE reason=training cycle still running "
+        "should_stop=False result preview: ERRORS NOT FOUND"
+    )

--- a/tests/attribution/unit/test_http_api.py
+++ b/tests/attribution/unit/test_http_api.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+from nvidia_resiliency_ext.attribution.orchestration.http_api import (
+    get_log_response,
+    log_result_params,
+    log_submit_payload,
+    post_log,
+)
+
+
+def test_log_submit_payload_omits_empty_optional_fields():
+    assert log_submit_payload("/tmp/train.log") == {"log_path": "/tmp/train.log"}
+
+
+def test_log_submit_payload_includes_smon_fields():
+    assert log_submit_payload("/tmp/train.log", user="alice", job_id="123") == {
+        "log_path": "/tmp/train.log",
+        "user": "alice",
+        "job_id": "123",
+    }
+
+
+def test_log_result_params_includes_splitlog_fields():
+    assert log_result_params("/tmp/train.log", file="cycle-0.log", wl_restart=2) == {
+        "log_path": "/tmp/train.log",
+        "file": "cycle-0.log",
+        "wl_restart": 2,
+    }
+
+
+def test_post_log_uses_shared_logs_route():
+    client = MagicMock()
+
+    post_log(client, "/tmp/train.log", user="alice", job_id="123")
+
+    client.post.assert_called_once_with(
+        "/logs",
+        json={"log_path": "/tmp/train.log", "user": "alice", "job_id": "123"},
+        headers={"accept": "application/json"},
+    )
+
+
+def test_get_log_response_uses_shared_logs_route():
+    client = MagicMock()
+
+    get_log_response(client, "/tmp/train.log", wl_restart=2)
+
+    client.get.assert_called_once_with(
+        "/logs",
+        params={"log_path": "/tmp/train.log", "wl_restart": 2},
+        headers={"accept": "application/json"},
+    )

--- a/tests/attribution/unit/test_llm_output.py
+++ b/tests/attribution/unit/test_llm_output.py
@@ -1,0 +1,172 @@
+import logging
+
+from nvidia_resiliency_ext.attribution.orchestration.llm_output import attribution_recommendation
+
+
+def test_attribution_recommendation_uses_state_stop():
+    recommendation = attribution_recommendation(
+        {
+            "module": "log_analyzer",
+            "state": "STOP",
+            "result": ["STOP - DONT RESTART"],
+        }
+    )
+
+    assert recommendation.action == "STOP"
+    assert recommendation.reason == "STOP - DONT RESTART"
+    assert recommendation.source == "log_analyzer"
+
+
+def test_attribution_recommendation_maps_timeout():
+    recommendation = attribution_recommendation(
+        {
+            "module": "log_analyzer",
+            "state": "timeout",
+            "error": "LLM analysis timed out",
+            "result": [],
+        }
+    )
+
+    assert recommendation.action == "TIMEOUT"
+    assert recommendation.reason == "LLM analysis timed out"
+    assert recommendation.source == "log_analyzer"
+
+
+def test_attribution_recommendation_maps_continue_state_with_restart_text_to_restart():
+    recommendation = attribution_recommendation(
+        {
+            "module": "log_analyzer",
+            "state": "CONTINUE",
+            "result": ["RESTART IMMEDIATE"],
+        }
+    )
+
+    assert recommendation.action == "RESTART"
+    assert recommendation.reason == "RESTART IMMEDIATE"
+    assert recommendation.source == "log_analyzer"
+
+
+def test_attribution_recommendation_unwraps_nested_restart_result_reason():
+    recommendation = attribution_recommendation(
+        {
+            "module": "log_analyzer",
+            "state": "CONTINUE",
+            "result": [["RESTART IMMEDIATE\ntransient timeout", "AttributionState.CONTINUE"]],
+        }
+    )
+
+    assert recommendation.action == "RESTART"
+    assert recommendation.reason == "RESTART IMMEDIATE\ntransient timeout"
+    assert recommendation.source == "log_analyzer"
+
+
+def test_attribution_recommendation_unwraps_nested_stop_result_reason():
+    recommendation = attribution_recommendation(
+        {
+            "module": "log_analyzer",
+            "state": "STOP",
+            "result": [["STOP - DONT RESTART IMMEDIATE\nuser error", "AttributionState.STOP"]],
+        }
+    )
+
+    assert recommendation.action == "STOP"
+    assert recommendation.reason == "STOP - DONT RESTART IMMEDIATE\nuser error"
+    assert recommendation.source == "log_analyzer"
+
+
+def test_attribution_recommendation_maps_bare_stop_text_to_stop():
+    recommendation = attribution_recommendation(
+        {
+            "module": "log_analyzer",
+            "state": "CONTINUE",
+            "result": ["STOP"],
+        }
+    )
+
+    assert recommendation.action == "STOP"
+    assert recommendation.reason == "STOP"
+    assert recommendation.source == "log_analyzer"
+
+
+def test_attribution_recommendation_keeps_continue_state_when_no_restart_text():
+    recommendation = attribution_recommendation(
+        {
+            "module": "log_analyzer",
+            "state": "CONTINUE",
+            "result": ["ERRORS NOT FOUND"],
+        }
+    )
+
+    assert recommendation.action == "CONTINUE"
+    assert recommendation.reason == "ERRORS NOT FOUND"
+    assert recommendation.source == "log_analyzer"
+
+
+def test_attribution_recommendation_does_not_warn_on_known_state(caplog):
+    caplog.set_level(
+        logging.WARNING,
+        logger="nvidia_resiliency_ext.attribution.orchestration.llm_output",
+    )
+
+    recommendation = attribution_recommendation(
+        {
+            "module": "log_analyzer",
+            "state": "CONTINUE",
+            "result": [],
+        }
+    )
+
+    assert recommendation.action == "CONTINUE"
+    assert recommendation.reason == "state=CONTINUE"
+    assert recommendation.source == "log_analyzer"
+    assert "falling through to string matching" not in caplog.text
+
+
+def test_attribution_recommendation_does_not_warn_on_fr_only_no_log(caplog):
+    caplog.set_level(
+        logging.WARNING,
+        logger="nvidia_resiliency_ext.attribution.orchestration.llm_output",
+    )
+
+    recommendation = attribution_recommendation(
+        {
+            "module": "fr_only",
+            "state": "no_log",
+            "result": [],
+        }
+    )
+
+    assert recommendation.action == "UNKNOWN"
+    assert recommendation.reason == "no_log"
+    assert recommendation.source == "fr_only"
+    assert "falling through to string matching" not in caplog.text
+
+
+def test_attribution_recommendation_ignores_blank_outer_source():
+    recommendation = attribution_recommendation(
+        {
+            "module": " ",
+            "result": {
+                "module": "log_analyzer",
+                "state": "CONTINUE",
+                "result": ["ERRORS NOT FOUND"],
+            },
+        }
+    )
+
+    assert recommendation.action == "CONTINUE"
+    assert recommendation.reason == "ERRORS NOT FOUND"
+    assert recommendation.source == "log_analyzer"
+
+
+def test_attribution_recommendation_warns_on_full_dict_fallback(caplog):
+    caplog.set_level(
+        logging.WARNING,
+        logger="nvidia_resiliency_ext.attribution.orchestration.llm_output",
+    )
+
+    recommendation = attribution_recommendation({"unexpected": "STOP - DONT RESTART"})
+
+    assert recommendation.action == "STOP"
+    assert recommendation.reason == ""
+    assert "falling through to string matching" in caplog.text

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -559,8 +559,9 @@ class TestAttributionService(unittest.TestCase):
 
         service._do_submit_log("/tmp/train.log")
 
+        mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=10.0)
         client.post.assert_called_once_with(
-            "http://attr.example:8000/logs",
+            "/logs",
             json={"log_path": "/tmp/train.log"},
             headers={"accept": "application/json"},
         )
@@ -572,6 +573,85 @@ class TestAttributionService(unittest.TestCase):
         service._do_submit_log("/tmp/train.log")
 
         mock_client.assert_not_called()
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_get_results_returns_stop_decision(self, mock_client):
+        client = mock_client.return_value.__enter__.return_value
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "{}"
+        response.json.return_value = {
+            "recommendation": {
+                "action": "STOP",
+                "reason": "STOP - DONT RESTART",
+                "source": "log_analyzer",
+            },
+            "result": {
+                "module": "log_analyzer",
+                "result_id": "abc123",
+                "resource_uri": "attribution://log_analyzer/abc123",
+                "result": ["raw attribution item"],
+            },
+            "status": "completed",
+        }
+        client.get.return_value = response
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        should_stop = service._get_results("/tmp/train.log")
+
+        self.assertTrue(should_stop)
+        mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=60.0)
+        client.get.assert_called_once_with(
+            "/logs",
+            params={"log_path": "/tmp/train.log"},
+            headers={"accept": "application/json"},
+        )
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_get_results_maps_restart_recommendation_to_no_stop(self, mock_client):
+        client = mock_client.return_value.__enter__.return_value
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "{}"
+        response.json.return_value = {
+            "result": {
+                "module": "log_analyzer",
+                "state": "CONTINUE",
+                "result": ["RESTART IMMEDIATE"],
+            },
+            "status": "completed",
+        }
+        client.get.return_value = response
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        should_stop = service._get_results("/tmp/train.log")
+
+        self.assertFalse(should_stop)
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_get_results_maps_continue_recommendation_to_no_stop(self, mock_client):
+        client = mock_client.return_value.__enter__.return_value
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "{}"
+        response.json.return_value = {
+            "recommendation": {
+                "action": "CONTINUE",
+                "reason": "training cycle still running",
+                "source": "log_analyzer",
+            },
+            "result": {
+                "module": "log_analyzer",
+                "result": ["ERRORS NOT FOUND"],
+            },
+            "status": "completed",
+        }
+        client.get.return_value = response
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        should_stop = service._get_results("/tmp/train.log")
+
+        self.assertFalse(should_stop)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a normalized attrsvc `recommendation` contract and shared parser.
Clients now use `recommendation.action` (`STOP`, `RESTART`, `CONTINUE`, `UNKNOWN`, `TIMEOUT`) instead of interpreting raw `result.state`. Updates ft_launcher client parsing, smonsvc output handling, docs, and focused tests.