### PR TITLE
Persist async checkpoint plans across resume

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/state_dict_saver.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/state_dict_saver.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
 
 logger = getLogger(__name__)
 
+_ALL_LOCAL_PLANS_KEY = "__nvrx_all_local_plans"
+
 
 def _compare_dataclasses(obj1, obj2):
     if type(obj1) is not type(obj2):
@@ -47,6 +49,25 @@ def _compare_dataclasses(obj1, obj2):
             differences.append(f"{field.name}: {value1} != {value2}")
 
     return differences if differences else "All fields are equal"
+
+
+def _get_all_local_plans(metadata: Optional[Metadata]) -> Optional[List[SavePlan]]:
+    """Return cached local plans from checkpoint metadata, including serialized metadata."""
+    if metadata is None:
+        return None
+    all_local_plans = getattr(metadata, "all_local_plans", None)
+    if all_local_plans is not None:
+        return all_local_plans
+    planner_data = getattr(metadata, "planner_data", None) or {}
+    return planner_data.get(_ALL_LOCAL_PLANS_KEY)
+
+
+def _set_all_local_plans(metadata: Metadata, all_local_plans: List[SavePlan]) -> None:
+    """Store local plans in serialized metadata and preserve the legacy in-memory attr."""
+    metadata.all_local_plans = all_local_plans
+    if metadata.planner_data is None:
+        metadata.planner_data = {}
+    metadata.planner_data[_ALL_LOCAL_PLANS_KEY] = all_local_plans
 
 
 class CheckpointMetadataCache:
@@ -108,7 +129,7 @@ class CheckpointMetadataCache:
             that global metadata reuse verification will not be possible.
         """
         self.cached_global_metadata = cached_global_metadata
-        self.loaded_all_plans = getattr(self.cached_global_metadata, "all_local_plans", None)
+        self.loaded_all_plans = _get_all_local_plans(self.cached_global_metadata)
         if self.loaded_all_plans is None:
             logger.debug("no all_local_plans in metadata - can't verify global metadata reuse...")
 
@@ -342,7 +363,7 @@ def save_state_dict_async_plan(
             all_local_plans = dist_wrapper.gather_object(local_plan)
             if dist_wrapper.is_coordinator:
                 _, global_metadata = planner.create_global_plan(all_local_plans)
-                global_metadata.all_local_plans = all_local_plans
+                _set_all_local_plans(global_metadata, all_local_plans)
         else:
             logger.debug(f"rank: {rank}, Passed cached global metadata, {global_md_verify_reuse}")
             global_metadata = None

--- a/tests/checkpointing/unit/test_async_writer.py
+++ b/tests/checkpointing/unit/test_async_writer.py
@@ -38,6 +38,7 @@ from nvidia_resiliency_ext.checkpointing.async_ckpt.core import (
 )
 from nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async import FileSystemWriterAsync
 from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
+    CheckpointMetadataCache,
     save_state_dict_async_finalize,
     save_state_dict_async_plan,
 )
@@ -81,6 +82,7 @@ class TestAsyncSave:
         is_multiproc_io=False,
         use_cached_data_structure=False,
         use_cpu_shm_for_gpu_tensors=False,
+        metadata_cache=None,
     ):
         """Performs an asynchronous model checkpoint save."""
         writer = FileSystemWriterAsync(
@@ -94,7 +96,13 @@ class TestAsyncSave:
         coordinator_rank = 0
 
         save_state_dict_ret = save_state_dict_async_plan(
-            state_dict, writer, None, coordinator_rank, planner=planner, enable_cache=caching
+            state_dict,
+            writer,
+            None,
+            coordinator_rank,
+            planner=planner,
+            enable_cache=caching,
+            metadata_cache=metadata_cache,
         )
         async_request = self.get_async_save_request(writer, save_state_dict_ret)
         async_queue.schedule_async_request(async_request)
@@ -281,6 +289,33 @@ class TestAsyncSave:
                 ), f'{field.name} is different in metadata from non-cached, cached metadata impls'
         ckpt_dir.cleanup()
         async_queue.close()
+
+    def test_cached_metadata_plans_survive_reload(self, tmp_path_dist_ckpt, async_queue):
+        """Cached local plans are restored from metadata after a checkpoint reload."""
+        Utils.initialize_distributed()
+        model = FSDP(Model((1024, 1024), 8))
+        state_dict = model.state_dict()
+        planner = DefaultSavePlanner()
+        metadata_cache = CheckpointMetadataCache()
+
+        with TempNamedDir(tmp_path_dist_ckpt / 'cached_metadata_reload', sync=True) as ckpt_dir:
+            self.async_save_checkpoint(
+                ckpt_dir,
+                state_dict,
+                planner,
+                async_queue,
+                caching=True,
+                metadata_cache=metadata_cache,
+            )
+            async_queue.maybe_finalize_async_calls(blocking=True, no_dist=False)
+
+            loaded_metadata = FileSystemReader(ckpt_dir).read_metadata()
+            resumed_metadata_cache = CheckpointMetadataCache()
+            resumed_metadata_cache.set_cached_global_metadata(loaded_metadata)
+            _, _, _, loaded_all_plans = resumed_metadata_cache.get_cache_metadata()
+
+            assert loaded_all_plans is not None
+            assert len(loaded_all_plans) == torch.distributed.get_world_size()
 
     def test_cached_data_structure(self, tmp_path_dist_ckpt):
         """


### PR DESCRIPTION
Store cached local save plans in serialized DCP planner metadata so the first save after restart can validate and reuse loaded global metadata.

Previously, NVRx attached the gathered local plans only as a dynamic `Metadata.all_local_plans` attribute. Newer PyTorch DCP writers may rebuild the `Metadata` dataclass before pickling `.metadata`, which drops dynamic attributes and prevents resumed jobs from finding `loaded_all_plans`.

Persist the plans under a reserved `Metadata.planner_data` key while preserving the legacy in-memory attribute for compatibility. Add a regression test that loads metadata back from disk and verifies a fresh metadata cache can recover the saved local plans.