### PR TITLE
[codex] Add progressive attribution plumbing

### DIFF
--- a/docs/source/attribution/features/index.rst
+++ b/docs/source/attribution/features/index.rst
@@ -1,0 +1,13 @@
+Attribution Feature Requirements
+================================
+
+This section is the product-doc home for attribution feature requirements before
+or alongside implementation. Keep implementation details in
+``src/nvidia_resiliency_ext/attribution`` and service API details in
+``services/attrsvc/ATTRSVC_SPEC.md`` when they become concrete.
+
+.. toctree::
+   :maxdepth: 1
+
+   progressive-ft-launcher-attribution
+   requirements-template

--- a/docs/source/attribution/features/progressive-ft-launcher-attribution.rst
+++ b/docs/source/attribution/features/progressive-ft-launcher-attribution.rst
@@ -1,0 +1,385 @@
+Progressive FT Launcher Attribution
+===================================
+
+Summary
+-------
+
+Progressive FT launcher attribution reduces restart-decision latency by starting
+log analysis when a fault-tolerance cycle starts, while the workload is still
+running. When the cycle ends and ``ft_launcher`` asks attrsvc for a stop/restart
+decision, attrsvc should reuse the analysis work already completed for the same
+per-cycle application log and only perform the final missing work needed to
+return an authoritative decision.
+
+The feature is aimed at the ``ft_launcher`` integration path. The cluster-wide
+service path may expose progressive behavior for validation, but it is not a
+user-facing requirement there because service-mode attribution is post-mortem
+and is not latency sensitive.
+
+Design conclusion: attrsvc should stay mostly as plumbing. The progressive
+option is offered at the NVRx-owned loganalysis tool boundary, and that tool can
+later decide whether to delegate progressive state to LogSage or drive multiple
+LogSage calls over the file flow. Until the LogSage contract is available,
+``POST /logs`` can carry the intent and the loganalysis tool can report
+``unsupported`` without changing ``GET /logs`` behavior.
+
+Problem
+-------
+
+Today, ``ft_launcher`` submits a per-cycle log path near cycle start with
+``POST /logs`` and later requests attribution with ``GET /logs`` after the
+workload has stopped. The ``POST`` path records/tracks the log, but the
+``GET`` path triggers the full LogSage attribution pipeline. For large
+application logs this makes ``ft_launcher`` wait for parsing and LLM analysis
+after the workload has already died, increasing the time before the launcher can
+act on a stop/restart decision.
+
+The per-cycle log path is already a stable correlation key. Both calls refer to
+the same path produced by the cycle log naming convention, for example
+``<applog>_cycle<id>.log``.
+
+Goals
+-----
+
+* Start attribution pre-work from the ``ft_launcher`` cycle-start ``POST``.
+* Preserve the existing ``GET /logs`` decision contract for ``ft_launcher``.
+* Make the final ``GET`` result equivalent to terminal analysis of the complete
+  per-cycle log.
+* Avoid enabling expensive progressive analysis by default for cluster-wide
+  service-mode submissions.
+* Keep progressive analysis an optimization: if pre-analysis is unavailable,
+  failed, stale, or unsupported, ``GET`` must fall back to the existing terminal
+  analysis behavior.
+
+Non-Goals
+---------
+
+* Do not require progressive analysis for service-mode cluster scans.
+* Do not introduce a user-facing live-attribution workflow outside
+  ``ft_launcher``.
+* Do not change the stop/restart policy consumed by ``ft_launcher``.
+* Do not make ``POST /logs`` block on analysis completion.
+* Do not make ``POST /logs`` generate or return an attribution result.
+
+User Flows
+----------
+
+``ft_launcher`` mode
+~~~~~~~~~~~~~~~~~~~~
+
+1. At cycle start, the launcher computes the per-cycle log path and sends
+   ``POST /logs`` for that path.
+2. Attrsvc recognizes the submission as an ``ft_launcher`` progressive-analysis
+   request and starts non-blocking pre-analysis for the growing file.
+3. The workload runs and continues writing to the same log file.
+4. At cycle end, ``ft_launcher`` sends ``GET /logs`` for the same path.
+5. Attrsvc uses the progressive state to complete the normal stop/end analysis
+   and returns the normal attribution payload with a normalized recommendation.
+6. If progressive state is missing or unusable, attrsvc computes the result with
+   the existing terminal pipeline.
+
+Service mode
+~~~~~~~~~~~~
+
+Service mode may continue using ``POST /logs`` for job/file tracking and
+``GET /logs`` for post-mortem attribution. Progressive analysis should remain
+disabled unless explicitly requested by a test or diagnostic client.
+
+Functional Requirements
+-----------------------
+
+* ``POST /logs`` must accept an explicit signal that the caller wants
+  progressive analysis for a single growing log.
+* The ft_launcher client must send that signal when submitting a per-cycle log.
+* Attrsvc must forward progressive intent to the loganalysis tool boundary and
+  return from ``POST`` without waiting for analyzer completion.
+* The loganalysis tool may delegate progressive state to LogSage or implement
+  the file-flow orchestration itself. Attrsvc should not need to know which
+  model was chosen.
+* Attrsvc must not infer progressive analysis only from the absence of
+  ``job_id`` because non-``ft_launcher`` callers can also submit single files.
+* ``GET /logs`` must continue to run the normal terminal analysis path before
+  returning a decision. Once LogSage/tool support exists, that terminal call can
+  reuse progressive work when available.
+* ``GET /logs`` must fall back to the existing full terminal analysis path when
+  progressive analysis is unsupported, incomplete, stale, failed, or disabled.
+* Progressive state, if any, must be correlated by normalized log path because
+  this is the stable key shared by ``POST`` and ``GET``.
+* ``POST /logs`` must remain a notification/early-start path. ``GET /logs``
+  remains the result-producing path.
+* The existing result cache behavior does not change: ``POST`` does not populate
+  the final analysis cache; ``GET`` remains the path that computes and records
+  final attribution results.
+
+API and Data Contract
+---------------------
+
+Handoff Points
+~~~~~~~~~~~~~~
+
+The feature crosses three handoff points. Each handoff should be documented
+separately so NVRx-owned plumbing is not confused with the shared LogSage
+capability contract.
+
+Service HTTP boundary
+   Owned by NVRx. ``POST /logs`` accepts the optional progressive intent and
+   ``GET /logs`` remains the stop/end decision API. This boundary should stay
+   backward compatible for existing attrsvc clients. The service does not own
+   progressive parsing, tailing, or final-result caching.
+
+MCP / loganalysis boundary
+   Owned by NVRx. This is the product feature boundary: it exposes the
+   progressive option regardless of whether the implementation is an MCP tool,
+   an in-process adapter, repeated LogSage calls, or a future LogSage-native
+   progressive session. This is where NVRx should hide implementation ownership
+   from attrsvc.
+
+LogSage API boundary
+   Shared with LogSage. This contract defines whether LogSage can start work
+   early, preserve progressive state, and let the terminal analysis call reuse
+   that state while producing a result equivalent to full terminal analysis. It
+   remains the main open design item.
+
+HTTP API
+~~~~~~~~
+
+Extend ``POST /logs`` with optional fields:
+
+``analysis_intent``
+   Optional analysis behavior requested by the client. Proposed values are
+   ``"track_only"`` and ``"progressive"``. Default is ``"track_only"`` for
+   backward compatibility.
+
+The existing ``log_path``, ``user``, and ``job_id`` fields stay compatible.
+Existing clients that omit ``analysis_intent`` retain current behavior.
+
+``GET /logs`` should keep the current response shape. It may optionally include
+diagnostic metadata in the future, but ``ft_launcher`` must continue to consume
+the normalized ``recommendation`` field without understanding progressive
+internals.
+
+Python API
+~~~~~~~~~~
+
+Extend the internal submit boundary from the HTTP adapter down to the analyzer
+with an optional progressive intent. The NVRx-side lifecycle should remain
+simple: ``POST`` starts early work when requested, and the existing
+``GET``/``analyze`` path remains the stop/end activity that returns the final
+decision.
+
+* ``submit_log(..., analysis_intent="track_only")``
+* analyzer-level delegation to
+  ``LogAnalyzer.start_progressive_analysis(path, user, job_id)``
+* loganalysis runner delegation to the selected lib/MCP tool adapter
+
+The current plumbing does not change ``Analyzer.analyze`` or the ``GET`` result
+path. When the LogSage/tool contract supports reuse, terminal analysis can add a
+``use_progressive``-style option at the loganalysis layer while preserving the
+existing caller-facing ``GET`` shape.
+
+MCP / Loganalysis Contract
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MCP/loganalysis boundary is NVRx-owned and should mirror the in-process
+library adapter. The boundary needs two concepts:
+
+Progressive start
+   A non-result-producing operation used by the ``POST /logs`` path when
+   ``analysis_intent="progressive"``. The initial code exposes this as
+   ``log_analyzer_progressive_start``. It accepts the normalized ``log_path``,
+   ``is_per_cycle=True`` for ft_launcher cycle logs, optional observability
+   fields, and any runtime settings needed by LogSage to bind a future
+   progressive session. It returns status metadata such as
+   accepted/unsupported/failed and, if useful, a handle or session id. It must
+   not return a final attribution result or create a cached MCP result resource.
+
+Terminal run with progressive reuse
+   The existing ``GET /logs`` path should still invoke terminal log analysis and
+   receive the current LogSage-shaped result. Once the LogSage API is settled,
+   the loganalysis boundary needs a way to ask the backend to reuse progressive
+   state for the same path, for example an optional ``use_progressive=True``
+   argument on ``log_analyzer``. If the backend cannot reuse state, the call
+   should fall back to normal terminal analysis. The current plumbing leaves
+   terminal ``GET`` unchanged.
+
+Flight-recorder analysis is unchanged by this feature. ``POST /logs`` does not
+notify FR. On ``GET /logs``, attrsvc can continue to run log analysis and FR
+analysis with the existing terminal orchestration; only the log-analysis call
+needs a way to reuse progressive LogSage state when it exists.
+
+Configuration
+-------------
+
+Add a service-side policy switch for progressive analysis. The default honors
+explicit progressive requests because ft_launcher is the expected caller and the
+POST path remains non-blocking even while the LogSage progressive API is being
+implemented.
+
+``NVRX_ATTRSVC_PROGRESSIVE_ANALYSIS``
+   ``all_explicit`` by default. Honors explicit progressive ``POST /logs``
+   requests. Set ``off`` to disable progressive start. A stricter
+   ft_launcher-only policy would require a caller identity or another
+   server-side way to identify the submitter.
+
+No attrsvc polling, cache, or concurrency settings are required in the current
+plumbing. If the loganalysis tool later owns repeated LogSage calls over a
+growing file, those operational controls should live with that tool
+implementation rather than in the HTTP service wrapper.
+
+Observability
+-------------
+
+Expose enough state to tell whether the latency optimization is working:
+
+* Count progressive ``POST`` requests and whether they were accepted, ignored,
+  or rejected by policy.
+* Count started, unsupported, failed, canceled, completed, and fallback
+  progressive analyses.
+* Track final ``GET`` latency and, where possible, time saved by progressive
+  work.
+* Include active progressive paths in status/debug output without dumping log
+  contents.
+* Log when ``GET`` falls back to terminal analysis, including the fallback
+  reason.
+
+Compatibility
+-------------
+
+Existing attrsvc callers must continue to work without sending new fields.
+Service-mode ``POST`` calls with ``job_id`` continue to support splitlog
+detection and tracking. Single-file ``POST`` calls from older clients remain
+track-only.
+
+The final ``GET`` result must remain semantically compatible with the current
+terminal analysis result. A progressive implementation may improve latency, but
+must not weaken final attribution correctness.
+
+NVRx-Side Implementation Plan
+-----------------------------
+
+1. Add an explicit progressive intent field to the shared HTTP helper and
+   attrsvc ``SubmitRequest``.
+2. Update the attribution-owned in-job HTTP client to send
+   ``analysis_intent="progressive"`` on its normal ``POST /logs`` notification.
+   ``ft_launcher`` should continue using the existing attribution submit hook
+   and should not own the HTTP payload detail.
+3. Thread the intent through ``AttributionHttpAdapter``,
+   ``AttributionController``, and ``Analyzer.submit``.
+4. In attrsvc, keep default ``POST`` behavior as track-only. When progressive
+   intent is requested and the service feature gate allows it, initiate
+   progressive analysis through ``LogAnalyzer.start_progressive_analysis``.
+5. In MCP mode, expose ``log_analyzer_progressive_start`` as a
+   non-result-producing tool. Until LogSage support exists, it returns
+   ``unsupported`` status metadata.
+6. On success, return the existing response shape. ``GET /logs`` remains the
+   path that produces and records final attribution results.
+7. Once the LogSage contract exists, extend the terminal loganalysis call so it
+   can request progressive reuse while keeping the existing ``GET`` response
+   shape and fallback behavior.
+
+Progressive Execution Model
+---------------------------
+
+Attrsvc owns request plumbing and policy. The NVRx loganalysis tool owns the
+progressive option exposed to attrsvc. The implementation behind that tool is
+still a design choice and should be settled with the LogSage implementation.
+
+LogSage-owned progression
+   The loganalysis tool calls a LogSage ``start`` operation and returns.
+   LogSage owns any background watching, tailing, checkpointing, or incremental
+   state. The normal ``GET`` path calls terminal analysis with progressive reuse
+   enabled. Attrsvc only sees accepted/unsupported/failure status.
+
+Tool-owned progression
+   The NVRx loganalysis tool advances analysis as the file grows, possibly by
+   calling LogSage multiple times or by using a smaller LogSage ``advance``
+   primitive. Polling/tailing configuration, concurrency limits, lifecycle
+   cleanup, and state tracking belong to that tool implementation.
+
+The requirement does not choose between these models. It requires that
+``POST`` can request an early start, ``GET`` remains the stop/end decision path,
+and terminal correctness is preserved by fallback to the existing full analysis.
+
+LogSage API Proposal
+--------------------
+
+The current LogSage-style API is effectively terminal:
+
+* input: complete ``log_path``
+* output: final LogSage-shaped result and recommendation
+
+For this feature, the NVRx loganalysis tool needs a way for LogSage to preserve
+and reuse work for a growing per-cycle log. The shared behavior can be expressed
+with two operations:
+
+``start(path, *, session_id=None, is_per_cycle=True, metadata=None)``
+   Create or return progressive state for a log. This should be idempotent for
+   the same normalized path or supplied session id.
+
+``run(path, *, use_progressive=True, final=True)``
+   Return the normal terminal LogSage result for the complete log, reusing any
+   progressive state that was started for the same path. This is invoked from
+   the existing ``GET /logs`` stop/end path.
+
+LogSage may internally expose an ``advance`` or completion primitive if that is
+the cleanest implementation, or the NVRx loganalysis tool may drive repeated
+LogSage calls. Attrsvc does not need a separate public
+``finalize_progressive`` operation. The important part is that the terminal
+``run`` can consume any remaining tail bytes, validate the final log state, and
+produce the same result shape used today.
+
+``cancel(handle)``
+   Release resources if the job ends without a final attribution request or the
+   service is shutting down.
+
+Minimum status metadata returned through the NVRx boundary:
+
+``handle`` or ``session_id``
+   Stable identifier for the progressive analysis.
+
+``consumed_offset``
+   Last byte or line offset included in progressive state.
+
+``status``
+   ``pending``, ``running``, ``ready_to_complete``, ``completed``, ``failed``,
+   or ``unsupported``.
+
+``error``
+   Structured failure reason when status is ``failed`` or ``unsupported``.
+
+The important semantic requirement is that the stop/end ``run`` must produce a
+result equivalent to running terminal LogSage on the complete final file.
+Attrsvc should not need to understand LogSage's internal summaries, LLM prompt
+state, or whether reuse was LogSage-owned or tool-owned.
+
+Validation
+----------
+
+* Unit-test that existing ``POST /logs`` requests remain track-only by default.
+* Unit-test that ft_launcher ``POST`` sends progressive intent.
+* Unit-test that ``Analyzer.submit`` delegates progressive start to the
+  loganalysis boundary only when the feature gate is enabled.
+* Unit-test that the MCP/loganalysis progressive-start operation returns status
+  metadata and does not run terminal attribution.
+* Once LogSage/tool reuse exists, unit-test that the terminal MCP/loganalysis
+  call can request progressive reuse while preserving the existing result shape.
+* Unit-test that service-mode ``POST`` with ``job_id`` does not initiate
+  progressive analysis by default.
+* Once reuse exists, unit-test ``GET`` fallback when progressive state is
+  missing, unsupported, failed, stale, or cannot be used to complete analysis.
+* Unit-test that ``POST`` does not return a completed attribution result.
+* Integration-test the full ``ft_launcher`` flow with a fake progressive
+  analyzer: POST starts state, log grows, GET returns a normal recommendation
+  through the existing stop/end path.
+* End-to-end validate latency improvement with real LogSage progressive support
+  once available.
+
+Open Questions
+--------------
+
+* What exact LogSage API should back ``log_analyzer_progressive_start`` and
+  terminal reuse?
+* Should progressive advancement be LogSage-owned after ``start``, or should the
+  NVRx loganalysis tool drive repeated LogSage calls over the growing file?
+* If the NVRx loganalysis tool owns advancement, what polling and concurrency
+  policy should it use?

--- a/docs/source/attribution/features/requirements-template.rst
+++ b/docs/source/attribution/features/requirements-template.rst
@@ -1,0 +1,81 @@
+Attribution Feature Requirements Template
+=========================================
+
+Use this template for new attribution product features. Copy it to a
+feature-specific file in this directory, for example
+``<feature-slug>.rst``.
+
+Summary
+-------
+
+Describe the feature in one or two paragraphs. Name the user-visible behavior,
+the product surface it changes, and the expected outcome.
+
+Problem
+-------
+
+Describe the customer or operator problem this feature solves. Include the
+current failure mode, workflow gap, or missing attribution signal.
+
+Goals
+-----
+
+* Define the intended behavior.
+* Identify the primary user or caller.
+* State the output contract or decision the feature should support.
+
+Non-Goals
+---------
+
+* List adjacent behavior that is intentionally out of scope.
+* Call out any lifecycle, service, UI, or policy changes this feature will not
+  own.
+
+User Flows
+----------
+
+Describe the expected flows, including input data, trigger points, and how the
+result is consumed by users, services, or automation.
+
+Functional Requirements
+-----------------------
+
+* Requirement 1.
+* Requirement 2.
+* Requirement 3.
+
+API and Data Contract
+---------------------
+
+Document any public Python API, service API, result payload, dataflow record,
+Slack notification, or compatibility contract this feature changes.
+
+Configuration
+-------------
+
+List new config fields, defaults, environment variables, feature gates, and
+deployment assumptions.
+
+Observability
+-------------
+
+Describe logging, metrics, dataflow records, Slack output, status reporting,
+and failure visibility.
+
+Compatibility
+-------------
+
+Document backward compatibility requirements, migration behavior, and
+interactions with existing attribution modes.
+
+Validation
+----------
+
+List unit, integration, service, and end-to-end checks required before the
+feature can ship.
+
+Open Questions
+--------------
+
+* Question 1.
+* Question 2.

--- a/docs/source/attribution/index.rst
+++ b/docs/source/attribution/index.rst
@@ -1,0 +1,11 @@
+Failure Attribution
+===================
+
+Failure attribution collects job logs and optional trace data to explain
+training failures and produce caller-stable attribution results.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Attribution contents:
+
+   features/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Features
 * `Async checkpointing <checkpointing/async/index.html>`_
 * `Local checkpointing <checkpointing/local/index.html>`_
 * `Straggler (slower ranks) detection <straggler_det/index.html>`_
+* `Failure attribution <attribution/index.html>`_
 * `Shared utilities and distributed logging <shared_utils/index.html>`_
 
 .. toctree::
@@ -26,4 +27,5 @@ Features
    checkpointing/async/index
    checkpointing/local/index
    straggler_det/index
+   attribution/index
    shared_utils/index

--- a/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
+++ b/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
@@ -54,6 +54,11 @@ from nvidia_resiliency_ext.attribution.orchestration.llm_output import (
     recommendation_payload,
 )
 from nvidia_resiliency_ext.attribution.orchestration.log_analyzer import LogAnalyzer
+from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+    ANALYSIS_INTENT_PROGRESSIVE,
+    ANALYSIS_INTENT_TRACK_ONLY,
+    normalize_analysis_intent,
+)
 from nvidia_resiliency_ext.attribution.orchestration.types import (
     LogAnalysisCycleResult,
     LogAnalysisSplitlogResult,
@@ -118,6 +123,7 @@ class Analyzer:
         analysis_pipeline_mode: AnalysisPipelineMode = AnalysisPipelineMode.LOG_AND_TRACE,
         compute_timeout: float | None = None,
         grace_period_seconds: float | None = None,
+        progressive_analysis_enabled: bool = False,
     ):
         """
         Args:
@@ -140,6 +146,8 @@ class Analyzer:
                 :attr:`AnalysisPipelineMode.LOG_AND_TRACE_WITH_LLM` without pre-building ``LogAnalyzer``.
             compute_timeout: Per-compute timeout for the coalescer (seconds). Default: coalescer default.
             grace_period_seconds: Cache grace before stat validation (seconds). Default: coalescer default.
+            progressive_analysis_enabled: If True, explicit progressive submit intent is forwarded
+                to the loganalysis tool boundary. If False, submit remains track-only.
 
         After construction, call :meth:`set_event_loop` when the asyncio loop exists (e.g. HTTP server
         startup) so splitlog fire-and-forget analysis can be scheduled; see module docstring.
@@ -178,6 +186,7 @@ class Analyzer:
             trace_analyzer=trace_analyzer,
             analysis_pipeline_mode=analysis_pipeline_mode,
         )
+        self._progressive_analysis_enabled = progressive_analysis_enabled
         self._main_loop: asyncio.AbstractEventLoop | None = None  # For thread-safe callbacks
 
         self._log.register_callbacks(self._fire_and_forget_analyze)
@@ -264,6 +273,7 @@ class Analyzer:
         log_path: str,
         user: str = "unknown",
         job_id: Optional[str] = None,
+        analysis_intent: str | None = ANALYSIS_INTENT_TRACK_ONLY,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
         """
         Submit a log file for analysis tracking.
@@ -275,11 +285,88 @@ class Analyzer:
             log_path: Path to the log file (or slurm output for splitlog mode)
             user: Job owner (for dataflow records)
             job_id: Job ID (required for split logging mode)
+            analysis_intent: Track-only by default; ``progressive`` starts early
+                analysis when the configured backend supports it.
 
         Returns:
             LogAnalyzerSubmitResult on success, LogAnalyzerError on failure
         """
-        return await self._log.submit(log_path, user=user, job_id=job_id)
+        try:
+            intent = normalize_analysis_intent(analysis_intent)
+        except ValueError as e:
+            return LogAnalyzerError(error_code=ErrorCode.INVALID_PARAMETER, message=str(e))
+
+        result = await self._log.submit(log_path, user=user, job_id=job_id)
+        if isinstance(result, LogAnalyzerError):
+            return result
+
+        if intent == ANALYSIS_INTENT_PROGRESSIVE:
+            self._schedule_progressive_analysis(result.normalized_path, user, job_id)
+
+        return result
+
+    def _schedule_progressive_analysis(
+        self,
+        normalized_path: str,
+        user: str,
+        job_id: Optional[str],
+    ) -> None:
+        """Schedule progressive analysis without delaying submit/POST response."""
+        if not self._progressive_analysis_enabled:
+            logger.debug(
+                "Progressive analysis intent ignored because the feature gate is disabled: %s",
+                normalized_path,
+            )
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            if self._main_loop is None or self._main_loop.is_closed():
+                logger.error(
+                    "Event loop not set — skipping progressive analysis start for %s",
+                    normalized_path,
+                )
+                return
+            asyncio.run_coroutine_threadsafe(
+                self._start_progressive_analysis(normalized_path, user, job_id),
+                self._main_loop,
+            )
+        else:
+            loop.create_task(self._start_progressive_analysis(normalized_path, user, job_id))
+        logger.debug("Scheduled progressive analysis start for %s", normalized_path)
+
+    async def _start_progressive_analysis(
+        self,
+        normalized_path: str,
+        user: str,
+        job_id: Optional[str],
+    ) -> None:
+        """Initiate progressive analysis if the feature gate and loganalysis tool allow it."""
+        if not self._progressive_analysis_enabled:
+            logger.debug(
+                "Progressive analysis intent ignored because the feature gate is disabled: %s",
+                normalized_path,
+            )
+            return
+        try:
+            result = await self._log.start_progressive_analysis(
+                normalized_path,
+                user=user,
+                job_id=job_id,
+            )
+            logger.debug(
+                "Progressive analysis start result for %s: status=%s message=%s",
+                normalized_path,
+                result.status,
+                result.message,
+            )
+        except Exception as e:
+            logger.warning(
+                "Progressive analysis start failed for %s: %s: %s",
+                normalized_path,
+                type(e).__name__,
+                e,
+            )
 
     async def analyze(
         self,

--- a/src/nvidia_resiliency_ext/attribution/controller.py
+++ b/src/nvidia_resiliency_ext/attribution/controller.py
@@ -30,6 +30,7 @@ from nvidia_resiliency_ext.attribution.coalescing import (
     SubmittedResult,
 )
 from nvidia_resiliency_ext.attribution.orchestration.config import LogSageExecutionConfig
+from nvidia_resiliency_ext.attribution.orchestration.progressive import ANALYSIS_INTENT_TRACK_ONLY
 from nvidia_resiliency_ext.attribution.orchestration.types import (
     LogAnalysisCycleResult,
     LogAnalysisSplitlogResult,
@@ -89,6 +90,24 @@ class AttributionPostprocessingConfig:
 
 
 @dataclass(frozen=True)
+class AttributionProgressiveConfig:
+    """Progressive analysis policy owned by attrsvc/controller."""
+
+    mode: str = "off"
+
+    def __post_init__(self) -> None:
+        mode = (self.mode or "off").strip().lower()
+        allowed = ("off", "all_explicit")
+        if mode not in allowed:
+            raise ValueError(f"progressive mode must be one of {allowed}, got {self.mode!r}")
+        object.__setattr__(self, "mode", mode)
+
+    @property
+    def enabled(self) -> bool:
+        return self.mode == "all_explicit"
+
+
+@dataclass(frozen=True)
 class AttributionCredentialsConfig:
     """Credential policy for attribution engines.
 
@@ -114,6 +133,7 @@ class AttributionControllerConfig:
     postprocessing: AttributionPostprocessingConfig = field(
         default_factory=AttributionPostprocessingConfig
     )
+    progressive: AttributionProgressiveConfig = field(default_factory=AttributionProgressiveConfig)
     credentials: AttributionCredentialsConfig = field(default_factory=AttributionCredentialsConfig)
 
 
@@ -151,6 +171,7 @@ class AttributionController:
         self._analyzer = Analyzer(
             allowed_root=config.allowed_root,
             log_sage=analyzer_engine,
+            progressive_analysis_enabled=config.progressive.enabled,
             **coalescing_kwargs,
         )
 
@@ -295,9 +316,15 @@ class AttributionController:
         log_path: str,
         user: str = "unknown",
         job_id: str | None = None,
+        analysis_intent: str | None = ANALYSIS_INTENT_TRACK_ONLY,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
         """Submit a log file for attribution tracking."""
-        return await self._analyzer.submit(log_path, user=user, job_id=job_id)
+        return await self._analyzer.submit(
+            log_path,
+            user=user,
+            job_id=job_id,
+            analysis_intent=analysis_intent,
+        )
 
     async def analyze_log(
         self,

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_server.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_server.py
@@ -21,6 +21,10 @@ from nvidia_resiliency_ext.attribution.mcp_integration.registry import (
     serialize_result,
 )
 from nvidia_resiliency_ext.attribution.orchestration.llm_output import recommendation_payload
+from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+    MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+    PROGRESSIVE_STATUS_FAILED,
+)
 from nvidia_resiliency_ext.attribution.orchestration.types import (
     AttributionRecommendation,
     LogSageAnalysisResult,
@@ -132,7 +136,14 @@ class NVRxMCPServer:
                     logger.warning("Error executing tool '%s': %s", name, e)
                 else:
                     logger.error("Error executing tool '%s': %s", name, e, exc_info=True)
-                if self.registry.get_module_metadata(name):
+                if name == MODULE_LOG_ANALYZER_PROGRESSIVE_START:
+                    error_body = {
+                        "module": name,
+                        "status": PROGRESSIVE_STATUS_FAILED,
+                        "message": str(e),
+                        "handle": None,
+                    }
+                elif self.registry.get_module_metadata(name):
                     error_body = {
                         "module": name,
                         "result": [],
@@ -241,6 +252,11 @@ class NVRxMCPServer:
 
         # Run the attribution with defaults applied
         result = await instance.run(arguments_with_defaults)
+
+        if module_name == MODULE_LOG_ANALYZER_PROGRESSIVE_START:
+            response = dict(result) if isinstance(result, dict) else {"status": str(result)}
+            response.setdefault("module", module_name)
+            return [TextContent(type="text", text=serialize_result(response))]
 
         result_id = self.registry.result_id_for_args(arguments_with_defaults)
 

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
@@ -18,6 +18,11 @@ from nvidia_resiliency_ext.attribution.orchestration.config import (
     DEFAULT_LLM_TEMPERATURE,
     DEFAULT_LLM_TOP_P,
 )
+from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+    MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+    PROGRESSIVE_STATUS_UNSUPPORTED,
+    ProgressiveLogAnalysisStartTool,
+)
 from nvidia_resiliency_ext.attribution.orchestration.types import (
     RAW_ANALYSIS_RESULT_ITEM_PAYLOAD_FIELDS,
     RECOMMENDATION_ACTIONS,
@@ -103,6 +108,111 @@ def _recommendation_schema() -> dict[str, Any]:
     }
 
 
+def _llm_runtime_properties(*, model_description: str) -> dict[str, dict[str, Any]]:
+    """Input-schema properties shared by LogSage-backed MCP tools."""
+    return {
+        "model": {
+            "type": "string",
+            "description": model_description,
+            "default": DEFAULT_LLM_MODEL,
+        },
+        "base_url": {
+            "type": "string",
+            "description": "LLM base url",
+            "default": DEFAULT_LLM_BASE_URL,
+        },
+        "temperature": {
+            "type": "number",
+            "description": "Temperature for LLM sampling",
+            "default": DEFAULT_LLM_TEMPERATURE,
+        },
+        "top_p": {
+            "type": "number",
+            "description": "Top-p for LLM sampling",
+            "default": DEFAULT_LLM_TOP_P,
+        },
+        "max_tokens": {
+            "type": "integer",
+            "description": "Maximum tokens for LLM response",
+            "default": DEFAULT_LLM_MAX_TOKENS,
+        },
+    }
+
+
+def _log_analyzer_input_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "log_path": {"type": "string", "description": "Path to log files"},
+            **_llm_runtime_properties(model_description="LLM model to use for analysis"),
+            "exclude_nvrx_logs": {
+                "type": "boolean",
+                "description": "Exclude NVRX internal logs",
+                "default": False,
+            },
+            "is_per_cycle": {
+                "type": "boolean",
+                "description": "Input is already per-cycle data (skip filtering and chunking)",
+                "default": False,
+            },
+        },
+        "required": ["log_path"],
+    }
+
+
+def _progressive_start_input_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "log_path": {"type": "string", "description": "Path to the growing log file"},
+            "is_per_cycle": {
+                "type": "boolean",
+                "description": "Input is already a single ft_launcher cycle log",
+                "default": False,
+            },
+            "user": {
+                "type": "string",
+                "description": "Optional submitting user for observability",
+                "default": "unknown",
+            },
+            "job_id": {
+                "type": "string",
+                "description": "Optional scheduler job id for observability",
+            },
+            **_llm_runtime_properties(
+                model_description="LLM model to bind to the progressive session"
+            ),
+        },
+        "required": ["log_path"],
+    }
+
+
+def _progressive_start_output_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "module": {
+                "type": "string",
+                "description": f"Module name: {MODULE_LOG_ANALYZER_PROGRESSIVE_START}",
+            },
+            "status": {
+                "type": "string",
+                "description": "Progressive start status",
+                "default": PROGRESSIVE_STATUS_UNSUPPORTED,
+            },
+            "message": {
+                "type": "string",
+                "description": "Human-readable status detail",
+            },
+            "handle": {
+                "type": ["string", "null"],
+                "description": "Optional backend session handle",
+            },
+        },
+        "required": ["module", "status", "message", "handle"],
+    }
+
+
 def register_all_modules():
     """Register all NVRX attribution modules with the global registry."""
 
@@ -111,48 +221,7 @@ def register_all_modules():
         name="log_analyzer",
         module_class=NVRxLogAnalyzer,
         description="Analyze application logs using LogSage to identify errors and propose solutions",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "log_path": {"type": "string", "description": "Path to log files"},
-                "model": {
-                    "type": "string",
-                    "description": "LLM model to use for analysis",
-                    "default": DEFAULT_LLM_MODEL,
-                },
-                "base_url": {
-                    "type": "string",
-                    "description": "LLM base url",
-                    "default": DEFAULT_LLM_BASE_URL,
-                },
-                "temperature": {
-                    "type": "number",
-                    "description": "Temperature for LLM sampling",
-                    "default": DEFAULT_LLM_TEMPERATURE,
-                },
-                "top_p": {
-                    "type": "number",
-                    "description": "Top-p for LLM sampling",
-                    "default": DEFAULT_LLM_TOP_P,
-                },
-                "max_tokens": {
-                    "type": "integer",
-                    "description": "Maximum tokens for LLM response",
-                    "default": DEFAULT_LLM_MAX_TOKENS,
-                },
-                "exclude_nvrx_logs": {
-                    "type": "boolean",
-                    "description": "Exclude NVRX internal logs",
-                    "default": False,
-                },
-                "is_per_cycle": {
-                    "type": "boolean",
-                    "description": "Input is already per-cycle data (skip filtering and chunking)",
-                    "default": False,
-                },
-            },
-            "required": ["log_path"],
-        },
+        input_schema=_log_analyzer_input_schema(),
         output_schema={
             "type": "object",
             "properties": {
@@ -170,6 +239,22 @@ def register_all_modules():
             "required": ["module", "result", "recommendation"],
         },
         requires_llm=True,
+        dependencies=[],
+    )
+
+    # Non-result-producing progressive start entry point. This advertises the
+    # NVRx-owned MCP/loganalysis boundary before the LogSage progressive API is
+    # available; the tool returns unsupported status metadata today.
+    global_registry.register(
+        name=MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+        module_class=ProgressiveLogAnalysisStartTool,
+        description=(
+            "Start progressive log analysis for a growing application log. "
+            "Returns status metadata only; it does not produce final attribution."
+        ),
+        input_schema=_progressive_start_input_schema(),
+        output_schema=_progressive_start_output_schema(),
+        requires_llm=False,
         dependencies=[],
     )
 

--- a/src/nvidia_resiliency_ext/attribution/orchestration/config.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/config.py
@@ -186,6 +186,7 @@ class ErrorCode(str, Enum):
 
     # Path validation errors (400 in HTTP)
     INVALID_PATH = "invalid_path"  # Path not absolute, null bytes, etc.
+    INVALID_PARAMETER = "invalid_parameter"  # Request field failed validation
     NOT_REGULAR = "not_regular"  # Not a regular file (directory, device, etc.)
     EMPTY_FILE = "empty_file"  # File is empty (GET only)
 

--- a/src/nvidia_resiliency_ext/attribution/orchestration/http_api.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/http_api.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .progressive import normalize_analysis_intent
+
 # Logs endpoint path
 ROUTE_LOGS = "/logs"
 ROUTE_HEALTHZ = "/healthz"
@@ -15,6 +17,7 @@ ROUTE_HEALTHZ = "/healthz"
 PARAM_LOG_PATH = "log_path"
 PARAM_USER = "user"
 PARAM_JOB_ID = "job_id"
+PARAM_ANALYSIS_INTENT = "analysis_intent"
 
 # GET /logs optional query parameters (splitlog mode)
 PARAM_FILE = "file"
@@ -28,6 +31,7 @@ def log_submit_payload(
     *,
     user: str | None = None,
     job_id: str | None = None,
+    analysis_intent: str | None = None,
 ) -> dict[str, str]:
     """Build the JSON body for ``POST /logs``."""
     payload = {PARAM_LOG_PATH: log_path}
@@ -35,6 +39,8 @@ def log_submit_payload(
         payload[PARAM_USER] = user
     if job_id is not None:
         payload[PARAM_JOB_ID] = job_id
+    if analysis_intent is not None:
+        payload[PARAM_ANALYSIS_INTENT] = normalize_analysis_intent(analysis_intent)
     return payload
 
 
@@ -59,11 +65,17 @@ def post_log(
     *,
     user: str | None = None,
     job_id: str | None = None,
+    analysis_intent: str | None = None,
 ) -> Any:
     """Submit a log to attrsvc with an existing HTTP client."""
     return client.post(
         ROUTE_LOGS,
-        json=log_submit_payload(log_path, user=user, job_id=job_id),
+        json=log_submit_payload(
+            log_path,
+            user=user,
+            job_id=job_id,
+            analysis_intent=analysis_intent,
+        ),
         headers=ACCEPT_JSON_HEADERS,
     )
 

--- a/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
@@ -35,6 +35,12 @@ from .analysis_pipeline import AnalysisPipelineMode, run_attribution_pipeline
 from .config import MODULE_LOG_FR_ANALYZER, ErrorCode, LogSageExecutionConfig
 from .job import Job
 from .log_path_metadata import CYCLE_LOG_PATTERN
+from .progressive import (
+    MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+    PROGRESSIVE_STATUS_UNSUPPORTED,
+    ProgressiveStartResult,
+    progressive_start_result_from_mcp_response,
+)
 from .splitlog import SplitlogTracker
 from .tracked_jobs import TrackedJobs
 from .types import LogAnalyzerError, LogAnalyzerFilePreview, LogAnalyzerSubmitResult
@@ -184,6 +190,57 @@ class LogSageRunner:
         if self.config.use_lib_log_analysis:
             return await self._fetch_log_result_lib(path)
         return await self._fetch_log_result_mcp(path)
+
+    async def _start_progressive_analysis_lib(
+        self,
+        path: str,
+        *,
+        user: str = "unknown",
+        job_id: str | None = None,
+    ) -> ProgressiveStartResult:
+        _ = (path, user, job_id)
+        return ProgressiveStartResult(
+            status=PROGRESSIVE_STATUS_UNSUPPORTED,
+            message="LogSage in-process progressive start API is not configured",
+        )
+
+    async def _start_progressive_analysis_mcp(
+        self,
+        path: str,
+        *,
+        user: str = "unknown",
+        job_id: str | None = None,
+    ) -> ProgressiveStartResult:
+        self._ensure_mcp_ready()
+        is_per_cycle = bool(re.search(CYCLE_LOG_PATTERN, path))
+        run_kwargs: Dict[str, Any] = {
+            "log_path": path,
+            "is_per_cycle": is_per_cycle,
+            "user": user,
+            **self.config.llm_runtime_overrides(),
+        }
+        if job_id:
+            run_kwargs["job_id"] = job_id
+
+        async with self._log_analysis_lock:
+            response = await self._mcp_client.run_module_resilient(
+                MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+                max_attempts=3,
+                **run_kwargs,
+            )
+        return progressive_start_result_from_mcp_response(response)
+
+    async def start_progressive_analysis(
+        self,
+        path: str,
+        *,
+        user: str = "unknown",
+        job_id: str | None = None,
+    ) -> ProgressiveStartResult:
+        """Start progressive log analysis for ``path`` without producing final attribution."""
+        if self.config.use_lib_log_analysis:
+            return await self._start_progressive_analysis_lib(path, user=user, job_id=job_id)
+        return await self._start_progressive_analysis_mcp(path, user=user, job_id=job_id)
 
     async def _fetch_fr_result_mcp(self, dump_path: str) -> Optional[FRAnalysisResult]:
         self._ensure_mcp_ready()
@@ -376,6 +433,16 @@ class LogAnalyzer:
 
     async def fetch_log_result(self, path: str) -> Dict[str, Any]:
         return await self._runner.fetch_log_result(path)
+
+    async def start_progressive_analysis(
+        self,
+        path: str,
+        *,
+        user: str = "unknown",
+        job_id: str | None = None,
+    ) -> ProgressiveStartResult:
+        """Forward progressive start to the selected loganalysis tool adapter."""
+        return await self._runner.start_progressive_analysis(path, user=user, job_id=job_id)
 
     def _post_analysis_results(
         self,

--- a/src/nvidia_resiliency_ext/attribution/orchestration/progressive.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/progressive.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Progressive log-analysis boundary for attribution orchestration.
+
+This module defines the NVRx-owned request shape for starting progressive log
+analysis. The concrete LogSage behavior is intentionally not implemented here
+yet; until that shared contract exists, the MCP/tool entry point reports
+``unsupported``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+ANALYSIS_INTENT_TRACK_ONLY = "track_only"
+ANALYSIS_INTENT_PROGRESSIVE = "progressive"
+ANALYSIS_INTENTS = (ANALYSIS_INTENT_TRACK_ONLY, ANALYSIS_INTENT_PROGRESSIVE)
+
+MODULE_LOG_ANALYZER_PROGRESSIVE_START = "log_analyzer_progressive_start"
+
+PROGRESSIVE_STATUS_UNSUPPORTED = "unsupported"
+PROGRESSIVE_STATUS_FAILED = "failed"
+
+
+def normalize_analysis_intent(value: str | None) -> str:
+    """Normalize and validate a POST /logs analysis intent."""
+    if value is None:
+        return ANALYSIS_INTENT_TRACK_ONLY
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return ANALYSIS_INTENT_TRACK_ONLY
+    if normalized not in ANALYSIS_INTENTS:
+        raise ValueError("analysis_intent must be one of: " + ", ".join(sorted(ANALYSIS_INTENTS)))
+    return normalized
+
+
+@dataclass(frozen=True)
+class ProgressiveStartResult:
+    """Result of a non-result-producing progressive analysis start request."""
+
+    status: str
+    message: str = ""
+    handle: str | None = None
+
+    def as_payload(self) -> dict[str, str | None]:
+        """Serialize status metadata for MCP/HTTP-adjacent boundaries."""
+        return asdict(self)
+
+
+def progressive_start_result_from_mcp_response(
+    response: Mapping[str, Any],
+) -> ProgressiveStartResult:
+    """Parse the MCP progressive-start response envelope into status metadata."""
+    result = response.get("result")
+    payload: Mapping[str, Any]
+    if isinstance(result, Mapping):
+        payload = result
+    else:
+        payload = response
+
+    status = str(payload.get("status") or PROGRESSIVE_STATUS_UNSUPPORTED)
+    message = str(payload.get("message") or "")
+    handle_value = payload.get("handle")
+    handle = str(handle_value) if handle_value is not None else None
+    return ProgressiveStartResult(status=status, message=message, handle=handle)
+
+
+class ProgressiveLogAnalysisStartTool:
+    """MCP tool stub for starting progressive log analysis.
+
+    This is deliberately a non-result-producing tool. It advertises the
+    NVRx-owned loganalysis boundary now, while the LogSage progressive API is
+    still being defined.
+    """
+
+    def __init__(self, _args: Mapping[str, Any] | None = None):
+        pass
+
+    async def run(self, _arguments: Mapping[str, Any]) -> dict[str, str | None]:
+        """Return status metadata without running terminal attribution."""
+        payload = ProgressiveStartResult(
+            status=PROGRESSIVE_STATUS_UNSUPPORTED,
+            message="LogSage progressive start API is not configured",
+        ).as_payload()
+        payload["module"] = MODULE_LOG_ANALYZER_PROGRESSIVE_START
+        return payload

--- a/src/nvidia_resiliency_ext/services/attrsvc/app.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/app.py
@@ -17,10 +17,15 @@ from typing import Any
 import uvicorn
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
+
+from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+    ANALYSIS_INTENT_TRACK_ONLY,
+    ANALYSIS_INTENTS,
+)
 
 from .config import ErrorCode, Settings, setup
 from .routes import PARAM_LOG_PATH, ROUTE_LOGS
@@ -66,6 +71,7 @@ def json_response(data: Any, *, pretty: bool = False, indent: int | None = None)
 _ERROR_CODE_TO_HTTP_STATUS: dict[ErrorCode, int] = {
     # 400 Bad Request
     ErrorCode.INVALID_PATH: 400,
+    ErrorCode.INVALID_PARAMETER: 400,
     ErrorCode.NOT_REGULAR: 400,
     ErrorCode.EMPTY_FILE: 400,
     # 403 Forbidden
@@ -99,6 +105,17 @@ class SubmitRequest(BaseModel):
     log_path: str
     user: str = "unknown"  # Optional: SLURM job user, for dataflow records
     job_id: str | None = None  # Optional: SLURM job ID, required for split logging mode
+    analysis_intent: str = ANALYSIS_INTENT_TRACK_ONLY  # Optional: progressive early-start hint
+
+    @field_validator("analysis_intent")
+    @classmethod
+    def validate_analysis_intent(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized not in ANALYSIS_INTENTS:
+            raise ValueError(
+                "analysis_intent must be one of: " + ", ".join(sorted(ANALYSIS_INTENTS))
+            )
+        return normalized
 
 
 def _raise_error(error: LogAnalyzerError) -> None:
@@ -254,7 +271,12 @@ def create_app(cfg: Settings) -> FastAPI:
         cycles and analyzes log files from the LOGS_DIR folder.
         """
         adapter: AttributionHttpAdapter = request.app.state.attribution
-        result = await adapter.submit_log(req.log_path, req.user, req.job_id)
+        result = await adapter.submit_log(
+            req.log_path,
+            req.user,
+            req.job_id,
+            analysis_intent=req.analysis_intent,
+        )
         if isinstance(result, LogAnalyzerError):
             _raise_error(result)
         return result

--- a/src/nvidia_resiliency_ext/services/attrsvc/config.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/config.py
@@ -169,6 +169,13 @@ class Settings(BaseSettings):
             "'mcp' (subprocess MCP, default) or 'lib' (in-process)."
         ),
     )
+    PROGRESSIVE_ANALYSIS: str = Field(
+        default="all_explicit",
+        description=(
+            "Progressive log-analysis policy: 'all_explicit' (default) honors explicit "
+            "progressive POST /logs requests; 'off' disables progressive start."
+        ),
+    )
 
     CLUSTER_NAME: str = Field(default="", description="Cluster name for dataflow")
 
@@ -223,6 +230,15 @@ class Settings(BaseSettings):
         v_lower = v.strip().lower()
         if v_lower not in allowed:
             raise ValueError(f"ANALYSIS_BACKEND must be one of {allowed}, got '{v}'")
+        return v_lower
+
+    @field_validator("PROGRESSIVE_ANALYSIS")
+    @classmethod
+    def validate_progressive_analysis(cls, v: str) -> str:
+        allowed = ("off", "all_explicit")
+        v_lower = v.strip().lower()
+        if v_lower not in allowed:
+            raise ValueError(f"PROGRESSIVE_ANALYSIS must be one of {allowed}, got '{v}'")
         return v_lower
 
     @property

--- a/src/nvidia_resiliency_ext/services/attrsvc/routes.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/routes.py
@@ -4,6 +4,7 @@
 """HTTP API route and parameter names for nvidia_resiliency_ext.services.attrsvc."""
 
 from nvidia_resiliency_ext.attribution.orchestration.http_api import (
+    PARAM_ANALYSIS_INTENT,
     PARAM_FILE,
     PARAM_JOB_ID,
     PARAM_LOG_PATH,
@@ -13,6 +14,7 @@ from nvidia_resiliency_ext.attribution.orchestration.http_api import (
 )
 
 __all__ = [
+    "PARAM_ANALYSIS_INTENT",
     "PARAM_FILE",
     "PARAM_JOB_ID",
     "PARAM_LOG_PATH",

--- a/src/nvidia_resiliency_ext/services/attrsvc/service.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/service.py
@@ -23,6 +23,7 @@ from nvidia_resiliency_ext.attribution.controller import (
     AttributionController,
     AttributionControllerConfig,
     AttributionPostprocessingConfig,
+    AttributionProgressiveConfig,
 )
 from nvidia_resiliency_ext.attribution.orchestration.types import (
     AttributionRecommendation,
@@ -75,6 +76,7 @@ def _controller_config_from_settings(cfg: Settings) -> AttributionControllerConf
             slack_bot_token=(cfg.SLACK_BOT_TOKEN or "").strip() or None,
             slack_channel=cfg.SLACK_CHANNEL,
         ),
+        progressive=AttributionProgressiveConfig(mode=cfg.PROGRESSIVE_ANALYSIS),
     )
 
 
@@ -143,9 +145,15 @@ class AttributionHttpAdapter:
         log_path: str,
         user: str = "unknown",
         job_id: str | None = None,
+        analysis_intent: str | None = None,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
         """Submit a log file for analysis tracking."""
-        return await self._controller.submit_log(log_path, user=user, job_id=job_id)
+        return await self._controller.submit_log(
+            log_path,
+            user=user,
+            job_id=job_id,
+            analysis_intent=analysis_intent,
+        )
 
     async def analyze_log(
         self,

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -1391,7 +1391,7 @@ class AttributionService:
 
     def _submit_log(self, log_path: str) -> None:
         """
-        Submit a log file for analysis via POST.
+        Submit a log file for progressive analysis via POST.
         Runs in a background daemon thread (fire-and-forget).
         """
         self._last_submitted = log_path
@@ -1410,7 +1410,7 @@ class AttributionService:
             with httpx.Client(base_url=base_url, timeout=10.0) as client:
                 url = f"{base_url}{ROUTE_LOGS}"
                 logger.debug("AttributionService POST: %s (log_path=%s)", url, log_path)
-                post_log(client, log_path)
+                post_log(client, log_path, analysis_intent="progressive")
         except Exception as e:
             logger.warning(
                 "AttributionService POST %s failed: %s: %s", log_path, type(e).__name__, e

--- a/tests/attribution/unit/test_attrsvc_settings.py
+++ b/tests/attribution/unit/test_attrsvc_settings.py
@@ -52,6 +52,30 @@ def test_attrsvc_analysis_backend_uses_current_env_name_only(tmp_path, monkeypat
     assert cfg.ANALYSIS_BACKEND == "lib"
 
 
+def test_attrsvc_progressive_analysis_defaults_to_all_explicit(tmp_path, monkeypatch):
+    monkeypatch.delenv("NVRX_ATTRSVC_PROGRESSIVE_ANALYSIS", raising=False)
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.PROGRESSIVE_ANALYSIS == "all_explicit"
+
+
+def test_attrsvc_progressive_analysis_accepts_off(tmp_path, monkeypatch):
+    monkeypatch.setenv("NVRX_ATTRSVC_PROGRESSIVE_ANALYSIS", "OFF")
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.PROGRESSIVE_ANALYSIS == "off"
+
+
+def test_attrsvc_progressive_analysis_accepts_all_explicit(tmp_path, monkeypatch):
+    monkeypatch.setenv("NVRX_ATTRSVC_PROGRESSIVE_ANALYSIS", "ALL_EXPLICIT")
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.PROGRESSIVE_ANALYSIS == "all_explicit"
+
+
 def test_attrsvc_log_analysis_backend_env_is_not_supported(tmp_path, monkeypatch):
     monkeypatch.delenv("NVRX_ATTRSVC_ANALYSIS_BACKEND", raising=False)
     monkeypatch.setenv("NVRX_ATTRSVC_LOG_ANALYSIS_BACKEND", "lib")

--- a/tests/attribution/unit/test_http_api.py
+++ b/tests/attribution/unit/test_http_api.py
@@ -6,6 +6,7 @@ from nvidia_resiliency_ext.attribution.orchestration.http_api import (
     log_submit_payload,
     post_log,
 )
+from nvidia_resiliency_ext.attribution.orchestration.progressive import ANALYSIS_INTENT_PROGRESSIVE
 
 
 def test_log_submit_payload_omits_empty_optional_fields():
@@ -17,6 +18,16 @@ def test_log_submit_payload_includes_smon_fields():
         "log_path": "/tmp/train.log",
         "user": "alice",
         "job_id": "123",
+    }
+
+
+def test_log_submit_payload_includes_analysis_intent_when_requested():
+    assert log_submit_payload(
+        "/tmp/train.log",
+        analysis_intent=ANALYSIS_INTENT_PROGRESSIVE,
+    ) == {
+        "log_path": "/tmp/train.log",
+        "analysis_intent": "progressive",
     }
 
 
@@ -36,6 +47,18 @@ def test_post_log_uses_shared_logs_route():
     client.post.assert_called_once_with(
         "/logs",
         json={"log_path": "/tmp/train.log", "user": "alice", "job_id": "123"},
+        headers={"accept": "application/json"},
+    )
+
+
+def test_post_log_uses_shared_logs_route_with_intent():
+    client = MagicMock()
+
+    post_log(client, "/tmp/train.log", analysis_intent=ANALYSIS_INTENT_PROGRESSIVE)
+
+    client.post.assert_called_once_with(
+        "/logs",
+        json={"log_path": "/tmp/train.log", "analysis_intent": "progressive"},
         headers={"accept": "application/json"},
     )
 

--- a/tests/attribution/unit/test_mcp_server_cache.py
+++ b/tests/attribution/unit/test_mcp_server_cache.py
@@ -79,6 +79,11 @@ if PY310_PLUS:
         from nvidia_resiliency_ext.attribution.mcp_integration.registry import (
             AttributionModuleRegistry,
         )
+        from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+            MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            PROGRESSIVE_STATUS_UNSUPPORTED,
+            ProgressiveLogAnalysisStartTool,
+        )
         from nvidia_resiliency_ext.attribution.orchestration.types import (
             AttributionRecommendation,
             LogSageAnalysisResult,
@@ -93,6 +98,11 @@ if PY310_PLUS:
         from nvidia_resiliency_ext.attribution.mcp_integration.mcp_server import NVRxMCPServer
         from nvidia_resiliency_ext.attribution.mcp_integration.registry import (
             AttributionModuleRegistry,
+        )
+        from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+            MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            PROGRESSIVE_STATUS_UNSUPPORTED,
+            ProgressiveLogAnalysisStartTool,
         )
         from nvidia_resiliency_ext.attribution.orchestration.types import (
             AttributionRecommendation,
@@ -178,6 +188,17 @@ class TestMCPServerCache(unittest.IsolatedAsyncioTestCase):
         )
         return NVRxMCPServer(registry=registry)
 
+    def _server_with_progressive_start(self):
+        registry = AttributionModuleRegistry()
+        registry.register(
+            name=MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            module_class=ProgressiveLogAnalysisStartTool,
+            description="progressive start",
+            input_schema={"type": "object", "properties": {}, "required": []},
+            output_schema={"type": "object"},
+        )
+        return NVRxMCPServer(registry=registry)
+
     async def test_cached_resource_matches_normalized_module_response(self):
         server = self._server()
 
@@ -236,6 +257,22 @@ class TestMCPServerCache(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response["recommendation"], {"action": "UNKNOWN", "source": "fr_analyzer"})
         self.assertEqual(response["result"]["hanging_ranks"], "hanging ranks: [1, 2]")
         self.assertNotIn("state", response)
+
+    async def test_progressive_start_response_is_not_cached_result(self):
+        server = self._server_with_progressive_start()
+
+        content = await server._handle_module_execution(
+            MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            {"log_path": "/tmp/job_cycle0.log", "is_per_cycle": True},
+        )
+        response = json.loads(content[0].text)
+
+        self.assertEqual(response["module"], MODULE_LOG_ANALYZER_PROGRESSIVE_START)
+        self.assertEqual(response["status"], PROGRESSIVE_STATUS_UNSUPPORTED)
+        self.assertNotIn("result", response)
+        self.assertNotIn("recommendation", response)
+        self.assertNotIn("result_id", response)
+        self.assertEqual(server.registry.count_results_cache_entries(), 0)
 
 
 if __name__ == "__main__":

--- a/tests/attribution/unit/test_progressive_plumbing.py
+++ b/tests/attribution/unit/test_progressive_plumbing.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import importlib
+import sys
+import types
+from typing import Any
+
+from nvidia_resiliency_ext.attribution.orchestration.config import ErrorCode, LogSageExecutionConfig
+from nvidia_resiliency_ext.attribution.orchestration.job import JobMode
+from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+    ANALYSIS_INTENT_PROGRESSIVE,
+    MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+    PROGRESSIVE_STATUS_UNSUPPORTED,
+    ProgressiveLogAnalysisStartTool,
+    ProgressiveStartResult,
+)
+from nvidia_resiliency_ext.attribution.orchestration.types import (
+    LogAnalyzerError,
+    LogAnalyzerSubmitResult,
+)
+
+
+def _stub_module(monkeypatch, name: str):
+    module = types.ModuleType(name)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _import_analyzer_with_optional_dependency_stubs(monkeypatch):
+    for module_name in (
+        "nvidia_resiliency_ext.attribution.analyzer.engine",
+        "nvidia_resiliency_ext.attribution.orchestration.log_analyzer",
+        "nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage",
+    ):
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    langchain_openai = _stub_module(monkeypatch, "langchain_openai")
+    langchain_openai.ChatOpenAI = object
+
+    _stub_module(monkeypatch, "logsage")
+    _stub_module(monkeypatch, "logsage.auto_resume_policy")
+    attribution_classes = _stub_module(
+        monkeypatch, "logsage.auto_resume_policy.attribution_classes"
+    )
+    attribution_classes.ApplicationData = object
+    attribution_classes.LRUCache = object
+
+    error_attribution = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_attribution")
+    error_attribution.get_proposed_solution_cat = lambda *args, **kwargs: None
+
+    error_extraction = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_extraction")
+    error_extraction.return_application_errors = lambda *args, **kwargs: []
+
+    httpx = _stub_module(monkeypatch, "httpx")
+    httpx.post = lambda *args, **kwargs: types.SimpleNamespace(status_code=201, text="created")
+
+    module = importlib.import_module("nvidia_resiliency_ext.attribution.analyzer.engine")
+    return module.Analyzer
+
+
+class FakeLogAnalyzer:
+    def __init__(self) -> None:
+        self.submissions: list[tuple[str, str, str | None]] = []
+        self.progressive_starts: list[tuple[str, str, str | None]] = []
+        self.progressive_started: asyncio.Event | None = None
+        self.progressive_release: asyncio.Event | None = None
+
+    def register_callbacks(self, _callback: Any) -> None:
+        pass
+
+    async def submit(
+        self,
+        log_path: str,
+        user: str = "unknown",
+        job_id: str | None = None,
+    ) -> LogAnalyzerSubmitResult:
+        self.submissions.append((log_path, user, job_id))
+        return LogAnalyzerSubmitResult(
+            submitted=True,
+            normalized_path=log_path,
+            mode=JobMode.SINGLE.value,
+        )
+
+    async def start(
+        self,
+        log_path: str,
+        *,
+        user: str = "unknown",
+        job_id: str | None = None,
+    ) -> ProgressiveStartResult:
+        self.progressive_starts.append((log_path, user, job_id))
+        if self.progressive_started is not None:
+            self.progressive_started.set()
+        if self.progressive_release is not None:
+            await self.progressive_release.wait()
+        return ProgressiveStartResult(status="accepted")
+
+    async def start_progressive_analysis(
+        self,
+        log_path: str,
+        *,
+        user: str = "unknown",
+        job_id: str | None = None,
+    ) -> ProgressiveStartResult:
+        return await self.start(log_path, user=user, job_id=job_id)
+
+
+class FakeMcpClient:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.session = object()
+        self.response = response
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def run_module_resilient(
+        self,
+        module_name: str,
+        *,
+        max_attempts: int,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.calls.append((module_name, {"max_attempts": max_attempts, **kwargs}))
+        return self.response
+
+
+def test_progressive_submit_starts_backend_when_enabled(monkeypatch, tmp_path):
+    Analyzer = _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    log_analyzer = FakeLogAnalyzer()
+    analyzer = Analyzer(
+        allowed_root=str(tmp_path),
+        log_analyzer=log_analyzer,
+        progressive_analysis_enabled=True,
+    )
+
+    async def run() -> None:
+        log_analyzer.progressive_started = asyncio.Event()
+        log_analyzer.progressive_release = asyncio.Event()
+
+        result = await asyncio.wait_for(
+            analyzer.submit(
+                str(tmp_path / "train_cycle0.log"),
+                user="alice",
+                analysis_intent=ANALYSIS_INTENT_PROGRESSIVE,
+            ),
+            timeout=0.5,
+        )
+        assert result.submitted is True
+        await asyncio.wait_for(log_analyzer.progressive_started.wait(), timeout=0.5)
+        log_analyzer.progressive_release.set()
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert log_analyzer.submissions == [(str(tmp_path / "train_cycle0.log"), "alice", None)]
+    assert log_analyzer.progressive_starts == [(str(tmp_path / "train_cycle0.log"), "alice", None)]
+
+
+def test_progressive_submit_is_ignored_when_feature_gate_disabled(monkeypatch, tmp_path):
+    Analyzer = _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    log_analyzer = FakeLogAnalyzer()
+    analyzer = Analyzer(
+        allowed_root=str(tmp_path),
+        log_analyzer=log_analyzer,
+        progressive_analysis_enabled=False,
+    )
+
+    async def run() -> None:
+        await analyzer.submit(
+            str(tmp_path / "train_cycle0.log"),
+            analysis_intent=ANALYSIS_INTENT_PROGRESSIVE,
+        )
+
+    asyncio.run(run())
+
+    assert log_analyzer.progressive_starts == []
+
+
+def test_invalid_analysis_intent_uses_parameter_error(monkeypatch, tmp_path):
+    Analyzer = _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    log_analyzer = FakeLogAnalyzer()
+    analyzer = Analyzer(
+        allowed_root=str(tmp_path),
+        log_analyzer=log_analyzer,
+        progressive_analysis_enabled=True,
+    )
+
+    async def run() -> LogAnalyzerError:
+        result = await analyzer.submit(
+            str(tmp_path / "train_cycle0.log"),
+            analysis_intent="unexpected",
+        )
+        assert isinstance(result, LogAnalyzerError)
+        return result
+
+    result = asyncio.run(run())
+
+    assert result.error_code == ErrorCode.INVALID_PARAMETER
+    assert log_analyzer.submissions == []
+
+
+def test_progressive_start_tool_returns_unsupported_without_final_result():
+    tool = ProgressiveLogAnalysisStartTool({})
+
+    async def run() -> dict[str, str | None]:
+        return await tool.run({"log_path": "/tmp/train_cycle0.log", "is_per_cycle": True})
+
+    result = asyncio.run(run())
+
+    assert result == {
+        "module": MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+        "status": PROGRESSIVE_STATUS_UNSUPPORTED,
+        "message": "LogSage progressive start API is not configured",
+        "handle": None,
+    }
+
+
+def test_progressive_start_uses_mcp_loganalysis_tool(monkeypatch, tmp_path):
+    _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    module = importlib.import_module("nvidia_resiliency_ext.attribution.orchestration.log_analyzer")
+    fake_client = FakeMcpClient(
+        {
+            "module": MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            "status": PROGRESSIVE_STATUS_UNSUPPORTED,
+            "message": "not wired yet",
+            "handle": None,
+        }
+    )
+    monkeypatch.setattr(module, "create_mcp_client", lambda **_kwargs: fake_client)
+    runner = module.LogSageRunner(LogSageExecutionConfig(use_lib_log_analysis=False))
+
+    async def run() -> ProgressiveStartResult:
+        return await runner.start_progressive_analysis(
+            str(tmp_path / "train_cycle0.log"),
+            user="alice",
+            job_id="123",
+        )
+
+    result = asyncio.run(run())
+
+    assert result == ProgressiveStartResult(
+        status=PROGRESSIVE_STATUS_UNSUPPORTED,
+        message="not wired yet",
+    )
+    assert fake_client.calls == [
+        (
+            MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            {
+                "max_attempts": 3,
+                "log_path": str(tmp_path / "train_cycle0.log"),
+                "is_per_cycle": True,
+                "user": "alice",
+                "job_id": "123",
+            },
+        )
+    ]

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -565,7 +565,7 @@ class TestNVLHealthCheck(unittest.TestCase):
 class TestAttributionService(unittest.TestCase):
 
     @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
-    def test_http_endpoint_posts_to_logs_route(self, mock_client):
+    def test_http_endpoint_posts_progressive_intent_to_logs_route(self, mock_client):
         client = mock_client.return_value.__enter__.return_value
         service = AttributionService(endpoint="http://attr.example:8000/")
 
@@ -574,7 +574,7 @@ class TestAttributionService(unittest.TestCase):
         mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=10.0)
         client.post.assert_called_once_with(
             "/logs",
-            json={"log_path": "/tmp/train.log"},
+            json={"log_path": "/tmp/train.log", "analysis_intent": "progressive"},
             headers={"accept": "application/json"},
         )
 


### PR DESCRIPTION
## Summary

Adds the NVRx-owned plumbing for progressive FT launcher attribution while keeping the LogSage progressive implementation as an open contract.

- Documents the design conclusion: attrsvc owns HTTP plumbing and policy, while the NVRx loganalysis tool boundary owns the progressive option.
- Adds `analysis_intent` support to the shared attrsvc POST helper and attrsvc request path.
- Makes the in-job `AttributionService` submit path send `analysis_intent="progressive"`, while preserving `GET /logs` as the final result-producing path.
- Delegates progressive start from `Analyzer` into `LogAnalyzer`/`LogSageRunner` instead of a generic analyzer-side backend.
- Adds the MCP tool boundary `log_analyzer_progressive_start`, which currently returns unsupported status metadata and deliberately does not create a cached MCP result/resource.

## Current behavior

- `POST /logs` remains a notification/early-start path and does not generate final attribution.
- `GET /logs` remains the only stop/end result-producing path and keeps the existing response shape.
- When `NVRX_ATTRSVC_PROGRESSIVE_ANALYSIS=all_explicit`, explicit progressive submit intent is forwarded to the loganalysis boundary.
- Until LogSage progressive support is implemented, the progressive-start tool reports `unsupported` and terminal analysis falls back to the existing behavior.

## Validation

- `PYTHONPATH=src poetry run python -m pytest -q tests/attribution/unit/test_progressive_plumbing.py tests/attribution/unit/test_http_api.py tests/attribution/unit/test_attrsvc_settings.py tests/attribution/unit/test_mcp_server_cache.py`
- `PYTHONPATH=src poetry run python -m ruff check src/nvidia_resiliency_ext/attribution/analyzer/engine.py src/nvidia_resiliency_ext/attribution/controller.py src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_server.py src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py src/nvidia_resiliency_ext/attribution/orchestration/http_api.py src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py src/nvidia_resiliency_ext/attribution/orchestration/progressive.py src/nvidia_resiliency_ext/services/attrsvc/app.py src/nvidia_resiliency_ext/services/attrsvc/config.py src/nvidia_resiliency_ext/services/attrsvc/routes.py src/nvidia_resiliency_ext/services/attrsvc/service.py src/nvidia_resiliency_ext/shared_utils/health_check.py tests/attribution/unit/test_attrsvc_settings.py tests/attribution/unit/test_http_api.py tests/attribution/unit/test_mcp_server_cache.py tests/attribution/unit/test_progressive_plumbing.py tests/shared_utils/test_health_check.py`
- `.venv-isort/bin/isort --check-only src/nvidia_resiliency_ext/attribution/analyzer/engine.py src/nvidia_resiliency_ext/attribution/controller.py src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_server.py src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py src/nvidia_resiliency_ext/attribution/orchestration/http_api.py src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py src/nvidia_resiliency_ext/attribution/orchestration/progressive.py src/nvidia_resiliency_ext/services/attrsvc/app.py src/nvidia_resiliency_ext/services/attrsvc/config.py src/nvidia_resiliency_ext/services/attrsvc/routes.py src/nvidia_resiliency_ext/services/attrsvc/service.py src/nvidia_resiliency_ext/shared_utils/health_check.py tests/attribution/unit/test_attrsvc_settings.py tests/attribution/unit/test_http_api.py tests/attribution/unit/test_mcp_server_cache.py tests/attribution/unit/test_progressive_plumbing.py tests/shared_utils/test_health_check.py`
- `PYTHONPATH=src poetry run python -m black --check src/nvidia_resiliency_ext/attribution/analyzer/engine.py src/nvidia_resiliency_ext/attribution/controller.py src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_server.py src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py src/nvidia_resiliency_ext/attribution/orchestration/http_api.py src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py src/nvidia_resiliency_ext/attribution/orchestration/progressive.py src/nvidia_resiliency_ext/services/attrsvc/app.py src/nvidia_resiliency_ext/services/attrsvc/config.py src/nvidia_resiliency_ext/services/attrsvc/routes.py src/nvidia_resiliency_ext/services/attrsvc/service.py src/nvidia_resiliency_ext/shared_utils/health_check.py tests/attribution/unit/test_attrsvc_settings.py tests/attribution/unit/test_http_api.py tests/attribution/unit/test_mcp_server_cache.py tests/attribution/unit/test_progressive_plumbing.py tests/shared_utils/test_health_check.py`
- `git diff --check`

Note: `tests/shared_utils/test_health_check.py::TestAttributionService` still cannot be collected locally because this environment is missing `defusedxml`.
