### PR TITLE
Distinguish failed rendezvous shutdown from graceful closure

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -80,6 +80,9 @@ from .utils import get_infrastructure_rank, is_slurm_job_array, slurm_sort_addrs
 
 log = logging.getLogger(LogConfig.name)
 
+RDZV_SHUTDOWN_REASON_GRACEFUL = "graceful"
+RDZV_SHUTDOWN_REASON_FAILURE = "failure"
+
 
 def _rdzv_signal_exception_handler(sig: int, frame: Optional[FrameType]) -> None:
     del frame
@@ -628,7 +631,7 @@ class _RendezvousBarrierState:
 
         # Key prefixes for the barrier
         self.prefix = f"ft_rendezvous_barrier:{run_id}"
-        # Permanent shutdown: once set, no further rendezvous rounds (graceful exit).
+        # Permanent shutdown reason: empty means open; non-empty means no further rounds.
         self.shutdown_key = f"{self.prefix}:shutdown"
         self._attribution_service: Optional[AttributionService] = None
         self._attribution_settled_for_round: int = -1
@@ -644,6 +647,10 @@ class _RendezvousBarrierState:
         # Initialize round_done_0 to 0 (open) if this is the first time any node connects.
         if not self.store.check([self.round_done_key]):
             self.store.set(self.round_done_key, "0".encode('utf-8'))
+        if self.is_store_host and not self.store.check([self.shutdown_key]):
+            # Empty value is the open-state sentinel. Consumers must check the value,
+            # not just key existence, to decide whether rendezvous is shut down.
+            self.store.set(self.shutdown_key, b"")
 
     @property
     def join_count_key(self) -> str:
@@ -1290,7 +1297,8 @@ class _RendezvousBarrierState:
             node_desc: Node descriptor for logging
 
         Raises:
-            RendezvousGracefulExitError: If rendezvous is permanently shut down (graceful exit 0)
+            RendezvousGracefulExitError: If rendezvous is permanently shut down. The
+                launcher maps the recorded shutdown reason to the final process exit code.
 
         Note:
             This wait does NOT timeout unless the rendezvous is permanently closed.
@@ -1374,7 +1382,7 @@ class _RendezvousBarrierState:
                 f"recommended stopping the job."
             )
             log.error(msg)
-            self.set_shutdown()
+            self.set_shutdown(RDZV_SHUTDOWN_REASON_FAILURE)
             raise RendezvousGracefulExitError(msg)
 
         self._attribution_settled_for_round = self._round
@@ -2053,12 +2061,24 @@ class _RendezvousBarrierState:
 
     def is_shutdown(self) -> bool:
         """Check if rendezvous is permanently shut down (no further rounds)."""
-        return self.store.check([self.shutdown_key])
+        if not self.store.check([self.shutdown_key]):
+            return False
+        return bool(self.store.get(self.shutdown_key))
 
-    def set_shutdown(self) -> None:
+    def get_shutdown_reason(self) -> Optional[str]:
+        """Return the recorded shutdown reason, if one was written."""
+        if not self.store.check([self.shutdown_key]):
+            return None
+        return self.store.get(self.shutdown_key).decode('utf-8') or None
+
+    def set_shutdown(self, reason: str = RDZV_SHUTDOWN_REASON_GRACEFUL) -> None:
         """Mark rendezvous as permanently shut down (graceful exit, no further rounds)."""
         try:
-            self.store.set(self.shutdown_key, "1".encode('utf-8'))
+            self.store.compare_set(
+                self.shutdown_key,
+                b"",
+                reason.encode('utf-8'),
+            )
         except Exception as e:
             log.error(f"Failed to set shutdown: {e}")
 
@@ -2679,10 +2699,10 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         addr_to_rank = dict(zip(addrs, ranks))
         return [addr_to_rank[a] for a in slurm_sort_addrs(addrs)]
 
-    def shutdown(self) -> bool:
+    def shutdown(self, reason: str = RDZV_SHUTDOWN_REASON_GRACEFUL) -> bool:
         """See base class."""
         try:
-            self._close()
+            self._close(reason)
             return True
         except RendezvousError as ex:
             msg = (
@@ -2699,13 +2719,19 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             )
             raise
 
+    def shutdown_due_to_failure(self) -> bool:
+        return self.shutdown(reason=RDZV_SHUTDOWN_REASON_FAILURE)
+
+    def is_shutdown_due_to_failure(self) -> bool:
+        return self._barrier_state.get_shutdown_reason() == RDZV_SHUTDOWN_REASON_FAILURE
+
     def shutdown_cycle_info_reporter(self) -> None:
         if self._cycle_info_reporter is not None:
             self._cycle_info_reporter.shutdown()
 
-    def _close(self) -> None:
+    def _close(self, reason: str = RDZV_SHUTDOWN_REASON_GRACEFUL) -> None:
         """Permanently shut down the rendezvous (no further rounds)."""
-        self._barrier_state.set_shutdown()
+        self._barrier_state.set_shutdown(reason)
         self.shutdown_cycle_info_reporter()
 
         msg = f"The node '{self._this_node}' has permanently closed the rendezvous '{self._settings.run_id}'."

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -202,6 +202,10 @@ class UnhealthyNodeException(Exception):
         super().__init__(self.message)
 
 
+class TerminalWorkerGroupFailure(Exception):
+    """Raised when the worker group failed without local child failure details."""
+
+
 def _wrap_entrypoint_with_numactl(
     entrypoint: str,
     args: Tuple,
@@ -499,6 +503,13 @@ class LocalElasticAgent(SimpleElasticAgent):
             self._record_worker_events(result)
             return result
         except RendezvousGracefulExitError as e:
+            if self._rdzv_handler.is_shutdown_due_to_failure():
+                msg = (
+                    "Rendezvous closed because another launcher reported "
+                    "a terminal worker-group failure."
+                )
+                logger.error("%s Original rendezvous message: %s", msg, e)
+                raise TerminalWorkerGroupFailure(msg) from e
             logger.info("Rendezvous gracefully exited: %s", e)
             return None
         except SignalException as e:
@@ -626,7 +637,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                 # No more restarts (either exhausted or early termination)
                 self._stop_workers(self._worker_group)
                 self._worker_group.state = WorkerState.FAILED
-                return RunResult(state=WorkerState.FAILED)
+                return RunResult(state=WorkerState.FAILED, failures=run_result.failures)
             elif state == WorkerState.HEALTHY:
                 # Check if any node in the cluster has opened the next rendezvous round,
                 # which signals that a peer detected a failure and triggered a restart.
@@ -1568,6 +1579,7 @@ def launch_agent(
     spec.rdzv_handler.set_agent(agent)
 
     shutdown_rdzv = True
+    shutdown_due_to_failure = False
     try:
         metrics.initialize_metrics(metrics.MetricsConfig(config.metrics_cfg))
 
@@ -1581,13 +1593,19 @@ def launch_agent(
             return None
 
         if result.is_failed():
+            shutdown_due_to_failure = True
             # ChildFailedError is treated specially by @record
             # if the error files for the failed children exist
             # @record will copy the first error (root cause)
             # to the error file of the launcher process.
-            raise ChildFailedError(
-                name=entrypoint_name,
-                failures=result.failures,
+            if result.failures:
+                raise ChildFailedError(
+                    name=entrypoint_name,
+                    failures=result.failures,
+                )
+            raise TerminalWorkerGroupFailure(
+                f"Worker group failed for {entrypoint_name}, but no local child "
+                "failure details were available."
             )
 
         logger.info(f"Agent .run() is OK. No failures in the result. {result=}")
@@ -1602,17 +1620,20 @@ def launch_agent(
         logger.error(f"Agent .run() raised UnhealthyNodeException: {e}")
         events.record(agent.get_event_failed())
 
-        # Exit behavior depends on deployment mode:
-        # - Job array: raise (exit 1) so replacement job can be launched
-        # - Single job with hot spares: don't raise (instead, exit 0) to avoid killing job
-        #   since --kill-on-bad-exit is the default srun behavior
+        # Always exit non-zero for unhealthy nodes so the scheduler/infrastructure
+        # can requeue or apply policy. Single-job hot-spare deployments that should
+        # keep the allocation alive must launch with srun --kill-on-bad-exit=0.
         if is_slurm_job_array():
             logger.info("Job array deployment: exiting with code 1 for replacement.")
-            raise
         else:
-            logger.info("Single job deployment: exiting with code 0 for hot spare takeover.")
-            # Don't raise - returns None, main() will exit with 0
+            logger.info("Single job deployment: exiting with code 1 for policy handling.")
+        raise
     except ChildFailedError:
+        raise
+    except TerminalWorkerGroupFailure as e:
+        shutdown_due_to_failure = True
+        logger.error(f"Agent .run() ended with terminal worker-group failure: {e}")
+        events.record(agent.get_event_failed())
         raise
     except SignalException as e:
         # when the agent dies with a signal do NOT shutdown the rdzv_handler
@@ -1624,8 +1645,7 @@ def launch_agent(
         if agent.any_rank_failed():
             logger.warning("Some ranks exited with non-zero. Re-raising SignalException.")
             raise
-        else:
-            logger.info("All ranks exited gracefully. Launcher exiting without an error.")
+        logger.info("All ranks exited gracefully. Launcher exiting without an error.")
     except Exception as e:
         logger.error(f"Agent .run() raised exception, {e=}")
         events.record(agent.get_event_failed())
@@ -1633,7 +1653,10 @@ def launch_agent(
     finally:
         # Shutdown rdzv and rank monitors (may produce logs; reader thread must stay alive).
         if shutdown_rdzv:
-            agent._rdzv_handler.shutdown()
+            if shutdown_due_to_failure:
+                agent._rdzv_handler.shutdown_due_to_failure()
+            else:
+                agent._rdzv_handler.shutdown()
         agent.shutdown_rank_monitors()
 
         # Store host: TCPStore lives in this process; on exit it is destroyed and rendezvous

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -226,6 +226,7 @@ class BarrierStateBasicTest(BaseRendezvousTest):
         )
 
         self.assertFalse(state.is_shutdown())
+        self.assertIsNone(state.get_shutdown_reason())
 
     def test_set_shutdown(self):
         """Test that set_shutdown marks rendezvous as permanently shut down."""
@@ -238,6 +239,62 @@ class BarrierStateBasicTest(BaseRendezvousTest):
 
         state.set_shutdown()
         self.assertTrue(state.is_shutdown())
+        self.assertEqual(
+            state.get_shutdown_reason(),
+            ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_GRACEFUL,
+        )
+
+    def test_set_shutdown_records_failure_reason(self):
+        """An explicit failure shutdown is visible as the shutdown reason."""
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+        )
+
+        state.set_shutdown(ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_FAILURE)
+
+        self.assertTrue(state.is_shutdown())
+        self.assertEqual(
+            state.get_shutdown_reason(),
+            ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_FAILURE,
+        )
+
+    def test_set_shutdown_does_not_overwrite_failure_reason(self):
+        """The first shutdown reason is stable once the shutdown is visible."""
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+        )
+
+        state.set_shutdown(ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_FAILURE)
+        state.set_shutdown()
+
+        self.assertTrue(state.is_shutdown())
+        self.assertEqual(
+            state.get_shutdown_reason(),
+            ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_FAILURE,
+        )
+
+    def test_attribution_gate_sets_failure_shutdown_when_stop_recommended(self):
+        """Attribution-stop is a terminal failure reason, not a graceful shutdown."""
+        state = object.__new__(_RendezvousBarrierState)
+        state._round = 1
+        state._attribution_service = MagicMock()
+        state._attribution_service.get_last_result.return_value = True
+        state._attribution_settled_for_round = -1
+        state.set_shutdown = MagicMock()
+
+        with self.assertRaises(RendezvousGracefulExitError):
+            state._attribution_gate("node-a")
+
+        state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
+        state.set_shutdown.assert_called_once_with(
+            ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_FAILURE
+        )
 
     def test_join_increments_join_count(self):
         """Test that joining increments join_count atomically."""
@@ -2275,7 +2332,7 @@ class ErrorCaseTest(BaseRendezvousTest):
             state.perform_rendezvous(node, min_nodes, max_nodes, segment_check_interval)
 
     def test_closed_rendezvous_raises_error(self):
-        """Test that joining a closed rendezvous raises RendezvousGracefulExitError (exit 0)."""
+        """A normal closed rendezvous raises the passive graceful-exit exception."""
         state = _RendezvousBarrierState(
             store=self.store,
             run_id=self.run_id,

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -471,6 +471,7 @@ class TestLauncherRunBehavior(unittest.TestCase):
         from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
 
         spec = _make_agent_spec(rdzv_round=3)
+        spec.rdzv_handler.is_shutdown_due_to_failure.return_value = False
         agent = LocalElasticAgent(
             spec=spec,
             fault_tol_cfg=self.fault_tol_cfg,
@@ -486,6 +487,69 @@ class TestLauncherRunBehavior(unittest.TestCase):
             result = agent.run()
 
         self.assertIsNone(result)
+        spec.rdzv_handler.is_shutdown_due_to_failure.assert_called_once_with()
+
+    def test_run_failure_shutdown_raises_terminal_worker_group_failure(self):
+        """A graceful rendezvous exception becomes failure when the store says why."""
+        from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
+
+        from nvidia_resiliency_ext.fault_tolerance import launcher
+        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
+
+        spec = _make_agent_spec(rdzv_round=3)
+        spec.rdzv_handler.is_shutdown_due_to_failure.return_value = True
+        agent = LocalElasticAgent(
+            spec=spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
+        )
+
+        with (
+            patch.object(
+                agent, '_invoke_run', side_effect=RendezvousGracefulExitError("round closed")
+            ),
+            patch.object(agent, '_shutdown'),
+        ):
+            with self.assertRaises(launcher.TerminalWorkerGroupFailure):
+                agent.run()
+
+    def test_invoke_run_preserves_failures_when_restarts_exhausted(self):
+        """The terminal failed result keeps the local child failure map."""
+        from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
+
+        from nvidia_resiliency_ext.fault_tolerance import launcher
+        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
+
+        spec = _make_agent_spec(rdzv_round=3)
+        spec.role = "trainer"
+        spec.monitor_interval = 0
+        agent = LocalElasticAgent(
+            spec=spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
+        )
+        agent._worker_group.state = WorkerState.HEALTHY
+        agent._worker_group.group_rank = 0
+        failure = MagicMock()
+        failures = {7: failure}
+
+        with (
+            patch.object(agent, '_initialize_workers'),
+            patch.object(
+                agent,
+                '_monitor_workers',
+                return_value=RunResult(state=WorkerState.FAILED, failures=failures),
+            ),
+            patch.object(agent, '_handle_restart_decision', return_value=False),
+            patch.object(agent, '_stop_workers'),
+            patch.object(launcher, 'record_profiling_event'),
+            patch.object(launcher, 'put_metric'),
+            patch.object(launcher.time, 'sleep'),
+        ):
+            result = agent._invoke_run_with_any_failed_policy()
+
+        self.assertEqual(result.state, WorkerState.FAILED)
+        self.assertEqual(result.failures, failures)
 
 
 class TestHandleRestartDecision(unittest.TestCase):
@@ -653,10 +717,13 @@ class TestHandleRestartDecision(unittest.TestCase):
         self.assertFalse(hasattr(legacy_rdzv, '_barrier_state'))
 
 
-def test_rendezvous_host_sets_graceful_shutdown_when_attribution_says_stop():
+def test_rendezvous_host_sets_failure_shutdown_when_attribution_says_stop():
     from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
 
-    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import _RendezvousBarrierState
+    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import (
+        RDZV_SHUTDOWN_REASON_FAILURE,
+        _RendezvousBarrierState,
+    )
 
     state = object.__new__(_RendezvousBarrierState)
     state._round = 1
@@ -669,7 +736,7 @@ def test_rendezvous_host_sets_graceful_shutdown_when_attribution_says_stop():
         state._attribution_gate("node-a")
 
     state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
-    state.set_shutdown.assert_called_once()
+    state.set_shutdown.assert_called_once_with(RDZV_SHUTDOWN_REASON_FAILURE)
 
 
 def test_rendezvous_host_retries_close_round_when_attribution_pending():
@@ -1071,19 +1138,10 @@ def test_nvrx_logfile_auto_enables_grpc_routing_to_rendezvous_host(tmp_path):
     assert config.logs_specs.grpc_server_address == "control.host:50051"
 
 
-def test_launch_agent_store_host_closes_cycle_info_reporter_without_rdzv_shutdown():
+def _make_launch_agent_config(**overrides):
     from types import SimpleNamespace
 
-    from nvidia_resiliency_ext.fault_tolerance import launcher
-
-    rdzv_handler = MagicMock()
-    rdzv_handler._attribution_service = None
-    spec = SimpleNamespace(rdzv_handler=rdzv_handler)
-    agent = MagicMock()
-    agent.run.side_effect = launcher.UnhealthyNodeException("node unhealthy")
-    agent._rdzv_handler = rdzv_handler
-
-    config = SimpleNamespace(
+    values = dict(
         run_id="run-a",
         rdzv_configs={},
         min_nodes=1,
@@ -1105,6 +1163,24 @@ def test_launch_agent_store_host_closes_cycle_info_reporter_without_rdzv_shutdow
         restart_policy="any-failed",
         rank_monitors={},
     )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.parametrize("is_job_array", [False, True])
+def test_launch_agent_unhealthy_node_exits_failure_without_rdzv_shutdown(is_job_array):
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    rdzv_handler = MagicMock()
+    rdzv_handler._attribution_service = None
+    spec = SimpleNamespace(rdzv_handler=rdzv_handler)
+    agent = MagicMock()
+    agent.run.side_effect = launcher.UnhealthyNodeException("node unhealthy")
+    agent._rdzv_handler = rdzv_handler
+
+    config = _make_launch_agent_config()
 
     with (
         patch.object(launcher, "_get_addr_and_port", return_value=("host", 29500)),
@@ -1114,11 +1190,191 @@ def test_launch_agent_store_host_closes_cycle_info_reporter_without_rdzv_shutdow
         patch.object(launcher, "LocalElasticAgent", return_value=agent),
         patch.object(launcher.metrics, "initialize_metrics"),
         patch.object(launcher.events, "record"),
-        patch.object(launcher, "is_slurm_job_array", return_value=False),
+        patch.object(launcher, "is_slurm_job_array", return_value=is_job_array),
         patch.object(launcher.time, "sleep", return_value=None),
+    ):
+        with pytest.raises(launcher.UnhealthyNodeException):
+            launcher.launch_agent(config, "train.py", [])
+
+    rdzv_handler.shutdown.assert_not_called()
+    rdzv_handler.shutdown_due_to_failure.assert_not_called()
+    rdzv_handler.shutdown_cycle_info_reporter.assert_called_once()
+
+
+def test_launch_agent_failed_result_marks_rendezvous_shutdown_failure():
+    from types import SimpleNamespace
+
+    from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    rdzv_handler = MagicMock()
+    rdzv_handler._attribution_service = None
+    spec = SimpleNamespace(rdzv_handler=rdzv_handler)
+    agent = MagicMock()
+    agent.run.return_value = RunResult(state=WorkerState.FAILED)
+    agent._rdzv_handler = rdzv_handler
+
+    config = _make_launch_agent_config()
+
+    with (
+        patch.object(launcher, "_get_addr_and_port", return_value=("host", 29500)),
+        patch.object(launcher, "_is_store_host", return_value=True),
+        patch.object(launcher, "WorkerSpec", return_value=spec),
+        patch.object(launcher.rdzv_registry, "get_rendezvous_handler", return_value=rdzv_handler),
+        patch.object(launcher, "LocalElasticAgent", return_value=agent),
+        patch.object(launcher.metrics, "initialize_metrics"),
+        patch.object(launcher.events, "record"),
+        patch.object(launcher.time, "sleep", return_value=None),
+    ):
+        with pytest.raises(launcher.TerminalWorkerGroupFailure):
+            launcher.launch_agent(config, "train.py", [])
+
+    rdzv_handler.shutdown_due_to_failure.assert_called_once_with()
+    rdzv_handler.shutdown.assert_not_called()
+
+
+def test_launch_agent_child_failed_error_marks_rendezvous_shutdown_failure():
+    from types import SimpleNamespace
+
+    from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
+    from torch.distributed.elastic.multiprocessing.errors import ChildFailedError, ProcessFailure
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    rdzv_handler = MagicMock()
+    rdzv_handler._attribution_service = None
+    spec = SimpleNamespace(rdzv_handler=rdzv_handler)
+    failure = ProcessFailure(local_rank=0, pid=1234, exitcode=1, error_file="/tmp/missing.json")
+    agent = MagicMock()
+    agent.run.return_value = RunResult(state=WorkerState.FAILED, failures={0: failure})
+    agent._rdzv_handler = rdzv_handler
+
+    config = _make_launch_agent_config()
+
+    with (
+        patch.object(launcher, "_get_addr_and_port", return_value=("host", 29500)),
+        patch.object(launcher, "_is_store_host", return_value=True),
+        patch.object(launcher, "WorkerSpec", return_value=spec),
+        patch.object(launcher.rdzv_registry, "get_rendezvous_handler", return_value=rdzv_handler),
+        patch.object(launcher, "LocalElasticAgent", return_value=agent),
+        patch.object(launcher.metrics, "initialize_metrics"),
+        patch.object(launcher.events, "record"),
+        patch.object(launcher.time, "sleep", return_value=None),
+    ):
+        with pytest.raises(ChildFailedError):
+            launcher.launch_agent(config, "train.py", [])
+
+    rdzv_handler.shutdown_due_to_failure.assert_called_once_with()
+    rdzv_handler.shutdown.assert_not_called()
+
+
+def test_launch_agent_success_result_returns_values_and_gracefully_shuts_down():
+    from types import SimpleNamespace
+
+    from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    rdzv_handler = MagicMock()
+    rdzv_handler._attribution_service = None
+    spec = SimpleNamespace(rdzv_handler=rdzv_handler)
+    agent = MagicMock()
+    agent.run.return_value = RunResult(
+        state=WorkerState.SUCCEEDED,
+        return_values={0: "ok"},
+    )
+    agent._rdzv_handler = rdzv_handler
+
+    config = _make_launch_agent_config()
+
+    with (
+        patch.object(launcher, "_get_addr_and_port", return_value=("host", 29500)),
+        patch.object(launcher, "_is_store_host", return_value=False),
+        patch.object(launcher, "WorkerSpec", return_value=spec),
+        patch.object(launcher.rdzv_registry, "get_rendezvous_handler", return_value=rdzv_handler),
+        patch.object(launcher, "LocalElasticAgent", return_value=agent),
+        patch.object(launcher.metrics, "initialize_metrics"),
+        patch.object(launcher.events, "record"),
+    ):
+        result = launcher.launch_agent(config, "train.py", [])
+
+    assert result == {0: "ok"}
+    rdzv_handler.shutdown.assert_called_once_with()
+    rdzv_handler.shutdown_due_to_failure.assert_not_called()
+
+
+def test_launch_agent_signal_exception_without_rank_failure_exits_normally():
+    from types import SimpleNamespace
+
+    from torch.distributed.elastic.multiprocessing import SignalException
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    rdzv_handler = MagicMock()
+    rdzv_handler._attribution_service = None
+    spec = SimpleNamespace(rdzv_handler=rdzv_handler)
+    agent = MagicMock()
+    agent.run.side_effect = SignalException(
+        "simulated signal",
+        sigval=signal.Signals(signal.SIGTERM),
+    )
+    agent._rdzv_handler = rdzv_handler
+    agent.any_rank_failed.return_value = False
+
+    config = _make_launch_agent_config(fault_tol_cfg=FaultToleranceConfig())
+
+    with (
+        patch.object(launcher, "_get_addr_and_port", return_value=("host", 29500)),
+        patch.object(launcher, "_is_store_host", return_value=False),
+        patch.object(launcher, "WorkerSpec", return_value=spec),
+        patch.object(launcher.rdzv_registry, "get_rendezvous_handler", return_value=rdzv_handler),
+        patch.object(launcher, "LocalElasticAgent", return_value=agent),
+        patch.object(launcher.metrics, "initialize_metrics"),
+        patch.object(launcher.events, "record") as record_event,
     ):
         result = launcher.launch_agent(config, "train.py", [])
 
     assert result is None
+    agent.any_rank_failed.assert_called_once_with()
+    record_event.assert_called_once_with(agent.get_event_failed.return_value)
     rdzv_handler.shutdown.assert_not_called()
-    rdzv_handler.shutdown_cycle_info_reporter.assert_called_once()
+    rdzv_handler.shutdown_due_to_failure.assert_not_called()
+
+
+def test_launch_agent_signal_exception_with_rank_failure_re_raises():
+    from types import SimpleNamespace
+
+    from torch.distributed.elastic.multiprocessing import SignalException
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    rdzv_handler = MagicMock()
+    rdzv_handler._attribution_service = None
+    spec = SimpleNamespace(rdzv_handler=rdzv_handler)
+    agent = MagicMock()
+    agent.run.side_effect = SignalException(
+        "simulated signal",
+        sigval=signal.Signals(signal.SIGTERM),
+    )
+    agent._rdzv_handler = rdzv_handler
+    agent.any_rank_failed.return_value = True
+
+    config = _make_launch_agent_config(fault_tol_cfg=FaultToleranceConfig())
+
+    with (
+        patch.object(launcher, "_get_addr_and_port", return_value=("host", 29500)),
+        patch.object(launcher, "_is_store_host", return_value=False),
+        patch.object(launcher, "WorkerSpec", return_value=spec),
+        patch.object(launcher.rdzv_registry, "get_rendezvous_handler", return_value=rdzv_handler),
+        patch.object(launcher, "LocalElasticAgent", return_value=agent),
+        patch.object(launcher.metrics, "initialize_metrics"),
+        patch.object(launcher.events, "record") as record_event,
+    ):
+        with pytest.raises(SignalException):
+            launcher.launch_agent(config, "train.py", [])
+
+    agent.any_rank_failed.assert_called_once_with()
+    record_event.assert_called_once_with(agent.get_event_failed.return_value)
+    rdzv_handler.shutdown.assert_not_called()
+    rdzv_handler.shutdown_due_to_failure.assert_not_called()


### PR DESCRIPTION
Record a shutdown reason in the barrier rendezvous store and use it in the launcher so peer launchers treat terminal worker-group failure differently from normal rendezvous closure.