### PR TITLE
[codex] Add ft launcher attribution integration

### DIFF
--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -230,6 +230,7 @@ service dependencies.
   - ``--ft-attribution-llm-base-url <URL>`` (alias: ``--ft_attribution_llm_base_url``)
   - ``--ft-attribution-llm-model <MODEL>`` (alias: ``--ft_attribution_llm_model``)
   - ``--ft-attribution-startup-timeout <SECONDS>`` (alias: ``--ft_attribution_startup_timeout``), default ``20``
+  - ``--ft-attribution-decision-timeout <SECONDS>`` (alias: ``--ft_attribution_decision_timeout``), default ``60``
   - ``--ft-attribution-export-url <URL>`` (alias: ``--ft_attribution_export_url``)
 
   The managed attribution app-log directory is derived from
@@ -243,6 +244,10 @@ service dependencies.
 
   To export managed attribution results, pass ``--ft-attribution-export-url`` or
   set ``attribution_export_url`` in the fault tolerance YAML config.
+
+  ``--ft-attribution-decision-timeout`` is the total launcher-side budget for one
+  attribution decision, measured from the terminal analysis request until the rendezvous
+  host fetches the STOP/RESTART recommendation.
 
   ``ft_launcher`` sends job metadata with each attribution submission: ``user`` is read from
   ``SLURM_JOB_USER`` or ``USER``, and ``job_id`` is read from ``SLURM_ARRAY_JOB_ID`` or

--- a/services/attrsvc/ATTRSVC_SPEC.md
+++ b/services/attrsvc/ATTRSVC_SPEC.md
@@ -233,6 +233,8 @@ Response: `{ "mode": "pending" | "single" | "splitlog" }`.
 **GET /logs**  
 Returns single-file or splitlog-shaped JSON; optional `file` selects a file in
 splitlog mode; `wl_restart` selects a workload chunk within the analyzed file.
+Optional `wait=false` probes cache/in-flight state without starting or awaiting
+analysis; responses may use `status="in_flight"` or `status="pending"`.
 Exact fields match library serializers — see **`types.py`** and OpenAPI **`/docs`**.
 Responses include a normalized `recommendation` object:
 `{ "action": "STOP" | "RESTART" | "CONTINUE" | "UNKNOWN" | "TIMEOUT",

--- a/services/attrsvc/README.md
+++ b/services/attrsvc/README.md
@@ -135,6 +135,7 @@ Example: `NVRX_ATTRSVC_CACHE_FILE=/var/lib/nvrx/attrsvc_cache.json`
 - `log_path` (required): Path to job output file
 - `file` (optional): Filename for splitlog mode
 - `wl_restart` (optional): Workload restart index within file (0-based; single-file supports multiple cycles)
+- `wait` (optional, default `true`): Set `false` to probe cache/in-flight state without starting or waiting for analysis.
 
 ---
 
@@ -168,13 +169,14 @@ All success responses use HTTP 200. Interpret outcome from the response body onl
 | `log_path` | string | Yes | Same path as used in POST |
 | `file` | string | No | Filename for splitlog (e.g. `model_12345_cycle0.log`) |
 | `wl_restart` | int | No | Workload restart index within file (0-based). Omit to get all cycles (single-file) or use default. |
+| `wait` | bool | No | Default `true`. Set `false` to return immediately with cached result, `in_flight`, or `pending`. |
 
 **Response (200)** — same top-level shape for single-file and splitlog; splitlog adds extra fields.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `result` | object | **Inner result** from the analysis pipeline (see below). |
-| `status` | string | Always `"completed"` (request completed). |
+| `status` | string | `"completed"` for a result. With `wait=false`, may be `"in_flight"` or `"pending"`. |
 | `recommendation` | object | Normalized client contract for restart/stop decisions. |
 | `wl_restart` | int | Which workload cycle this result is for (0 when returning all). |
 | `wl_restart_count` | int \| null | Total workload cycles in the file (single-file; null if N/A). |

--- a/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
+++ b/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
@@ -92,6 +92,33 @@ def _recommendation_payload_for_result(result: Dict[str, Any]) -> Dict[str, str]
     return recommendation_payload(logsage_recommendation_from_payload(result))
 
 
+def _nonblocking_cycle_result(status: str, wl_restart: Optional[int]) -> LogAnalysisCycleResult:
+    return LogAnalysisCycleResult(
+        result={},
+        status=status,
+        wl_restart=wl_restart or 0,
+        wl_restart_count=None,
+        recommendation=_recommendation_payload_for_result({}),
+    )
+
+
+def _nonblocking_splitlog_result(
+    status: str,
+    job: Job,
+    log_file: str,
+    wl_restart: Optional[int],
+) -> LogAnalysisSplitlogResult:
+    return LogAnalysisSplitlogResult(
+        result={},
+        status=status,
+        mode=JobMode.SPLITLOG.value,
+        sched_restarts=job.sched_restarts,
+        log_file=log_file,
+        wl_restart=wl_restart or 0,
+        recommendation=_recommendation_payload_for_result({}),
+    )
+
+
 class Analyzer:
     """
     Entry point: request coalescing plus :class:`~nvidia_resiliency_ext.attribution.orchestration.log_analyzer.LogAnalyzer`.
@@ -430,6 +457,7 @@ class Analyzer:
         log_path: str,
         file: Optional[str] = None,
         wl_restart: Optional[int] = None,
+        wait: bool = True,
     ) -> LogAnalyzerOutcome:
         """
         Analyze a log file using LLM.
@@ -441,6 +469,8 @@ class Analyzer:
             log_path: Path to the log file (or slurm output for splitlog mode)
             file: Filename for splitlog mode (None = all files)
             wl_restart: Workload restart index within file (None = all)
+            wait: When false, only probe cache/in-flight state and never start or
+                await analysis.
 
         Returns:
             LogAnalysisCycleResult or LogAnalysisSplitlogResult on success, LogAnalyzerError on failure
@@ -476,7 +506,7 @@ class Analyzer:
                 self._log.record_deferred_single_demotion()
 
         if mode == JobMode.SPLITLOG and job:
-            return await self._analyze_splitlog_mode(validated, job, file, wl_restart)
+            return await self._analyze_splitlog_mode(validated, job, file, wl_restart, wait=wait)
 
         # Single file mode
         validated = self.validate_path(log_path, require_regular_file=True, reject_empty=True)
@@ -491,9 +521,15 @@ class Analyzer:
                     f"No job_id for path {validated}: job_found={job is not None}, "
                     f"job.job_id={getattr(job, 'job_id', 'N/A') if job else 'N/A'}"
                 )
-            coalesced_raw = await self._coalescer.get_or_compute(
-                validated, lambda: self._run_llm_analysis(validated, user=user, job_id=job_id)
-            )
+            if wait:
+                coalesced_raw = await self._coalescer.get_or_compute(
+                    validated, lambda: self._run_llm_analysis(validated, user=user, job_id=job_id)
+                )
+            else:
+                peek = await self._coalescer.peek(validated)
+                if peek["status"] != "completed":
+                    return _nonblocking_cycle_result(peek["status"], wl_restart)
+                coalesced_raw = peek["result"]
             bundle = coalesced_from_cache(coalesced_raw)
             fr_dump = bundle.fr_dump_path
             fr_analysis = bundle.fr_analysis
@@ -602,6 +638,7 @@ class Analyzer:
         job: Job,
         file: Optional[str],
         wl_restart: Optional[int],
+        wait: bool = True,
     ) -> LogAnalysisSplitlogResult | LogAnalyzerError:
         """Handle analysis for split logging mode jobs."""
         tracker = self._log.splitlog_tracker
@@ -625,12 +662,23 @@ class Analyzer:
             )
 
         try:
-            coalesced_raw = await self._coalescer.get_or_compute(
-                file_info.log_file,
-                lambda: self._run_llm_analysis(
-                    file_info.log_file, user=job.user, job_id=job.job_id
-                ),
-            )
+            if wait:
+                coalesced_raw = await self._coalescer.get_or_compute(
+                    file_info.log_file,
+                    lambda: self._run_llm_analysis(
+                        file_info.log_file, user=job.user, job_id=job.job_id
+                    ),
+                )
+            else:
+                peek = await self._coalescer.peek(file_info.log_file)
+                if peek["status"] != "completed":
+                    return _nonblocking_splitlog_result(
+                        peek["status"],
+                        job,
+                        file_info.log_file,
+                        wl_restart,
+                    )
+                coalesced_raw = peek["result"]
         except FrDumpPathNotFoundError as e:
             return LogAnalyzerError(
                 error_code=ErrorCode.FR_DUMP_NOT_FOUND,

--- a/src/nvidia_resiliency_ext/attribution/coalescing/coalescer.py
+++ b/src/nvidia_resiliency_ext/attribution/coalescing/coalescer.py
@@ -29,11 +29,13 @@ from .types import (
     ComputeStats,
     InFlightEntry,
     InflightResult,
+    PeekResult,
     StatsResult,
     SubmittedResult,
 )
 
 logger = logging.getLogger(__name__)
+_CACHE_MISS = object()
 
 
 def _cache_recommendation(payload: Any, *, module: str) -> Dict[str, str]:
@@ -502,6 +504,48 @@ class RequestCoalescer:
         )
         return imported
 
+    def _get_valid_cached_result_unsafe(self, key: str, now: float) -> Any:
+        """Return a valid cached result, or ``_CACHE_MISS``. Caller must hold lock."""
+        if key not in self._cache:
+            return _CACHE_MISS
+
+        cache_entry = self._cache[key]
+        cache_age = now - cache_entry.cached_at
+
+        def cache_hit() -> Any:
+            self._stats.cache_hits += 1
+            self._submitted.pop(key, None)
+            return cache_entry.result
+
+        # Within grace period: serve without validation
+        if cache_age < self._grace_period:
+            return cache_hit()
+
+        # After grace period: validate file (mtime, size)
+        if cache_entry.file_mtime is not None and cache_entry.file_size is not None:
+            current_mtime, current_size = self._get_file_metadata(key)
+            if current_mtime == cache_entry.file_mtime and current_size == cache_entry.file_size:
+                return cache_hit()
+
+            # File changed - invalidate and treat as miss
+            self._cache.pop(key, None)
+            self._stats.cache_invalidated += 1
+            logger.debug(
+                f"Cache invalidated (file changed): {key} "
+                f"(mtime: {cache_entry.file_mtime}->{current_mtime}, "
+                f"size: {cache_entry.file_size}->{current_size})"
+            )
+        elif cache_entry.file_mtime is not None and cache_entry.file_size is None:
+            # Timeout entry: has mtime (for cleanup) but no size -> always retry
+            self._cache.pop(key, None)
+            self._stats.cache_invalidated += 1
+            logger.debug(f"Cache invalidated (timeout entry, retry): {key}")
+        else:
+            # No file metadata - treat as hit
+            return cache_hit()
+
+        return _CACHE_MISS
+
     async def get_inflight(self) -> InflightResult:
         """
         Get currently in-flight requests.
@@ -515,6 +559,22 @@ class RequestCoalescer:
                 "count": len(paths),
                 "paths": paths,
             }
+
+    async def peek(self, key: str) -> PeekResult:
+        """Return cache/coalescer status without starting or awaiting compute."""
+        async with self._lock:
+            cached_result = self._get_valid_cached_result_unsafe(key, time.monotonic())
+            if cached_result is not _CACHE_MISS:
+                if self._is_cached_timeout(cached_result):
+                    logger.info(f"Cache hit for {key} (timeout result)")
+                else:
+                    logger.info(f"Cache hit for {key}")
+                return {"status": "completed", "result": cached_result}
+
+            if key in self._in_flight:
+                return {"status": "in_flight", "result": None}
+
+            return {"status": "pending", "result": None}
 
     async def track_submission(self, key: str) -> None:
         """Track a submitted key."""
@@ -589,7 +649,7 @@ class RequestCoalescer:
         future: "asyncio.Future[Any] | None" = None
         is_compute_owner = False
 
-        cached_result = None
+        cached_result = _CACHE_MISS
         is_waiting = False
 
         # Check if cleanup is needed (minimal lock time)
@@ -609,49 +669,10 @@ class RequestCoalescer:
         async with self._lock:
             now = time.monotonic()
             # Check cache first
-            if key in self._cache:
-                cache_entry = self._cache[key]
-                cache_age = now - cache_entry.cached_at
-
-                # Within grace period: serve without validation
-                if cache_age < self._grace_period:
-                    self._stats.cache_hits += 1
-                    self._submitted.pop(key, None)
-                    cached_result = cache_entry.result
-                else:
-                    # After grace period: validate file (mtime, size)
-                    if cache_entry.file_mtime is not None and cache_entry.file_size is not None:
-                        current_mtime, current_size = self._get_file_metadata(key)
-                        if (
-                            current_mtime == cache_entry.file_mtime
-                            and current_size == cache_entry.file_size
-                        ):
-                            # File unchanged - cache hit
-                            self._stats.cache_hits += 1
-                            self._submitted.pop(key, None)
-                            cached_result = cache_entry.result
-                        else:
-                            # File changed - invalidate and treat as miss
-                            self._cache.pop(key, None)
-                            self._stats.cache_invalidated += 1
-                            logger.debug(
-                                f"Cache invalidated (file changed): {key} "
-                                f"(mtime: {cache_entry.file_mtime}->{current_mtime}, "
-                                f"size: {cache_entry.file_size}->{current_size})"
-                            )
-                    elif cache_entry.file_mtime is not None and cache_entry.file_size is None:
-                        # Timeout entry: has mtime (for cleanup) but no size → always retry
-                        self._cache.pop(key, None)
-                        self._stats.cache_invalidated += 1
-                        logger.debug(f"Cache invalidated (timeout entry, retry): {key}")
-                    else:
-                        # No file metadata - treat as hit
-                        self._stats.cache_hits += 1
-                        self._submitted.pop(key, None)
-                        cached_result = cache_entry.result
+            cached_result = self._get_valid_cached_result_unsafe(key, now)
 
             # Not in cache or invalidated - check in-flight or start compute
-            if cached_result is None:
+            if cached_result is _CACHE_MISS:
                 if key in self._in_flight:
                     # Already in-flight, we'll wait
                     future = self._in_flight[key].future
@@ -667,7 +688,7 @@ class RequestCoalescer:
                     is_compute_owner = True
 
         # Logging outside lock
-        if cached_result is not None:
+        if cached_result is not _CACHE_MISS:
             if self._is_cached_timeout(cached_result):
                 logger.info(f"Cache hit for {key} (timeout result)")
             else:

--- a/src/nvidia_resiliency_ext/attribution/coalescing/types.py
+++ b/src/nvidia_resiliency_ext/attribution/coalescing/types.py
@@ -102,6 +102,13 @@ class SubmittedResult(TypedDict):
     entries: List[SubmittedEntryInfo]
 
 
+class PeekResult(TypedDict):
+    """Non-blocking cache/coalescer status for a single key."""
+
+    status: str
+    result: Any
+
+
 @dataclass
 class CoalescerStats:
     """Statistics counters for :class:`~nvidia_resiliency_ext.attribution.coalescing.coalescer.RequestCoalescer`.

--- a/src/nvidia_resiliency_ext/attribution/controller.py
+++ b/src/nvidia_resiliency_ext/attribution/controller.py
@@ -331,9 +331,10 @@ class AttributionController:
         log_path: str,
         file: str | None = None,
         wl_restart: int | None = None,
+        wait: bool = True,
     ) -> LogAnalysisCycleResult | LogAnalysisSplitlogResult | LogAnalyzerError:
         """Analyze a log file and return the attribution result."""
-        return await self._analyzer.analyze(log_path, file=file, wl_restart=wl_restart)
+        return await self._analyzer.analyze(log_path, file=file, wl_restart=wl_restart, wait=wait)
 
     def read_file_preview(
         self, log_path: str, max_bytes: int = 4096

--- a/src/nvidia_resiliency_ext/attribution/orchestration/http_api.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/http_api.py
@@ -22,6 +22,7 @@ PARAM_ANALYSIS_INTENT = "analysis_intent"
 # GET /logs optional query parameters (splitlog mode)
 PARAM_FILE = "file"
 PARAM_WL_RESTART = "wl_restart"
+PARAM_WAIT = "wait"
 
 ACCEPT_JSON_HEADERS = {"accept": "application/json"}
 
@@ -49,6 +50,7 @@ def log_result_params(
     *,
     file: str | None = None,
     wl_restart: int | None = None,
+    wait: bool | None = None,
 ) -> dict[str, Any]:
     """Build query params for ``GET /logs``."""
     params: dict[str, Any] = {PARAM_LOG_PATH: log_path}
@@ -56,6 +58,8 @@ def log_result_params(
         params[PARAM_FILE] = file
     if wl_restart is not None:
         params[PARAM_WL_RESTART] = wl_restart
+    if wait is not None:
+        params[PARAM_WAIT] = wait
     return params
 
 
@@ -86,10 +90,11 @@ def get_log_response(
     *,
     file: str | None = None,
     wl_restart: int | None = None,
+    wait: bool | None = None,
 ) -> Any:
     """Fetch a log-analysis response from attrsvc with an existing HTTP client."""
     return client.get(
         ROUTE_LOGS,
-        params=log_result_params(log_path, file=file, wl_restart=wl_restart),
+        params=log_result_params(log_path, file=file, wl_restart=wl_restart, wait=wait),
         headers=ACCEPT_JSON_HEADERS,
     )

--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -40,6 +40,7 @@ class AttributionEndpoint:
     """Endpoint used by the in-launcher attribution client."""
 
     endpoint: str
+    decision_timeout: Optional[float]
 
 
 @dataclass(frozen=True)
@@ -54,7 +55,7 @@ class AttributionConfig:
     llm_base_url: Optional[str] = None
     llm_model: Optional[str] = None
     analysis_backend: Optional[str] = None
-    compute_timeout: Optional[float] = None
+    decision_timeout: Optional[float] = None
     log_level: Optional[str] = None
     export_url: Optional[str] = None
 
@@ -75,8 +76,14 @@ class AttributionConfig:
             raise ValueError("attribution endpoint requested while attribution service is disabled")
         assert self.endpoint is not None
         if self.is_managed:
-            return AttributionEndpoint(endpoint=_managed_attribution_client_endpoint())
-        return AttributionEndpoint(endpoint=self.endpoint)
+            return AttributionEndpoint(
+                endpoint=_managed_attribution_client_endpoint(),
+                decision_timeout=self.decision_timeout,
+            )
+        return AttributionEndpoint(
+            endpoint=self.endpoint,
+            decision_timeout=self.decision_timeout,
+        )
 
     @classmethod
     def from_args(
@@ -110,6 +117,8 @@ class AttributionConfig:
         if startup_timeout <= 0:
             raise ValueError("--ft-attribution-startup-timeout must be positive")
 
+        decision_timeout = _resolve_decision_timeout(args, ft_cfg)
+
         if endpoint is None:
             return cls(
                 endpoint=None,
@@ -120,7 +129,7 @@ class AttributionConfig:
                 llm_base_url=getattr(args, "ft_attribution_llm_base_url", None),
                 llm_model=getattr(args, "ft_attribution_llm_model", None),
                 analysis_backend=getattr(args, "ft_attribution_analysis_backend", None),
-                compute_timeout=getattr(args, "ft_attribution_compute_timeout", None),
+                decision_timeout=decision_timeout,
                 log_level=getattr(args, "ft_attribution_log_level", None),
                 export_url=None,
             )
@@ -149,7 +158,7 @@ class AttributionConfig:
             llm_base_url=getattr(args, "ft_attribution_llm_base_url", None),
             llm_model=getattr(args, "ft_attribution_llm_model", None),
             analysis_backend=getattr(args, "ft_attribution_analysis_backend", None),
-            compute_timeout=getattr(args, "ft_attribution_compute_timeout", None),
+            decision_timeout=decision_timeout,
             log_level=getattr(args, "ft_attribution_log_level", None),
             export_url=export_url,
         )
@@ -185,11 +194,16 @@ class AttributionManager:
 
         logger.info(
             "Starting managed attribution service on localhost:%s "
-            "(applog_dir=%s, log_file=%s, startup_timeout=%.1fs)",
+            "(applog_dir=%s, log_file=%s, startup_timeout=%.1fs, decision_timeout=%s)",
             DEFAULT_ATTRIBUTION_PORT,
             self.cfg.applog_dir,
             self.cfg.log_file,
             self.cfg.startup_timeout,
+            (
+                f"{self.cfg.decision_timeout:.1f}s"
+                if self.cfg.decision_timeout is not None
+                else "default"
+            ),
         )
 
         log_fd = open(self.cfg.log_file, "w")
@@ -280,7 +294,6 @@ class AttributionManager:
         _set_if_not_none(env, "NVRX_ATTRSVC_LLM_BASE_URL", self.cfg.llm_base_url)
         _set_if_not_none(env, "NVRX_ATTRSVC_LLM_MODEL", self.cfg.llm_model)
         _set_if_not_none(env, "NVRX_ATTRSVC_ANALYSIS_BACKEND", self.cfg.analysis_backend)
-        _set_if_not_none(env, "NVRX_ATTRSVC_COMPUTE_TIMEOUT", self.cfg.compute_timeout)
         _set_if_not_none(env, "NVRX_ATTRSVC_LOG_LEVEL", self.cfg.log_level)
         _set_if_not_none(env, _ATTRSVC_EXPORT_URL_ENV, self.cfg.export_url)
         return env
@@ -387,6 +400,18 @@ def _resolve_export_url(args: Any, ft_cfg: FaultToleranceConfig) -> Optional[str
     if not value:
         return None
     _validate_export_url(value)
+    return value
+
+
+def _resolve_decision_timeout(args: Any, ft_cfg: FaultToleranceConfig) -> Optional[float]:
+    value = getattr(args, "ft_attribution_decision_timeout", None)
+    if value is None:
+        value = getattr(ft_cfg, "attribution_decision_timeout", None)
+    if value is None:
+        return None
+    value = float(value)
+    if value <= 0:
+        raise ValueError("--ft-attribution-decision-timeout must be positive")
     return value
 
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Optional, Sequence
 from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
     DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT,
 )
+from nvidia_resiliency_ext.shared_utils.health_check import AttributionService
 
 
 def str_to_bool(value: Any) -> bool:
@@ -390,12 +391,16 @@ def _add_attribution_args(parser: argparse.ArgumentParser) -> None:
         help="Analysis backend for launcher-managed attribution service: mcp or lib.",
     )
     parser.add_argument(
-        "--ft-attribution-compute-timeout",
-        "--ft_attribution_compute_timeout",
+        "--ft-attribution-decision-timeout",
+        "--ft_attribution_decision_timeout",
         type=float,
         default=None,
-        dest="ft_attribution_compute_timeout",
-        help="Analysis compute timeout in seconds for launcher-managed attribution service.",
+        dest="ft_attribution_decision_timeout",
+        help=(
+            "Total launcher-side attribution decision budget in seconds, measured from "
+            "terminal analysis request to rendezvous result fetch. "
+            f"Default: {AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS}."
+        ),
     )
     parser.add_argument(
         "--ft-attribution-log-level",

--- a/src/nvidia_resiliency_ext/fault_tolerance/config.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/config.py
@@ -97,6 +97,8 @@ class FaultToleranceConfig:
       Default: 5. Can be overridden by workload (e.g., Megatron-LM via init_workload_monitoring).
     * Attribution service (optional, disabled unless `attribution_endpoint` is set):
       - `attribution_endpoint` [str] endpoint of the attribution service
+      - `attribution_decision_timeout` [float] launcher-side attribution decision
+        budget in seconds, measured from terminal analysis request to result fetch.
       - `attribution_export_url` [str] complete export posting URL for
         launcher-managed attribution service postprocessing.
 
@@ -148,6 +150,7 @@ class FaultToleranceConfig:
     )
     # Attribution service configuration (optional)
     attribution_endpoint: Optional[str] = None
+    attribution_decision_timeout: Optional[float] = None
     attribution_export_url: Optional[str] = None
 
     # NVRx cycle info: base directory for cycle_info JSON files

--- a/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
@@ -179,7 +179,8 @@ def _start_control_services(
             attribution_endpoint = services.attribution_manager.start_if_needed()
             if attribution_endpoint is not None:
                 services.attribution_service = AttributionService(
-                    endpoint=attribution_endpoint.endpoint
+                    endpoint=attribution_endpoint.endpoint,
+                    decision_timeout=getattr(attribution_endpoint, "decision_timeout", None),
                 )
 
         if args.ft_enable_log_server:
@@ -244,10 +245,11 @@ def _run_control_rendezvous_loop(
     )
     if services.cycle_info_reporter is not None:
         state._cycle_info_reporter = services.cycle_info_reporter
+    state._attribution_service = services.attribution_service
 
     while not stop_event.is_set():
         if services.attribution_service is not None:
-            services.attribution_service()
+            services.attribution_service.request_terminal_analysis()
         try:
             closed_round = state.close_current_round_as_host(
                 node,

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -630,6 +630,8 @@ class _RendezvousBarrierState:
         self.prefix = f"ft_rendezvous_barrier:{run_id}"
         # Permanent shutdown: once set, no further rendezvous rounds (graceful exit).
         self.shutdown_key = f"{self.prefix}:shutdown"
+        self._attribution_service: Optional[AttributionService] = None
+        self._attribution_settled_for_round: int = -1
         # Job-level unhealthy counter; persists across all rounds.
         self.unhealthy_count_key = f"{self.prefix}:unhealthy_count"
         # Latest closed round's active membership. This is host-local by design:
@@ -1250,7 +1252,7 @@ class _RendezvousBarrierState:
             node_desc: Node descriptor for logging
 
         Raises:
-            RendezvousClosedError: If rendezvous was permanently shut down
+            RendezvousClosedError: If rendezvous was permanently shut down.
             RendezvousTimeoutError: If rendezvous has timed out
         """
         # Check for permanent shutdown
@@ -1349,6 +1351,35 @@ class _RendezvousBarrierState:
             wait_count += 1
             time.sleep(1.0)  # Poll every 1 second
 
+    def _attribution_gate(self, node_desc: _NodeDesc) -> bool:
+        """Return whether attribution permits closing the current round.
+
+        Raises ``RendezvousGracefulExitError`` if attribution recommends stopping.
+        Returns ``False`` while attribution is still pending.
+        """
+        if self._attribution_service is None or self._round == 0:
+            return True
+
+        if self._attribution_settled_for_round == self._round:
+            return True
+
+        result = self._attribution_service.get_last_result(node_id=node_desc)
+
+        if result is None:
+            return False
+
+        if result is True:
+            msg = (
+                f"The node '{node_desc}' is closing rendezvous because attribution "
+                f"recommended stopping the job."
+            )
+            log.error(msg)
+            self.set_shutdown()
+            raise RendezvousGracefulExitError(msg)
+
+        self._attribution_settled_for_round = self._round
+        return True
+
     def _host_close_round(
         self,
         node_desc: _NodeDesc,
@@ -1406,6 +1437,10 @@ class _RendezvousBarrierState:
 
             # Only attempt snapshot + constraint check when enough nodes have joined.
             if current_joined < min_nodes:
+                time.sleep(0.1)
+                continue
+
+            if not self._attribution_gate(node_desc):
                 time.sleep(0.1)
                 continue
 
@@ -2085,6 +2120,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         link_state_path_template: Optional[str] = None,
         storage_healthcheck_paths: Optional[list] = None,
         attribution_endpoint: Optional[str] = None,
+        attribution_decision_timeout: Optional[float] = None,
         cycle_info_dir: Optional[str] = None,
         cycle_log_prefix: Optional[str] = None,
     ):
@@ -2121,6 +2157,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
                 List of storage paths to check for health.
             attribution_endpoint:
                 Endpoint of the attribution service.
+            attribution_decision_timeout:
+                Launcher-side attribution decision budget in seconds.
         """
         # We associate each handler instance with a unique node descriptor.
         node = cls._node_desc_generator.generate(local_addr)
@@ -2148,6 +2186,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             link_state_path_template=link_state_path_template,
             storage_healthcheck_paths=storage_healthcheck_paths,
             attribution_endpoint=attribution_endpoint,
+            attribution_decision_timeout=attribution_decision_timeout,
             cycle_info_dir=cycle_info_dir,
             cycle_log_prefix=cycle_log_prefix,
         )
@@ -2164,6 +2203,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         link_state_path_template: Optional[str] = None,
         storage_healthcheck_paths: Optional[list] = None,
         attribution_endpoint: Optional[str] = None,
+        attribution_decision_timeout: Optional[float] = None,
         cycle_info_dir: Optional[str] = None,
         cycle_log_prefix: Optional[str] = None,
     ) -> None:
@@ -2239,9 +2279,13 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
 
         # Attribution service client (optional, only on master node)
         if is_store_host and attribution_endpoint:
-            self._attribution_service = AttributionService(endpoint=attribution_endpoint)
+            self._attribution_service = AttributionService(
+                endpoint=attribution_endpoint,
+                decision_timeout=attribution_decision_timeout,
+            )
         else:
             self._attribution_service = None
+        self._barrier_state._attribution_service = self._attribution_service
 
     @property
     def _rendezvous_round(self) -> int:
@@ -2387,11 +2431,6 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
                 "Storage path health check",
                 f"Node {self._this_node} has invalid or unreadable paths.",
             )
-
-        # Perform optional log analysis (non-fatal)
-        # Note: _submit_log() was already called from launcher before workers started
-        if self._attribution_service is not None:
-            self._attribution_service()
 
         # Perform Node health check (external service if available)
         _nodehealth_checker = get_node_health_check()
@@ -2784,6 +2823,9 @@ def create_handler(
         storage_healthcheck_paths = params.config.get('storage_healthcheck_paths', None)
         link_state_path_template = params.config.get('link_state_path_template', None)
         attribution_endpoint = params.config.get('attribution_endpoint', None)
+        attribution_decision_timeout = params.config.get('attribution_decision_timeout', None)
+        if attribution_decision_timeout is not None:
+            attribution_decision_timeout = float(attribution_decision_timeout)
         cycle_info_dir = params.config.get('cycle_info_dir', None)
         cycle_log_prefix = params.config.get('cycle_log_prefix', None)
 
@@ -2804,6 +2846,7 @@ def create_handler(
             link_state_path_template=link_state_path_template,
             storage_healthcheck_paths=storage_healthcheck_paths,
             attribution_endpoint=attribution_endpoint,
+            attribution_decision_timeout=attribution_decision_timeout,
             cycle_info_dir=cycle_info_dir,
             cycle_log_prefix=cycle_log_prefix,
         )

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -475,7 +475,6 @@ class LocalElasticAgent(SimpleElasticAgent):
         """
         return self._rdzv_handler.round()
 
-
     def _current_cycle_info_path(self) -> Optional[str]:
         if not self._ft_cfg.cycle_info_dir:
             return None
@@ -536,7 +535,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         log_msg: str,
         open_rendezvous: bool = False,
     ) -> bool:
-        """Handle restart decision logic based on progress tracking and remaining restarts.
+        """Handle restart decision logic based on attribution, progress, and restart budget.
 
         Args:
             role: The role name for logging
@@ -548,6 +547,7 @@ class LocalElasticAgent(SimpleElasticAgent):
             True if restart was initiated (caller should continue monitoring loop)
             False if no restart (caller should stop workers and return failure)
         """
+        self._request_terminal_attribution()
         self._progress_tracker.analyze_previous_cycle()
         should_terminate_early = self._progress_tracker.should_terminate_early()
 
@@ -867,6 +867,15 @@ class LocalElasticAgent(SimpleElasticAgent):
         #       The 'name' field of the Event is NOT used in the TorchelasticStatusLogEntry.
         event = events.Event(name=name, source=events.EventSource.AGENT, metadata=metadata)
         events.record(event)
+
+    def _request_terminal_attribution(self) -> None:
+        """Ask attrsvc to start final analysis for the last submitted cycle log."""
+        if not self._is_store_host:
+            return
+        attribution_service = getattr(self._rdzv_handler, "_attribution_service", None)
+        if attribution_service is None:
+            return
+        attribution_service.request_terminal_analysis()
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.
@@ -2790,7 +2799,6 @@ def _validate_attribution_requires_per_cycle_applog(
             "Attribution service needs per-cycle application logs as analysis input."
         )
 
-
 def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -> Tuple[LaunchConfig, Union[Callable, str], List[str]]:
     # If ``args`` not passed, defaults to ``sys.argv[:1]``
     _validate_args(args)
@@ -2871,6 +2879,7 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
     # Pass enable_nic_healthcheck and link_state_path_template from fault tolerance config to rendezvous config
     rdzv_configs['enable_nic_healthcheck'] = fault_tol_cfg.enable_nic_healthcheck
     rdzv_configs['link_state_path_template'] = fault_tol_cfg.link_state_path_template
+
     # Pass distributed storage health check configuration
     cli_dist_storage = getattr(args, 'ft_enable_dist_storage_healthcheck', None)
     if cli_dist_storage is not None:
@@ -2972,6 +2981,11 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
         attribution_endpoint = attribution_manager.start_if_needed()
         if attribution_endpoint is not None:
             rdzv_configs['attribution_endpoint'] = attribution_endpoint.endpoint
+            decision_timeout = getattr(attribution_endpoint, "decision_timeout", None)
+            if decision_timeout is not None:
+                rdzv_configs['attribution_decision_timeout'] = str(
+                    decision_timeout
+                )
 
         if getattr(args, 'ft_enable_log_server', False):
             assert log_funnel_ports is not None

--- a/src/nvidia_resiliency_ext/services/attrsvc/app.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/app.py
@@ -330,6 +330,12 @@ def create_app(cfg: Settings) -> FastAPI:
             ge=0,
             description="Workload restart index within file (0-indexed). See spec Section 17.",
         ),
+        wait: bool = Query(
+            default=True,
+            description=(
+                "Wait for analysis completion. Set false to only probe cached/in-flight state."
+            ),
+        ),
     ) -> LogAnalysisCycleResult | LogAnalysisSplitlogResult:
         """
         Analyze a log file and return attribution results.
@@ -347,7 +353,7 @@ def create_app(cfg: Settings) -> FastAPI:
         See spec Section 10 and 17 for GET flow details.
         """
         adapter: AttributionHttpAdapter = request.app.state.attribution
-        result = await adapter.analyze_log(log_path, file, wl_restart)
+        result = await adapter.analyze_log(log_path, file, wl_restart, wait=wait)
         if isinstance(result, LogAnalyzerError):
             _raise_error(result)
         return result

--- a/src/nvidia_resiliency_ext/services/attrsvc/routes.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/routes.py
@@ -9,6 +9,7 @@ from nvidia_resiliency_ext.attribution.orchestration.http_api import (
     PARAM_JOB_ID,
     PARAM_LOG_PATH,
     PARAM_USER,
+    PARAM_WAIT,
     PARAM_WL_RESTART,
     ROUTE_LOGS,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "PARAM_JOB_ID",
     "PARAM_LOG_PATH",
     "PARAM_USER",
+    "PARAM_WAIT",
     "PARAM_WL_RESTART",
     "ROUTE_LOGS",
 ]

--- a/src/nvidia_resiliency_ext/services/attrsvc/service.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/service.py
@@ -160,12 +160,14 @@ class AttributionHttpAdapter:
         log_path: str,
         file: str | None = None,
         wl_restart: int | None = None,
+        wait: bool = True,
     ) -> LogAnalysisCycleResult | LogAnalysisSplitlogResult | LogAnalyzerError:
         """Analyze a log file using the configured attribution backend."""
         return await self._controller.analyze_log(
             log_path,
             file=file,
             wl_restart=wl_restart,
+            wait=wait,
         )
 
     def read_file_preview(

--- a/src/nvidia_resiliency_ext/services/smonsvc/job_handlers.py
+++ b/src/nvidia_resiliency_ext/services/smonsvc/job_handlers.py
@@ -125,10 +125,10 @@ def fetch_results(
         job.terminal_signaled = True
 
         def on_terminal_success(_response):
-            logger.info(f"[{job.job_id}] Terminal analysis signaled: {log_path}")
+            logger.info(f"[{job.job_id}] Terminal analysis requested: {log_path}")
 
         def on_terminal_client_error(error_msg: str):
-            logger.debug(f"[{job.job_id}] Terminal signal POST failed: {error_msg}")
+            logger.debug(f"[{job.job_id}] Terminal analysis request POST failed: {error_msg}")
 
         attrsvc_client.request_with_retry(
             method="POST",

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -23,10 +23,11 @@ import os
 import subprocess  # nosec B404
 import sys
 import threading
+import time
 import traceback
 from collections import defaultdict, deque
 from functools import wraps
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import defusedxml.ElementTree as ET
 import httpx
@@ -37,11 +38,18 @@ from nvidia_resiliency_ext.attribution.orchestration.http_api import (
     get_log_response,
     post_log,
 )
+from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+    ANALYSIS_INTENT_PROGRESSIVE,
+    ANALYSIS_INTENT_TERMINAL,
+)
 from nvidia_resiliency_ext.shared_utils.job_metadata import job_id_from_env, job_user_from_env
 from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
+from nvidia_resiliency_ext.shared_utils.profiling import ProfilingEvent, record_profiling_event
 
 # Get the nvrx logger
 logger = logging.getLogger(LogConfig.name)
+
+_ATTRIBUTION_REQUEST_TIMEOUT_SECONDS = 2.0
 
 
 # -----------------------------
@@ -1781,87 +1789,184 @@ class AttributionService:
       - GETs results by the last submitted log_path
     """
 
+    DEFAULT_DECISION_TIMEOUT_SECONDS = 60.0
+
     def __init__(
         self,
         endpoint: str,
+        decision_timeout: Optional[float] = None,
     ):
         self.endpoint = endpoint.rstrip("/")
+        if decision_timeout is None:
+            decision_timeout = self.DEFAULT_DECISION_TIMEOUT_SECONDS
+        self.decision_timeout = float(decision_timeout)
+        if self.decision_timeout <= 0:
+            raise ValueError("attribution decision timeout must be positive")
         self._unsupported_transport_warned = False
         # Track the most recent log_path we submitted
         self._last_submitted: Optional[str] = None
+        self._terminal_deadline: Optional[float] = None
+        self._get_started_recorded = False
 
     def __call__(self) -> None:
         """
-        Fire-and-forget entrypoint. GET results for the previously submitted log.
-        Runs in a background daemon thread.
+        Request terminal analysis for the previously submitted log.
 
         Note: _submit_log() should be called first (from launcher) to set _last_submitted.
         """
-        log_path = self._last_submitted
-        if log_path:
-            threading.Thread(
-                target=self._get_results,
-                args=(log_path,),
-                daemon=True,
-            ).start()
+        self.request_terminal_analysis()
 
-    def get_last_result(self) -> Optional[bool]:
-        """Synchronously fetch whether attribution recommends stopping the last log."""
+    def get_last_result(
+        self,
+        node_id: Optional[Any] = None,
+    ) -> Optional[bool]:
+        """Briefly join terminal analysis and fetch whether attribution recommends stopping.
+
+        Returns:
+          - True when attribution recommends stopping the job.
+          - False when attribution recommends continuing, or when the launcher-side
+            decision budget expires and restart should fail open.
+          - None when attribution is still pending within the decision budget.
+        """
         log_path = self._last_submitted
         if not log_path:
             logger.debug("AttributionService GET skipped: no submitted log path")
+            return False
+
+        self._start_get_profiling(node_id)
+        decision_remaining = self._remaining_decision_timeout()
+        if decision_remaining <= 0:
+            logger.warning(
+                "AttributionService decision budget exhausted for %s; attempting final "
+                "bounded GET",
+                log_path,
+            )
+            result = self._get_results(log_path, timeout=_ATTRIBUTION_REQUEST_TIMEOUT_SECONDS)
+            record_profiling_event(
+                ProfilingEvent.ATTRIBUTION_GET_COMPLETED,
+                node_id=node_id,
+            )
+            if result is None:
+                return False
+            return result
+
+        result = self._get_results(log_path, timeout=_ATTRIBUTION_REQUEST_TIMEOUT_SECONDS)
+
+        if result is None:
             return None
-        return self._get_results(log_path)
+
+        record_profiling_event(
+            ProfilingEvent.ATTRIBUTION_GET_COMPLETED,
+            node_id=node_id,
+        )
+        return result
+
+    def _start_get_profiling(self, node_id: Optional[Any]) -> None:
+        if self._get_started_recorded:
+            return
+        self._get_started_recorded = True
+        record_profiling_event(
+            ProfilingEvent.ATTRIBUTION_GET_STARTED,
+            node_id=node_id,
+        )
+
+    def _ensure_decision_deadline(self) -> float:
+        if self._terminal_deadline is None:
+            self._terminal_deadline = time.monotonic() + self.decision_timeout
+        return self._terminal_deadline
+
+    def _remaining_decision_timeout(self) -> float:
+        """Return the remaining launcher-side budget for the current attribution decision."""
+        return self._ensure_decision_deadline() - time.monotonic()
 
     def _submit_log(self, log_path: str) -> None:
         """
         Submit a log file for progressive analysis via POST.
-        Runs in a background daemon thread (fire-and-forget).
+        The POST is synchronous but bounded to avoid delaying launcher progress.
         """
         self._last_submitted = log_path
-        threading.Thread(
-            target=self._do_submit_log,
-            args=(log_path,),
-            daemon=True,
-        ).start()
+        self._terminal_deadline = None
+        self._get_started_recorded = False
+        self._do_submit_log(log_path, analysis_intent=ANALYSIS_INTENT_PROGRESSIVE)
 
-    def _do_submit_log(self, log_path: str) -> None:
-        """Perform the actual POST request (runs in background thread)."""
+    def request_terminal_analysis(self) -> None:
+        """
+        Request terminal analysis for the last submitted workload log.
+
+        The POST returns after attrsvc accepts the request and schedules final analysis.
+        Later GETs use non-blocking probes until a verdict is cached.
+        """
+        log_path = self._last_submitted
+        if not log_path:
+            logger.debug("AttributionService terminal POST skipped: no submitted log path")
+            return
+        self._ensure_decision_deadline()
+        self._do_submit_log(
+            log_path,
+            analysis_intent=ANALYSIS_INTENT_TERMINAL,
+        )
+
+    def _do_submit_log(
+        self,
+        log_path: str,
+        analysis_intent: str = ANALYSIS_INTENT_PROGRESSIVE,
+        timeout: float = _ATTRIBUTION_REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        """Perform the actual POST request."""
         base_url = self._http_base_url()
         if base_url is None:
             return
         try:
-            with httpx.Client(base_url=base_url, timeout=10.0) as client:
+            with httpx.Client(base_url=base_url, timeout=timeout) as client:
                 url = f"{base_url}{ROUTE_LOGS}"
-                logger.debug("AttributionService POST: %s (log_path=%s)", url, log_path)
+                logger.debug(
+                    "AttributionService POST: %s (log_path=%s, analysis_intent=%s)",
+                    url,
+                    log_path,
+                    analysis_intent,
+                )
                 post_log(
                     client,
                     log_path,
                     user=job_user_from_env(),
                     job_id=job_id_from_env(),
-                    analysis_intent="progressive",
+                    analysis_intent=analysis_intent,
                 )
         except Exception as e:
             logger.warning(
                 "AttributionService POST %s failed: %s: %s", log_path, type(e).__name__, e
             )
 
-    def _get_results(self, log_path: str) -> Optional[bool]:
+    def _get_results(
+        self,
+        log_path: str,
+        timeout: float = _ATTRIBUTION_REQUEST_TIMEOUT_SECONDS,
+    ) -> Optional[bool]:
         """
         Get the stop decision for a previously submitted log file via GET.
+
+        Terminal analysis is triggered earlier via POST, so launcher uses a
+        non-blocking probe before rendezvous closes the next round.
         """
         base_url = self._http_base_url()
         if base_url is None:
             return None
         try:
-            with httpx.Client(base_url=base_url, timeout=60.0) as client:
+            with httpx.Client(base_url=base_url, timeout=timeout) as client:
                 url = f"{base_url}{ROUTE_LOGS}"
                 logger.debug("AttributionService GET: %s (log_path=%s)", url, log_path)
-                resp = get_log_response(client, log_path)
+                resp = get_log_response(client, log_path, wait=False)
                 if resp.status_code == 200:
                     payload = resp.json() if resp.text else {}
                     attrsvc_result = parse_attrsvc_response(payload, log_path=log_path)
                     logger.info(attrsvc_result.format_log_message())
+                    if attrsvc_result.status.lower() != "completed":
+                        logger.debug(
+                            "AttributionService GET for %s returned status=%s; polling again",
+                            log_path,
+                            attrsvc_result.status,
+                        )
+                        return None
                     return attrsvc_result.should_stop
                 else:
                     logger.warning(

--- a/src/nvidia_resiliency_ext/shared_utils/profiling.py
+++ b/src/nvidia_resiliency_ext/shared_utils/profiling.py
@@ -35,6 +35,8 @@ class ProfilingEvent(Enum):
     RENDEZVOUS_COMPLETED = "rendezvous_completed"
     WORKER_START_STARTED = "worker_start_started"
     WORKER_START_COMPLETED = "worker_start_completed"
+    ATTRIBUTION_GET_STARTED = "attribution_get_started"
+    ATTRIBUTION_GET_COMPLETED = "attribution_get_completed"
 
 
 class FaultToleranceProfiler:

--- a/tests/attribution/unit/test_coalescer_peek.py
+++ b/tests/attribution/unit/test_coalescer_peek.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import time
+
+from nvidia_resiliency_ext.attribution.coalescing.coalescer import RequestCoalescer
+from nvidia_resiliency_ext.attribution.coalescing.types import CacheEntry, InFlightEntry
+
+
+def test_peek_returns_cached_result_without_compute():
+    async def run():
+        coalescer = RequestCoalescer()
+        coalescer._cache["/tmp/job.log"] = CacheEntry(
+            result={"result": []},
+            cached_at=time.monotonic(),
+            file_mtime=None,
+            file_size=None,
+        )
+
+        result = await coalescer.peek("/tmp/job.log")
+
+        assert result == {"status": "completed", "result": {"result": []}}
+        stats = await coalescer.get_stats()
+        assert stats["cache"]["hits"] == 1
+        assert stats["compute"]["total"] == 0
+
+    asyncio.run(run())
+
+
+def test_peek_returns_in_flight_without_awaiting_future():
+    async def run():
+        coalescer = RequestCoalescer()
+        future = asyncio.get_running_loop().create_future()
+        coalescer._in_flight["/tmp/job.log"] = InFlightEntry(
+            future=future,
+            started_at=time.monotonic(),
+        )
+
+        result = await coalescer.peek("/tmp/job.log")
+
+        assert result == {"status": "in_flight", "result": None}
+        assert not future.done()
+        stats = await coalescer.get_stats()
+        assert stats["compute"]["total"] == 0
+
+    asyncio.run(run())
+
+
+def test_peek_returns_pending_without_starting_compute():
+    async def run():
+        coalescer = RequestCoalescer()
+        await coalescer.track_submission("/tmp/job.log")
+
+        result = await coalescer.peek("/tmp/job.log")
+
+        assert result == {"status": "pending", "result": None}
+        stats = await coalescer.get_stats()
+        assert stats["cache"]["misses"] == 0
+        assert stats["compute"]["total"] == 0
+
+    asyncio.run(run())

--- a/tests/attribution/unit/test_http_api.py
+++ b/tests/attribution/unit/test_http_api.py
@@ -42,6 +42,13 @@ def test_log_result_params_includes_splitlog_fields():
     }
 
 
+def test_log_result_params_includes_wait_when_requested():
+    assert log_result_params("/tmp/train.log", wait=False) == {
+        "log_path": "/tmp/train.log",
+        "wait": False,
+    }
+
+
 def test_post_log_uses_shared_logs_route():
     client = MagicMock()
 
@@ -81,10 +88,10 @@ def test_post_log_uses_shared_logs_route_with_terminal_intent():
 def test_get_log_response_uses_shared_logs_route():
     client = MagicMock()
 
-    get_log_response(client, "/tmp/train.log", wl_restart=2)
+    get_log_response(client, "/tmp/train.log", wl_restart=2, wait=False)
 
     client.get.assert_called_once_with(
         "/logs",
-        params={"log_path": "/tmp/train.log", "wl_restart": 2},
+        params={"log_path": "/tmp/train.log", "wl_restart": 2, "wait": False},
         headers={"accept": "application/json"},
     )

--- a/tests/attribution/unit/test_progressive_plumbing.py
+++ b/tests/attribution/unit/test_progressive_plumbing.py
@@ -266,6 +266,61 @@ def test_terminal_submit_starts_final_analysis_that_get_can_join(monkeypatch, tm
     assert log_analyzer.terminal_runs == [(log_path, "alice", "123")]
 
 
+def test_terminal_get_nonblocking_reports_in_flight_without_joining(monkeypatch, tmp_path):
+    Analyzer = _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    log_analyzer = FakeLogAnalyzer()
+    analyzer = Analyzer(
+        allowed_root=str(tmp_path),
+        log_analyzer=log_analyzer,
+        progressive_analysis_enabled=False,
+    )
+    log_path = str(tmp_path / "train_cycle0.log")
+
+    async def run() -> None:
+        log_analyzer.terminal_started = asyncio.Event()
+        log_analyzer.terminal_release = asyncio.Event()
+
+        result = await analyzer.submit(
+            log_path,
+            user="alice",
+            job_id="123",
+            analysis_intent=ANALYSIS_INTENT_TERMINAL,
+        )
+        assert result.submitted is True
+
+        await asyncio.wait_for(log_analyzer.terminal_started.wait(), timeout=0.5)
+        probe = await asyncio.wait_for(analyzer.analyze(log_path, wait=False), timeout=0.5)
+
+        assert probe.status == "in_flight"
+        assert log_analyzer.terminal_runs == [(log_path, "alice", "123")]
+
+        log_analyzer.terminal_release.set()
+        completed = await asyncio.wait_for(analyzer.analyze(log_path), timeout=0.5)
+        assert completed.status == "completed"
+
+    asyncio.run(run())
+
+
+def test_nonblocking_get_does_not_start_analysis_on_pending_result(monkeypatch, tmp_path):
+    Analyzer = _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    log_analyzer = FakeLogAnalyzer()
+    analyzer = Analyzer(
+        allowed_root=str(tmp_path),
+        log_analyzer=log_analyzer,
+        progressive_analysis_enabled=False,
+    )
+    log_path = str(tmp_path / "train_cycle0.log")
+
+    async def run() -> None:
+        result = await analyzer.analyze(log_path, wait=False)
+
+        assert result.status == "pending"
+
+    asyncio.run(run())
+
+    assert log_analyzer.terminal_runs == []
+
+
 def test_terminal_analysis_threadsafe_cancellation_logs_debug(monkeypatch, caplog):
     Analyzer = _import_analyzer_with_optional_dependency_stubs(monkeypatch)
     future = concurrent.futures.Future()

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -13,6 +13,7 @@ from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
     _attribution_command,
 )
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
+from nvidia_resiliency_ext.shared_utils.health_check import AttributionService
 
 
 def _args(**overrides):
@@ -23,7 +24,7 @@ def _args(**overrides):
         "ft_attribution_llm_base_url": None,
         "ft_attribution_llm_model": None,
         "ft_attribution_analysis_backend": None,
-        "ft_attribution_compute_timeout": None,
+        "ft_attribution_decision_timeout": None,
         "ft_attribution_log_level": None,
         "ft_attribution_export_url": None,
     }
@@ -95,6 +96,8 @@ def test_managed_attribution_config_derives_applog_dir_and_log_file(tmp_path):
     assert cfg.client_endpoint.endpoint == f"http://localhost:{DEFAULT_ATTRIBUTION_PORT}"
     assert cfg.applog_dir == str(tmp_path / "logs")
     assert cfg.log_file == str(tmp_path / "logs" / "train_attribution.log")
+    assert cfg.client_endpoint.decision_timeout is None
+    assert AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS == 60.0
     assert cfg.is_enabled
     assert cfg.is_managed
 
@@ -179,7 +182,7 @@ def test_attribution_config_maps_launcher_args(tmp_path):
             ft_attribution_llm_base_url="https://llm.example/v1",
             ft_attribution_llm_model="model-a",
             ft_attribution_analysis_backend="lib",
-            ft_attribution_compute_timeout=12.5,
+            ft_attribution_decision_timeout=12.5,
             ft_attribution_log_level="DEBUG",
             ft_attribution_export_url=(
                 "https://dataflow.example.test/dataflow2/example-index/posting"
@@ -196,12 +199,33 @@ def test_attribution_config_maps_launcher_args(tmp_path):
     assert env["NVRX_ATTRSVC_LLM_BASE_URL"] == "https://llm.example/v1"
     assert env["NVRX_ATTRSVC_LLM_MODEL"] == "model-a"
     assert env["NVRX_ATTRSVC_ANALYSIS_BACKEND"] == "lib"
-    assert env["NVRX_ATTRSVC_COMPUTE_TIMEOUT"] == "12.5"
+    assert cfg.client_endpoint.decision_timeout == 12.5
     assert env["NVRX_ATTRSVC_LOG_LEVEL"] == "DEBUG"
     assert (
         env["NVRX_ATTRSVC_EXPORT_URL"]
         == "https://dataflow.example.test/dataflow2/example-index/posting"
     )
+
+
+def test_yaml_attribution_decision_timeout_is_used(tmp_path):
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(attribution_decision_timeout=9.0),
+    )
+
+    assert cfg.decision_timeout == 9.0
+    assert cfg.client_endpoint.decision_timeout == 9.0
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_attribution_decision_timeout_must_be_positive(tmp_path, value):
+    with pytest.raises(ValueError, match="--ft-attribution-decision-timeout"):
+        AttributionConfig.from_args(
+            _args(ft_attribution_endpoint="localhost", ft_attribution_decision_timeout=value),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(),
+        )
 
 
 def test_attribution_child_env_does_not_inherit_export_url_from_launcher_env(tmp_path, monkeypatch):

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -695,6 +695,42 @@ class Step2CompletionTest(BaseRendezvousTest):
         ]
         self.assertEqual(ranks, [0, 1])
 
+    def test_step2_rechecks_close_state_after_attribution_resolves(self):
+        """Restart attribution resolution forces one fresh close-loop pass."""
+        min_nodes = 2
+        max_nodes = 2
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+        )
+        state._round = 1
+        state._compute_step2_poll_interval = lambda min_nodes, segment_check_interval: 0.0
+        state._get_unhealthy_count = MagicMock(return_value=0)
+        state._attribution_service = MagicMock()
+        state._attribution_service.get_last_result.side_effect = [None, False]
+        state.get_all_participants = MagicMock(wraps=state.get_all_participants)
+
+        participants = [
+            (_NodeDesc("node0", 100, 0), 0, "none", None),
+            (_NodeDesc("node1", 101, 0), 1, "none", None),
+        ]
+        _seed_joined_participants(self.store, state, participants, round_id=1)
+
+        state._rendezvous_start_time = time.monotonic()
+        state._host_close_round(
+            _NodeDesc("control", 10, 0),
+            min_nodes=min_nodes,
+            max_nodes=max_nodes,
+            segment_check_interval=0.0,
+        )
+
+        self.assertEqual(state._attribution_service.get_last_result.call_count, 2)
+        self.assertEqual(state._get_unhealthy_count.call_count, 2)
+        state.get_all_participants.assert_called_once()
+        self.assertEqual(self.store.get(state.round_done_key).decode("utf-8"), "1")
+
     def test_step2_waits_for_complete_replacement_group_before_segment_check(self):
         """Raw participants may satisfy segment while complete replacement groups do not."""
         min_nodes = 2

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -359,6 +359,7 @@ def _make_agent_spec(rdzv_round=1):
     spec.rdzv_handler.get_active_node_addrs.return_value = ["node001", "node002"]
     spec.rdzv_handler.get_standby_node_addrs.return_value = ["node003"]
     spec.rdzv_handler.get_active_ranks.return_value = [0, 1]
+    spec.rdzv_handler._attribution_service = None
     spec.max_restarts = 3
     return spec
 
@@ -508,9 +509,11 @@ class TestHandleRestartDecision(unittest.TestCase):
     def test_handle_restart_decision_progress_terminate(self):
         """Returns False without restarting when progress tracker says terminate early."""
         agent = self._make_agent()
+        agent._is_store_host = True
         agent._progress_tracker = MagicMock()
         agent._progress_tracker.should_terminate_early.return_value = True
         agent._remaining_restarts = 2
+        agent._rdzv_handler._attribution_service = MagicMock()
 
         with (
             patch.object(agent, '_restart_workers') as mock_restart,
@@ -521,6 +524,7 @@ class TestHandleRestartDecision(unittest.TestCase):
             )
 
         self.assertFalse(result)
+        agent._rdzv_handler._attribution_service.request_terminal_analysis.assert_called_once_with()
         mock_restart.assert_not_called()
         mock_open.assert_not_called()
 
@@ -544,12 +548,41 @@ class TestHandleRestartDecision(unittest.TestCase):
         mock_restart.assert_called_once()
         mock_open.assert_not_called()
 
-    def test_handle_restart_decision_no_restarts_left(self):
-        """Returns False when _remaining_restarts is 0."""
+    def test_handle_restart_decision_requests_terminal_attribution_before_restart(self):
+        """Starts terminal attribution before local restart decisions and keeps moving."""
         agent = self._make_agent()
+        agent._is_store_host = True
+        agent._progress_tracker = MagicMock()
+        agent._remaining_restarts = 2
+        agent._rdzv_handler._attribution_service = MagicMock()
+        calls = []
+        agent._rdzv_handler._attribution_service.request_terminal_analysis.side_effect = (
+            lambda: calls.append("terminal")
+        )
+        agent._progress_tracker.analyze_previous_cycle.side_effect = lambda: calls.append("analyze")
+        agent._progress_tracker.should_terminate_early.side_effect = (
+            lambda: calls.append("progress-check") or False
+        )
+
+        with patch.object(
+            agent, '_restart_workers', side_effect=lambda _wg: calls.append("restart")
+        ):
+            result = agent._handle_restart_decision(
+                role="test", spec=self.spec, log_msg="[%s] restarting"
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(calls, ["terminal", "analyze", "progress-check", "restart"])
+        agent._rdzv_handler._attribution_service.get_last_result.assert_not_called()
+
+    def test_handle_restart_decision_no_restarts_left(self):
+        """Returns False when _remaining_restarts is 0 after requesting terminal attribution."""
+        agent = self._make_agent()
+        agent._is_store_host = True
         agent._progress_tracker = MagicMock()
         agent._progress_tracker.should_terminate_early.return_value = False
         agent._remaining_restarts = 0
+        agent._rdzv_handler._attribution_service = MagicMock()
 
         with patch.object(agent, '_restart_workers') as mock_restart:
             result = agent._handle_restart_decision(
@@ -557,6 +590,7 @@ class TestHandleRestartDecision(unittest.TestCase):
             )
 
         self.assertFalse(result)
+        agent._rdzv_handler._attribution_service.request_terminal_analysis.assert_called_once_with()
         mock_restart.assert_not_called()
 
     def test_handle_restart_decision_open_rendezvous_called_when_requested(self):
@@ -617,6 +651,69 @@ class TestHandleRestartDecision(unittest.TestCase):
         agent._open_rendezvous_for_restart()
         # No open_rendezvous() on the legacy handler
         self.assertFalse(hasattr(legacy_rdzv, '_barrier_state'))
+
+
+def test_rendezvous_host_sets_graceful_shutdown_when_attribution_says_stop():
+    from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
+
+    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import _RendezvousBarrierState
+
+    state = object.__new__(_RendezvousBarrierState)
+    state._round = 1
+    state._attribution_service = MagicMock()
+    state._attribution_service.get_last_result.return_value = True
+    state._attribution_settled_for_round = -1
+    state.set_shutdown = MagicMock()
+
+    with pytest.raises(RendezvousGracefulExitError):
+        state._attribution_gate("node-a")
+
+    state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
+    state.set_shutdown.assert_called_once()
+
+
+def test_rendezvous_host_retries_close_round_when_attribution_pending():
+    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import _RendezvousBarrierState
+
+    state = object.__new__(_RendezvousBarrierState)
+    state._round = 1
+    state._attribution_service = MagicMock()
+    state._attribution_service.get_last_result.return_value = None
+    state._attribution_settled_for_round = -1
+
+    should_close = state._attribution_gate("node-a")
+
+    assert should_close is False
+    state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
+    assert state._attribution_settled_for_round == -1
+
+
+def test_rendezvous_host_skips_attribution_gate_for_initial_round():
+    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import _RendezvousBarrierState
+
+    state = object.__new__(_RendezvousBarrierState)
+    state._round = 0
+    state._attribution_service = MagicMock()
+    state._attribution_settled_for_round = -1
+
+    assert state._attribution_gate("node-a") is True
+    state._attribution_service.get_last_result.assert_not_called()
+
+
+def test_rendezvous_host_closes_round_when_attribution_allows_restart():
+    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import _RendezvousBarrierState
+
+    state = object.__new__(_RendezvousBarrierState)
+    state._round = 1
+    state._attribution_service = MagicMock()
+    state._attribution_service.get_last_result.return_value = False
+    state._attribution_settled_for_round = -1
+
+    should_close = state._attribution_gate("node-a")
+
+    assert should_close is True
+    assert state._attribution_settled_for_round == 1
+    state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
 
 
 def test_ft_log_aggregator_count_rejects_negative():

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -564,6 +564,21 @@ class TestNVLHealthCheck(unittest.TestCase):
 
 class TestAttributionService(unittest.TestCase):
 
+    def test_default_decision_timeout_is_owned_by_service(self):
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        none_service = AttributionService(
+            endpoint="http://attr.example:8000/",
+            decision_timeout=None,
+        )
+
+        self.assertEqual(
+            service.decision_timeout, AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS
+        )
+        self.assertEqual(
+            none_service.decision_timeout, AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS
+        )
+        self.assertEqual(AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS, 60.0)
+
     @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
     def test_http_endpoint_posts_progressive_intent_to_logs_route(self, mock_client):
         client = mock_client.return_value.__enter__.return_value
@@ -580,7 +595,7 @@ class TestAttributionService(unittest.TestCase):
         ):
             service._do_submit_log("/tmp/train.log")
 
-        mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=10.0)
+        mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=2.0)
         client.post.assert_called_once_with(
             "/logs",
             json={
@@ -590,6 +605,202 @@ class TestAttributionService(unittest.TestCase):
                 "analysis_intent": "progressive",
             },
             headers={"accept": "application/json"},
+        )
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_http_endpoint_posts_terminal_intent_to_logs_route(self, mock_client):
+        client = mock_client.return_value.__enter__.return_value
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        with patch.dict(
+            os.environ,
+            {
+                "SLURM_JOB_USER": "alice",
+                "SLURM_ARRAY_JOB_ID": "12345",
+            },
+        ):
+            service._do_submit_log("/tmp/train.log", analysis_intent="terminal")
+
+        mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=2.0)
+        client.post.assert_called_once_with(
+            "/logs",
+            json={
+                "log_path": "/tmp/train.log",
+                "user": "alice",
+                "job_id": "12345",
+                "analysis_intent": "terminal",
+            },
+            headers={"accept": "application/json"},
+        )
+
+    def test_submit_log_posts_progressive_work_synchronously(self):
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        with patch.object(service, "_do_submit_log") as mock_submit:
+            service._submit_log("/tmp/train.log")
+
+        self.assertEqual(service._last_submitted, "/tmp/train.log")
+        mock_submit.assert_called_once_with(
+            "/tmp/train.log",
+            analysis_intent="progressive",
+        )
+
+    def test_request_terminal_analysis_posts_terminal_work_synchronously(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
+        service._last_submitted = "/tmp/train.log"
+
+        with (
+            patch.object(service, "_do_submit_log") as mock_submit,
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
+                return_value=10.0,
+            ),
+        ):
+            service.request_terminal_analysis()
+
+        mock_submit.assert_called_once_with(
+            "/tmp/train.log",
+            analysis_intent="terminal",
+        )
+        self.assertEqual(service._terminal_deadline, 17.0)
+
+    def test_request_terminal_analysis_skips_without_submitted_log(self):
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        with patch.object(service, "_do_submit_log") as mock_submit:
+            service.request_terminal_analysis()
+
+        mock_submit.assert_not_called()
+
+    def test_get_last_result_allows_close_without_submitted_log(self):
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        should_stop = service.get_last_result()
+
+        self.assertFalse(should_stop)
+
+    def test_get_last_result_uses_remaining_decision_budget(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
+        service._last_submitted = "/tmp/train.log"
+        service._terminal_deadline = 20.0
+
+        with (
+            patch.object(service, "_get_results", return_value=False) as mock_get,
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
+                return_value=16.5,
+            ),
+        ):
+            should_stop = service.get_last_result()
+
+        self.assertFalse(should_stop)
+        mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
+
+    def test_terminal_analysis_does_not_extend_existing_decision_budget(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
+        service._last_submitted = "/tmp/train.log"
+        service._terminal_deadline = 20.0
+
+        with (
+            patch.object(service, "_do_submit_log") as mock_submit,
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
+                return_value=19.0,
+            ),
+        ):
+            service.request_terminal_analysis()
+
+        self.assertEqual(service._terminal_deadline, 20.0)
+        mock_submit.assert_called_once_with(
+            "/tmp/train.log",
+            analysis_intent="terminal",
+        )
+
+    def test_get_last_result_uses_final_get_after_decision_budget_expires(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
+        service._last_submitted = "/tmp/train.log"
+        service._terminal_deadline = 20.0
+
+        with (
+            patch.object(service, "_get_results", return_value=True) as mock_get,
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
+                return_value=21.0,
+            ),
+        ):
+            should_stop = service.get_last_result()
+
+        self.assertTrue(should_stop)
+        mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
+
+    def test_get_last_result_uses_default_get_timeout_with_remaining_budget(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
+        service._last_submitted = "/tmp/train.log"
+        service._terminal_deadline = 20.0
+
+        with (
+            patch.object(service, "_get_results", return_value=None) as mock_get,
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
+                return_value=19.8,
+            ),
+        ):
+            should_stop = service.get_last_result()
+
+        self.assertIsNone(should_stop)
+        mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
+
+    def test_get_last_result_profiles_wait_until_decision(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
+        service._last_submitted = "/tmp/train.log"
+        service._terminal_deadline = 20.0
+
+        with (
+            patch.object(service, "_get_results", side_effect=[None, True]),
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
+                return_value=10.0,
+            ),
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.record_profiling_event"
+            ) as record_event,
+        ):
+            self.assertIsNone(service.get_last_result(node_id="node-a"))
+            self.assertTrue(service.get_last_result(node_id="node-a"))
+
+        self.assertEqual(record_event.call_args_list[0].args[0].value, "attribution_get_started")
+        self.assertEqual(record_event.call_args_list[0].kwargs, {"node_id": "node-a"})
+        self.assertEqual(record_event.call_args_list[1].args[0].value, "attribution_get_completed")
+        self.assertEqual(
+            record_event.call_args_list[1].kwargs,
+            {"node_id": "node-a"},
+        )
+
+    def test_get_last_result_profiles_budget_expiry_as_fail_open(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
+        service._last_submitted = "/tmp/train.log"
+        service._terminal_deadline = 20.0
+        service._get_started_recorded = True
+
+        with (
+            patch.object(service, "_get_results", return_value=None) as mock_get,
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
+                return_value=21.25,
+            ),
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.record_profiling_event"
+            ) as record_event,
+        ):
+            should_stop = service.get_last_result(node_id="node-a")
+
+        self.assertFalse(should_stop)
+        mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
+        record_event.assert_called_once()
+        self.assertEqual(record_event.call_args.args[0].value, "attribution_get_completed")
+        self.assertEqual(
+            record_event.call_args.kwargs,
+            {"node_id": "node-a"},
         )
 
     @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
@@ -643,10 +854,10 @@ class TestAttributionService(unittest.TestCase):
         should_stop = service._get_results("/tmp/train.log")
 
         self.assertTrue(should_stop)
-        mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=60.0)
+        mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=2.0)
         client.get.assert_called_once_with(
             "/logs",
-            params={"log_path": "/tmp/train.log"},
+            params={"log_path": "/tmp/train.log", "wait": False},
             headers={"accept": "application/json"},
         )
 
@@ -674,6 +885,27 @@ class TestAttributionService(unittest.TestCase):
         should_stop = service._get_results("/tmp/train.log")
 
         self.assertFalse(should_stop)
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_get_results_treats_non_completed_status_as_not_ready(self, mock_client):
+        client = mock_client.return_value.__enter__.return_value
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "{}"
+        response.json.return_value = {
+            "status": "in_flight",
+            "recommendation": {
+                "action": "UNKNOWN",
+                "reason": "analysis still running",
+                "source": "log_analyzer",
+            },
+        }
+        client.get.return_value = response
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        should_stop = service._get_results("/tmp/train.log")
+
+        self.assertIsNone(should_stop)
 
     @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
     def test_get_results_maps_continue_recommendation_to_no_stop(self, mock_client):


### PR DESCRIPTION
## Summary
- builds on merged #339 service/smonsvc terminal attribution support
- add launcher-managed attribution restart decisions and host-managed attribution service wiring
- move the final STOP decision to the rendezvous host before closing the next round, so launcher only signals terminal attribution early
- keep attribution shutdown state simple: the rendezvous host exits gracefully when it decides STOP; other ranks just observe rendezvous closure
- reframe attribution timeout as a launcher-side decision budget; terminal POST starts the budget, each GET is a short local request, and the rendezvous host reruns its normal close loop until a decision arrives or the budget expires
- record attribution GET wait profiling events, including completed-event duration_seconds metadata

## Validation
- compileall on changed launcher/rendezvous/shared-utils files and tests
- git diff --check
- isort --check-only on changed Python files
- black --check on changed Python files

Note: focused pytest could not run in the local desktop runtime because required test dependencies are not installed there.