### PR TITLE
Backport of the progress tracker YAML default fix to release/v0.6

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -2543,7 +2543,7 @@ def get_args_parser() -> ArgumentParser:
         "--ft-max-no-progress-cycles",
         "--ft-max_no_progress_cycles",
         type=int,
-        default=2,
+        default=None,
         dest="ft_max_no_progress_cycles",
         help="Maximum consecutive cycles (including initial cycle 0) without progress before early "
         "termination. E.g. 2 = allow cycle 0 and 1 with no progress, then terminate before cycle 2. "
@@ -2554,7 +2554,7 @@ def get_args_parser() -> ArgumentParser:
         "--ft-min-progress-iterations",
         "--ft-min_progress_iterations",
         type=int,
-        default=1,
+        default=None,
         dest="ft_min_progress_iterations",
         help="Minimum iteration increase to consider a restart as making progress (default: 1).",
     )

--- a/tests/fault_tolerance/unit/test_config.py
+++ b/tests/fault_tolerance/unit/test_config.py
@@ -143,6 +143,24 @@ def tmp_yaml_file(lines):
         os.remove(temp_file.name)
 
 
+def test_from_args_preserves_progress_tracking_yaml_when_cli_absent():
+    from nvidia_resiliency_ext.fault_tolerance.launcher import get_args_parser
+
+    YAML_LINES = [
+        "fault_tolerance:",
+        "    max_no_progress_cycles: 3",
+        "    min_progress_iterations: 7",
+    ]
+
+    parser = get_args_parser()
+    with tmp_yaml_file(YAML_LINES) as temp_file:
+        args = parser.parse_args(["--ft-cfg-path", temp_file, "dummy.py"])
+        ft = fault_tolerance.FaultToleranceConfig.from_args(args)
+
+    assert ft.max_no_progress_cycles == 3
+    assert ft.min_progress_iterations == 7
+
+
 def test_read_from_yaml():
     YAML_LINES = [
         "fault_tolerance:",


### PR DESCRIPTION
## Summary

This fixes progress tracker YAML values being overwritten by CLI defaults.

(cherry picked from commit 78a7db564e5f5e0828413dcf748016b1256d0872)