### PR TITLE
[codex] Enable ft launcher attrsvc observability

### DIFF
--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -230,6 +230,7 @@ service dependencies.
   - ``--ft-attribution-llm-base-url <URL>`` (alias: ``--ft_attribution_llm_base_url``)
   - ``--ft-attribution-llm-model <MODEL>`` (alias: ``--ft_attribution_llm_model``)
   - ``--ft-attribution-startup-timeout <SECONDS>`` (alias: ``--ft_attribution_startup_timeout``), default ``20``
+  - ``--ft-attribution-export-url <URL>`` (alias: ``--ft_attribution_export_url``)
 
   The managed attribution app-log directory is derived from
   ``dirname(realpath(--ft-per-cycle-applog-prefix))``. Its stdout/stderr log is derived
@@ -239,6 +240,14 @@ service dependencies.
   The managed attribution API key must come from ``--ft-attribution-llm-api-key-file`` or inherited
   ``LLM_API_KEY_FILE``. If neither points to a readable file, the TCPStore-host launcher fails
   before starting the attribution service.
+
+  To export managed attribution results, pass ``--ft-attribution-export-url`` or
+  set ``attribution_export_url`` in the fault tolerance YAML config.
+
+  ``ft_launcher`` sends job metadata with each attribution submission: ``user`` is read from
+  ``SLURM_JOB_USER`` or ``USER``, and ``job_id`` is read from ``SLURM_ARRAY_JOB_ID`` or
+  ``SLURM_JOB_ID``. If no corresponding environment variable is set, that field is omitted from
+  the submission payload.
 
   Example:
 
@@ -250,6 +259,7 @@ service dependencies.
        --ft-attribution-llm-api-key-file /secure/llm_api_key \
        --ft-attribution-llm-base-url https://integrate.api.nvidia.com/v1 \
        --ft-attribution-llm-model nvidia/nemotron-3-super-120b-a12b \
+       --ft-attribution-export-url https://dataflow.example.test/dataflow2/example-index/posting \
        train.py
 
   To use an externally managed attribution service instead, specify an explicit endpoint:

--- a/services/attrsvc/ATTRSVC_SPEC.md
+++ b/services/attrsvc/ATTRSVC_SPEC.md
@@ -396,7 +396,7 @@ Refer to live **`GET /stats`** response or OpenAPI for the current JSON shape.
 21. DATAFLOW & SLACK (OPTIONAL)
 --------------------------------------------------------------------------------
 
-Postprocessing posts results when `DATAFLOW_HTTP_URL` is configured with the
+Postprocessing posts results when `EXPORT_URL` is configured with the
 complete posting URI. No endpoint is built into the package. Slack posts when
 `SLACK_BOT_TOKEN` set or token fallback files are present. Wiring:
 `Settings` → `AttributionControllerConfig` → `AttributionController`. Record build:

--- a/services/attrsvc/README.md
+++ b/services/attrsvc/README.md
@@ -42,7 +42,7 @@ Environment variables (prefix: `NVRX_ATTRSVC_`):
 | `PORT` | `8000` | Listen port |
 | `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, or `WARNING` for root logging and MCP; FastAPI `debug` when set to `DEBUG`. |
 | `CLUSTER_NAME` | `""` | Cluster name for dataflow posting |
-| `DATAFLOW_HTTP_URL` | `""` | Complete dataflow HTTP posting URI. Empty disables dataflow posting. |
+| `EXPORT_URL` | `""` | Complete result export URI. Empty disables result export. |
 | `DATAFLOW_QUEUE` | `""` | Optional queue parameter for dataflow HTTP posting |
 | `DATAFLOW_TIMEOUT_SECONDS` | `10.0` | Dataflow HTTP request timeout |
 | `RATE_LIMIT_SUBMIT` | `1200/minute` | Rate limit for POST /logs |

--- a/services/attrsvc/deploy/kubernetes.yaml
+++ b/services/attrsvc/deploy/kubernetes.yaml
@@ -25,7 +25,7 @@ data:
   NVRX_ATTRSVC_ALLOWED_ROOT: "/data/logs"
   NVRX_ATTRSVC_LOG_LEVEL: "INFO"
   # NVRX_ATTRSVC_CLUSTER_NAME: "my-cluster"
-  # NVRX_ATTRSVC_DATAFLOW_HTTP_URL: ""  # Leave empty to disable dataflow
+  # NVRX_ATTRSVC_EXPORT_URL: ""  # Leave empty to disable result export
 
 ---
 apiVersion: apps/v1

--- a/services/scripts/setup_systemd.sh
+++ b/services/scripts/setup_systemd.sh
@@ -308,7 +308,7 @@ NVRX_ATTRSVC_ALLOWED_ROOT=/
 NVRX_ATTRSVC_PORT=8000
 NVRX_ATTRSVC_HOST=0.0.0.0
 NVRX_ATTRSVC_LOG_LEVEL=DEBUG
-# NVRX_ATTRSVC_DATAFLOW_HTTP_URL=https://example.test/dataflow2/your-index/posting
+# NVRX_ATTRSVC_EXPORT_URL=https://example.test/dataflow2/your-index/posting
 # NVRX_ATTRSVC_CLUSTER_NAME=your-cluster
 
 # ─── SLURM Monitor (nvrx-smonsvc) ───

--- a/src/nvidia_resiliency_ext/attribution/postprocessing/config.py
+++ b/src/nvidia_resiliency_ext/attribution/postprocessing/config.py
@@ -12,17 +12,17 @@ from nvidia_resiliency_ext.attribution.api_keys import load_slack_bot_token
 
 logger = logging.getLogger(__name__)
 
-DATAFLOW_HTTP_URL_ENV = "NVRX_ATTRSVC_DATAFLOW_HTTP_URL"
+EXPORT_URL_ENV = "NVRX_ATTRSVC_EXPORT_URL"
 
 
-def dataflow_http_url_from_env() -> str:
-    """Configured dataflow HTTP endpoint, if any."""
-    return os.getenv(DATAFLOW_HTTP_URL_ENV, "").strip()
+def export_url_from_env() -> str:
+    """Configured export posting endpoint, if any."""
+    return os.getenv(EXPORT_URL_ENV, "").strip()
 
 
 def dataflow_posting_enabled() -> bool:
     """Return whether postprocessing should attempt dataflow posting."""
-    return bool(dataflow_http_url_from_env())
+    return bool(export_url_from_env())
 
 
 def load_slack_from_env() -> Tuple[str, str]:
@@ -100,7 +100,7 @@ def configure_from_env(
             is used as-is (after ``strip``). Token and channel are resolved **independently** so an
             explicit empty token does not cause the channel to be replaced by env (and vice versa).
         cluster_name_env: Env var used when ``cluster_name`` is empty.
-        autoconfigure_poster: If ``True``, dataflow HTTP is configured, and ``default_poster``
+        autoconfigure_poster: If ``True``, dataflow posting is configured, and ``default_poster``
             is ``None``, builds a poster from :func:`~.post_backend.get_retrying_post_fn`.
     """
     # Resolve token and channel independently: None = "not provided, use env", else explicit

--- a/src/nvidia_resiliency_ext/attribution/postprocessing/post_backend.py
+++ b/src/nvidia_resiliency_ext/attribution/postprocessing/post_backend.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, Optional
 
 import httpx
 
-from .config import DATAFLOW_HTTP_URL_ENV, dataflow_http_url_from_env
+from .config import EXPORT_URL_ENV, export_url_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ def _dataflow_http_timeout_seconds() -> float:
 
 
 def _dataflow_http_endpoint() -> str:
-    return dataflow_http_url_from_env()
+    return export_url_from_env()
 
 
 def _dataflow_http_queue() -> str:
@@ -65,10 +65,10 @@ def _dataflow_http_queue() -> str:
 
 
 def _dataflow_http_url(endpoint: str) -> str:
-    """Return the explicitly configured dataflow HTTP post URL."""
+    """Return the explicitly configured export URL for dataflow HTTP posts."""
     endpoint = endpoint.strip()
     if not endpoint:
-        raise ValueError("NVRX_ATTRSVC_DATAFLOW_HTTP_URL is required for dataflow HTTP posting")
+        raise ValueError("NVRX_ATTRSVC_EXPORT_URL is required for dataflow HTTP posting")
     return endpoint
 
 
@@ -90,7 +90,7 @@ def make_dataflow_http_post_fn(
     if not resolved_endpoint.strip():
 
         def _missing_endpoint_post(_data: Dict[str, Any], _unused: str) -> bool:
-            logger.error("%s is required for dataflow HTTP posting", DATAFLOW_HTTP_URL_ENV)
+            logger.error("%s is required for dataflow HTTP posting", EXPORT_URL_ENV)
             return False
 
         return _missing_endpoint_post

--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -30,6 +30,9 @@ _ATTRIBUTION_STOP_TIMEOUT = 5.0
 _ATTRIBUTION_READY_POLL_INTERVAL = 0.5
 _MANAGED_ATTRIBUTION_ENDPOINT = "localhost"
 _EXTERNAL_ATTRIBUTION_SCHEMES = {"http", "grpc"}
+_ATTRSVC_EXPORT_URL_ENV = "NVRX_ATTRSVC_EXPORT_URL"
+_ATTRIBUTION_EXPORT_URL_CONFIG = "--ft-attribution-export-url / attribution_export_url"
+_EXPORT_URL_SCHEMES = {"http", "https"}
 
 
 @dataclass(frozen=True)
@@ -53,6 +56,7 @@ class AttributionConfig:
     analysis_backend: Optional[str] = None
     compute_timeout: Optional[float] = None
     log_level: Optional[str] = None
+    export_url: Optional[str] = None
 
     @property
     def is_enabled(self) -> bool:
@@ -89,6 +93,16 @@ class AttributionConfig:
         if endpoint is not None:
             _validate_attribution_endpoint(endpoint)
 
+        export_url = _resolve_export_url(args, ft_cfg)
+        if export_url is not None and (
+            endpoint is None or not is_managed_attribution_endpoint(endpoint)
+        ):
+            endpoint_desc = endpoint if endpoint is not None else "disabled"
+            raise ValueError(
+                f"{_ATTRIBUTION_EXPORT_URL_CONFIG} requires launcher-managed attribution "
+                f"with --ft-attribution-endpoint localhost, got {endpoint_desc!r}"
+            )
+
         startup_timeout = getattr(args, "ft_attribution_startup_timeout", None)
         if startup_timeout is None:
             startup_timeout = DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT
@@ -108,6 +122,7 @@ class AttributionConfig:
                 analysis_backend=getattr(args, "ft_attribution_analysis_backend", None),
                 compute_timeout=getattr(args, "ft_attribution_compute_timeout", None),
                 log_level=getattr(args, "ft_attribution_log_level", None),
+                export_url=None,
             )
 
         applog_dir = os.path.dirname(os.path.realpath(os.path.abspath(base_log_file)))
@@ -136,6 +151,7 @@ class AttributionConfig:
             analysis_backend=getattr(args, "ft_attribution_analysis_backend", None),
             compute_timeout=getattr(args, "ft_attribution_compute_timeout", None),
             log_level=getattr(args, "ft_attribution_log_level", None),
+            export_url=export_url,
         )
 
 
@@ -255,6 +271,8 @@ class AttributionManager:
     def _child_env(self, api_key_file: str) -> dict[str, str]:
         assert self.cfg.applog_dir is not None
         env = os.environ.copy()
+        # Export URL for launcher-managed attrsvc is explicit via CLI/YAML, not parent env.
+        env.pop(_ATTRSVC_EXPORT_URL_ENV, None)
         env["LLM_API_KEY_FILE"] = api_key_file
         # nvrx-attrsvc owns the service-side environment variable contract.
         env["NVRX_ATTRSVC_ENDPOINT"] = _managed_attribution_client_endpoint()
@@ -264,6 +282,7 @@ class AttributionManager:
         _set_if_not_none(env, "NVRX_ATTRSVC_ANALYSIS_BACKEND", self.cfg.analysis_backend)
         _set_if_not_none(env, "NVRX_ATTRSVC_COMPUTE_TIMEOUT", self.cfg.compute_timeout)
         _set_if_not_none(env, "NVRX_ATTRSVC_LOG_LEVEL", self.cfg.log_level)
+        _set_if_not_none(env, _ATTRSVC_EXPORT_URL_ENV, self.cfg.export_url)
         return env
 
     def _wait_until_ready(self) -> None:
@@ -355,6 +374,32 @@ def _validate_attribution_endpoint(endpoint: str) -> None:
         raise ValueError("--ft-attribution-endpoint must include a port")
 
     _validate_attribution_endpoint_host(parsed.hostname)
+
+
+def _resolve_export_url(args: Any, ft_cfg: FaultToleranceConfig) -> Optional[str]:
+    value = getattr(args, "ft_attribution_export_url", None)
+    if value is None:
+        value = getattr(ft_cfg, "attribution_export_url", None)
+    if value is None:
+        return None
+
+    value = str(value).strip()
+    if not value:
+        return None
+    _validate_export_url(value)
+    return value
+
+
+def _validate_export_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in _EXPORT_URL_SCHEMES or not parsed.netloc:
+        raise ValueError(
+            f"{_ATTRIBUTION_EXPORT_URL_CONFIG} must be a complete http(s) URL, got {url!r}"
+        )
+    if parsed.query or parsed.fragment:
+        raise ValueError(
+            f"{_ATTRIBUTION_EXPORT_URL_CONFIG} must not include query parameters or fragments"
+        )
 
 
 def _validate_attribution_endpoint_host(hostname: str) -> None:

--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -406,6 +406,14 @@ def _add_attribution_args(parser: argparse.ArgumentParser) -> None:
         choices=("DEBUG", "INFO", "WARNING"),
         help="Log level for launcher-managed attribution service.",
     )
+    parser.add_argument(
+        "--ft-attribution-export-url",
+        "--ft_attribution_export_url",
+        type=str,
+        default=None,
+        dest="ft_attribution_export_url",
+        help="Complete result export URL for launcher-managed attribution service.",
+    )
 
 
 def add_attribution_args(parser: argparse.ArgumentParser) -> None:

--- a/src/nvidia_resiliency_ext/fault_tolerance/config.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/config.py
@@ -97,6 +97,8 @@ class FaultToleranceConfig:
       Default: 5. Can be overridden by workload (e.g., Megatron-LM via init_workload_monitoring).
     * Attribution service (optional, disabled unless `attribution_endpoint` is set):
       - `attribution_endpoint` [str] endpoint of the attribution service
+      - `attribution_export_url` [str] complete export posting URL for
+        launcher-managed attribution service postprocessing.
 
     * `cycle_info_dir` [str|None] Full path to the NVRx cycle info directory (e.g.
       <base>/nvrx/). If set, the rendezvous host writes cycle info JSON files and
@@ -146,6 +148,7 @@ class FaultToleranceConfig:
     )
     # Attribution service configuration (optional)
     attribution_endpoint: Optional[str] = None
+    attribution_export_url: Optional[str] = None
 
     # NVRx cycle info: base directory for cycle_info JSON files
     cycle_info_dir: Optional[str] = None

--- a/src/nvidia_resiliency_ext/fault_tolerance/cycle_info_writer.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cycle_info_writer.py
@@ -31,6 +31,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple
 
 from google.protobuf import json_format
 
+from nvidia_resiliency_ext.shared_utils.job_metadata import job_id_from_env
 from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
 from nvidia_resiliency_ext.shared_utils.proto import nvrx_interface_pb2
 
@@ -53,7 +54,7 @@ def cycle_log_file(base_log_file: str, cycle_index: int) -> str:
 
 
 def _cycle_info_job_id_from_env() -> str:
-    return os.environ.get("SLURM_ARRAY_JOB_ID") or os.environ.get("SLURM_JOB_ID", "")
+    return job_id_from_env() or ""
 
 
 def _cycle_info_attempt_index_from_env() -> int:

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -101,6 +101,7 @@ from nvidia_resiliency_ext.fault_tolerance.utils import (
     write_obj_to_ipc_stream,
 )
 from nvidia_resiliency_ext.shared_utils.health_check import NodeHealthCheck
+from nvidia_resiliency_ext.shared_utils.job_metadata import job_id_from_env
 from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig, setup_logger
 from nvidia_resiliency_ext.shared_utils.memory import GPUMemoryLogger
 from nvidia_resiliency_ext.shared_utils.profiling import ProfilingEvent, record_profiling_event
@@ -478,7 +479,7 @@ class LocalElasticAgent(SimpleElasticAgent):
     def _current_cycle_info_path(self) -> Optional[str]:
         if not self._ft_cfg.cycle_info_dir:
             return None
-        job_id = os.environ.get("SLURM_ARRAY_JOB_ID") or os.environ.get("SLURM_JOB_ID", "")
+        job_id = job_id_from_env() or ""
         return CycleInfoReporter.current_cycle_info_path(self._ft_cfg.cycle_info_dir, job_id)
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -37,6 +37,7 @@ from nvidia_resiliency_ext.attribution.orchestration.http_api import (
     get_log_response,
     post_log,
 )
+from nvidia_resiliency_ext.shared_utils.job_metadata import job_id_from_env, job_user_from_env
 from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
 
 # Get the nvrx logger
@@ -1410,7 +1411,13 @@ class AttributionService:
             with httpx.Client(base_url=base_url, timeout=10.0) as client:
                 url = f"{base_url}{ROUTE_LOGS}"
                 logger.debug("AttributionService POST: %s (log_path=%s)", url, log_path)
-                post_log(client, log_path, analysis_intent="progressive")
+                post_log(
+                    client,
+                    log_path,
+                    user=job_user_from_env(),
+                    job_id=job_id_from_env(),
+                    analysis_intent="progressive",
+                )
         except Exception as e:
             logger.warning(
                 "AttributionService POST %s failed: %s: %s", log_path, type(e).__name__, e

--- a/src/nvidia_resiliency_ext/shared_utils/job_metadata.py
+++ b/src/nvidia_resiliency_ext/shared_utils/job_metadata.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for job metadata derived from launcher environment variables."""
+
+import os
+
+
+def job_user_from_env() -> str | None:
+    """Read job user from SLURM_JOB_USER or USER env."""
+    return os.environ.get("SLURM_JOB_USER") or os.environ.get("USER") or None
+
+
+def job_id_from_env() -> str | None:
+    """Read job id from SLURM_ARRAY_JOB_ID or SLURM_JOB_ID env."""
+    return os.environ.get("SLURM_ARRAY_JOB_ID") or os.environ.get("SLURM_JOB_ID") or None

--- a/tests/attribution/unit/test_post_backend.py
+++ b/tests/attribution/unit/test_post_backend.py
@@ -104,7 +104,7 @@ class TestDataflowHttpPost(unittest.TestCase):
         with mock.patch.dict(
             "os.environ",
             {
-                "NVRX_ATTRSVC_DATAFLOW_HTTP_URL": (
+                "NVRX_ATTRSVC_EXPORT_URL": (
                     "https://dataflow.example.test/dataflow2/sandbox-nvrx/posting"
                 )
             },

--- a/tests/attribution/unit/test_postprocessing_pipeline.py
+++ b/tests/attribution/unit/test_postprocessing_pipeline.py
@@ -167,7 +167,7 @@ class TestBuildDataflowRecord(unittest.TestCase):
                 with patch.dict(
                     "os.environ",
                     {
-                        "NVRX_ATTRSVC_DATAFLOW_HTTP_URL": (
+                        "NVRX_ATTRSVC_EXPORT_URL": (
                             "https://dataflow.example.test/dataflow2/test/posting"
                         )
                     },

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -25,6 +25,7 @@ def _args(**overrides):
         "ft_attribution_analysis_backend": None,
         "ft_attribution_compute_timeout": None,
         "ft_attribution_log_level": None,
+        "ft_attribution_export_url": None,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -180,6 +181,9 @@ def test_attribution_config_maps_launcher_args(tmp_path):
             ft_attribution_analysis_backend="lib",
             ft_attribution_compute_timeout=12.5,
             ft_attribution_log_level="DEBUG",
+            ft_attribution_export_url=(
+                "https://dataflow.example.test/dataflow2/example-index/posting"
+            ),
         ),
         str(base_log),
         FaultToleranceConfig(),
@@ -194,6 +198,123 @@ def test_attribution_config_maps_launcher_args(tmp_path):
     assert env["NVRX_ATTRSVC_ANALYSIS_BACKEND"] == "lib"
     assert env["NVRX_ATTRSVC_COMPUTE_TIMEOUT"] == "12.5"
     assert env["NVRX_ATTRSVC_LOG_LEVEL"] == "DEBUG"
+    assert (
+        env["NVRX_ATTRSVC_EXPORT_URL"]
+        == "https://dataflow.example.test/dataflow2/example-index/posting"
+    )
+
+
+def test_attribution_child_env_does_not_inherit_export_url_from_launcher_env(tmp_path, monkeypatch):
+    api_key_file = tmp_path / "key"
+    api_key_file.write_text("secret")
+    base_log = tmp_path / "train.log"
+    monkeypatch.setenv(
+        "NVRX_ATTRSVC_EXPORT_URL",
+        "https://dataflow.example.test/dataflow2/launcher-env/posting",
+    )
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"),
+        str(base_log),
+        FaultToleranceConfig(),
+    )
+
+    env = AttributionManager(cfg, is_store_host=True)._child_env(str(api_key_file))
+
+    assert cfg.export_url is None
+    assert "NVRX_ATTRSVC_EXPORT_URL" not in env
+
+
+def test_cli_export_url_overrides_launcher_env(tmp_path, monkeypatch):
+    api_key_file = tmp_path / "key"
+    api_key_file.write_text("secret")
+    base_log = tmp_path / "train.log"
+    monkeypatch.setenv(
+        "NVRX_ATTRSVC_EXPORT_URL",
+        "https://dataflow.example.test/old/posting",
+    )
+    cfg = AttributionConfig.from_args(
+        _args(
+            ft_attribution_endpoint="localhost",
+            ft_attribution_export_url="https://dataflow.example.test/new/posting",
+        ),
+        str(base_log),
+        FaultToleranceConfig(),
+    )
+
+    env = AttributionManager(cfg, is_store_host=True)._child_env(str(api_key_file))
+
+    assert cfg.export_url == "https://dataflow.example.test/new/posting"
+    assert env["NVRX_ATTRSVC_EXPORT_URL"] == "https://dataflow.example.test/new/posting"
+
+
+def test_yaml_export_url_overrides_launcher_env(tmp_path, monkeypatch):
+    api_key_file = tmp_path / "key"
+    api_key_file.write_text("secret")
+    base_log = tmp_path / "train.log"
+    monkeypatch.setenv(
+        "NVRX_ATTRSVC_EXPORT_URL",
+        "https://dataflow.example.test/old/posting",
+    )
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"),
+        str(base_log),
+        FaultToleranceConfig(attribution_export_url="https://dataflow.example.test/yaml/posting"),
+    )
+
+    env = AttributionManager(cfg, is_store_host=True)._child_env(str(api_key_file))
+
+    assert cfg.export_url == "https://dataflow.example.test/yaml/posting"
+    assert env["NVRX_ATTRSVC_EXPORT_URL"] == "https://dataflow.example.test/yaml/posting"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "dataflow.example.test/posting",
+        "ftp://dataflow.example.test/posting",
+        "https://dataflow.example.test/posting?queue=fast",
+    ],
+)
+def test_export_url_rejects_invalid_values(tmp_path, url):
+    with pytest.raises(ValueError, match="--ft-attribution-export-url"):
+        AttributionConfig.from_args(
+            _args(
+                ft_attribution_endpoint="localhost",
+                ft_attribution_export_url=url,
+            ),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(),
+        )
+
+
+def test_export_url_rejects_external_attribution_endpoint(tmp_path):
+    with pytest.raises(ValueError, match="launcher-managed attribution"):
+        AttributionConfig.from_args(
+            _args(
+                ft_attribution_endpoint="http://attribution.external:50123",
+                ft_attribution_export_url="https://dataflow.example.test/posting",
+            ),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(),
+        )
+
+
+def test_yaml_export_url_rejects_external_attribution_endpoint(tmp_path):
+    with pytest.raises(ValueError, match="launcher-managed attribution"):
+        AttributionConfig.from_args(
+            _args(ft_attribution_endpoint="http://attribution.external:50123"),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(attribution_export_url="https://dataflow.example.test/posting"),
+        )
+
+
+def test_export_url_rejects_disabled_attribution(tmp_path):
+    with pytest.raises(ValueError, match="--ft-attribution-endpoint localhost"):
+        AttributionConfig.from_args(
+            _args(ft_attribution_export_url="https://dataflow.example.test/posting"),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(),
+        )
 
 
 def test_child_env_overrides_inherited_attrsvc_endpoint(tmp_path, monkeypatch):
@@ -292,6 +413,19 @@ def test_external_attribution_does_not_require_key_or_start_process(tmp_path, mo
 
     assert endpoint is not None
     assert endpoint.endpoint == "http://attribution.external:50123"
+
+
+def test_external_attribution_ignores_launcher_export_env(tmp_path, monkeypatch):
+    base_log = tmp_path / "train.log"
+    monkeypatch.setenv("NVRX_ATTRSVC_EXPORT_URL", "not-a-url")
+
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="http://attribution.external:50123"),
+        str(base_log),
+        FaultToleranceConfig(),
+    )
+
+    assert cfg.export_url is None
 
 
 def test_wait_until_ready_accepts_2xx_health_response(tmp_path, monkeypatch):

--- a/tests/fault_tolerance/unit/test_config.py
+++ b/tests/fault_tolerance/unit/test_config.py
@@ -64,6 +64,8 @@ def test_from_args():
         "123.0",
         "--ft-rank-section-timeouts",
         "custom1:111.1,custom2:222.2",
+        "--ft-attribution-export-url",
+        "https://dataflow.example.test/dataflow2/example-index/posting",
     ]
 
     # Add a the dummy training script required by the torchrun argparser
@@ -77,6 +79,9 @@ def test_from_args():
     assert ft.log_level == logging.DEBUG
     assert ft.rank_out_of_section_timeout == 123.0
     assert ft.rank_section_timeouts == {'custom1': 111.1, 'custom2': 222.2}
+    assert (
+        ft.attribution_export_url == "https://dataflow.example.test/dataflow2/example-index/posting"
+    )
 
 
 def test_signal_field_with_valid_values():

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -569,12 +569,43 @@ class TestAttributionService(unittest.TestCase):
         client = mock_client.return_value.__enter__.return_value
         service = AttributionService(endpoint="http://attr.example:8000/")
 
-        service._do_submit_log("/tmp/train.log")
+        with patch.dict(
+            os.environ,
+            {
+                "SLURM_JOB_USER": "alice",
+                "USER": "fallback-user",
+                "SLURM_ARRAY_JOB_ID": "12345",
+                "SLURM_JOB_ID": "67890",
+            },
+        ):
+            service._do_submit_log("/tmp/train.log")
 
         mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=10.0)
         client.post.assert_called_once_with(
             "/logs",
-            json={"log_path": "/tmp/train.log", "analysis_intent": "progressive"},
+            json={
+                "log_path": "/tmp/train.log",
+                "user": "alice",
+                "job_id": "12345",
+                "analysis_intent": "progressive",
+            },
+            headers={"accept": "application/json"},
+        )
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_http_endpoint_omits_job_metadata_when_env_unset(self, mock_client):
+        client = mock_client.return_value.__enter__.return_value
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        with patch.dict(os.environ, {}, clear=True):
+            service._do_submit_log("/tmp/train.log")
+
+        client.post.assert_called_once_with(
+            "/logs",
+            json={
+                "log_path": "/tmp/train.log",
+                "analysis_intent": "progressive",
+            },
             headers={"accept": "application/json"},
         )
 

--- a/tests/shared_utils/test_job_metadata.py
+++ b/tests/shared_utils/test_job_metadata.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from nvidia_resiliency_ext.shared_utils.job_metadata import job_id_from_env, job_user_from_env
+
+
+class TestJobMetadata(unittest.TestCase):
+
+    def test_job_metadata_helpers_read_slurm_env_first(self):
+        with patch.dict(
+            os.environ,
+            {
+                "SLURM_JOB_USER": "slurm-user",
+                "USER": "fallback-user",
+                "SLURM_ARRAY_JOB_ID": "array-job",
+                "SLURM_JOB_ID": "plain-job",
+            },
+        ):
+            self.assertEqual(job_user_from_env(), "slurm-user")
+            self.assertEqual(job_id_from_env(), "array-job")
+
+    def test_job_metadata_helpers_fallback_to_user_and_slurm_job_id(self):
+        with patch.dict(
+            os.environ,
+            {
+                "USER": "fallback-user",
+                "SLURM_JOB_ID": "plain-job",
+            },
+            clear=True,
+        ):
+            self.assertEqual(job_user_from_env(), "fallback-user")
+            self.assertEqual(job_id_from_env(), "plain-job")
+
+    def test_job_metadata_helpers_return_none_when_unset(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(job_user_from_env())
+            self.assertIsNone(job_id_from_env())


### PR DESCRIPTION
## Summary

- Add ft_launcher plumbing for launcher-managed attrsvc dataflow posting via explicit `--ft-attribution-dataflow-url` / `attribution_dataflow_url` configuration.
- Set the managed child service `NVRX_ATTRSVC_DATAFLOW_URL` only from that explicit launcher config, and strip any parent env value so launcher does not configure dataflow from env.
- Keep the dev feature on the new canonical env/flag names only, with no old-name compatibility path.
- Pass launcher environment-derived `user` and `job_id` metadata on attrsvc `POST /logs` submissions, using shared job metadata helpers.
- Document the dataflow URL configuration and launcher job metadata behavior using public-safe example URLs.

## Impact

Managed ft_launcher attribution can now post results to a configured dataflow endpoint and include job/user metadata needed by attrsvc for splitlog tracking and dataflow records.

## Validation

- `compileall` on touched Python files
- `git diff --check`
- Confirmed old env/flag/config spellings are absent under `src`, `services`, `tests`, and `docs`
- Confirmed internal dataflow hostname/index strings are absent under the repo
- `black --check .`, `isort --check-only .`, `ruff check .`
- `tests/attribution/unit/test_post_backend.py`, `tests/attribution/unit/test_postprocessing_pipeline.py`, `tests/shared_utils/test_health_check.py::TestAttributionService`, `tests/shared_utils/test_job_metadata.py`
- `tests/fault_tolerance/unit/test_attribution_manager.py` under a local import harness because this local Python environment lacks the full torch runtime
- Focused launcher CLI/config verification for `--ft-attribution-dataflow-url`

## Notes

- `tests/fault_tolerance/unit/test_cycle_info_writer.py` could not be run in this local checkout because generated protobuf modules are absent, but the touched cycle-info code path now delegates to the separately tested shared job-id helper.