### PR TITLE
[codex] Backport BCM node healthcheck docs to v0.6

### DIFF
--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -54,10 +54,9 @@ using ``--ft-<parameter-name>``.
 
 Details:
 
-* ``--ft-node-health-check-endpoint`` (alias: ``--ft-node_health_check_endpoint``) sets the node health check service endpoint used by InJob.
-  Accepts Unix domain socket (UDS): ``/var/run/nodehealth.sock`` or ``unix:///var/run/nodehealth.sock``.
-* The rendezvous implementations call ``NodeHealthCheck`` which will connect to the provided endpoint.
-* Connectivity errors are treated as non-fatal (health passes); explicit RPC failures reported by the service mark the node unhealthy.
+* ``--ft-node-health-check-endpoint`` (alias: ``--ft-node_health_check_endpoint``) sets the optional node health check service endpoint used by InJob.
+  Accepts Unix domain socket (UDS): ``/var/run/nvhcd.sock`` or ``unix:///var/run/nvhcd.sock``.
+  See `Node health check service`_ for the BCM-backed and compatible-service usage model.
 
 If ``--max-restarts`` is specified, the launcher restarts failed workers.
 The ``--ft-restart-policy`` parameter is deprecated; only ``any-failed`` is supported: all workers
@@ -66,13 +65,96 @@ are restarted if any worker fails (torchrun-style behavior). This option may be 
 Node health check service
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The launcher accepts an optional argument to point to the node health check service endpoint.
-When provided, the launcher exports the socket path to child processes and
-the rendezvous handlers will use it in their node health checks.
+The launcher can query an optional node-local health check service before workers enter
+rendezvous. A practical public deployment model is to reuse NVIDIA Base Command
+Manager (BCM) Slurm prolog or epilog health checks behind an ``nvhcd``-compatible
+daemon. The NVRx integration point is service-compatible: any equivalent daemon
+can be used if it implements the expected gRPC API over a Unix domain socket
+(UDS).
 
-* ``--ft-node-health-check-endpoint`` (alias: ``--ft-node_health_check_endpoint``) sets the node health check service endpoint (UDS).
-* The rendezvous implementations call ``NodeHealthCheck`` which will connect to this UDS endpoint.
-* Connectivity errors are treated as non-fatal (health passes); explicit RPC failures reported by the service mark the node unhealthy.
+To enable the external node health check with BCM:
+
+* Build and deploy an ``nvhcd``-compatible daemon on every allocated node.
+* Configure the daemon to invoke a BCM health check script, or a wrapper around
+  an existing BCM prolog or epilog health check.
+* Ensure the wrapper translates the BCM result into JSON with ``fail_count == 0``
+  for a healthy node and a nonzero ``fail_count`` for an unhealthy node.
+* Make the daemon's UDS visible from the job environment or training container.
+* Pass the socket path to ``ft_launcher`` with ``--ft-node-health-check-endpoint``
+  (alias: ``--ft-node_health_check_endpoint``).
+
+Example:
+
+.. code-block:: bash
+
+   ft_launcher \
+     --ft-node-health-check-endpoint unix:///var/run/nvhcd.sock \
+     train.py
+
+Endpoint behavior:
+
+* UDS endpoints are supported. The value can be a path such as ``/var/run/nvhcd.sock``
+  or a ``unix://`` URI such as ``unix:///var/run/nvhcd.sock``.
+* If the endpoint is omitted, NVRx skips the external node health check.
+* If the gRPC client dependencies are unavailable, the UDS socket is missing, or a
+  connectivity error occurs, NVRx treats the external check as unavailable and does
+  not fail the job for that reason.
+* Explicit failures reported by the service mark the node unhealthy.
+
+Compatible service contract:
+
+* The service must implement ``HealthCheckService.RunHealthCheck`` from the NVRx
+  ``nvhcd`` protobuf API and listen on the configured UDS.
+* NVRx calls the service with ``args=["--no-slurm"]``.
+* The response must set ``success`` and return JSON in ``output``. A healthy node
+  is reported with ``success=true`` and ``{"fail_count": 0}``.
+* If ``success`` is false, ``fail_count`` is nonzero, or ``output`` cannot be parsed
+  as JSON with a ``fail_count`` field, NVRx treats the node as unhealthy.
+
+Example ``nvhcd`` configuration for BCM:
+
+.. code-block:: yaml
+
+   socket_path: /var/run/nvhcd.sock
+   healthcheck_path: /usr/local/sbin/nvrx-bcm-healthcheck-wrapper.sh
+   log_level: info
+   timeout: 120
+
+Start the daemon on each node with this configuration, for example as a node-level
+service or directly with:
+
+.. code-block:: bash
+
+   nvhcd -config /etc/nvhcd/config.yaml
+
+If the training job runs inside a container, bind mount the UDS path into the
+container so that ``ft_launcher`` can reach the daemon.
+
+The wrapper can call the same reusable health check entry point that BCM uses for
+Slurm prolog or epilog validation, then normalize the result for NVRx. For example:
+
+.. code-block:: bash
+
+   #!/usr/bin/env bash
+   set -euo pipefail
+
+   if /path/to/bcm-healthcheck "$@"; then
+     printf '{"fail_count": 0, "failed_checks": []}\n'
+     exit 0
+   else
+     printf '{"fail_count": 1, "failed_checks": ["bcm_healthcheck"]}\n'
+     exit 1
+   fi
+
+Because NVRx invokes this check during rendezvous rather than during Slurm's
+actual prolog or epilog phase, the wrapper should also provide any inputs that
+the BCM script expects from the Slurm lifecycle environment, or call a reusable
+health check entry point from the local BCM deployment that does not depend on
+those lifecycle-only variables.
+
+This lets NVRx run the same class of node validation during in-job restart
+rendezvous that cluster administrators may already run at Slurm prolog or epilog
+time.
 
 Distributed storage health check (Lustre + NFS)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -83,6 +83,11 @@ To enable the external node health check with BCM:
 * Pass the socket path to ``ft_launcher`` with ``--ft-node-health-check-endpoint``
   (alias: ``--ft-node_health_check_endpoint``).
 
+For protocol details, see the ``nvhcd`` protobuf schema at
+``src/nvidia_resiliency_ext/shared_utils/proto/nvhcd.proto``. The functional test
+server at ``tests/fault_tolerance/func/nodehc_service.py`` is a minimal example
+of a UDS gRPC service that implements this API.
+
 Example:
 
 .. code-block:: bash
@@ -131,7 +136,10 @@ If the training job runs inside a container, bind mount the UDS path into the
 container so that ``ft_launcher`` can reach the daemon.
 
 The wrapper can call the same reusable health check entry point that BCM uses for
-Slurm prolog or epilog validation, then normalize the result for NVRx. For example:
+Slurm prolog or epilog validation, then normalize the result for NVRx. When using
+``nvhcd``, the gRPC request ``args`` are forwarded to the configured
+``healthcheck_path`` as command-line arguments, so NVRx's ``--no-slurm`` argument
+will appear in the wrapper's ``"$@"``. For example:
 
 .. code-block:: bash
 

--- a/docs/source/release-notes.md
+++ b/docs/source/release-notes.md
@@ -24,6 +24,12 @@ NVIDIA Resiliency Extension is a Python package for framework developers and use
         - Automatic health check chaining in `Wrapper` class `ChainedGPUHealthCheck` and `ChainedNVLHealthCheck` for in-process use
         - Single GPU health check API for individual device validation and updated trace collector to use new GPU health check API
 
+- Node health check service integration
+    - `ft_launcher` can query a node-local health check service before rendezvous by passing `--ft-node-health-check-endpoint`.
+    - Users can reuse NVIDIA Base Command Manager (BCM) Slurm prolog or epilog health checks behind the same service interface. For example, customers can deploy an `nvhcd`-compatible daemon that invokes an existing BCM health check script and converts the result to the NVRx health check response format.
+    - The integration is service-compatible: users can provide any equivalent daemon that implements the NVRx `HealthCheckService.RunHealthCheck` gRPC API over a Unix domain socket and returns JSON output with `fail_count == 0` for healthy nodes.
+    - Example: `--ft-node-health-check-endpoint unix:///var/run/nvhcd.sock`. If the endpoint is not configured, or the optional service is unavailable, NVRx skips the external node health check; explicit failures returned by the service mark the node unhealthy.
+
 - Checkpointing
     - PRs ([108](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/108), [138](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/138), [154](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/154), [169](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/169), [170](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/170), [193](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/193), [197](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/197), [199](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/199)) improve the stability of checkpointing by deprecating the use of fork in asynchronous checkpointing, simplifying error propagation and shutdown cleanup logic
         - Introduced the option to use **Multithread File IO Instead of Multiprocess** to simplify error propagation logic, improve shutdown cleanup and enhance overall stability


### PR DESCRIPTION
## Summary

- Backport PR #332 documentation changes to `release/v0.6`.
- Add the BCM-backed node health check service release note.
- Document the `nvhcd`-compatible daemon flow, gRPC/UDS service contract, wrapper argument forwarding, and proto/test-server references.

## Cherry-picked commits

- `31fb3e0f6cda087eeabc4ec55dcd405bee40e636` - Add BCM node healthcheck docs
- `deef2d1f4bdcf77e3789e6b4e5e3be371e26d006` - Address node healthcheck docs comments

## Validation

- `git diff --check origin/release/v0.6...HEAD`
- Confirmed the touched docs contain no `DCA` or `Mission Control` references.

Full Sphinx docs build was not run locally because `sphinx-build` is not installed in this environment.
