### PR TITLE
Add external InJob control plane support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ protobuf = ">=4.22.0"
 
 [tool.poetry.scripts]
 ft_launcher = "nvidia_resiliency_ext.fault_tolerance.launcher:main"
+nvrx-control = "nvidia_resiliency_ext.fault_tolerance.control_plane:main"
 nvrx-mcp-analysis = "nvidia_resiliency_ext.attribution.mcp_integration.server_launcher:main"
 nvrx-attrsvc = "nvidia_resiliency_ext.attribution.nvrx_attrsvc.app:main"
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -1,0 +1,445 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared CLI argument registration for fault-tolerance entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Callable, Optional, Sequence
+
+from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
+    DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT,
+)
+
+
+def str_to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes"}:
+        return True
+    if normalized in {"0", "false", "no"}:
+        return False
+    raise argparse.ArgumentTypeError(f"expected a boolean value, got {value!r}")
+
+
+def _add_argument(
+    parser: argparse.ArgumentParser,
+    *names: str,
+    action: Optional[Callable[..., Any]] = None,
+    **kwargs: Any,
+) -> None:
+    if action is not None:
+        kwargs["action"] = action
+    parser.add_argument(*names, **kwargs)
+
+
+def _add_nnodes_arg(
+    parser: argparse.ArgumentParser,
+    *,
+    action: Optional[Callable[..., Any]] = None,
+    default: Optional[str] = "1:1",
+    required: bool = False,
+    help: str = "Number of nodes, or the range of nodes in form <minimum_nodes>:<maximum_nodes>.",
+) -> None:
+    kwargs: dict[str, Any] = {
+        "type": str,
+        "help": help,
+    }
+    if required:
+        kwargs["required"] = True
+    else:
+        kwargs["default"] = default
+    _add_argument(parser, "--nnodes", action=action, **kwargs)
+
+
+def _add_rendezvous_core_args(
+    parser: argparse.ArgumentParser,
+    *,
+    action: Optional[Callable[..., Any]] = None,
+    endpoint_default: Optional[str] = "",
+    endpoint_required: bool = False,
+) -> None:
+    _add_argument(
+        parser,
+        "--rdzv-backend",
+        "--rdzv_backend",
+        action=action,
+        type=str,
+        default="c10d",
+        help="Rendezvous backend. Currently only c10d is supported.",
+    )
+    endpoint_kwargs: dict[str, Any] = {
+        "type": str,
+        "help": "Rendezvous backend endpoint; usually in form <host>:<port>.",
+    }
+    if endpoint_required:
+        endpoint_kwargs["required"] = True
+    else:
+        endpoint_kwargs["default"] = endpoint_default
+    _add_argument(
+        parser,
+        "--rdzv-endpoint",
+        "--rdzv_endpoint",
+        action=action,
+        **endpoint_kwargs,
+    )
+    _add_argument(
+        parser,
+        "--rdzv-id",
+        "--rdzv_id",
+        action=action,
+        type=str,
+        default="none",
+        help="User-defined group id.",
+    )
+    _add_argument(
+        parser,
+        "--rdzv-conf",
+        "--rdzv_conf",
+        action=action,
+        type=str,
+        default="",
+        help="Additional rendezvous configuration (<key1>=<value1>,<key2>=<value2>,...).",
+    )
+
+
+def _add_local_addr_arg(
+    parser: argparse.ArgumentParser,
+    *,
+    action: Optional[Callable[..., Any]] = None,
+) -> None:
+    _add_argument(
+        parser,
+        "--local-addr",
+        "--local_addr",
+        action=action,
+        default=None,
+        type=str,
+        help="Address of the local node. If specified, will use the given address for connection. "
+        "Else, will look up the local node address instead. Else, it will be default to local "
+        "machine's FQDN.",
+    )
+
+
+def _add_ft_segment_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--ft-segment",
+        "--ft_segment",
+        type=int,
+        default=None,
+        dest="ft_segment",
+        help="Controls hot spare node behavior and segment-aware rank assignment. "
+        "Default: None (simple hot spare mode for H100 and non-NVSwitch systems, no ClusterUUID required). "
+        "When set to N: Enables segment-aware mode for NVSwitch systems (DGX H200, HGX B200). "
+        "Specifies minimum nodes per NVLink domain (identified by GPU ClusterUUID via nvidia-smi). "
+        "Domains with fewer than N nodes are excluded. From valid domains, complete segments are selected. "
+        "min_nodes must be divisible by segment. "
+        "Note: segment=None (default) is suitable for H100; segment=1 is similar but requires ClusterUUID.",
+    )
+
+
+def add_rendezvous_args(
+    parser: argparse.ArgumentParser,
+    *,
+    action: Optional[Callable[..., Any]] = None,
+    nnodes_default: Optional[str] = "1:1",
+    nnodes_required: bool = False,
+    nnodes_help: str = "Number of nodes, or the range of nodes in form <minimum_nodes>:<maximum_nodes>.",
+    endpoint_default: Optional[str] = "",
+    endpoint_required: bool = False,
+    include_local_addr: bool = False,
+    include_ft_segment: bool = False,
+) -> None:
+    _add_nnodes_arg(
+        parser,
+        action=action,
+        default=nnodes_default,
+        required=nnodes_required,
+        help=nnodes_help,
+    )
+    _add_rendezvous_core_args(
+        parser,
+        action=action,
+        endpoint_default=endpoint_default,
+        endpoint_required=endpoint_required,
+    )
+    if include_local_addr:
+        _add_local_addr_arg(parser, action=action)
+    if include_ft_segment:
+        _add_ft_segment_arg(parser)
+
+
+def add_log_funnel_args(
+    parser: argparse.ArgumentParser,
+    *,
+    action: Optional[Callable[..., Any]] = None,
+    enable_default: Optional[bool] = None,
+    enable_type: Callable[[Any], bool] = str_to_bool,
+) -> None:
+    if enable_default is None:
+        enable_default_help = (
+            "False unless auto-enabled by another log-routing option such as --ft-nvrx-logfile"
+        )
+    else:
+        enable_default_help = str(enable_default)
+
+    _add_argument(
+        parser,
+        "--ft-per-cycle-applog-prefix",
+        "--ft_per_cycle_applog_prefix",
+        action=action,
+        type=str,
+        default=None,
+        dest="ft_per_cycle_applog_prefix",
+        help="Prefix for per-cycle application log files (must be absolute path, e.g. /lustre/logs/job_12345.log). "
+        "Creates training worker logs per cycle: /lustre/logs/job_12345_cycle0.log, job_12345_cycle1.log, etc. "
+        "All ranks/nodes capture logs with automatic rank prefixes (like 'srun -l'). "
+        "Without --ft-enable-log-server: Each node writes directly to Lustre with O_APPEND (safe concurrent writes). "
+        "With --ft-enable-log-server (recommended): All nodes stream logs to gRPC server on rank 0, which becomes the single Lustre writer. "
+        "gRPC mode eliminates Lustre lock contention and scales to 1000+ nodes. "
+        "Note: NVRx launcher logs go to stdout/stderr by default unless --ft-nvrx-logfile is specified.",
+    )
+    _add_argument(
+        parser,
+        "--ft-nvrx-logfile",
+        "--ft_nvrx_logfile",
+        action=action,
+        type=str,
+        default=None,
+        dest="ft_nvrx_logfile",
+        help="Optional: Path for NVRx process logs (must be absolute path if specified). "
+        "ft_launcher routes these logs through the same infrastructure as worker logs. "
+        "nvrx-control also uses this path as a fallback source for gRPC server diagnostic logs. "
+        "Example: --ft-nvrx-logfile /lustre/logs/launcher.log",
+    )
+    _add_argument(
+        parser,
+        "--ft-enable-log-server",
+        "--ft_enable_log_server",
+        action=action,
+        type=enable_type,
+        default=enable_default,
+        dest="ft_enable_log_server",
+        help="Enable gRPC-based log funneling to a single Lustre file. "
+        "When enabled with --ft-per-cycle-applog-prefix, NVRx automatically: "
+        "(1) Starts gRPC log server(s) on the TCPStore host, "
+        "(2) Configures all nodes as gRPC clients to a first-level aggregator port, "
+        "(3) Root server writes to Lustre (single writer). "
+        "With --ft-log-aggregator-count=N>1, N leaf processes plus one root use ports P..P+N (see --ft-log-server-port). "
+        "Use --ft-log-aggregator-count=1 for a single server on P only. "
+        "Benefits: No Lustre lock contention, scales to 1500+ nodes. "
+        f"Requires: grpcio. Default: {enable_default_help}.",
+    )
+    _add_argument(
+        parser,
+        "--ft-log-server-port",
+        "--ft_log_server_port",
+        action=action,
+        type=int,
+        default=50051,
+        dest="ft_log_server_port",
+        help="Port for gRPC log funnel server (only used if --ft-enable-log-server is enabled). "
+        "Default: 50051",
+    )
+    _add_argument(
+        parser,
+        "--ft-log-aggregator-count",
+        "--ft_log_aggregator_count",
+        action=action,
+        type=int,
+        default=0,
+        dest="ft_log_aggregator_count",
+        help="Number of first-level gRPC log aggregators. "
+        "0 (default): auto - single root server for up to 1536 nodes, "
+        "adds leaf servers beyond that (one per 1536 nodes). "
+        "1: single root server (legacy). "
+        "N>1: N leaf servers on ports [P, P+1, ..., P+N-1] and one root on P+N "
+        "(P = --ft-log-server-port). "
+        "Open TCP ports P through P+N on the TCP store host. "
+        "Each node picks a leaf from SLURM array/procid when set, else from hostname.",
+    )
+    _add_argument(
+        parser,
+        "--ft-log-leaf-max-queue-chunks",
+        "--ft_log_leaf_max_queue_chunks",
+        action=action,
+        type=int,
+        default=-1,
+        dest="ft_log_leaf_max_queue_chunks",
+        help="Max queued log chunks per leaf (only when N>1). "
+        "Default -1: auto scale with fan-in, max(16384, min(1000000, per_leaf*256)).",
+    )
+    _add_argument(
+        parser,
+        "--ft-log-server-log-prefix",
+        "--ft_log_server_log_prefix",
+        action=action,
+        type=str,
+        default=None,
+        dest="ft_log_server_log_prefix",
+        help="Prefix for gRPC log server process logs (only used if --ft-enable-log-server is enabled). "
+        "Root and leaf process logs are written to '<prefix>_root.log' and "
+        "'<prefix>_leaf_<N>.log'. If not specified, derives from --ft-nvrx-logfile first, "
+        "then --ft-per-cycle-applog-prefix by stripping a trailing '.log' and appending '_grpc'.",
+    )
+    _add_argument(
+        parser,
+        "--ft-log-server-graceful-shutdown-timeout",
+        "--ft_log_server_graceful_shutdown_timeout",
+        action=action,
+        type=float,
+        default=60.0,
+        dest="ft_log_server_graceful_shutdown_timeout",
+        help="Maximum seconds to wait for clients during gRPC server graceful shutdown (only used if --ft-enable-log-server is enabled). "
+        "When store host exits, server will continue accepting logs from other ranks for up to this timeout "
+        "or until all clients disconnect, whichever comes first. This ensures other nodes can flush their final logs. "
+        "When --ft-log-aggregator-count>1, each leaf uses this timeout; the root log server uses 2x so leaves can finish "
+        "waiting for downstream clients and drain to root first. "
+        "Default: 60.0",
+    )
+
+
+def _add_ft_config_file_arg(
+    parser: argparse.ArgumentParser,
+    *,
+    aliases: Sequence[str],
+    action: Optional[Callable[..., Any]] = None,
+) -> None:
+    _add_argument(
+        parser,
+        *aliases,
+        action=action,
+        default=None,
+        type=str,
+        dest="ft_cfg_path",
+        help="Path to a YAML file that contains Fault Tolerance pkg config (`fault_tolerance` section)."
+        " NOTE: config items from the file can be overwritten by `--ft-param-*` args.",
+    )
+
+
+def add_ft_config_file_args(
+    parser: argparse.ArgumentParser,
+    *,
+    aliases: Sequence[str],
+    action: Optional[Callable[..., Any]] = None,
+) -> None:
+    _add_ft_config_file_arg(parser, aliases=aliases, action=action)
+
+
+def _add_attribution_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--ft-attribution-endpoint",
+        "--ft_attribution_endpoint",
+        type=str,
+        default=None,
+        dest="ft_attribution_endpoint",
+        help=(
+            "Endpoint for the attribution service. Default: disabled. "
+            "Set to localhost to let the TCPStore host process manage nvrx-attrsvc. "
+            "Use an explicit endpoint such as http://host:port, grpc://host:port, "
+            "or unix:///path/to/socket for an externally managed attribution service."
+        ),
+    )
+    parser.add_argument(
+        "--ft-attribution-startup-timeout",
+        "--ft_attribution_startup_timeout",
+        type=float,
+        default=DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT,
+        dest="ft_attribution_startup_timeout",
+        help=(
+            "Seconds to wait for launcher-managed attribution service /healthz readiness. "
+            f"Default: {DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT}."
+        ),
+    )
+    parser.add_argument(
+        "--ft-attribution-llm-api-key-file",
+        "--ft_attribution_llm_api_key_file",
+        type=str,
+        default=None,
+        dest="ft_attribution_llm_api_key_file",
+        help=(
+            "Path to the LLM API key file for launcher-managed attribution service. "
+            "If unset, LLM_API_KEY_FILE from the launcher environment is used."
+        ),
+    )
+    parser.add_argument(
+        "--ft-attribution-llm-base-url",
+        "--ft_attribution_llm_base_url",
+        type=str,
+        default=None,
+        dest="ft_attribution_llm_base_url",
+        help="LLM base URL for launcher-managed attribution service.",
+    )
+    parser.add_argument(
+        "--ft-attribution-llm-model",
+        "--ft_attribution_llm_model",
+        type=str,
+        default=None,
+        dest="ft_attribution_llm_model",
+        help="LLM model identifier for launcher-managed attribution service.",
+    )
+    parser.add_argument(
+        "--ft-attribution-analysis-backend",
+        "--ft_attribution_analysis_backend",
+        type=str,
+        default=None,
+        dest="ft_attribution_analysis_backend",
+        choices=("mcp", "lib"),
+        help="Analysis backend for launcher-managed attribution service: mcp or lib.",
+    )
+    parser.add_argument(
+        "--ft-attribution-compute-timeout",
+        "--ft_attribution_compute_timeout",
+        type=float,
+        default=None,
+        dest="ft_attribution_compute_timeout",
+        help="Analysis compute timeout in seconds for launcher-managed attribution service.",
+    )
+    parser.add_argument(
+        "--ft-attribution-log-level",
+        "--ft_attribution_log_level",
+        type=str.upper,
+        default=None,
+        dest="ft_attribution_log_level",
+        choices=("DEBUG", "INFO", "WARNING"),
+        help="Log level for launcher-managed attribution service.",
+    )
+
+
+def add_attribution_args(parser: argparse.ArgumentParser) -> None:
+    _add_attribution_args(parser)
+
+
+def _add_cycle_info_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--ft-cycle-info-dir",
+        "--ft_cycle_info_dir",
+        type=str,
+        default=None,
+        dest="ft_cycle_info_dir",
+        help="Full path to NVRx cycle info directory (e.g. <base>/nvrx/). The rendezvous "
+        "host writes cycle_info.<job_id>.<attempt>.<cycle> and symlink "
+        "cycle_info.<job_id>.current there. Workload receives current cycle file path via "
+        "NVRX_CURRENT_CYCLE_INFO env.",
+    )
+
+
+def add_cycle_info_args(parser: argparse.ArgumentParser) -> None:
+    _add_cycle_info_arg(parser)
+
+
+def add_control_services_args(parser: argparse.ArgumentParser) -> None:
+    add_attribution_args(parser)
+    add_cycle_info_args(parser)
+    parser.add_argument(
+        "--ft-cycle-info-job-id",
+        "--ft_cycle_info_job_id",
+        type=str,
+        default=None,
+        dest="ft_cycle_info_job_id",
+        help="Job id used by nvrx-control when writing cycle_info files. Use the same "
+        "effective job id compute launchers use for NVRX_CURRENT_CYCLE_INFO "
+        "(SLURM_ARRAY_JOB_ID when present, otherwise SLURM_JOB_ID).",
+    )

--- a/src/nvidia_resiliency_ext/fault_tolerance/config.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/config.py
@@ -99,9 +99,10 @@ class FaultToleranceConfig:
       - `attribution_endpoint` [str] endpoint of the attribution service
 
     * `cycle_info_dir` [str|None] Full path to the NVRx cycle info directory (e.g.
-      <base>/nvrx/). If set, the TCPStore host writes cycle info JSON files and the
-      cycle_info.<job_id>.current symlink there. The workload receives the path to
-      the current cycle file via NVRX_CURRENT_CYCLE_INFO. Default: None (disabled).
+      <base>/nvrx/). If set, the rendezvous host writes cycle info JSON files and
+      the cycle_info.<job_id>.current symlink there. The workload receives the path
+      to the current cycle file via NVRX_CURRENT_CYCLE_INFO.
+      Default: None (disabled).
 
     If any timeout is None, it has no effect (as if it was +INF).
     All timeouts can be deduced and set during runtime.

--- a/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""External NVRx control-node process.
+
+``nvrx-control`` owns long-lived store-host responsibilities for deployments where
+compute ``ft_launcher`` processes should only connect as TCPStore clients.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import logging
+import os
+import signal
+import sys
+import threading
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Optional
+
+from torch.distributed import TCPStore
+from torch.distributed.elastic.rendezvous.api import (
+    RendezvousClosedError,
+    RendezvousGracefulExitError,
+)
+from torch.distributed.elastic.rendezvous.utils import (
+    _parse_rendezvous_config,
+    parse_rendezvous_endpoint,
+)
+
+from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
+    DEFAULT_ATTRIBUTION_PORT,
+    AttributionConfig,
+    AttributionManager,
+)
+from nvidia_resiliency_ext.fault_tolerance.cli_args import (
+    add_control_services_args,
+    add_ft_config_file_args,
+    add_log_funnel_args,
+    add_rendezvous_args,
+    str_to_bool,
+)
+from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
+from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import (
+    CycleInfoReporter,
+    cycle_log_file,
+)
+from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import (
+    _NodeDescGenerator,
+    _RendezvousBarrierState,
+)
+from nvidia_resiliency_ext.fault_tolerance.launcher import (
+    LogFunnelPorts,
+    _resolve_grpc_log_server_log_prefix,
+    _start_grpc_log_servers,
+    _validate_managed_attribution_listen_port_not_in_log_funnel,
+    parse_min_max_nnodes,
+    stop_grpc_log_servers,
+)
+from nvidia_resiliency_ext.fault_tolerance.rdzv_utils import (
+    rdzv_config_get_as_float,
+    rdzv_config_get_as_int,
+)
+from nvidia_resiliency_ext.shared_utils.health_check import AttributionService
+from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig, setup_logger
+
+logger = logging.getLogger(LogConfig.name)
+
+
+@dataclass
+class ControlServices:
+    grpc_processes: list[Any] = field(default_factory=list)
+    attribution_manager: Optional[AttributionManager] = None
+    attribution_service: Optional[AttributionService] = None
+    cycle_info_reporter: Optional[CycleInfoReporter] = None
+
+
+def get_args_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="nvrx-control",
+        description="Run the external NVRx control-node process.",
+    )
+    add_rendezvous_args(
+        parser,
+        nnodes_required=True,
+        nnodes_help="Training node range MIN[:MAX].",
+        endpoint_required=True,
+        include_local_addr=True,
+        include_ft_segment=True,
+    )
+    add_ft_config_file_args(parser, aliases=("--ft-cfg-path", "--ft-cfg_path"))
+    add_log_funnel_args(parser, enable_default=True, enable_type=str_to_bool)
+    add_control_services_args(parser)
+    return parser
+
+
+def parse_args(args: Optional[list[str]] = None) -> argparse.Namespace:
+    return get_args_parser().parse_args(args)
+
+
+def _validate_args(args: argparse.Namespace, ft_cfg: FaultToleranceConfig) -> None:
+    if args.rdzv_backend.lower() != "c10d":
+        raise ValueError(f"nvrx-control supports only --rdzv-backend=c10d, got {args.rdzv_backend}")
+    host, port = parse_rendezvous_endpoint(args.rdzv_endpoint, default_port=-1)
+    if not host or port == -1:
+        raise ValueError("--rdzv-endpoint must include host and port, e.g. control-host:29500")
+
+    if args.ft_enable_log_server and _resolve_grpc_log_server_log_prefix(args) is None:
+        raise ValueError(
+            "nvrx-control requires one of --ft-log-server-log-prefix, "
+            "--ft-nvrx-logfile, or --ft-per-cycle-applog-prefix when log funneling is enabled."
+        )
+
+    if (args.ft_attribution_endpoint or ft_cfg.attribution_endpoint) and (
+        not args.ft_per_cycle_applog_prefix
+    ):
+        raise ValueError(
+            "nvrx-control requires --ft-per-cycle-applog-prefix when attribution is enabled."
+        )
+
+    if args.ft_per_cycle_applog_prefix and not os.path.isabs(args.ft_per_cycle_applog_prefix):
+        raise ValueError(
+            "--ft-per-cycle-applog-prefix must be an absolute path, "
+            f"got {args.ft_per_cycle_applog_prefix!r}"
+        )
+    if ft_cfg.cycle_info_dir and not args.ft_cycle_info_job_id:
+        raise ValueError("nvrx-control requires --ft-cycle-info-job-id with --ft-cycle-info-dir.")
+    if args.ft_nvrx_logfile and not os.path.isabs(args.ft_nvrx_logfile):
+        raise ValueError(
+            "--ft-nvrx-logfile must be an absolute path, " f"got {args.ft_nvrx_logfile!r}"
+        )
+
+
+def _create_tcp_store(args: argparse.Namespace, read_timeout: float) -> TCPStore:
+    host, port = parse_rendezvous_endpoint(args.rdzv_endpoint, default_port=-1)
+    logger.info("Starting control TCPStore on %s:%s", host, port)
+    return TCPStore(
+        host_name=host,
+        port=port,
+        is_master=True,
+        timeout=timedelta(seconds=read_timeout),
+        wait_for_workers=False,
+        multi_tenant=True,
+    )
+
+
+def _start_control_services(
+    args: argparse.Namespace,
+    ft_cfg: FaultToleranceConfig,
+) -> ControlServices:
+    services = ControlServices()
+    try:
+        if ft_cfg.cycle_info_dir:
+            services.cycle_info_reporter = CycleInfoReporter(
+                ft_cfg.cycle_info_dir,
+                cycle_log_prefix=args.ft_per_cycle_applog_prefix,
+                cycle_info_job_id=args.ft_cycle_info_job_id,
+                attempt_index=0,
+            )
+
+        applog_prefix = args.ft_per_cycle_applog_prefix
+        log_funnel_ports = None
+        grpc_log_prefix = None
+        if args.ft_enable_log_server:
+            grpc_log_prefix = _resolve_grpc_log_server_log_prefix(args)
+            assert grpc_log_prefix is not None
+            log_funnel_ports = LogFunnelPorts.from_launcher_args(args)
+
+        if args.ft_attribution_endpoint or ft_cfg.attribution_endpoint:
+            assert applog_prefix is not None
+            attribution_cfg = AttributionConfig.from_args(args, applog_prefix, ft_cfg)
+            if log_funnel_ports is not None and attribution_cfg.is_managed:
+                _validate_managed_attribution_listen_port_not_in_log_funnel(
+                    DEFAULT_ATTRIBUTION_PORT, log_funnel_ports
+                )
+            services.attribution_manager = AttributionManager(attribution_cfg, is_store_host=True)
+            attribution_endpoint = services.attribution_manager.start_if_needed()
+            if attribution_endpoint is not None:
+                services.attribution_service = AttributionService(
+                    endpoint=attribution_endpoint.endpoint
+                )
+
+        if args.ft_enable_log_server:
+            assert log_funnel_ports is not None
+            assert grpc_log_prefix is not None
+            services.grpc_processes = _start_grpc_log_servers(
+                args, grpc_log_prefix, log_funnel_ports
+            )
+            if not services.grpc_processes:
+                raise RuntimeError("failed to start gRPC log funnel process(es)")
+
+        return services
+    except Exception:
+        with contextlib.suppress(Exception):
+            if services.grpc_processes:
+                stop_grpc_log_servers(
+                    services.grpc_processes,
+                    float(args.ft_log_server_graceful_shutdown_timeout),
+                )
+        with contextlib.suppress(Exception):
+            if services.attribution_manager is not None:
+                services.attribution_manager.stop()
+        with contextlib.suppress(Exception):
+            if services.cycle_info_reporter is not None:
+                services.cycle_info_reporter.shutdown()
+        raise
+
+
+def _run_control_rendezvous_loop(
+    args: argparse.Namespace,
+    ft_cfg: FaultToleranceConfig,
+    store: TCPStore,
+    services: ControlServices,
+    stop_event: threading.Event,
+) -> None:
+    min_nodes, max_nodes = parse_min_max_nnodes(args.nnodes)
+    rdzv_configs = _parse_rendezvous_config(args.rdzv_conf)
+    join_timeout = rdzv_config_get_as_float(
+        rdzv_configs, "join_timeout", rdzv_config_get_as_float(rdzv_configs, "timeout", 600.0)
+    )
+    segment_check_interval = rdzv_config_get_as_float(rdzv_configs, "segment_check_interval", 5.0)
+    segment = ft_cfg.segment
+    if segment is None:
+        segment = rdzv_config_get_as_int(rdzv_configs, "segment", 0) or None
+
+    state = _RendezvousBarrierState(
+        store=store,
+        run_id=args.rdzv_id,
+        is_store_host=True,
+        join_timeout_seconds=join_timeout,
+        segment=segment,
+    )
+    node = _NodeDescGenerator().generate(args.local_addr)
+
+    logger.info(
+        "nvrx-control rendezvous loop started: run_id=%s nnodes=%s endpoint=%s",
+        args.rdzv_id,
+        args.nnodes,
+        args.rdzv_endpoint,
+    )
+    if services.cycle_info_reporter is not None:
+        state._cycle_info_reporter = services.cycle_info_reporter
+
+    while not stop_event.is_set():
+        if services.attribution_service is not None:
+            services.attribution_service()
+        try:
+            closed_round = state.close_current_round_as_host(
+                node,
+                min_nodes,
+                max_nodes,
+                segment_check_interval=segment_check_interval,
+                stop_event=stop_event,
+            )
+        except (RendezvousGracefulExitError, RendezvousClosedError) as exc:
+            logger.info("nvrx-control rendezvous loop exiting: %s", exc)
+            return
+
+        logger.info("nvrx-control closed rendezvous round %s", closed_round)
+        if services.attribution_service is not None and args.ft_per_cycle_applog_prefix:
+            services.attribution_service._submit_log(
+                cycle_log_file(args.ft_per_cycle_applog_prefix, closed_round)
+            )
+
+
+def run(args: argparse.Namespace) -> None:
+    setup_logger(node_local_tmp_prefix="nvrxcontrol")
+    ft_cfg = FaultToleranceConfig.from_args(args)
+    _validate_args(args, ft_cfg)
+    rdzv_configs = _parse_rendezvous_config(args.rdzv_conf)
+    read_timeout = rdzv_config_get_as_float(rdzv_configs, "read_timeout", 60.0)
+
+    stop_event = threading.Event()
+
+    def _handle_signal(signum: int, _frame: Any) -> None:
+        logger.info("nvrx-control received %s; shutting down", signal.Signals(signum).name)
+        stop_event.set()
+
+    previous_handlers = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGINT)}
+    for sig in previous_handlers:
+        signal.signal(sig, _handle_signal)
+
+    services = ControlServices()
+    try:
+        store = _create_tcp_store(args, read_timeout)
+        services = _start_control_services(args, ft_cfg)
+        _run_control_rendezvous_loop(args, ft_cfg, store, services, stop_event)
+    finally:
+        with contextlib.suppress(Exception):
+            if services.grpc_processes:
+                stop_grpc_log_servers(
+                    services.grpc_processes,
+                    float(args.ft_log_server_graceful_shutdown_timeout),
+                )
+        with contextlib.suppress(Exception):
+            if services.attribution_manager is not None:
+                services.attribution_manager.stop()
+        with contextlib.suppress(Exception):
+            if services.cycle_info_reporter is not None:
+                services.cycle_info_reporter.shutdown()
+        for sig, handler in previous_handlers.items():
+            signal.signal(sig, handler)
+
+
+def main(args: Optional[list[str]] = None) -> None:
+    parsed_args = parse_args(args)
+    try:
+        run(parsed_args)
+    except Exception as exc:
+        logger.error("nvrx-control exited with exception: %s", exc, exc_info=True)
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nvidia_resiliency_ext/fault_tolerance/cycle_info_writer.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cycle_info_writer.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-NVRx cycle info writer: writes NVRxCycleInfo as JSON to Lustre (or local) from the TCPStore host.
+NVRx cycle info writer: writes NVRxCycleInfo as JSON to Lustre (or local).
 
 Uses the NVRxCycleInfo protobuf and protobuf JSON serialization. A dedicated background
 thread performs file I/O so the main launcher thread is not blocked. Writes are
@@ -25,13 +25,16 @@ import logging
 import os
 import queue
 import threading
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 from google.protobuf import json_format
 
 from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
 from nvidia_resiliency_ext.shared_utils.proto import nvrx_interface_pb2
+
+from .utils import hostnames_to_slurm_nodelist, ranks_to_range_str, slurm_sort_addrs
 
 logger = logging.getLogger(LogConfig.name)
 
@@ -42,6 +45,43 @@ def _cycle_info_filename(job_id: str, attempt_index: int, cycle_number: int) -> 
 
 def _current_symlink_name(job_id: str) -> str:
     return f"cycle_info.{job_id}.current"
+
+
+def cycle_log_file(base_log_file: str, cycle_index: int) -> str:
+    base_without_ext, ext = os.path.splitext(os.path.abspath(base_log_file))
+    return f"{base_without_ext}_cycle{cycle_index}{ext or '.log'}"
+
+
+def _cycle_info_job_id_from_env() -> str:
+    return os.environ.get("SLURM_ARRAY_JOB_ID") or os.environ.get("SLURM_JOB_ID", "")
+
+
+def _cycle_info_attempt_index_from_env() -> int:
+    raw_attempt_index = os.environ.get("SLURM_RESTART_CNT", "0")
+    try:
+        return int(raw_attempt_index)
+    except ValueError:
+        logger.warning(
+            "Invalid SLURM_RESTART_CNT=%r for cycle info; using 0",
+            raw_attempt_index,
+        )
+        return 0
+
+
+@dataclass(frozen=True)
+class CycleInfoRoundSnapshot:
+    cycle_number: int
+    active_node_addrs: Optional[Sequence[str]] = None
+    standby_node_addrs: Optional[Sequence[str]] = None
+    active_ranks: Optional[Sequence[int]] = None
+    cycle_log_file: str = ""
+
+
+@dataclass(frozen=True)
+class _ReportedCycle:
+    job_id: str
+    attempt_index: int
+    cycle_number: int
 
 
 class _CycleInfoTask:
@@ -60,8 +100,8 @@ class CycleInfoWriter:
     """
     Writes NVRx cycle info JSON files under <base_dir>/nvrx/ on a dedicated thread.
 
-    Only the TCPStore host should create and use one instance. Call write_cycle_start()
-    after rendezvous (before workers start) and update_cycle_end() when the cycle ends.
+    The rendezvous host should call write_cycle_start() after rendezvous and
+    update_cycle_end() when the cycle ends.
     """
 
     def __init__(self, cycle_info_dir: str) -> None:
@@ -241,6 +281,7 @@ class CycleInfoWriter:
         if not os.path.isfile(path):
             logger.warning("Cycle info file not found for update: %s", path)
             return
+
         tmp_path = path + ".tmp"
         try:
             with open(path) as f:
@@ -274,6 +315,110 @@ class CycleInfoWriter:
     def get_current_cycle_info_path(self, job_id: str) -> str:
         """Return the full path to the cycle_info.<job_id>.current symlink (for NVRX_CURRENT_CYCLE_INFO env)."""
         return os.path.join(self._nvrx_dir, _current_symlink_name(job_id))
+
+
+class CycleInfoReporter:
+    """Owns cycle-info lifecycle reporting for a rendezvous host."""
+
+    def __init__(
+        self,
+        cycle_info_dir: str,
+        cycle_log_prefix: Optional[str] = None,
+        cycle_info_job_id: Optional[str] = None,
+        attempt_index: Optional[int] = None,
+        writer: Optional[CycleInfoWriter] = None,
+    ) -> None:
+        if cycle_info_job_id is not None and not cycle_info_job_id.strip():
+            raise ValueError("cycle_info_job_id must be non-empty when set")
+        self._writer = writer or CycleInfoWriter(cycle_info_dir)
+        self._cycle_log_prefix = cycle_log_prefix
+        self._cycle_info_job_id = cycle_info_job_id
+        self._attempt_index = attempt_index
+        self._current_cycle: Optional[_ReportedCycle] = None
+        self._started_cycles: set[int] = set()
+        self._shutdown = False
+
+    @staticmethod
+    def current_cycle_info_path(cycle_info_dir: str, job_id: str) -> str:
+        return os.path.join(
+            os.path.abspath(cycle_info_dir.rstrip("/")),
+            _current_symlink_name(job_id),
+        )
+
+    def report_cycle_start(
+        self,
+        snapshot: CycleInfoRoundSnapshot,
+    ) -> bool:
+        if self._shutdown:
+            logger.warning("CycleInfoReporter already shutdown, ignoring cycle start")
+            return False
+        if snapshot.cycle_number in self._started_cycles:
+            return False
+
+        job_id, attempt_index = self._resolve_file_namespace()
+        if self._current_cycle is not None:
+            self.report_cycle_end()
+
+        self._writer.write_cycle_start(
+            job_id=job_id,
+            attempt_index=attempt_index,
+            cycle_number=snapshot.cycle_number,
+            cycle_start_time=utc_iso_now(),
+            cycle_log_file=self._resolve_cycle_log_file(snapshot),
+            active_nodes=self._format_nodes(snapshot.active_node_addrs),
+            standby_nodes=self._format_nodes(snapshot.standby_node_addrs),
+            active_ranks=self._format_active_ranks(snapshot),
+        )
+        self._current_cycle = _ReportedCycle(job_id, attempt_index, snapshot.cycle_number)
+        self._started_cycles.add(snapshot.cycle_number)
+        return True
+
+    def report_cycle_end(self) -> bool:
+        if self._shutdown or self._current_cycle is None:
+            return False
+        current_cycle = self._current_cycle
+        self._current_cycle = None
+        self._writer.update_cycle_end(
+            job_id=current_cycle.job_id,
+            attempt_index=current_cycle.attempt_index,
+            cycle_number=current_cycle.cycle_number,
+            cycle_end_time=utc_iso_now(),
+        )
+        return True
+
+    def shutdown(self) -> None:
+        if self._shutdown:
+            return
+        self.report_cycle_end()
+        self._shutdown = True
+        self._writer.shutdown()
+
+    def _resolve_file_namespace(self) -> Tuple[str, int]:
+        if self._cycle_info_job_id is not None:
+            return self._cycle_info_job_id, self._attempt_index or 0
+        return _cycle_info_job_id_from_env(), _cycle_info_attempt_index_from_env()
+
+    def _resolve_cycle_log_file(self, snapshot: CycleInfoRoundSnapshot) -> str:
+        if snapshot.cycle_log_file:
+            return snapshot.cycle_log_file
+        if self._cycle_log_prefix:
+            return cycle_log_file(self._cycle_log_prefix, snapshot.cycle_number)
+        return ""
+
+    @staticmethod
+    def _format_nodes(addrs: Optional[Sequence[str]]) -> str:
+        return hostnames_to_slurm_nodelist(list(addrs)) if addrs else ""
+
+    @staticmethod
+    def _format_active_ranks(snapshot: CycleInfoRoundSnapshot) -> str:
+        if snapshot.active_ranks is None:
+            return ""
+        active_ranks = list(snapshot.active_ranks)
+        active_addrs = list(snapshot.active_node_addrs or [])
+        if active_addrs and len(active_addrs) == len(active_ranks):
+            addr_to_rank = dict(zip(active_addrs, active_ranks))
+            active_ranks = [addr_to_rank[addr] for addr in slurm_sort_addrs(active_addrs)]
+        return ranks_to_range_str(active_ranks)
 
 
 def utc_iso_now() -> str:

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -67,6 +67,7 @@ from ..shared_utils.profiling import (
     record_profiling_event,
     set_profiling_cycle,
 )
+from .cycle_info_writer import CycleInfoReporter, CycleInfoRoundSnapshot
 from .data import WorkloadAction
 from .ipc_connector import IpcConnector
 from .launcher import FT_LAUNCHER_IPC_SOCKET, UnhealthyNodeException, get_node_health_check
@@ -74,6 +75,7 @@ from .launcher import FT_LAUNCHER_IPC_SOCKET, UnhealthyNodeException, get_node_h
 # Conditionally import failure injector (only active when NVRX_INJECT_GPU_FAILURE is set)
 if os.environ.get("NVRX_INJECT_GPU_FAILURE"):
     from ..testing_utils import health_check_injector
+
 from .utils import get_infrastructure_rank, is_slurm_job_array, slurm_sort_addrs
 
 log = logging.getLogger(LogConfig.name)
@@ -510,6 +512,7 @@ class _RendezvousBarrierState:
         self._standby_node_addrs: Optional[List[str]] = None
         # Group ranks of active nodes, parallel to _active_node_addrs (same slot order)
         self._active_ranks: Optional[List[int]] = None
+        self._cycle_info_reporter: Optional[CycleInfoReporter] = None
 
         # Reference to agent (set via set_agent() method in handler)
         # Will be set by handler via set_agent() method
@@ -1020,7 +1023,9 @@ class _RendezvousBarrierState:
         except Exception as e:
             log.warning("Failed to leave rendezvous: %s", e)
 
-    def _wait_for_rendezvous_open(self, node_desc: _NodeDesc) -> None:
+    def _wait_for_rendezvous_open(
+        self, node_desc: _NodeDesc, stop_event: Optional[threading.Event] = None
+    ) -> None:
         """Step 0: Wait until the current round is open. Hot spares and late arrivals wait here.
 
         This prevents hot spares and late-arriving nodes from disrupting ongoing training.
@@ -1048,6 +1053,9 @@ class _RendezvousBarrierState:
         logged_waiting = False  # Track if we've logged the waiting message
 
         while True:
+            if stop_event is not None and stop_event.is_set():
+                raise RendezvousGracefulExitError("Control rendezvous stop requested")
+
             # Check for permanent shutdown (no further rounds)
             if self.is_shutdown():
                 msg = f"The node '{node_desc}' detected that rendezvous was permanently closed"
@@ -1101,6 +1109,7 @@ class _RendezvousBarrierState:
         min_nodes: int,
         max_nodes: int,
         segment_check_interval: float,
+        stop_event: Optional[threading.Event] = None,
     ) -> None:
         """Step 2 (store host only): Poll until segment constraint is met, assign ranks, close round.
 
@@ -1122,6 +1131,9 @@ class _RendezvousBarrierState:
         mismatch_first_seen: Optional[float] = None
 
         while True:
+            if stop_event is not None and stop_event.is_set():
+                raise RendezvousGracefulExitError("Control rendezvous stop requested")
+
             self._check_timeout_and_closure(node_desc)
 
             # Early termination: if too many nodes are unhealthy it is mathematically
@@ -1136,6 +1148,10 @@ class _RendezvousBarrierState:
                 log.error(msg)
                 self.set_shutdown()
                 # Loop: _check_timeout_and_closure will raise RendezvousClosedError next iteration.
+                continue
+
+            if not self.store.check([self.join_count_key]):
+                time.sleep(0.1)
                 continue
 
             current_joined = int(self.store.get(self.join_count_key).decode('utf-8'))
@@ -1225,8 +1241,30 @@ class _RendezvousBarrierState:
             # Assign ranks BEFORE setting round_done=1 so Step 3 readers can get their rank
             # immediately without any additional waiting.
             self.assign_group_ranks(min_nodes, max_nodes, current_joined, node_desc)
+            self._report_cycle_start_as_host(self._round)
             self.store.set(self.round_done_key, "1".encode('utf-8'))
             return
+
+    def _report_cycle_start_as_host(self, round_id: int) -> None:
+        """Report cycle start from the rendezvous-host rank assignment snapshot."""
+        if self._cycle_info_reporter is None:
+            return
+        try:
+            self._cycle_info_reporter.report_cycle_start(
+                CycleInfoRoundSnapshot(
+                    cycle_number=round_id,
+                    active_node_addrs=self._active_node_addrs,
+                    standby_node_addrs=self._standby_node_addrs,
+                    active_ranks=self._active_ranks,
+                )
+            )
+        except Exception as e:
+            log.warning(
+                "Failed to report cycle info after closing rendezvous round %s: %s",
+                round_id,
+                e,
+                exc_info=True,
+            )
 
     def _wait_for_round_done(self, node_desc: _NodeDesc, rank_key: str) -> Tuple[int, int]:
         """Step 3 (all participants): Wait for round_done_key=1 then read the assigned rank.
@@ -1292,6 +1330,41 @@ class _RendezvousBarrierState:
             return GroupRankStatus.UNASSIGNED.value, 0
 
         return rank, total
+
+    def close_current_round_as_host(
+        self,
+        node_desc: _NodeDesc,
+        min_nodes: int,
+        max_nodes: int,
+        segment_check_interval: float = 5.0,
+        stop_event: Optional[threading.Event] = None,
+    ) -> int:
+        """Close one open rendezvous round without joining as a participant.
+
+        This is used by an external control process that owns TCPStore. The
+        control process is the store host, but it does not increment
+        join_count_key, write a slot, or receive a rank. Participant accounting
+        remains compute-only.
+
+        Returns:
+            The rendezvous round number that was closed.
+        """
+        if not self.is_store_host:
+            raise RuntimeError("host-only rendezvous close must run on the TCPStore host")
+
+        self._slot = None
+        self._last_stale_check_time = 0.0
+
+        self._wait_for_rendezvous_open(node_desc, stop_event=stop_event)
+        self._rendezvous_start_time = time.monotonic()
+        self._host_close_round(
+            node_desc,
+            min_nodes,
+            max_nodes,
+            segment_check_interval,
+            stop_event=stop_event,
+        )
+        return self._round
 
     def perform_rendezvous(
         self,
@@ -1735,6 +1808,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         link_state_path_template: Optional[str] = None,
         storage_healthcheck_paths: Optional[list] = None,
         attribution_endpoint: Optional[str] = None,
+        cycle_info_dir: Optional[str] = None,
+        cycle_log_prefix: Optional[str] = None,
     ):
         """Create a new :py:class:`FtRendezvousBarrierHandler`.
 
@@ -1793,6 +1868,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             link_state_path_template=link_state_path_template,
             storage_healthcheck_paths=storage_healthcheck_paths,
             attribution_endpoint=attribution_endpoint,
+            cycle_info_dir=cycle_info_dir,
+            cycle_log_prefix=cycle_log_prefix,
         )
 
     def __init__(
@@ -1807,6 +1884,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         link_state_path_template: Optional[str] = None,
         storage_healthcheck_paths: Optional[list] = None,
         attribution_endpoint: Optional[str] = None,
+        cycle_info_dir: Optional[str] = None,
+        cycle_log_prefix: Optional[str] = None,
     ) -> None:
         if not settings.run_id:
             raise ValueError("The run id must be a non-empty string.")
@@ -1840,6 +1919,13 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             settings.segment,
             stale_check_interval=10.0,  # Check for stale rounds every 10 seconds
         )
+        self._cycle_info_reporter: Optional[CycleInfoReporter] = None
+        if is_store_host and cycle_info_dir:
+            self._cycle_info_reporter = CycleInfoReporter(
+                cycle_info_dir,
+                cycle_log_prefix=cycle_log_prefix,
+            )
+            self._barrier_state._cycle_info_reporter = self._cycle_info_reporter
         self._assigned_rank = None
         self._world_size = None
         self._agent = None  # Reference to the agent (set via set_agent())
@@ -2289,9 +2375,14 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             )
             raise
 
+    def shutdown_cycle_info_reporter(self) -> None:
+        if self._cycle_info_reporter is not None:
+            self._cycle_info_reporter.shutdown()
+
     def _close(self) -> None:
         """Permanently shut down the rendezvous (no further rounds)."""
         self._barrier_state.set_shutdown()
+        self.shutdown_cycle_info_reporter()
 
         msg = f"The node '{self._this_node}' has permanently closed the rendezvous '{self._settings.run_id}'."
         self._record(message=msg, node_state=NodeState.SUCCEEDED)
@@ -2377,6 +2468,8 @@ def create_handler(
         storage_healthcheck_paths = params.config.get('storage_healthcheck_paths', None)
         link_state_path_template = params.config.get('link_state_path_template', None)
         attribution_endpoint = params.config.get('attribution_endpoint', None)
+        cycle_info_dir = params.config.get('cycle_info_dir', None)
+        cycle_log_prefix = params.config.get('cycle_log_prefix', None)
 
         return FtRendezvousBarrierHandler.from_backend(
             params.run_id,
@@ -2394,6 +2487,8 @@ def create_handler(
             link_state_path_template=link_state_path_template,
             storage_healthcheck_paths=storage_healthcheck_paths,
             attribution_endpoint=attribution_endpoint,
+            cycle_info_dir=cycle_info_dir,
+            cycle_log_prefix=cycle_log_prefix,
         )
     except Exception as e:
         construct_and_record_rdzv_event(

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -71,12 +71,18 @@ from torch.distributed.elastic.utils import macros
 
 from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
     DEFAULT_ATTRIBUTION_PORT,
-    DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT,
     AttributionConfig,
     AttributionManager,
 )
+from nvidia_resiliency_ext.fault_tolerance.cli_args import (
+    add_attribution_args,
+    add_cycle_info_args,
+    add_ft_config_file_args,
+    add_log_funnel_args,
+    add_rendezvous_args,
+)
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
-from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import CycleInfoWriter, utc_iso_now
+from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import CycleInfoReporter
 from nvidia_resiliency_ext.fault_tolerance.data import (
     FT_LAUNCHER_IPC_SOCKET_ENV_VAR,
     FT_RANK_MONITOR_IPC_SOCKET_ENV_VAR,
@@ -85,13 +91,12 @@ from nvidia_resiliency_ext.fault_tolerance.data import (
 from nvidia_resiliency_ext.fault_tolerance.per_cycle_logs import PipeBasedLogsSpecs
 from nvidia_resiliency_ext.fault_tolerance.progress_tracker import TrainingProgressTracker
 from nvidia_resiliency_ext.fault_tolerance.rank_monitor_server import RankMonitorServer
+from nvidia_resiliency_ext.fault_tolerance.rdzv_utils import rdzv_config_get_as_bool
 from nvidia_resiliency_ext.fault_tolerance.utils import (
     get_log_aggregator_shard_index,
     get_processes_by_pgids,
-    hostnames_to_slurm_nodelist,
     is_slurm_job_array,
     patched_method,
-    ranks_to_range_str,
     terminate_mp_processes,
     write_obj_to_ipc_stream,
 )
@@ -150,6 +155,14 @@ def _register_ft_rdzv_handler(impl_type: str = "barrier"):
     from torch.distributed.elastic.rendezvous import rendezvous_handler_registry
     from torch.distributed.elastic.rendezvous.c10d_rendezvous_backend import create_backend
 
+    from .c10d_monkey_patch import apply_c10d_patch
+
+    # Apply NVRx TCPStore creation behavior for all c10d-based FT rendezvous
+    # implementations. The patch consumes generic rdzv config such as
+    # store_connect_wait_seconds and use_libuv before either rendezvous protocol
+    # sees the store.
+    apply_c10d_patch()
+
     if impl_type == "barrier":
         from .ft_rendezvous_barrier import create_handler as create_barrier_handler
 
@@ -168,10 +181,6 @@ def _register_ft_rdzv_handler(impl_type: str = "barrier"):
             )
             _legacy_ft_rdzv_deprecation_warned = True
         from ._ft_rendezvous import create_handler as create_legacy_handler
-        from .c10d_monkey_patch import apply_c10d_patch
-
-        # Apply monkey patch to add use_libuv support to c10d backend
-        apply_c10d_patch()
 
         def _create_ft_rdzv_handler(params: RendezvousParameters):
             backend, store = create_backend(params)
@@ -368,7 +377,6 @@ class LocalElasticAgent(SimpleElasticAgent):
         restart_policy: str = "any-failed",
         is_store_host: bool = False,
         rank_monitors: Optional[Dict[int, RankMonitorState]] = None,
-        cycle_info_writer: Optional[CycleInfoWriter] = None,
     ):
         super().__init__(spec, exit_barrier_timeout)
         self._start_method = start_method
@@ -380,7 +388,6 @@ class LocalElasticAgent(SimpleElasticAgent):
         self._term_timeout = term_timeout
         self._workers_stop_timeout = workers_stop_timeout
         self._is_store_host = is_store_host
-        self._cycle_info_writer = cycle_info_writer
         # Rank monitor state (process, IPC connections, listener tasks) per local rank
         # Pre-created rank monitors passed from config (created before gRPC)
         self._rank_monitors: Dict[int, RankMonitorState] = rank_monitors or dict()
@@ -468,54 +475,11 @@ class LocalElasticAgent(SimpleElasticAgent):
         return self._rdzv_handler.round()
 
 
-    def _on_cycle_end(self, cycle_number: Optional[int] = None) -> None:
-        """Record cycle end time in cycle info file.
-
-        Args:
-            cycle_number: Cycle to record. Defaults to current cycle (_get_global_cycle_number()).
-                Standby nodes must pass round()-1 since their _round was already advanced
-                to N+1 by the time shutdown is detected.
-        """
-        if self._cycle_info_writer is None:
-            return
-        current_cycle = cycle_number if cycle_number is not None else self._get_global_cycle_number()
-        job_id = os.environ.get("SLURM_ARRAY_JOB_ID") or os.environ.get("SLURM_JOB_ID", "")
-        attempt_index = int(os.environ.get("SLURM_RESTART_CNT", "0"))
-        self._cycle_info_writer.update_cycle_end(
-            job_id=job_id,
-            attempt_index=attempt_index,
-            cycle_number=current_cycle,
-            cycle_end_time=utc_iso_now(),
-        )
-
-    def _write_cycle_start_info(self, current_cycle: int) -> Optional[str]:
-        """Write NVRx cycle info at cycle start. Returns path to current cycle info file, or None."""
-        if self._cycle_info_writer is None:
+    def _current_cycle_info_path(self) -> Optional[str]:
+        if not self._ft_cfg.cycle_info_dir:
             return None
         job_id = os.environ.get("SLURM_ARRAY_JOB_ID") or os.environ.get("SLURM_JOB_ID", "")
-        attempt_index = int(os.environ.get("SLURM_RESTART_CNT", "0"))
-        cycle_log_file = self._logs_specs.get_cycle_log_file(current_cycle)
-        # Legacy FtRendezvousHandler does not define these; barrier handler does.
-        get_active = getattr(self._rdzv_handler, "get_active_node_addrs", None)
-        get_standby = getattr(self._rdzv_handler, "get_standby_node_addrs", None)
-        get_active_ranks = getattr(self._rdzv_handler, "get_active_ranks", None)
-        active_addrs = get_active() if callable(get_active) else None
-        standby_addrs = get_standby() if callable(get_standby) else None
-        active_rank_list = get_active_ranks() if callable(get_active_ranks) else None
-        active_nodes = hostnames_to_slurm_nodelist(active_addrs) if active_addrs else ""
-        standby_nodes = hostnames_to_slurm_nodelist(standby_addrs) if standby_addrs else ""
-        active_ranks = ranks_to_range_str(active_rank_list) if active_rank_list is not None else ""
-        self._cycle_info_writer.write_cycle_start(
-            job_id=job_id,
-            attempt_index=attempt_index,
-            cycle_number=current_cycle,
-            cycle_start_time=utc_iso_now(),
-            cycle_log_file=cycle_log_file,
-            active_nodes=active_nodes,
-            standby_nodes=standby_nodes,
-            active_ranks=active_ranks,
-        )
-        return self._cycle_info_writer.get_current_cycle_info_path(job_id)
+        return CycleInfoReporter.current_cycle_info_path(self._ft_cfg.cycle_info_dir, job_id)
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.
@@ -536,9 +500,6 @@ class LocalElasticAgent(SimpleElasticAgent):
             return result
         except RendezvousGracefulExitError as e:
             logger.info("Rendezvous gracefully exited: %s", e)
-            # Standby nodes: _round was advanced to N+1 when round N closed before shutdown
-            # was detected. Record end of cycle N (the last completed cycle).
-            self._on_cycle_end(cycle_number=self._rdzv_handler.round() - 1)
             return None
         except SignalException as e:
             logger.warning("Received %s death signal, shutting down workers, timeout %s sec.", e.sigval, self._term_timeout)
@@ -633,7 +594,6 @@ class LocalElasticAgent(SimpleElasticAgent):
             put_metric(f"workers.{role}.{state.name.lower()}", 1)
 
             if state == WorkerState.SUCCEEDED:
-                self._on_cycle_end()
                 logger.info(
                     "[%s] worker group successfully finished."
                     " Waiting %s seconds for other agents to finish.",
@@ -971,9 +931,6 @@ class LocalElasticAgent(SimpleElasticAgent):
             # that would cause cycle N+1 data to be written to cycle N log files.
             self._logs_specs.clear_all_pipes_from_reader()
 
-        # Record cycle end time in cycle info file
-        self._on_cycle_end()
-
         # Record worker termination event after shutdown is complete
         record_profiling_event(
             ProfilingEvent.WORKER_TERMINATED,
@@ -1034,8 +991,7 @@ class LocalElasticAgent(SimpleElasticAgent):
             cycle_log_file = self._logs_specs.get_cycle_log_file(current_cycle)
             self._rdzv_handler._attribution_service._submit_log(cycle_log_file)
 
-        # Write NVRx cycle info and set env for workload
-        current_cycle_info_path = self._write_cycle_start_info(current_cycle)
+        current_cycle_info_path = self._current_cycle_info_path()
 
         for worker in worker_group.workers:
             local_rank = worker.local_rank
@@ -1490,13 +1446,17 @@ def _get_addr_and_port(
     return (master_addr, master_port)
 
 
-def _is_store_host(params: RendezvousParameters) -> bool:
-    """Returns true if this agent is hosting the TCP store"""
-    host, _ = parse_rendezvous_endpoint(params.endpoint, default_port=0)
-    cfg_is_host = params.get_as_bool("is_host")
+def _is_store_host_from_config(host: str, configs: Dict[str, Any]) -> bool:
+    cfg_is_host = rdzv_config_get_as_bool(configs, "is_host")
     if cfg_is_host is not None:
         return bool(cfg_is_host)
     return _matches_machine_hostname(host)
+
+
+def _is_store_host(params: RendezvousParameters) -> bool:
+    """Returns true if this agent is hosting the TCP store"""
+    host, _ = parse_rendezvous_endpoint(params.endpoint, default_port=0)
+    return _is_store_host_from_config(host, params.config)
 
 
 def launch_agent(
@@ -1561,6 +1521,8 @@ def launch_agent(
     rdzv_parameters.config["is_store_host"] = is_store_host
     # Add nproc_per_node so the rendezvous handler can restore local_world_size for standby->active transitions
     rdzv_parameters.config["nproc_per_node"] = config.nproc_per_node
+    if config.fault_tol_cfg.cycle_info_dir:
+        rdzv_parameters.config["cycle_info_dir"] = config.fault_tol_cfg.cycle_info_dir
 
     spec = WorkerSpec(
         role=config.role,
@@ -1575,10 +1537,6 @@ def launch_agent(
         local_addr=config.local_addr,
     )
 
-    cycle_info_writer = None
-    if is_store_host and config.fault_tol_cfg.cycle_info_dir:
-        cycle_info_writer = CycleInfoWriter(config.fault_tol_cfg.cycle_info_dir)
-
     agent = LocalElasticAgent(
         spec=spec,
         fault_tol_cfg=config.fault_tol_cfg,
@@ -1590,7 +1548,6 @@ def launch_agent(
         restart_policy=config.restart_policy,
         is_store_host=is_store_host,
         rank_monitors=config.rank_monitors,  # Pass pre-created rank monitors
-        cycle_info_writer=cycle_info_writer,
     )
 
     # Set agent reference in rendezvous handler for callbacks
@@ -1676,9 +1633,12 @@ def launch_agent(
             if agent._rdzv_handler._attribution_service is not None:
                 agent._rdzv_handler._attribution_service()
 
-            # No ordering required between cycle_info_writer and rendezvous: the writer
-            # is independent I/O. Run grace-period wait and writer shutdown in parallel
-            # so total time is max(grace_period, writer drain) instead of sum.
+            shutdown_cycle_info_reporter = getattr(
+                agent._rdzv_handler, "shutdown_cycle_info_reporter", None
+            )
+            if callable(shutdown_cycle_info_reporter):
+                shutdown_cycle_info_reporter()
+
             grace_period = 3.0  # seconds
             logger.info(
                 f"Store host waiting {grace_period} seconds before exit "
@@ -1690,8 +1650,6 @@ def launch_agent(
 
             t = threading.Thread(target=_wait_grace, daemon=True)
             t.start()
-            if cycle_info_writer is not None:
-                cycle_info_writer.shutdown()
             t.join()
 
         with contextlib.suppress(Exception):
@@ -2082,60 +2040,16 @@ def get_args_parser() -> ArgumentParser:
     )
 
     #
-    # Worker/node size related arguments.
+    # Rendezvous related arguments.
     #
 
-    parser.add_argument(
-        "--nnodes",
+    add_rendezvous_args(
+        parser,
         action=env,
-        type=str,
-        default="1:1",
-        help="Number of nodes, or the range of nodes in form <minimum_nodes>:<maximum_nodes>.",
-    )
-    parser.add_argument(
-        "--nproc-per-node",
-        "--nproc_per_node",
-        action=env,
-        type=str,
-        default="1",
-        help="Number of workers per node; supported values: [auto, cpu, gpu, int].",
-    )
-
-    #
-    # Rendezvous related arguments
-    #
-
-    parser.add_argument(
-        "--rdzv-backend",
-        "--rdzv_backend",
-        action=env,
-        type=str,
-        default="c10d",
-        help="Rendezvous backend. Currently only c10d is supported.",
-    )
-    parser.add_argument(
-        "--rdzv-endpoint",
-        "--rdzv_endpoint",
-        action=env,
-        type=str,
-        default="",
-        help="Rendezvous backend endpoint; usually in form <host>:<port>.",
-    )
-    parser.add_argument(
-        "--rdzv-id",
-        "--rdzv_id",
-        action=env,
-        type=str,
-        default="none",
-        help="User-defined group id.",
-    )
-    parser.add_argument(
-        "--rdzv-conf",
-        "--rdzv_conf",
-        action=env,
-        type=str,
-        default="",
-        help="Additional rendezvous configuration (<key1>=<value1>,<key2>=<value2>,...).",
+        nnodes_default="1:1",
+        endpoint_default="",
+        include_local_addr=True,
+        include_ft_segment=True,
     )
     parser.add_argument(
         "--standalone",
@@ -2144,6 +2058,19 @@ def get_args_parser() -> ArgumentParser:
         "on a free port. Useful when launching single-node, multi-worker job. If specified "
         "--rdzv-backend, --rdzv-endpoint, --rdzv-id are auto-assigned and any explicitly set values "
         "are ignored.",
+    )
+
+    #
+    # Worker/node size related arguments.
+    #
+
+    parser.add_argument(
+        "--nproc-per-node",
+        "--nproc_per_node",
+        action=env,
+        type=str,
+        default="1",
+        help="Number of workers per node; supported values: [auto, cpu, gpu, int].",
     )
 
     #
@@ -2232,119 +2159,11 @@ def get_args_parser() -> ArgumentParser:
         "rdzv_id as the prefix).",
     )
 
-    parser.add_argument(
-        "--ft-per-cycle-applog-prefix",
-        "--ft_per_cycle_applog_prefix",
+    add_log_funnel_args(
+        parser,
         action=env,
-        type=str,
-        default=None,
-        dest="ft_per_cycle_applog_prefix",
-        help="Prefix for per-cycle application log files (must be absolute path, e.g. /lustre/logs/job_12345.log). "
-        "Creates training worker logs per cycle: /lustre/logs/job_12345_cycle0.log, job_12345_cycle1.log, etc. "
-        "All ranks/nodes capture logs with automatic rank prefixes (like 'srun -l'). "
-        "Without --ft-enable-log-server: Each node writes directly to Lustre with O_APPEND (safe concurrent writes). "
-        "With --ft-enable-log-server (recommended): All nodes stream logs to gRPC server on rank 0, which becomes the single Lustre writer. "
-        "gRPC mode eliminates Lustre lock contention and scales to 1000+ nodes. "
-        "Note: NVRx launcher logs go to stdout/stderr by default unless --ft-nvrx-logfile is specified.",
-    )
-
-    parser.add_argument(
-        "--ft-nvrx-logfile",
-        "--ft_nvrx_logfile",
-        action=env,
-        type=str,
-        default=None,
-        dest="ft_nvrx_logfile",
-        help="Optional: Path for NVRx launcher's own logs (must be absolute path if specified). "
-        "If not specified, launcher logs go to stdout/stderr (default, captured by orchestrator). "
-        "If specified, launcher logs are redirected via pipe → gRPC → server writes to this file. "
-        "This routes launcher logs through the same infrastructure as worker logs. "
-        "Example: --ft-nvrx-logfile /lustre/logs/launcher.log",
-    )
-
-    parser.add_argument(
-        "--ft-enable-log-server",
-        "--ft_enable_log_server",
-        action=env,
-        type=lambda x: x.lower() == 'true',
-        default=None,
-        dest="ft_enable_log_server",
-        help="Enable gRPC-based log funneling to a single Lustre file. "
-        "When enabled with --ft-per-cycle-applog-prefix, the launcher automatically: "
-        "(1) Starts gRPC log server(s) on TCP store host, "
-        "(2) Configures all nodes as gRPC clients to a first-level aggregator port, "
-        "(3) Root server writes to Lustre (single writer). "
-        "With --ft-log-aggregator-count=N>1, N leaf processes plus one root use ports P..P+N (see --ft-log-server-port). "
-        "Use --ft-log-aggregator-count=1 for a single server on P only. "
-        "Benefits: No Lustre lock contention, scales to 1500+ nodes. "
-        "Requires: grpcio. Default: False.",
-    )
-
-    parser.add_argument(
-        "--ft-log-server-port",
-        "--ft_log_server_port",
-        action=env,
-        type=int,
-        default=50051,
-        dest="ft_log_server_port",
-        help="Port for gRPC log funnel server (only used if --ft-enable-log-server is enabled). "
-        "Default: 50051",
-    )
-
-    parser.add_argument(
-        "--ft-log-aggregator-count",
-        "--ft_log_aggregator_count",
-        action=env,
-        type=int,
-        default=0,
-        dest="ft_log_aggregator_count",
-        help="Number of first-level gRPC log aggregators. "
-        "0 (default): auto — single root server for up to 1536 nodes, "
-        "adds leaf servers beyond that (one per 1536 nodes). "
-        "1: single root server (legacy). "
-        "N>1: N leaf servers on ports [P, P+1, ..., P+N-1] and one root on P+N "
-        "(P = --ft-log-server-port). "
-        "Open TCP ports P through P+N on the TCP store host. "
-        "Each node picks a leaf from SLURM array/procid when set, else from hostname.",
-    )
-
-    parser.add_argument(
-        "--ft-log-leaf-max-queue-chunks",
-        "--ft_log_leaf_max_queue_chunks",
-        action=env,
-        type=int,
-        default=-1,
-        dest="ft_log_leaf_max_queue_chunks",
-        help="Max queued log chunks per leaf (only when N>1). "
-        "Default -1: auto scale with fan-in, max(16384, min(1000000, per_leaf*256)).",
-    )
-
-    parser.add_argument(
-        "--ft-log-server-log",
-        "--ft_log_server_log",
-        action=env,
-        type=str,
-        default=None,
-        dest="ft_log_server_log",
-        help="Path to gRPC root log server's own log file (only used if --ft-enable-log-server is enabled). "
-        "If not specified, derives from --ft-per-cycle-applog-prefix by replacing the trailing '.log' with "
-        "'_grpc_root.log' (same default basename as the two-level root writer). "
-        "Example: If --ft-per-cycle-applog-prefix=/path/to/app.log, defaults to /path/to/app_grpc_root.log",
-    )
-
-    parser.add_argument(
-        "--ft-log-server-graceful-shutdown-timeout",
-        "--ft_log_server_graceful_shutdown_timeout",
-        action=env,
-        type=float,
-        default=60.0,
-        dest="ft_log_server_graceful_shutdown_timeout",
-        help="Maximum seconds to wait for clients during gRPC server graceful shutdown (only used if --ft-enable-log-server is enabled). "
-        "When store host exits, server will continue accepting logs from other ranks for up to this timeout "
-        "or until all clients disconnect, whichever comes first. This ensures other nodes can flush their final logs. "
-        "When --ft-log-aggregator-count>1, each leaf uses this timeout; the root log server uses 2× so leaves can finish "
-        "waiting for downstream clients and drain to root first. "
-        "Default: 60.0",
+        enable_default=None,
+        enable_type=lambda x: x.lower() == 'true',
     )
 
     parser.add_argument(
@@ -2410,17 +2229,6 @@ def get_args_parser() -> ArgumentParser:
         "training. It is used for static and c10d rendezvous backends when rdzv_endpoint is not specified.",
     )
     parser.add_argument(
-        "--local-addr",
-        "--local_addr",
-        default=None,
-        type=str,
-        action=env,
-        help="Address of the local node. If specified, will use the given address for connection. "
-        "Else, will look up the local node address instead. Else, it will be default to local "
-        "machine's FQDN.",
-    )
-
-    parser.add_argument(
         "--logs-specs",
         "--logs_specs",
         default=None,
@@ -2435,16 +2243,7 @@ def get_args_parser() -> ArgumentParser:
     # Fault tolerance related items
     #
 
-    parser.add_argument(
-        "--ft-cfg-path",
-        "--ft-cfg_path",
-        default=None,
-        type=str,
-        action=env,
-        dest="ft_cfg_path",
-        help="Path to a YAML file that contains Fault Tolerance pkg config (`fault_tolerance` section)."
-        " NOTE: config items from the file can be overwritten by `--ft-param-*` args.",
-    )
+    add_ft_config_file_args(parser, aliases=("--ft-cfg-path", "--ft-cfg_path"), action=env)
 
     parser.add_argument(
         "--ft-workload-check-interval",
@@ -2661,21 +2460,6 @@ def get_args_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
-        "--ft-segment",
-        "--ft_segment",
-        type=int,
-        default=None,
-        dest="ft_segment",
-        help="Controls hot spare node behavior and segment-aware rank assignment. "
-        "Default: None (simple hot spare mode for H100 and non-NVSwitch systems, no ClusterUUID required). "
-        "When set to N: Enables segment-aware mode for NVSwitch systems (DGX H200, HGX B200). "
-        "Specifies minimum nodes per NVLink domain (identified by GPU ClusterUUID via nvidia-smi). "
-        "Domains with fewer than N nodes are excluded. From valid domains, complete segments are selected. "
-        "min_nodes must be divisible by segment. "
-        "Note: segment=None (default) is suitable for H100; segment=1 is similar but requires ClusterUUID.",
-    )
-
-    parser.add_argument(
         "--ft-numa-bind-strict",
         "--ft-numa_bind_strict",
         type=lambda x: str(x).lower() not in ["false", "0", "no"],
@@ -2742,97 +2526,8 @@ def get_args_parser() -> ArgumentParser:
         "format and log the traceback, and use os._exit() to exit the process reliably. Default: False.",
     )
 
-    # Attribution service configuration. Disabled by default. The literal
-    # endpoint "localhost" means ft_launcher manages the attribution service on
-    # the TCPStore host; other endpoints are treated as external services.
-    parser.add_argument(
-        "--ft-attribution-endpoint",
-        "--ft_attribution_endpoint",
-        type=str,
-        default=None,
-        dest="ft_attribution_endpoint",
-        help=(
-            "Endpoint for the attribution service. Default: disabled. "
-            "Set to localhost to let ft_launcher manage nvrx-attrsvc on the TCPStore host. "
-            "Use an explicit endpoint such as http://host:port, grpc://host:port, "
-            "or unix:///path/to/socket for an externally managed attribution service."
-        ),
-    )
-    parser.add_argument(
-        "--ft-attribution-startup-timeout",
-        "--ft_attribution_startup_timeout",
-        type=float,
-        default=DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT,
-        dest="ft_attribution_startup_timeout",
-        help=(
-            "Seconds to wait for launcher-managed attribution service /healthz readiness. "
-            f"Default: {DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT}."
-        ),
-    )
-    parser.add_argument(
-        "--ft-attribution-llm-api-key-file",
-        "--ft_attribution_llm_api_key_file",
-        type=str,
-        default=None,
-        dest="ft_attribution_llm_api_key_file",
-        help=(
-            "Path to the LLM API key file for launcher-managed attribution service. "
-            "If unset, LLM_API_KEY_FILE from the launcher environment is used."
-        ),
-    )
-    parser.add_argument(
-        "--ft-attribution-llm-base-url",
-        "--ft_attribution_llm_base_url",
-        type=str,
-        default=None,
-        dest="ft_attribution_llm_base_url",
-        help="LLM base URL for launcher-managed attribution service.",
-    )
-    parser.add_argument(
-        "--ft-attribution-llm-model",
-        "--ft_attribution_llm_model",
-        type=str,
-        default=None,
-        dest="ft_attribution_llm_model",
-        help="LLM model identifier for launcher-managed attribution service.",
-    )
-    parser.add_argument(
-        "--ft-attribution-analysis-backend",
-        "--ft_attribution_analysis_backend",
-        type=str,
-        default=None,
-        dest="ft_attribution_analysis_backend",
-        choices=("mcp", "lib"),
-        help="Analysis backend for launcher-managed attribution service: mcp or lib.",
-    )
-    parser.add_argument(
-        "--ft-attribution-compute-timeout",
-        "--ft_attribution_compute_timeout",
-        type=float,
-        default=None,
-        dest="ft_attribution_compute_timeout",
-        help="Analysis compute timeout in seconds for launcher-managed attribution service.",
-    )
-    parser.add_argument(
-        "--ft-attribution-log-level",
-        "--ft_attribution_log_level",
-        type=str.upper,
-        default=None,
-        dest="ft_attribution_log_level",
-        choices=("DEBUG", "INFO", "WARNING"),
-        help="Log level for launcher-managed attribution service.",
-    )
-
-    parser.add_argument(
-        "--ft-cycle-info-dir",
-        "--ft_cycle_info_dir",
-        type=str,
-        default=None,
-        dest="ft_cycle_info_dir",
-        help="Full path to NVRx cycle info directory (e.g. <base>/nvrx/). TCPStore host only. "
-        "If set, writes cycle_info.<job_id>.<attempt>.<cycle> and symlink cycle_info.<job_id>.current "
-        "there. Workload receives current cycle file path via NVRX_CURRENT_CYCLE_INFO env.",
-    )
+    add_attribution_args(parser)
+    add_cycle_info_args(parser)
 
     parser.add_argument(
         action='store_true',
@@ -3061,11 +2756,6 @@ def _validate_args(args: Any) -> None:
             f"--ft-log-aggregator-count must be >= 0 (0 = auto), got {n_log_agg}"
         )
     _validate_slurm_single_launcher_per_node()
-    if getattr(args, "ft_cycle_info_dir", None) and not getattr(args, "ft_per_cycle_applog_prefix", None):
-        raise ValueError(
-            "--ft-cycle-info-dir requires --ft-per-cycle-applog-prefix to be specified. "
-            "Cycle info needs per-cycle log file path from the applog prefix."
-        )
     if getattr(args, "ft_nvrx_logfile", None) and not getattr(args, "ft_per_cycle_applog_prefix", None):
         raise ValueError(
             "--ft-nvrx-logfile requires --ft-per-cycle-applog-prefix to be specified."
@@ -3232,6 +2922,8 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
 
     # Determine logs_specs based on ft_per_cycle_applog_prefix or logs_specs argument
     base_log_file = getattr(args, 'ft_per_cycle_applog_prefix', None)
+    if base_log_file:
+        rdzv_configs['cycle_log_prefix'] = base_log_file
 
     if base_log_file:
         # Validate that the path is absolute (not relative)
@@ -3251,7 +2943,7 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
 
         rdzv_endpoint_host = parse_rendezvous_endpoint(rdzv_endpoint, default_port=-1)[0]
         host, _ = parse_rendezvous_endpoint(rdzv_endpoint, default_port=0)
-        is_tcp_store_host = _matches_machine_hostname(host)
+        is_tcp_store_host = _is_store_host_from_config(host, rdzv_configs)
 
         # Configure gRPC if enabled
         grpc_server_address = None
@@ -3293,7 +2985,11 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
                 grpc_server_address = f"localhost:{grpc_port}"
 
                 global _GRPC_SERVER_PROCESSES
-                _GRPC_SERVER_PROCESSES = _start_grpc_log_servers(args, base_log_file, log_funnel_ports)
+                grpc_log_prefix = _resolve_grpc_log_server_log_prefix(args)
+                assert grpc_log_prefix is not None
+                _GRPC_SERVER_PROCESSES = _start_grpc_log_servers(
+                    args, grpc_log_prefix, log_funnel_ports
+                )
 
                 if not _GRPC_SERVER_PROCESSES:
                     logger.error(
@@ -3401,10 +3097,30 @@ def run_script_path(training_script: str, *training_script_args: str):
     runpy.run_path(sys.argv[0], run_name="__main__")
 
 
-def _grpc_log_path(base_log_file: str, suffix: str) -> str:
-    if base_log_file.endswith('.log'):
-        return base_log_file[:-4] + suffix
-    return base_log_file + suffix
+def _strip_log_suffix(path: str) -> str:
+    if path.endswith('.log'):
+        return path[:-4]
+    return path
+
+
+def _resolve_grpc_log_server_log_prefix(args: Any) -> Optional[str]:
+    explicit_prefix = getattr(args, 'ft_log_server_log_prefix', None)
+    if explicit_prefix:
+        return explicit_prefix
+
+    nvrx_logfile = getattr(args, 'ft_nvrx_logfile', None)
+    if nvrx_logfile:
+        return _strip_log_suffix(nvrx_logfile) + '_grpc'
+
+    app_log_prefix = getattr(args, 'ft_per_cycle_applog_prefix', None)
+    if app_log_prefix:
+        return _strip_log_suffix(app_log_prefix) + '_grpc'
+
+    return None
+
+
+def _grpc_log_path(log_prefix: str, suffix: str) -> str:
+    return log_prefix + suffix
 
 
 _LOG_FUNNEL_NODES_PER_LEAF = 1536  # max nodes per single log server (≈6K GPU at 4 GPUs/node)
@@ -3511,7 +3227,7 @@ _GRPC_LOG_FUNNEL_BIND_HOST = "0.0.0.0"  # nosec B104
 
 
 def _start_grpc_log_servers(
-    args: Any, base_log_file: str, funnel_ports: LogFunnelPorts
+    args: Any, log_prefix: str, funnel_ports: LogFunnelPorts
 ) -> List[subprocess.Popen]:
     """
     On TCP store host: start root log server (Lustre writer), and optionally N leaf
@@ -3525,14 +3241,13 @@ def _start_grpc_log_servers(
     _, max_nodes = parse_min_max_nnodes(args.nnodes)
 
     def _open_log(path: str):
+        os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
         return open(path, 'w')
 
     procs: List[subprocess.Popen] = []
     try:
         if not funnel_ports.uses_two_level:
-            grpc_server_log = getattr(args, 'ft_log_server_log', None)
-            if grpc_server_log is None:
-                grpc_server_log = _grpc_log_path(base_log_file, '_grpc_root.log')
+            grpc_server_log = _grpc_log_path(log_prefix, '_root.log')
             max_workers = min(4096, max(100, max_nodes + 10))
             fd = _open_log(grpc_server_log)
             try:
@@ -3572,9 +3287,7 @@ def _start_grpc_log_servers(
             max_queue = min(1_000_000, max(16_384, per_leaf * 256))
         else:
             max_queue = max(64, raw_leaf_chunks)
-        root_log = getattr(args, 'ft_log_server_log', None) or _grpc_log_path(
-            base_log_file, '_grpc_root.log'
-        )
+        root_log = _grpc_log_path(log_prefix, '_root.log')
 
         # Root must outlive leaves: leaves may wait the full leaf grace window for downstream
         # clients before draining their queues to root; root's own grace must still be open then.
@@ -3611,7 +3324,7 @@ def _start_grpc_log_servers(
         upstream = f'localhost:{root_port}'
         for i in range(n):
             leaf_port = funnel_ports.leaf_listen_port(i)
-            leaf_log = _grpc_log_path(base_log_file, f'_grpc_leaf_{i}.log')
+            leaf_log = _grpc_log_path(log_prefix, f'_leaf_{i}.log')
             lf = _open_log(leaf_log)
             try:
                 leaf_cmd = [
@@ -3677,6 +3390,63 @@ def _wait_grpc_subprocess_after_terminate(p: subprocess.Popen, wait_timeout: flo
             p.kill()
         with contextlib.suppress(Exception):
             p.wait()
+
+
+def stop_grpc_log_servers(
+    processes: List[subprocess.Popen],
+    graceful_shutdown_timeout: float,
+) -> None:
+    if not processes:
+        return
+
+    uses_two_level = len(processes) > 1
+    single_wait = _grpc_child_wait_timeout_after_terminate(graceful_shutdown_timeout)
+    if uses_two_level:
+        root_grace = graceful_shutdown_timeout * 2.0
+        leaf_wait = _grpc_child_wait_timeout_after_terminate(graceful_shutdown_timeout)
+        root_wait = _grpc_child_wait_timeout_after_terminate(root_grace)
+        wait_msg = (
+            f"leaf child wait up to {leaf_wait:.0f}s, root child up to {root_wait:.0f}s "
+            f"(ft_log_server_graceful_shutdown_timeout={graceful_shutdown_timeout}s, root uses 2×)"
+        )
+    else:
+        leaf_wait = root_wait = single_wait
+        wait_msg = (
+            f"per-process shutdown wait up to {single_wait:.0f}s "
+            f"(ft_log_server_graceful_shutdown_timeout={graceful_shutdown_timeout}s)"
+        )
+
+    logger.info(
+        "Sending SIGTERM to gRPC log funnel process(es) (root last in wait order). "
+        f"{wait_msg}. "
+        "Check gRPC root and leaf server logs for Shutdown snapshot lines: "
+        "in_memory_pending_bytes, chunk_queue_depth, still_connected_streams, etc."
+    )
+    # Terminate leaves first so they drain to root before root exits.
+    for p in reversed(processes):
+        with contextlib.suppress(Exception):
+            p.terminate()
+
+    # All processes got SIGTERM together; wait in parallel so wall time is roughly one timeout.
+    procs_to_wait = list(reversed(processes))
+    root_proc = processes[0]
+    with ThreadPoolExecutor(max_workers=max(1, len(procs_to_wait))) as pool:
+        pending_futures = [
+            pool.submit(
+                _wait_grpc_subprocess_after_terminate,
+                p,
+                root_wait if p is root_proc else leaf_wait,
+            )
+            for p in procs_to_wait
+        ]
+        for fut in as_completed(pending_futures):
+            with contextlib.suppress(Exception):
+                fut.result()
+
+    for p in processes:
+        rc = getattr(p, "returncode", None)
+        logger.info(f"gRPC log subprocess PID={p.pid} finished with returncode={rc}")
+    processes.clear()
 
 
 def run(args):
@@ -3784,52 +3554,7 @@ def main(args=None):
             grpc_graceful_shutdown_timeout = float(
                 getattr(args, 'ft_log_server_graceful_shutdown_timeout', 60.0)
             )
-            n_log_agg = int(getattr(args, 'ft_log_aggregator_count', 2))
-            single_wait = _grpc_child_wait_timeout_after_terminate(grpc_graceful_shutdown_timeout)
-            if n_log_agg > 1:
-                root_grace = grpc_graceful_shutdown_timeout * 2.0
-                leaf_wait = _grpc_child_wait_timeout_after_terminate(grpc_graceful_shutdown_timeout)
-                root_wait = _grpc_child_wait_timeout_after_terminate(root_grace)
-                wait_msg = (
-                    f"leaf child wait up to {leaf_wait:.0f}s, root child up to {root_wait:.0f}s "
-                    f"(ft_log_server_graceful_shutdown_timeout={grpc_graceful_shutdown_timeout}s, root uses 2×)"
-                )
-            else:
-                leaf_wait = root_wait = single_wait
-                wait_msg = (
-                    f"per-process shutdown wait up to {single_wait:.0f}s "
-                    f"(ft_log_server_graceful_shutdown_timeout={grpc_graceful_shutdown_timeout}s)"
-                )
-            logger.info(
-                "Sending SIGTERM to gRPC log funnel process(es) (root last in wait order). "
-                f"{wait_msg}. "
-                "Check *_grpc_root.log and *_grpc_leaf_*.log for Shutdown snapshot lines: "
-                "in_memory_pending_bytes, chunk_queue_depth, still_connected_streams, etc."
-            )
-            # Terminate leaves first so they drain to root before root exits
-            for p in reversed(_GRPC_SERVER_PROCESSES):
-                with contextlib.suppress(Exception):
-                    p.terminate()
-            # All processes got SIGTERM together; wait in parallel so wall time ≈ one timeout,
-            # not (N+1) × wait_timeout.
-            procs_to_wait = list(reversed(_GRPC_SERVER_PROCESSES))
-            root_proc = _GRPC_SERVER_PROCESSES[0]
-            with ThreadPoolExecutor(max_workers=max(1, len(procs_to_wait))) as pool:
-                pending_futures = [
-                    pool.submit(
-                        _wait_grpc_subprocess_after_terminate,
-                        p,
-                        root_wait if p is root_proc else leaf_wait,
-                    )
-                    for p in procs_to_wait
-                ]
-                for fut in as_completed(pending_futures):
-                    with contextlib.suppress(Exception):
-                        fut.result()
-            for p in _GRPC_SERVER_PROCESSES:
-                rc = getattr(p, "returncode", None)
-                logger.info(f"gRPC log subprocess PID={p.pid} finished with returncode={rc}")
-            _GRPC_SERVER_PROCESSES.clear()
+            stop_grpc_log_servers(_GRPC_SERVER_PROCESSES, grpc_graceful_shutdown_timeout)
 
         if _ATTRIBUTION_MANAGER is not None:
             _ATTRIBUTION_MANAGER.stop()

--- a/src/nvidia_resiliency_ext/fault_tolerance/rdzv_utils.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/rdzv_utils.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for interpreting raw rendezvous configuration dictionaries."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+def rdzv_config_get_as_bool(
+    configs: Mapping[str, Any], key: str, default: Optional[bool] = None
+) -> Optional[bool]:
+    """Return a raw rendezvous config value as a bool.
+
+    This mirrors ``torch.distributed.elastic.rendezvous.RendezvousParameters.get_as_bool``
+    for call sites that only have the parsed rendezvous config dictionary.
+    """
+    value = configs.get(key, default)
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+    elif isinstance(value, str):
+        if value.lower() in ["1", "true", "t", "yes", "y"]:
+            return True
+        if value.lower() in ["0", "false", "f", "no", "n"]:
+            return False
+    raise ValueError(
+        f"The rendezvous configuration option '{key}' does not represent a valid boolean value."
+    )
+
+
+def rdzv_config_get_as_int(
+    configs: Mapping[str, Any], key: str, default: Optional[int] = None
+) -> Optional[int]:
+    """Return a raw rendezvous config value as an int."""
+    value = configs.get(key, default)
+    if value is None:
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"The rendezvous configuration option '{key}' does not represent a valid integer value."
+        ) from exc
+
+
+def rdzv_config_get_as_float(
+    configs: Mapping[str, Any], key: str, default: Optional[float] = None
+) -> Optional[float]:
+    """Return a raw rendezvous config value as a float."""
+    value = configs.get(key, default)
+    if value is None:
+        return value
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"The rendezvous configuration option '{key}' does not represent a valid float value."
+        ) from exc

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -36,6 +36,7 @@ import time
 import uuid
 from datetime import timedelta
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from torch.distributed import TCPStore
 from torch.distributed.elastic.multiprocessing import SignalException
@@ -288,7 +289,9 @@ class BaseRendezvousTest(TestCase):
             'SLURMD_NODENAME',
             'CROSS_SLURM_PROCID',
             'SLURM_ARRAY_TASK_ID',
+            'SLURM_ARRAY_JOB_ID',
             'SLURM_JOB_ID',  # Must clear to avoid validation error when SLURM_PROCID is cleared
+            'SLURM_RESTART_CNT',
             'SLURM_NNODES',
             'SLURM_JOB_NUM_NODES',
         ]
@@ -1122,6 +1125,104 @@ class GroupRankAssignmentTest(TestCase):
         self.assertEqual(result[participants[0][0]], 0)
         self.assertEqual(result[participants[1][0]], 1)
         self.assertEqual(result[participants[2][0]], 2)
+
+    def test_control_host_closes_round_without_joining(self):
+        """An external control host closes a compute-only round without claiming a slot."""
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+        )
+
+        join_count_key = state.join_count_key
+        prefix = state.prefix
+        train_0 = _NodeDesc("node_a", 100, 0)
+        train_1 = _NodeDesc("node_b", 101, 0)
+
+        self.store.add(join_count_key, 1)
+        self.store.add(join_count_key, 1)
+        self.store.set(
+            f"{prefix}:slot_1",
+            state._pack_participant_value(train_0, 0, "none", 0),
+        )
+        self.store.set(
+            f"{prefix}:slot_2",
+            state._pack_participant_value(train_1, 1, "none", 0),
+        )
+
+        closed_round = state.close_current_round_as_host(
+            _NodeDesc("control", 10, 0),
+            min_nodes=2,
+            max_nodes=2,
+            segment_check_interval=_test_segment_check_interval(),
+        )
+
+        self.assertEqual(closed_round, 0)
+        self.assertEqual(state._round, 0)
+        self.assertEqual(int(self.store.get(join_count_key).decode("utf-8")), 2)
+        self.assertFalse(self.store.check([f"{prefix}:slot_3"]))
+        rank_0, total_0, round_0 = state._unpack_rank_value(self.store.get(f"{prefix}:slot_1_rank"))
+        rank_1, total_1, round_1 = state._unpack_rank_value(self.store.get(f"{prefix}:slot_2_rank"))
+        self.assertEqual((rank_0, rank_1), (0, 1))
+        self.assertEqual((total_0, total_1), (2, 2))
+        self.assertEqual((round_0, round_1), (0, 0))
+
+    def test_control_host_reports_cycle_start_when_round_closes(self):
+        """A colocated store host reports cycle start after rank assignment."""
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+        )
+        reporter = MagicMock()
+        state._cycle_info_reporter = reporter
+
+        join_count_key = state.join_count_key
+        prefix = state.prefix
+        train_0 = _NodeDesc("node_a", 100, 0)
+        train_1 = _NodeDesc("node_b", 101, 0)
+
+        self.store.add(join_count_key, 1)
+        self.store.add(join_count_key, 1)
+        self.store.set(
+            f"{prefix}:slot_1",
+            state._pack_participant_value(train_0, 0, "none", 0),
+        )
+        self.store.set(
+            f"{prefix}:slot_2",
+            state._pack_participant_value(train_1, 1, "none", 0),
+        )
+
+        state.close_current_round_as_host(
+            _NodeDesc("control", 10, 0),
+            min_nodes=2,
+            max_nodes=2,
+            segment_check_interval=_test_segment_check_interval(),
+        )
+
+        reporter.report_cycle_start.assert_called_once()
+        snapshot = reporter.report_cycle_start.call_args.args[0]
+        self.assertEqual(snapshot.cycle_number, 0)
+        self.assertEqual(snapshot.active_node_addrs, ["node_a", "node_b"])
+        self.assertEqual(snapshot.standby_node_addrs, [])
+        self.assertEqual(snapshot.active_ranks, [0, 1])
+
+    def test_open_rendezvous_does_not_report_cycle_end(self):
+        """Opening the next round only opens rendezvous; cycle end is reporter-owned."""
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+        )
+        reporter = MagicMock()
+        state._cycle_info_reporter = reporter
+
+        state.open_rendezvous()
+
+        reporter.report_cycle_end.assert_not_called()
 
     def test_rank_assignment_standby_nodes(self):
         """Test rank assignment for standby nodes (beyond min_nodes)."""

--- a/tests/fault_tolerance/unit/test_control_plane.py
+++ b/tests/fault_tolerance/unit/test_control_plane.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from nvidia_resiliency_ext.fault_tolerance import control_plane
+from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import CycleInfoRoundSnapshot
+
+
+def test_nvrx_control_starts_owned_services_without_worker_agent(tmp_path):
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--rdzv-id",
+            "job-a",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+            "--ft-enable-log-server",
+            "true",
+            "--ft-attribution-endpoint",
+            "localhost",
+            "--ft-cycle-info-dir",
+            str(tmp_path / "nvrx"),
+            "--ft-cycle-info-job-id",
+            "job-a",
+        ]
+    )
+    manager = MagicMock()
+    manager.start_if_needed.return_value = SimpleNamespace(endpoint="http://localhost:50050")
+    grpc_proc = MagicMock()
+    cycle_reporter = MagicMock()
+
+    with (
+        patch.object(control_plane, "_create_tcp_store", return_value=object()) as create_store,
+        patch.object(control_plane, "AttributionManager", return_value=manager) as manager_cls,
+        patch.object(
+            control_plane, "CycleInfoReporter", return_value=cycle_reporter
+        ) as reporter_cls,
+        patch.object(
+            control_plane, "_start_grpc_log_servers", return_value=[grpc_proc]
+        ) as start_grpc,
+        patch.object(control_plane, "stop_grpc_log_servers") as stop_grpc,
+        patch.object(control_plane, "_run_control_rendezvous_loop") as run_loop,
+    ):
+        control_plane.run(args)
+
+    create_store.assert_called_once()
+    manager_cls.assert_called_once()
+    manager.start_if_needed.assert_called_once()
+    start_grpc.assert_called_once()
+    assert start_grpc.call_args.args[1] == str(tmp_path / "train_grpc")
+    reporter_cls.assert_called_once_with(
+        str(tmp_path / "nvrx"),
+        cycle_log_prefix=str(tmp_path / "train.log"),
+        cycle_info_job_id="job-a",
+        attempt_index=0,
+    )
+    run_loop.assert_called_once()
+    stop_grpc.assert_called_once_with([grpc_proc], 60.0)
+    manager.stop.assert_called_once()
+    cycle_reporter.shutdown.assert_called_once()
+    assert not hasattr(control_plane, "LocalElasticAgent")
+
+
+def test_nvrx_control_does_not_start_attribution_without_endpoint(tmp_path):
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+        ]
+    )
+    grpc_proc = MagicMock()
+
+    with (
+        patch.object(control_plane, "_create_tcp_store", return_value=object()),
+        patch.object(control_plane, "AttributionManager") as manager_cls,
+        patch.object(control_plane, "_start_grpc_log_servers", return_value=[grpc_proc]),
+        patch.object(control_plane, "stop_grpc_log_servers"),
+        patch.object(control_plane, "_run_control_rendezvous_loop"),
+    ):
+        control_plane.run(args)
+
+    manager_cls.assert_not_called()
+
+
+def test_control_parser_rejects_log_server_without_diagnostic_prefix():
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+        ]
+    )
+    ft_cfg = control_plane.FaultToleranceConfig.from_args(args)
+
+    try:
+        control_plane._validate_args(args, ft_cfg)
+    except ValueError as exc:
+        assert "--ft-log-server-log-prefix" in str(exc)
+    else:
+        raise AssertionError("expected missing log server diagnostic prefix to be rejected")
+
+
+def test_control_parser_rejects_attribution_without_applog_prefix(tmp_path):
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--ft-log-server-log-prefix",
+            str(tmp_path / "grpc"),
+            "--ft-attribution-endpoint",
+            "localhost",
+        ]
+    )
+    ft_cfg = control_plane.FaultToleranceConfig.from_args(args)
+
+    try:
+        control_plane._validate_args(args, ft_cfg)
+    except ValueError as exc:
+        assert "--ft-per-cycle-applog-prefix" in str(exc)
+    else:
+        raise AssertionError("expected missing applog prefix to be rejected")
+
+
+def test_control_parser_accepts_cycle_info_dir_with_job_id_without_applog_prefix(tmp_path):
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--ft-log-server-log-prefix",
+            str(tmp_path / "grpc"),
+            "--ft-cycle-info-dir",
+            str(tmp_path / "nvrx"),
+            "--ft-cycle-info-job-id",
+            "job-a",
+        ]
+    )
+    ft_cfg = control_plane.FaultToleranceConfig.from_args(args)
+
+    control_plane._validate_args(args, ft_cfg)
+
+    assert ft_cfg.cycle_info_dir == str(tmp_path / "nvrx")
+    assert args.ft_cycle_info_job_id == "job-a"
+
+
+def test_control_parser_rejects_cycle_info_dir_without_job_id(tmp_path):
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--ft-log-server-log-prefix",
+            str(tmp_path / "grpc"),
+            "--ft-cycle-info-dir",
+            str(tmp_path / "nvrx"),
+        ]
+    )
+    ft_cfg = control_plane.FaultToleranceConfig.from_args(args)
+
+    try:
+        control_plane._validate_args(args, ft_cfg)
+    except ValueError as exc:
+        assert "--ft-cycle-info-job-id" in str(exc)
+    else:
+        raise AssertionError("expected missing cycle-info job id to be rejected")
+
+
+def test_control_parser_uses_launcher_config_file_alias(tmp_path):
+    cfg_path = tmp_path / "ft.yaml"
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--ft-log-server-log-prefix",
+            str(tmp_path / "grpc"),
+            "--ft-cfg_path",
+            str(cfg_path),
+        ]
+    )
+
+    assert args.ft_cfg_path == str(cfg_path)
+
+
+def test_control_rendezvous_loop_submits_attribution_and_reports_cycle_info(tmp_path):
+    args = SimpleNamespace(
+        nnodes="2",
+        rdzv_conf="",
+        rdzv_id="job-a",
+        rdzv_endpoint="127.0.0.1:29500",
+        local_addr=None,
+        ft_per_cycle_applog_prefix=str(tmp_path / "train.log"),
+    )
+    ft_cfg = SimpleNamespace(segment=None)
+    attribution_service = MagicMock()
+    services = control_plane.ControlServices(
+        attribution_service=attribution_service,
+        cycle_info_reporter=MagicMock(),
+    )
+    stop_event = threading.Event()
+    states = []
+
+    class FakeState:
+        def __init__(self, *args, **kwargs):
+            states.append(self)
+            self._rounds = iter([0, 1])
+            self._cycle_info_reporter = None
+            self._active_node_addrs = ["node-a", "node-b"]
+            self._standby_node_addrs = ["node-c"]
+            self._active_ranks = [0, 1]
+
+        def close_current_round_as_host(self, *args, **kwargs):
+            try:
+                round_id = next(self._rounds)
+            except StopIteration as exc:
+                raise control_plane.RendezvousClosedError("done") from exc
+
+            self._cycle_info_reporter.report_cycle_start(
+                CycleInfoRoundSnapshot(
+                    cycle_number=round_id,
+                    active_node_addrs=self._active_node_addrs,
+                    standby_node_addrs=self._standby_node_addrs,
+                    active_ranks=self._active_ranks,
+                )
+            )
+            return round_id
+
+    node_generator = MagicMock()
+    node_generator.generate.return_value = object()
+
+    with (
+        patch.object(control_plane, "_RendezvousBarrierState", FakeState),
+        patch.object(control_plane, "_NodeDescGenerator", return_value=node_generator),
+    ):
+        control_plane._run_control_rendezvous_loop(
+            args,
+            ft_cfg,
+            store=object(),
+            services=services,
+            stop_event=stop_event,
+        )
+
+    reported_rounds = [
+        call.args[0].cycle_number
+        for call in services.cycle_info_reporter.report_cycle_start.call_args_list
+    ]
+    assert reported_rounds == [0, 1]
+    assert states[0]._cycle_info_reporter is services.cycle_info_reporter
+    attribution_service._submit_log.assert_any_call(str(tmp_path / "train_cycle0.log"))
+    attribution_service._submit_log.assert_any_call(str(tmp_path / "train_cycle1.log"))

--- a/tests/fault_tolerance/unit/test_cycle_info_writer.py
+++ b/tests/fault_tolerance/unit/test_cycle_info_writer.py
@@ -19,10 +19,16 @@ import json
 import os
 import tempfile
 import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import CycleInfoWriter, utc_iso_now
+from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import (
+    CycleInfoReporter,
+    CycleInfoRoundSnapshot,
+    CycleInfoWriter,
+    utc_iso_now,
+)
 
 
 @pytest.fixture
@@ -148,6 +154,132 @@ def test_cycle_info_writer_update_cycle_end_missing_file_no_crash(tmp_dir):
     # No file created for the update target
     path = os.path.join(tmp_dir, "cycle_info.nonexistent.0.99")
     assert not os.path.isfile(path)
+
+
+def test_cycle_info_reporter_formats_and_starts_cycle(tmp_dir):
+    """CycleInfoReporter formats round snapshots and writes cycle start."""
+    writer = MagicMock()
+    reporter = CycleInfoReporter(
+        tmp_dir,
+        cycle_log_prefix="/logs/train.log",
+        cycle_info_job_id="job1",
+        attempt_index=7,
+        writer=writer,
+    )
+    snapshot = CycleInfoRoundSnapshot(
+        cycle_number=0,
+        active_node_addrs=["node002", "node001"],
+        standby_node_addrs=["node003"],
+        active_ranks=[1, 0],
+    )
+
+    with patch(
+        "nvidia_resiliency_ext.fault_tolerance.cycle_info_writer.utc_iso_now",
+        return_value="2024-01-01T00:00:00Z",
+    ):
+        assert reporter.report_cycle_start(snapshot)
+
+    writer.write_cycle_start.assert_called_once()
+    call_kw = writer.write_cycle_start.call_args.kwargs
+    assert call_kw["job_id"] == "job1"
+    assert call_kw["attempt_index"] == 7
+    assert call_kw["cycle_number"] == 0
+    assert call_kw["cycle_start_time"] == "2024-01-01T00:00:00Z"
+    assert call_kw["cycle_log_file"] == "/logs/train_cycle0.log"
+    assert call_kw["active_nodes"] == "node[001-002]"
+    assert call_kw["standby_nodes"] == "node[003]"
+    assert call_kw["active_ranks"] == "0-1"
+
+
+def test_cycle_info_reporter_derives_file_namespace_from_env(tmp_dir):
+    """Colocated reporter derives cycle-info file naming from its SLURM environment."""
+    writer = MagicMock()
+    reporter = CycleInfoReporter(tmp_dir, writer=writer)
+    snapshot = CycleInfoRoundSnapshot(cycle_number=0, active_node_addrs=["node001"])
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "SLURM_ARRAY_JOB_ID": "array-job",
+                "SLURM_JOB_ID": "job",
+                "SLURM_RESTART_CNT": "4",
+            },
+            clear=False,
+        ),
+        patch(
+            "nvidia_resiliency_ext.fault_tolerance.cycle_info_writer.utc_iso_now",
+            return_value="2024-01-01T00:00:00Z",
+        ),
+    ):
+        assert reporter.report_cycle_start(snapshot)
+
+    call_kw = writer.write_cycle_start.call_args.kwargs
+    assert call_kw["job_id"] == "array-job"
+    assert call_kw["attempt_index"] == 4
+
+
+def test_cycle_info_reporter_closes_cycle_on_shutdown(tmp_dir):
+    """CycleInfoReporter shutdown finalizes the active cycle and drains the writer."""
+    writer = MagicMock()
+    reporter = CycleInfoReporter(
+        tmp_dir,
+        cycle_info_job_id="job1",
+        attempt_index=2,
+        writer=writer,
+    )
+    snapshot = CycleInfoRoundSnapshot(cycle_number=3, active_node_addrs=["node001"])
+
+    with patch(
+        "nvidia_resiliency_ext.fault_tolerance.cycle_info_writer.utc_iso_now",
+        side_effect=[
+            "2024-01-01T00:00:00Z",
+            "2024-01-01T00:01:00Z",
+        ],
+    ):
+        reporter.report_cycle_start(snapshot)
+        reporter.shutdown()
+
+    writer.update_cycle_end.assert_called_once_with(
+        job_id="job1",
+        attempt_index=2,
+        cycle_number=3,
+        cycle_end_time="2024-01-01T00:01:00Z",
+    )
+    writer.shutdown.assert_called_once_with()
+
+
+def test_cycle_info_reporter_closes_previous_cycle_on_next_start(tmp_dir):
+    """Starting cycle N+1 finalizes cycle N before writing the new start file."""
+    writer = MagicMock()
+    reporter = CycleInfoReporter(
+        tmp_dir,
+        cycle_info_job_id="job1",
+        attempt_index=2,
+        writer=writer,
+    )
+    snapshot0 = CycleInfoRoundSnapshot(cycle_number=0, active_node_addrs=["node001"])
+    snapshot1 = CycleInfoRoundSnapshot(cycle_number=1, active_node_addrs=["node002"])
+
+    with patch(
+        "nvidia_resiliency_ext.fault_tolerance.cycle_info_writer.utc_iso_now",
+        side_effect=[
+            "2024-01-01T00:00:00Z",
+            "2024-01-01T00:01:00Z",
+            "2024-01-01T00:02:00Z",
+        ],
+    ):
+        reporter.report_cycle_start(snapshot0)
+        reporter.report_cycle_start(snapshot1)
+
+    writer.update_cycle_end.assert_called_once_with(
+        job_id="job1",
+        attempt_index=2,
+        cycle_number=0,
+        cycle_end_time="2024-01-01T00:01:00Z",
+    )
+    assert writer.write_cycle_start.call_count == 2
+    assert writer.write_cycle_start.call_args_list[1].kwargs["cycle_number"] == 1
 
 
 def test_utc_iso_now_format():

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -72,6 +72,47 @@ def _get_util_script_path():
     return os.path.join(os.path.dirname(__file__), "_launcher_test_util.py")
 
 
+def test_register_barrier_rdzv_handler_applies_c10d_patch():
+    from torch.distributed.elastic.rendezvous import rendezvous_handler_registry
+
+    from nvidia_resiliency_ext.fault_tolerance import c10d_monkey_patch, launcher
+
+    with (
+        patch.object(c10d_monkey_patch, "apply_c10d_patch") as apply_c10d_patch,
+        patch.object(rendezvous_handler_registry, "_registry", {"c10d": object()}),
+        patch.object(rendezvous_handler_registry, "register") as register,
+    ):
+        launcher._register_ft_rdzv_handler("barrier")
+
+    apply_c10d_patch.assert_called_once()
+    register.assert_called_once()
+    assert register.call_args.args[0] == "c10d"
+
+
+def test_legacy_rdzv_impl_injects_use_libuv_false():
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    parser = launcher.get_args_parser()
+    args = parser.parse_args(
+        [
+            "--nnodes",
+            "1",
+            "--nproc-per-node",
+            "1",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--ft-rdzv-impl",
+            "legacy",
+            "train.py",
+        ]
+    )
+
+    with patch.object(launcher.LocalElasticAgent, "setup_rank_monitors_early", return_value={}):
+        config, _, _ = launcher.config_from_args(args)
+
+    assert config.rdzv_configs["use_libuv"] is False
+
+
 def test_rank_not_send_initial_hb(tmp_dir):
     # If one rank does not send initial heartbeat,
     # FT should terminate the rank, and launcher should kill all other ranks
@@ -287,23 +328,24 @@ def test_config_provided_via_cli_overwrites_yaml(tmp_dir):
 
 
 # ==============================================================================
-# Unit tests for launcher cycle_info_writer interaction
+# Unit tests for launcher cycle-info env path interaction
 # ==============================================================================
 
 
 def _make_agent_spec(rdzv_round=1):
-    """Minimal WorkerSpec-like object for testing cycle_info_writer interaction."""
+    """Minimal WorkerSpec-like object for testing launcher cycle-info env interaction."""
     spec = MagicMock()
     spec.rdzv_handler = MagicMock()
     spec.rdzv_handler.round.return_value = rdzv_round
     spec.rdzv_handler.get_active_node_addrs.return_value = ["node001", "node002"]
     spec.rdzv_handler.get_standby_node_addrs.return_value = ["node003"]
+    spec.rdzv_handler.get_active_ranks.return_value = [0, 1]
     spec.max_restarts = 3
     return spec
 
 
-class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
-    """Unit tests for launcher's interaction with CycleInfoWriter."""
+class TestLauncherCycleInfoEnvPath(unittest.TestCase):
+    """Unit tests for launcher's read-only cycle-info worker env plumbing."""
 
     def setUp(self):
         """Set up test fixtures."""
@@ -311,108 +353,6 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
         self.fault_tol_cfg = FaultToleranceConfig()
         self.logs_specs = MagicMock()
         self.logs_specs.get_cycle_log_file.return_value = "/path/to/cycle_0.log"
-
-    def test_on_cycle_end_when_writer_is_none(self):
-        """_on_cycle_end does nothing when cycle_info_writer is None."""
-        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
-
-        agent = LocalElasticAgent(
-            spec=self.spec,
-            fault_tol_cfg=self.fault_tol_cfg,
-            logs_specs=self.logs_specs,
-            cycle_info_writer=None,
-        )
-        # Should not raise; no writer to call
-        agent._on_cycle_end()
-
-    def test_on_cycle_end_calls_update_cycle_end_with_env_and_restart_count(self):
-        """_on_cycle_end calls writer.update_cycle_end with job_id, attempt_index, cycle_number, cycle_end_time."""
-        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
-
-        writer = MagicMock()
-        # rdzv_round=1 -> _get_global_cycle_number() = 1 (cycle 1)
-        spec = _make_agent_spec(rdzv_round=1)
-        with patch.dict(
-            os.environ,
-            {
-                "SLURM_JOB_ID": "12345",
-                "SLURM_RESTART_CNT": "0",
-            },
-            clear=False,
-        ):
-            agent = LocalElasticAgent(
-                spec=spec,
-                fault_tol_cfg=self.fault_tol_cfg,
-                logs_specs=self.logs_specs,
-                cycle_info_writer=writer,
-            )
-            with patch(
-                "nvidia_resiliency_ext.fault_tolerance.launcher.utc_iso_now",
-                return_value="2024-01-01T12:00:00Z",
-            ):
-                agent._on_cycle_end()
-
-        writer.update_cycle_end.assert_called_once()
-        call_kw = writer.update_cycle_end.call_args[1]
-        self.assertEqual(call_kw["job_id"], "12345")
-        self.assertEqual(call_kw["attempt_index"], 0)
-        self.assertEqual(call_kw["cycle_number"], 1)
-        self.assertEqual(call_kw["cycle_end_time"], "2024-01-01T12:00:00Z")
-
-    def test_on_cycle_end_uses_slurm_array_job_id_when_set(self):
-        """_on_cycle_end uses SLURM_ARRAY_JOB_ID over SLURM_JOB_ID when present."""
-        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
-
-        writer = MagicMock()
-        spec = _make_agent_spec(rdzv_round=2)  # restart_count = 2 (cycle 2)
-        with patch.dict(
-            os.environ,
-            {
-                "SLURM_ARRAY_JOB_ID": "array_99",
-                "SLURM_JOB_ID": "12345",
-                "SLURM_RESTART_CNT": "1",
-            },
-            clear=False,
-        ):
-            agent = LocalElasticAgent(
-                spec=spec,
-                fault_tol_cfg=self.fault_tol_cfg,
-                logs_specs=self.logs_specs,
-                cycle_info_writer=writer,
-            )
-            with patch(
-                "nvidia_resiliency_ext.fault_tolerance.launcher.utc_iso_now",
-                return_value="2024-01-01T12:00:00Z",
-            ):
-                agent._on_cycle_end()
-
-        call_kw = writer.update_cycle_end.call_args[1]
-        self.assertEqual(call_kw["job_id"], "array_99")
-        self.assertEqual(call_kw["attempt_index"], 1)
-        self.assertEqual(call_kw["cycle_number"], 2)
-
-    def test_on_cycle_end_cycle_number_override(self):
-        """_on_cycle_end accepts explicit cycle_number, bypassing _get_global_cycle_number()."""
-        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
-
-        writer = MagicMock()
-        # rdzv_round=3 (standby advanced _round to 3 before shutdown detected);
-        # calling with cycle_number=2 records the last completed cycle.
-        spec = _make_agent_spec(rdzv_round=3)
-        agent = LocalElasticAgent(
-            spec=spec,
-            fault_tol_cfg=self.fault_tol_cfg,
-            logs_specs=self.logs_specs,
-            cycle_info_writer=writer,
-        )
-        with patch(
-            "nvidia_resiliency_ext.fault_tolerance.launcher.utc_iso_now",
-            return_value="2024-01-01T12:00:00Z",
-        ):
-            agent._on_cycle_end(cycle_number=2)
-
-        call_kw = writer.update_cycle_end.call_args[1]
-        self.assertEqual(call_kw["cycle_number"], 2)
 
     def test_remaining_restarts_corrected_in_run(self):
         """run() re-syncs _remaining_restarts before delegating to _invoke_run.
@@ -428,7 +368,6 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
             spec=spec,
             fault_tol_cfg=self.fault_tol_cfg,
             logs_specs=self.logs_specs,
-            cycle_info_writer=None,
         )
 
         captured = {}
@@ -450,96 +389,50 @@ class TestLauncherCycleInfoWriterInteraction(unittest.TestCase):
         # run() always re-computes so the value is guaranteed correct regardless.
         self.assertEqual(captured['remaining'], 1)  # max_restarts(3) - round()(2) = 1
 
-    def test_write_cycle_start_info_returns_none_when_writer_is_none(self):
-        """_write_cycle_start_info returns None when cycle_info_writer is None."""
+    def test_current_cycle_info_path_returns_none_when_disabled(self):
+        """No cycle-info env path is set when cycle info is disabled."""
         from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
 
         agent = LocalElasticAgent(
             spec=self.spec,
             fault_tol_cfg=self.fault_tol_cfg,
             logs_specs=self.logs_specs,
-            cycle_info_writer=None,
         )
-        result = agent._write_cycle_start_info(current_cycle=0)
+        result = agent._current_cycle_info_path()
         self.assertIsNone(result)
 
-    def test_write_cycle_start_info_calls_write_cycle_start_and_returns_current_path(self):
-        """_write_cycle_start_info calls write_cycle_start and returns get_current_cycle_info_path."""
+    def test_current_cycle_info_path_uses_slurm_job_id(self):
+        """Launchers compute the current symlink path without writing cycle info."""
         from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
 
-        writer = MagicMock()
-        writer.get_current_cycle_info_path.return_value = "/nvrx/cycle_info.job1.current"
-        spec = _make_agent_spec(rdzv_round=1)
-        with patch.dict(
-            os.environ,
-            {"SLURM_JOB_ID": "job1", "SLURM_RESTART_CNT": "0"},
-            clear=False,
-        ):
+        fault_tol_cfg = FaultToleranceConfig(cycle_info_dir="/nvrx")
+        with patch.dict(os.environ, {"SLURM_JOB_ID": "job1"}, clear=False):
             agent = LocalElasticAgent(
-                spec=spec,
-                fault_tol_cfg=self.fault_tol_cfg,
+                spec=self.spec,
+                fault_tol_cfg=fault_tol_cfg,
                 logs_specs=self.logs_specs,
-                cycle_info_writer=writer,
             )
-            with patch(
-                "nvidia_resiliency_ext.fault_tolerance.launcher.utc_iso_now",
-                return_value="2024-01-01T12:00:00Z",
-            ):
-                with patch(
-                    "nvidia_resiliency_ext.fault_tolerance.launcher.hostnames_to_slurm_nodelist",
-                    side_effect=["node[001-002]", "node003"],  # active_addrs, then standby_addrs
-                ):
-                    result = agent._write_cycle_start_info(current_cycle=0)
+            result = agent._current_cycle_info_path()
 
-        writer.write_cycle_start.assert_called_once()
-        call_kw = writer.write_cycle_start.call_args[1]
-        self.assertEqual(call_kw["job_id"], "job1")
-        self.assertEqual(call_kw["attempt_index"], 0)
-        self.assertEqual(call_kw["cycle_number"], 0)
-        self.assertEqual(call_kw["cycle_start_time"], "2024-01-01T12:00:00Z")
-        self.assertEqual(call_kw["cycle_log_file"], "/path/to/cycle_0.log")
-        self.assertEqual(call_kw["active_nodes"], "node[001-002]")
-        self.assertEqual(call_kw["standby_nodes"], "node003")
-        writer.get_current_cycle_info_path.assert_called_once_with("job1")
         self.assertEqual(result, "/nvrx/cycle_info.job1.current")
 
-    def test_write_cycle_start_info_standby_nodes_from_rdzv(self):
-        """_write_cycle_start_info passes active and standby node lists from rdzv handler."""
+    def test_current_cycle_info_path_prefers_slurm_array_job_id(self):
         from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
 
-        writer = MagicMock()
-        writer.get_current_cycle_info_path.return_value = "/nvrx/current"
-        spec = _make_agent_spec(rdzv_round=1)
-        spec.rdzv_handler.get_active_node_addrs.return_value = ["host1"]
-        spec.rdzv_handler.get_standby_node_addrs.return_value = ["host2"]
+        fault_tol_cfg = FaultToleranceConfig(cycle_info_dir="/nvrx")
         with patch.dict(
             os.environ,
-            {"SLURM_JOB_ID": "j", "SLURM_RESTART_CNT": "0"},
+            {"SLURM_ARRAY_JOB_ID": "array1", "SLURM_JOB_ID": "job1"},
             clear=False,
         ):
             agent = LocalElasticAgent(
-                spec=spec,
-                fault_tol_cfg=self.fault_tol_cfg,
+                spec=self.spec,
+                fault_tol_cfg=fault_tol_cfg,
                 logs_specs=self.logs_specs,
-                cycle_info_writer=writer,
             )
-            with patch(
-                "nvidia_resiliency_ext.fault_tolerance.launcher.utc_iso_now",
-                return_value="2024-01-01T12:00:00Z",
-            ):
-                with patch(
-                    "nvidia_resiliency_ext.fault_tolerance.launcher.hostnames_to_slurm_nodelist",
-                    side_effect=lambda addrs: (
-                        "active"
-                        if addrs == ["host1"]
-                        else ("standby" if addrs == ["host2"] else "")
-                    ),
-                ):
-                    agent._write_cycle_start_info(current_cycle=0)
+            result = agent._current_cycle_info_path()
 
-        call_kw = writer.write_cycle_start.call_args[1]
-        self.assertEqual(call_kw["active_nodes"], "active")
-        self.assertEqual(call_kw["standby_nodes"], "standby")
+        self.assertEqual(result, "/nvrx/cycle_info.array1.current")
 
 
 class TestLauncherRunBehavior(unittest.TestCase):
@@ -551,12 +444,8 @@ class TestLauncherRunBehavior(unittest.TestCase):
         self.logs_specs = MagicMock()
         self.logs_specs.get_cycle_log_file.return_value = "/path/to/cycle_0.log"
 
-    def test_run_graceful_exit_calls_on_cycle_end_with_round_minus_1(self):
-        """run() calls _on_cycle_end(cycle_number=round()-1) on RendezvousGracefulExitError.
-
-        Standby nodes: _round advanced to N+1 when round N closed before shutdown was
-        detected. run() records end of cycle N (the last completed cycle).
-        """
+    def test_run_graceful_exit_returns_none_without_cycle_info_update(self):
+        """RendezvousGracefulExitError is not a launcher-owned cycle-info path."""
         from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
 
         from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
@@ -566,7 +455,6 @@ class TestLauncherRunBehavior(unittest.TestCase):
             spec=spec,
             fault_tol_cfg=self.fault_tol_cfg,
             logs_specs=self.logs_specs,
-            cycle_info_writer=MagicMock(),
         )
 
         with (
@@ -574,12 +462,9 @@ class TestLauncherRunBehavior(unittest.TestCase):
                 agent, '_invoke_run', side_effect=RendezvousGracefulExitError("round closed")
             ),
             patch.object(agent, '_shutdown'),
-            patch.object(agent, '_on_cycle_end') as mock_end,
         ):
             result = agent.run()
 
-        # round()-1 = 3-1 = 2: record the last completed cycle, not the advanced one
-        mock_end.assert_called_once_with(cycle_number=2)
         self.assertIsNone(result)
 
 
@@ -599,7 +484,6 @@ class TestHandleRestartDecision(unittest.TestCase):
             spec=self.spec,
             fault_tol_cfg=self.fault_tol_cfg,
             logs_specs=self.logs_specs,
-            cycle_info_writer=None,
         )
 
     def test_handle_restart_decision_progress_terminate(self):
@@ -683,7 +567,6 @@ class TestHandleRestartDecision(unittest.TestCase):
             spec=self.spec,
             fault_tol_cfg=self.fault_tol_cfg,
             logs_specs=self.logs_specs,
-            cycle_info_writer=None,
         )
         agent._open_rendezvous_for_restart()
 
@@ -710,7 +593,6 @@ class TestHandleRestartDecision(unittest.TestCase):
             spec=self.spec,
             fault_tol_cfg=self.fault_tol_cfg,
             logs_specs=self.logs_specs,
-            cycle_info_writer=None,
         )
         # Should not raise
         agent._open_rendezvous_for_restart()
@@ -725,6 +607,15 @@ def test_ft_log_aggregator_count_rejects_negative():
     args = parser.parse_args(['--ft-log-aggregator-count', '-1', 'train.py'])
     with pytest.raises(ValueError, match='--ft-log-aggregator-count'):
         _validate_args(args)
+
+
+def test_cli_cycle_info_dir_does_not_require_per_cycle_applog():
+    from nvidia_resiliency_ext.fault_tolerance.launcher import _validate_args, get_args_parser
+
+    parser = get_args_parser()
+    args = parser.parse_args(['--ft-cycle-info-dir', '/nvrx', 'train.py'])
+
+    _validate_args(args)
 
 
 def test_cli_attribution_endpoint_requires_per_cycle_applog():
@@ -802,9 +693,11 @@ def test_attribution_endpoint_with_per_cycle_applog_is_valid():
         "--ft_attribution_host",
         "--ft-attribution-port",
         "--ft_attribution_port",
+        "--ft-log-server-log",
+        "--ft_log_server_log",
     ],
 )
-def test_removed_attribution_options_are_rejected(removed_option):
+def test_removed_options_are_rejected(removed_option):
     from nvidia_resiliency_ext.fault_tolerance.launcher import get_args_parser
 
     parser = get_args_parser()
@@ -847,6 +740,73 @@ def test_log_funnel_ports_from_launcher_args_rejects_negative():
         )
 
 
+def test_grpc_log_server_log_prefix_resolution(tmp_path):
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance.launcher import _resolve_grpc_log_server_log_prefix
+
+    assert _resolve_grpc_log_server_log_prefix(
+        SimpleNamespace(
+            ft_log_server_log_prefix=str(tmp_path / "explicit"),
+            ft_nvrx_logfile=str(tmp_path / "nvrx.log"),
+            ft_per_cycle_applog_prefix=str(tmp_path / "app.log"),
+        )
+    ) == str(tmp_path / "explicit")
+    assert _resolve_grpc_log_server_log_prefix(
+        SimpleNamespace(
+            ft_log_server_log_prefix=None,
+            ft_nvrx_logfile=str(tmp_path / "nvrx.log"),
+            ft_per_cycle_applog_prefix=str(tmp_path / "app.log"),
+        )
+    ) == str(tmp_path / "nvrx_grpc")
+    assert _resolve_grpc_log_server_log_prefix(
+        SimpleNamespace(
+            ft_log_server_log_prefix=None,
+            ft_nvrx_logfile=None,
+            ft_per_cycle_applog_prefix=str(tmp_path / "app.log"),
+        )
+    ) == str(tmp_path / "app_grpc")
+
+
+def test_start_grpc_log_servers_uses_prefix_for_root_and_leaf_logs(tmp_path):
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    class FakePopen:
+        next_pid = 1000
+
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.pid = FakePopen.next_pid
+            FakePopen.next_pid += 1
+
+        def kill(self):
+            pass
+
+        def wait(self):
+            pass
+
+    args = SimpleNamespace(
+        nnodes="2",
+        ft_log_server_graceful_shutdown_timeout=60.0,
+        ft_log_leaf_max_queue_chunks=-1,
+    )
+    log_dir = tmp_path / "missing" / "logs"
+    log_prefix = str(log_dir / "grpc_diag")
+    ports = launcher.LogFunnelPorts(base_port=50051, first_level_count=2)
+
+    with patch.object(launcher.subprocess, "Popen", FakePopen):
+        procs = launcher._start_grpc_log_servers(args, log_prefix, ports)
+
+    assert len(procs) == 3
+    assert log_dir.is_dir()
+    assert (log_dir / "grpc_diag_root.log").is_file()
+    assert (log_dir / "grpc_diag_leaf_0.log").is_file()
+    assert (log_dir / "grpc_diag_leaf_1.log").is_file()
+
+
 def test_managed_attribution_listen_port_rejects_log_funnel_overlap():
     from nvidia_resiliency_ext.fault_tolerance.launcher import (
         LogFunnelPorts,
@@ -859,3 +819,216 @@ def test_managed_attribution_listen_port_rejects_log_funnel_overlap():
         _validate_managed_attribution_listen_port_not_in_log_funnel(50053, funnel_ports)
 
     _validate_managed_attribution_listen_port_not_in_log_funnel(50050, funnel_ports)
+
+
+def test_non_host_launcher_routes_logs_to_rendezvous_host_and_skips_host_services(tmp_path):
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    class FakePipeBasedLogsSpecs:
+        def __init__(
+            self,
+            base_log_file,
+            launcher_pipe_fd=None,
+            launcher_log_file=None,
+            grpc_server_address=None,
+            node_id=None,
+        ):
+            self.base_log_file = base_log_file
+            self.grpc_server_address = grpc_server_address
+            self.node_id = node_id
+
+    parser = launcher.get_args_parser()
+    args = parser.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "control.host:29500",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+            "--ft-enable-log-server",
+            "true",
+            "--ft-attribution-endpoint",
+            "localhost",
+            "train.py",
+        ]
+    )
+
+    with (
+        patch.object(launcher, "_matches_machine_hostname", return_value=False),
+        patch.object(launcher, "PipeBasedLogsSpecs", FakePipeBasedLogsSpecs),
+        patch.object(launcher.LocalElasticAgent, "setup_rank_monitors_early", return_value={}),
+        patch.object(
+            launcher,
+            "_start_grpc_log_servers",
+            side_effect=AssertionError("compute launcher must not start gRPC servers"),
+        ),
+        patch.object(
+            launcher.AttributionManager,
+            "start_if_needed",
+            return_value=None,
+        ),
+    ):
+        config, _, _ = launcher.config_from_args(args)
+
+    assert "is_host" not in config.rdzv_configs
+    assert "attribution_endpoint" not in config.rdzv_configs
+    assert config.logs_specs.grpc_server_address == "control.host:50051"
+
+
+def test_same_node_external_control_honors_is_host_false(tmp_path):
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    class FakePipeBasedLogsSpecs:
+        def __init__(
+            self,
+            base_log_file,
+            launcher_pipe_fd=None,
+            launcher_log_file=None,
+            grpc_server_address=None,
+            node_id=None,
+        ):
+            self.grpc_server_address = grpc_server_address
+
+    parser = launcher.get_args_parser()
+    args = parser.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--rdzv-conf",
+            "is_host=false",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+            "--ft-enable-log-server",
+            "true",
+            "--ft-attribution-endpoint",
+            "localhost",
+            "train.py",
+        ]
+    )
+    attribution_manager = MagicMock()
+    attribution_manager.start_if_needed.return_value = None
+
+    with (
+        patch.object(launcher, "_matches_machine_hostname", return_value=True),
+        patch.object(launcher, "PipeBasedLogsSpecs", FakePipeBasedLogsSpecs),
+        patch.object(launcher.LocalElasticAgent, "setup_rank_monitors_early", return_value={}),
+        patch.object(
+            launcher,
+            "_start_grpc_log_servers",
+            side_effect=AssertionError("compute launcher must not start gRPC servers"),
+        ),
+        patch.object(
+            launcher,
+            "AttributionManager",
+            return_value=attribution_manager,
+        ) as attribution_manager_cls,
+    ):
+        config, _, _ = launcher.config_from_args(args)
+
+    attribution_manager_cls.assert_called_once()
+    assert attribution_manager_cls.call_args.kwargs["is_store_host"] is False
+    assert config.rdzv_configs["is_host"] == "false"
+    assert "attribution_endpoint" not in config.rdzv_configs
+    assert config.logs_specs.grpc_server_address == "127.0.0.1:50051"
+
+
+def test_nvrx_logfile_auto_enables_grpc_routing_to_rendezvous_host(tmp_path):
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    class FakePipeBasedLogsSpecs:
+        def __init__(
+            self,
+            base_log_file,
+            launcher_pipe_fd=None,
+            launcher_log_file=None,
+            grpc_server_address=None,
+            node_id=None,
+        ):
+            self.grpc_server_address = grpc_server_address
+
+    parser = launcher.get_args_parser()
+    args = parser.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "control.host:29500",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+            "--ft-nvrx-logfile",
+            str(tmp_path / "nvrx.log"),
+            "train.py",
+        ]
+    )
+    assert args.ft_enable_log_server is None
+
+    with (
+        patch.object(launcher, "_matches_machine_hostname", return_value=False),
+        patch.object(launcher, "PipeBasedLogsSpecs", FakePipeBasedLogsSpecs),
+        patch.object(launcher.LocalElasticAgent, "setup_rank_monitors_early", return_value={}),
+        patch.object(
+            launcher,
+            "_start_grpc_log_servers",
+            side_effect=AssertionError("compute launcher must not start gRPC servers"),
+        ),
+    ):
+        config, _, _ = launcher.config_from_args(args)
+
+    assert args.ft_enable_log_server is True
+    assert config.logs_specs.grpc_server_address == "control.host:50051"
+
+
+def test_launch_agent_store_host_closes_cycle_info_reporter_without_rdzv_shutdown():
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    rdzv_handler = MagicMock()
+    rdzv_handler._attribution_service = None
+    spec = SimpleNamespace(rdzv_handler=rdzv_handler)
+    agent = MagicMock()
+    agent.run.side_effect = launcher.UnhealthyNodeException("node unhealthy")
+    agent._rdzv_handler = rdzv_handler
+
+    config = SimpleNamespace(
+        run_id="run-a",
+        rdzv_configs={},
+        min_nodes=1,
+        max_nodes=1,
+        nproc_per_node=1,
+        rdzv_backend="c10d",
+        rdzv_endpoint="host:29500",
+        local_addr=None,
+        fault_tol_cfg=FaultToleranceConfig(cycle_info_dir="/nvrx"),
+        role="trainer",
+        max_restarts=1,
+        monitor_interval=1,
+        logs_specs=SimpleNamespace(root_log_dir="/tmp/logs"),
+        metrics_cfg={},
+        start_method="spawn",
+        log_line_prefix_template=None,
+        term_timeout=1,
+        workers_stop_timeout=1,
+        restart_policy="any-failed",
+        rank_monitors={},
+    )
+
+    with (
+        patch.object(launcher, "_get_addr_and_port", return_value=("host", 29500)),
+        patch.object(launcher, "_is_store_host", return_value=True),
+        patch.object(launcher, "WorkerSpec", return_value=spec),
+        patch.object(launcher.rdzv_registry, "get_rendezvous_handler", return_value=rdzv_handler),
+        patch.object(launcher, "LocalElasticAgent", return_value=agent),
+        patch.object(launcher.metrics, "initialize_metrics"),
+        patch.object(launcher.events, "record"),
+        patch.object(launcher, "is_slurm_job_array", return_value=False),
+        patch.object(launcher.time, "sleep", return_value=None),
+    ):
+        result = launcher.launch_agent(config, "train.py", [])
+
+    assert result is None
+    rdzv_handler.shutdown.assert_not_called()
+    rdzv_handler.shutdown_cycle_info_reporter.assert_called_once()

--- a/tests/fault_tolerance/unit/test_launcher_grpc_integration.py
+++ b/tests/fault_tolerance/unit/test_launcher_grpc_integration.py
@@ -361,15 +361,16 @@ def test_launcher_without_grpc_flag_does_not_start_server(tmp_dir):
     assert "gRPC log server started" not in output, "gRPC server should not be started"
 
 
-def test_launcher_custom_server_log_path(tmp_dir):
-    """Test that --ft-log-server-log is used for the root in two-level mode (aggregator count 2)."""
+def test_launcher_custom_server_log_prefix(tmp_dir):
+    """Test that --ft-log-server-log-prefix is used for root diagnostics."""
     ft_cfg = fault_tolerance.FaultToleranceConfig()
     ft_cfg.initial_rank_heartbeat_timeout = 3.0
     ft_cfg.rank_heartbeat_timeout = 3.0
     ft_cfg_path = _save_ft_cfg(ft_cfg, tmp_dir)
 
     base_log_file = os.path.join(tmp_dir, "test.log")
-    custom_server_log = os.path.join(tmp_dir, "custom_grpc_server.log")
+    custom_server_log_prefix = os.path.join(tmp_dir, "custom_grpc_server")
+    custom_root_log = custom_server_log_prefix + "_root.log"
     default_root_log = os.path.join(tmp_dir, "test_grpc_root.log")
 
     cmd_to_run = f"{_get_util_script_path()} --scenario=test_ranks_exit_gracefully"
@@ -379,8 +380,8 @@ def test_launcher_custom_server_log_path(tmp_dir):
         f" --ft-cfg-path={ft_cfg_path}"
         " --ft-enable-log-server=true"
         f" --ft-per-cycle-applog-prefix={base_log_file}"
-        f" --ft-log-server-log={custom_server_log}"
-        " --ft-log-aggregator-count=2"
+        f" --ft-log-server-log-prefix={custom_server_log_prefix}"
+        " --ft-log-server-graceful-shutdown-timeout=1"
         f" --nproc-per-node={WORLD_SIZE}"
         f" {cmd_to_run}"
     )
@@ -388,20 +389,14 @@ def test_launcher_custom_server_log_path(tmp_dir):
     ret_code, output = _run_launcher(launcher_cmd)
 
     assert ret_code in [0, 1], f"Launcher should complete; output:\n{output}"
-    assert (
-        "gRPC root log server:" in output
-    ), f"Expected two-level root startup log line; output:\n{output}"
-    assert "gRPC log server started" not in output, (
-        "Single-level gRPC startup should not appear when --ft-log-aggregator-count=2 "
-        f"(would mask a silent fallback to one root on base port). Output:\n{output}"
-    )
+    assert "gRPC log server started" in output, f"Expected gRPC startup log line; output:\n{output}"
     assert os.path.isfile(
-        custom_server_log
-    ), f"Root log should be written to custom path {custom_server_log}. Output:\n{output}"
-    with open(custom_server_log, 'r') as f:
+        custom_root_log
+    ), f"Root log should be written to custom path {custom_root_log}. Output:\n{output}"
+    with open(custom_root_log, 'r') as f:
         custom_content = f.read()
     assert len(custom_content) > 0, "Custom root gRPC log file should not be empty"
     assert not os.path.isfile(default_root_log), (
         f"Default root log {default_root_log} should not be created when "
-        f"--ft-log-server-log is set (two-level mode regression check)"
+        f"--ft-log-server-log-prefix is set (two-level mode regression check)"
     )

--- a/tests/fault_tolerance/unit/test_rdzv_utils.py
+++ b/tests/fault_tolerance/unit/test_rdzv_utils.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from nvidia_resiliency_ext.fault_tolerance.rdzv_utils import (
+    rdzv_config_get_as_bool,
+    rdzv_config_get_as_float,
+    rdzv_config_get_as_int,
+)
+
+
+@pytest.mark.parametrize("value", [True, 1, "1", "true", "t", "yes", "y"])
+def test_rdzv_config_get_as_bool_accepts_true_values(value):
+    assert rdzv_config_get_as_bool({"is_host": value}, "is_host") is True
+
+
+@pytest.mark.parametrize("value", [False, 0, "0", "false", "f", "no", "n"])
+def test_rdzv_config_get_as_bool_accepts_false_values(value):
+    assert rdzv_config_get_as_bool({"is_host": value}, "is_host") is False
+
+
+def test_rdzv_config_get_as_bool_uses_default_for_absent_key():
+    assert rdzv_config_get_as_bool({}, "is_host") is None
+    assert rdzv_config_get_as_bool({}, "is_host", default=True) is True
+
+
+def test_rdzv_config_get_as_bool_rejects_invalid_values():
+    with pytest.raises(ValueError, match="valid boolean"):
+        rdzv_config_get_as_bool({"is_host": "maybe"}, "is_host")
+
+
+def test_rdzv_config_get_as_int_casts_values_and_uses_default():
+    assert rdzv_config_get_as_int({"read_timeout": "60"}, "read_timeout") == 60
+    assert rdzv_config_get_as_int({}, "read_timeout", default=30) == 30
+    assert rdzv_config_get_as_int({}, "read_timeout") is None
+
+
+def test_rdzv_config_get_as_int_rejects_invalid_values():
+    with pytest.raises(ValueError, match="valid integer"):
+        rdzv_config_get_as_int({"read_timeout": "slow"}, "read_timeout")
+
+
+def test_rdzv_config_get_as_float_casts_values_and_uses_default():
+    assert rdzv_config_get_as_float({"join_timeout": "12.5"}, "join_timeout") == 12.5
+    assert rdzv_config_get_as_float({}, "join_timeout", default=5.0) == 5.0
+    assert rdzv_config_get_as_float({}, "join_timeout") is None
+
+
+def test_rdzv_config_get_as_float_rejects_invalid_values():
+    with pytest.raises(ValueError, match="valid float"):
+        rdzv_config_get_as_float({"join_timeout": "slow"}, "join_timeout")


### PR DESCRIPTION
Restructure InJob fault-tolerance control so the same rendezvous protocol can run in two deployment modes:

- colocated control: control-plane duties run inside the compute-side ft_launcher on the rendezvous/TCPStore host
- external control: control-plane duties run in a dedicated nvrx-control process outside the compute launcher/job

The control plane owns the long-lived coordination services for an InJob run:
- TCPStore hosting
- rendezvous coordination
- gRPC log aggregation
- Managed attribution service interaction
- cycle-info reporting including rank assignment

Add the nvrx-control entrypoint for external control. The external control process closes compute-only rendezvous rounds without joining as a training participant, so compute rank assignment, WORLD_SIZE, standby assignment, and worker launch remain compute-only.

Make external control independent of SLURM environment. Cycle-info file naming uses an explicit --ft-cycle-info-job-id with attempt_index=0, while colocated control continues to derive its cycle-info namespace from the local SLURM rank0 environment. This allows nvrx-control to run on a CPU node that does not have SLURM_JOB_ID, SLURM_PROCID, or SLURM_RESTART_CNT set.