### PR TITLE
Move chatty logs from INFO to DEBUG

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -615,7 +615,10 @@ class PersistentAsyncCaller(AsyncCaller):
             abort (bool, optional): Default to False. Needs to be manually set to true when
                 the checkpoint async process needs to be aborted.
         """
-        logger.debug(f"PersistentAsyncCaller: {self.rank}, Destroying Async Caller")
+        if self.rank == 0:
+            logger.info(f"PersistentAsyncCaller: {self.rank}, Destroying Async Caller")
+        else:
+            logger.debug(f"PersistentAsyncCaller: {self.rank}, Destroying Async Caller")
         if self.process:
             if abort:
                 logger.error(f"Persistent worker aborted in rank {self.rank}")

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -666,7 +666,9 @@ class PersistentAsyncCaller(AsyncCaller):
         to properly release any IPC handles stored in the cache.
         """
         if cls._worker_data_cache:
-            logger.debug(f"Cleaning up worker data cache with {len(cls._worker_data_cache)} entries")
+            logger.debug(
+                f"Cleaning up worker data cache with {len(cls._worker_data_cache)} entries"
+            )
             # Clear all cached data structures which may contain IPC handles
             cls._worker_data_cache.clear()
             gc.collect()

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -486,7 +486,10 @@ class PersistentAsyncCaller(AsyncCaller):
             rank (int): the rank of the current trainer process.
         """
         ctx = mp.get_context('spawn')
-        logger.info(f"PersistentAsyncCaller: {rank}, Starting Async Caller")
+        if rank == 0:
+            logger.info(f"PersistentAsyncCaller: {rank}, Starting Async Caller")
+        else:
+            logger.debug(f"PersistentAsyncCaller: {rank}, Starting Async Caller")
         if self.background_worker_is_daemon:
             async_loop_target = PersistentAsyncCaller.async_loop_for_daemon_worker
         else:
@@ -612,7 +615,7 @@ class PersistentAsyncCaller(AsyncCaller):
             abort (bool, optional): Default to False. Needs to be manually set to true when
                 the checkpoint async process needs to be aborted.
         """
-        logger.info(f"PersistentAsyncCaller: {self.rank}, Destroying Async Caller")
+        logger.debug(f"PersistentAsyncCaller: {self.rank}, Destroying Async Caller")
         if self.process:
             if abort:
                 logger.error(f"Persistent worker aborted in rank {self.rank}")
@@ -663,7 +666,7 @@ class PersistentAsyncCaller(AsyncCaller):
         to properly release any IPC handles stored in the cache.
         """
         if cls._worker_data_cache:
-            logger.info(f"Cleaning up worker data cache with {len(cls._worker_data_cache)} entries")
+            logger.debug(f"Cleaning up worker data cache with {len(cls._worker_data_cache)} entries")
             # Clear all cached data structures which may contain IPC handles
             cls._worker_data_cache.clear()
             gc.collect()


### PR DESCRIPTION
Moves the following three logs from INFO to DEBUG levels

 - PersistentAsyncCaller: ..., Starting Async Caller
 - PersistentAsyncCaller: ..., Destroying Async Caller
 - Cleaning up worker data cache with ... entries

Keeps only rank 0 at INFO level for "PersistentAsyncCaller: ...", but all ranks to DEBUG for "Cleaning up worker data cache"