### PR TITLE
Fix per-cycle attribution state over MCP

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py
+++ b/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py
@@ -177,6 +177,8 @@ class CombinedLogFRMCPOrchestrator:
 
     def __init__(self, _args: Any = None) -> None:
         """Registry constructs one instance per process; per-call params come via ``run``."""
+        self._log_analyzer: NVRxLogAnalyzer | None = None
+        self._log_analyzer_lock = asyncio.Lock()
 
     async def run(self, arguments: dict[str, Any]) -> tuple[dict[str, Any], AttributionState]:
         if arguments.get("log_path") and arguments.get("fr_path"):
@@ -208,6 +210,8 @@ class CombinedLogFRMCPOrchestrator:
             "is_per_cycle": is_per_cycle,
             **llm_kwargs,
         }
+        if is_per_cycle:
+            log_kw["cycle_counter"] = int(arguments.get("cycle_counter", 0))
         fr_kw: dict[str, Any] = {
             "fr_path": fr_path,
             "pattern": str(arguments.get("pattern", "_dump_*")),
@@ -218,10 +222,15 @@ class CombinedLogFRMCPOrchestrator:
             "threshold": arguments.get("threshold"),
         }
 
-        log_analyzer = NVRxLogAnalyzer(log_kw)
+        async def _run_log_analyzer() -> Any:
+            async with self._log_analyzer_lock:
+                if self._log_analyzer is None:
+                    self._log_analyzer = NVRxLogAnalyzer(log_kw)
+                return await self._log_analyzer.run(log_kw)
+
         fr_analyzer = CollectiveAnalyzer(fr_kw)
         log_raw, fr_raw = await asyncio.gather(
-            log_analyzer.run(log_kw),
+            _run_log_analyzer(),
             _run_fr_or_skip_missing_dumps(fr_analyzer, fr_kw, fr_path),
         )
         log_payload_section, log_actual, log_st = _log_section_from_run_result(log_raw)

--- a/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
+++ b/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
@@ -109,11 +109,11 @@ def _previous_path(path: str) -> str | None:
 
 
 def _cycle_counter_key(path: str) -> str:
-    """Strip a trailing ``_<digits>`` from the filename stem so per-cycle
-    paths (``nvrx_0.log``, ``nvrx_1.log``, ...) share one
+    """Strip a per-cycle suffix from the filename stem so cycle paths share one
     ``cycle_counter_dict`` entry.
     """
     stem, ext = os.path.splitext(path)
+    stem = re.sub(r"_cycle\d+$", "", stem, flags=re.IGNORECASE)
     stem = re.sub(r"_\d+$", "", stem)
     return stem + ext
 
@@ -242,6 +242,13 @@ def _result_item_from_logsage_fields(
         primary_issues=primary_issues,
         secondary_issues=secondary_issues,
     )
+
+
+def _attribution_text_from_logsage_field(attribution_field: Any) -> str:
+    text = str(attribution_field)
+    if "Attribution:" in text:
+        return text.split("Attribution:", 1)[1].strip().replace('"\\', "").replace('\\"', "")
+    return text.strip()
 
 
 def attribution_from_finished_status(
@@ -901,6 +908,7 @@ class NVRxLogAnalyzer(NVRxAttribution):
 
         cfg = effective_run_or_init_config(self._init_config)
         path = cfg.get("log_path")
+        is_per_cycle = bool(cfg.get("is_per_cycle", self.is_per_cycle))
         if path and self.job_inline_data_dict.get(path) and len(output_list) == 1:
             rt_result = self._streaming_attribution(output_list[0], cfg, path)
             # Final attribution has consumed the progressive state (and already
@@ -958,12 +966,29 @@ class NVRxLogAnalyzer(NVRxAttribution):
                 )
             else:
                 if len(output.application_errors_list_full):
-                    result.append(
-                        _with_exponential_backoff(
-                            lambda: get_proposed_solution_cat(self.llm, output),
-                            checkpoint_saved=output.checkpoint_saved,
-                        )
+                    fields = _with_exponential_backoff(
+                        lambda: get_proposed_solution_cat(self.llm, output),
+                        checkpoint_saved=output.checkpoint_saved,
                     )
+                    if path and is_per_cycle and len(output_list) == 1:
+                        auto_resume_output, auto_resume_verbose = (
+                            self._apply_cross_cycle_repeated_policy(
+                                path=path,
+                                cfg=cfg,
+                                attribution_output=_attribution_text_from_logsage_field(fields[2]),
+                                auto_resume_output=str(fields[0]),
+                                auto_resume_verbose=str(fields[1]),
+                                checkpoint_saved=bool(output.checkpoint_saved),
+                            )
+                        )
+                        fields = (
+                            auto_resume_output,
+                            auto_resume_verbose,
+                            fields[2],
+                            fields[3],
+                            fields[4],
+                        )
+                    result.append(fields)
                 else:
                     if output.finished == FINISHED_STATUS_LLM_FAILURE:
                         result.append(
@@ -1027,6 +1052,85 @@ class NVRxLogAnalyzer(NVRxAttribution):
                         )
         return result
 
+    def _apply_cross_cycle_repeated_policy(
+        self,
+        *,
+        path: str,
+        cfg: Mapping[str, Any],
+        attribution_output: str,
+        auto_resume_output: str,
+        auto_resume_verbose: str,
+        checkpoint_saved: bool,
+    ) -> tuple[str, str]:
+        """Apply the FT repeated-attribution policy across per-cycle log files."""
+        path_previous = _previous_path(path)
+        attribution_previous = self.attribution_dict.get(path_previous, '') if path_previous else ''
+        cycle_counter = int(cfg.get("cycle_counter", 0))
+        cycle_counter_key = _cycle_counter_key(path)
+        if cycle_counter == 0:
+            self.cycle_counter_dict.setdefault(cycle_counter_key, cycle_counter)
+
+        logger.info(
+            f"[ckpt] repeated-attribution policy entry: "
+            f"checkpoint_saved={checkpoint_saved}, "
+            f"cycle_counter={cycle_counter}, "
+            f"cycle_counter_dict[{cycle_counter_key}]="
+            f"{self.cycle_counter_dict.get(cycle_counter_key)}",
+        )
+
+        self.attribution_dict[path] = attribution_output
+
+        is_attribution_current_last = get_auto_resume_postprocessing(
+            attribution_output,
+            attribution_previous,
+            cycle_counter,
+            self.llm,
+        )
+        logger.info(
+            f"[ckpt] repeated-attribution policy: post-processing → "
+            f"is_attribution_current_last={is_attribution_current_last} "
+            f"(checkpoint_saved={checkpoint_saved}, "
+            f"cycle_counter={cycle_counter})",
+        )
+
+        if checkpoint_saved and cycle_counter > 0:
+            is_attribution_current_last = False
+            logger.info(
+                "[ckpt] repeated-attribution policy: checkpoint_saved bypass FIRED "
+                "→ is_attribution_current_last forced to False; "
+                "repeated-issue STOP override will be skipped",
+            )
+
+        if (
+            is_attribution_current_last
+            and self.cycle_counter_dict.get(cycle_counter_key, 0) == self.repeated_amount - 1
+        ):
+            auto_resume_output = 'STOP - DONT RESTART IMMEDIATE'
+            auto_resume_verbose = "Stop job due to repeated issue"
+
+        if is_attribution_current_last:
+            if auto_resume_verbose != "Stop job due to repeated issue":
+                self.cycle_counter_dict[cycle_counter_key] = (
+                    self.cycle_counter_dict.get(cycle_counter_key, 0) + 1
+                )
+        else:
+            self.cycle_counter_dict[cycle_counter_key] = 1
+
+        if checkpoint_saved:
+            if len(auto_resume_verbose) > 0 and "STOP" in auto_resume_output:
+                logger.info(
+                    "[ckpt] repeated-attribution policy: checkpoint_saved override "
+                    f"FIRED; flipping {auto_resume_output!r} → 'RESTART IMMEDIATE'",
+                )
+                auto_resume_output = "RESTART IMMEDIATE"
+                auto_resume_verbose = (
+                    auto_resume_verbose[0]
+                    + "Restart immediate, due to checkpoint saved. "
+                    + auto_resume_verbose[1:]
+                )
+
+        return auto_resume_output, auto_resume_verbose
+
     def _streaming_attribution(
         self,
         last_with_errors: ApplicationData,
@@ -1041,20 +1145,6 @@ class NVRxLogAnalyzer(NVRxAttribution):
         """
         s_time = time.time()
         llm = self.llm
-
-        path_previous = _previous_path(path)
-        attribution_previous = self.attribution_dict.get(path_previous, '') if path_previous else ''
-        cycle_counter = int(cfg.get("cycle_counter", 0))
-        cycle_counter_key = _cycle_counter_key(path)
-
-        logger.info(
-            f"[ckpt] _streaming_attribution entry: "
-            f"input checkpoint_saved="
-            f"{getattr(last_with_errors, 'checkpoint_saved', False)}, "
-            f"cycle_counter={cycle_counter}, "
-            f"cycle_counter_dict[{cycle_counter_key}]="
-            f"{self.cycle_counter_dict.get(cycle_counter_key)}",
-        )
 
         last_attribution_dict_chunk = None
         last_attribution_raw_chunk = None
@@ -1126,7 +1216,6 @@ class NVRxLogAnalyzer(NVRxAttribution):
             )
 
         attribution_output = last_attribution_dict_chunk["attribution"]
-        self.attribution_dict[path] = attribution_output
         auto_resume_output, auto_resume_verbose = get_auto_resume(
             llm,
             last_with_errors,
@@ -1136,54 +1225,14 @@ class NVRxLogAnalyzer(NVRxAttribution):
             last_application_log_chunk,
         )
 
-        is_attribution_current_last = get_auto_resume_postprocessing(
-            attribution_output,
-            attribution_previous,
-            cycle_counter,
-            llm,
+        auto_resume_output, auto_resume_verbose = self._apply_cross_cycle_repeated_policy(
+            path=path,
+            cfg=cfg,
+            attribution_output=str(attribution_output),
+            auto_resume_output=str(auto_resume_output),
+            auto_resume_verbose=str(auto_resume_verbose),
+            checkpoint_saved=bool(last_with_errors.checkpoint_saved),
         )
-        logger.info(
-            f"[ckpt] _streaming_attribution: post-processing → "
-            f"is_attribution_current_last={is_attribution_current_last} "
-            f"(checkpoint_saved={last_with_errors.checkpoint_saved}, "
-            f"cycle_counter={cycle_counter})",
-        )
-
-        if last_with_errors.checkpoint_saved and cycle_counter > 0:
-            is_attribution_current_last = False
-            logger.info(
-                "[ckpt] _streaming_attribution: checkpoint_saved bypass FIRED "
-                "→ is_attribution_current_last forced to False; "
-                "repeated-issue STOP override will be skipped",
-            )
-
-        if (
-            is_attribution_current_last
-            and self.cycle_counter_dict.get(cycle_counter_key, 0) == self.repeated_amount - 1
-        ):
-            auto_resume_output = 'STOP - DONT RESTART IMMEDIATE'
-            auto_resume_verbose = "Stop job due to repeated issue"
-
-        if is_attribution_current_last:
-            if auto_resume_verbose != "Stop job due to repeated issue":
-                self.cycle_counter_dict[cycle_counter_key] = (
-                    self.cycle_counter_dict.get(cycle_counter_key, 0) + 1
-                )
-        else:
-            self.cycle_counter_dict[cycle_counter_key] = 1
-
-        if last_with_errors.checkpoint_saved:
-            if len(auto_resume_verbose) > 0 and "STOP" in auto_resume_output:
-                logger.info(
-                    "[ckpt] _streaming_attribution: checkpoint_saved override "
-                    f"FIRED; flipping {auto_resume_output!r} → 'RESTART IMMEDIATE'",
-                )
-                auto_resume_output = "RESTART IMMEDIATE"
-                auto_resume_verbose = (
-                    auto_resume_verbose[0]
-                    + "Restart immediate, due to checkpoint saved. "
-                    + auto_resume_verbose[1:]
-                )
 
         logger.info("Policy recommendation and error attribution:")
         logger.info("Recommendation: ", auto_resume_output)

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
@@ -139,6 +139,14 @@ def _llm_runtime_properties(*, model_description: str) -> dict[str, dict[str, An
     }
 
 
+def _cycle_counter_property() -> dict[str, Any]:
+    return {
+        "type": "integer",
+        "description": "FT per-cycle log index, parsed from *_cycle<N>.log by launcher clients",
+        "default": 0,
+    }
+
+
 def _log_analyzer_input_schema() -> dict[str, Any]:
     return {
         "type": "object",
@@ -155,6 +163,7 @@ def _log_analyzer_input_schema() -> dict[str, Any]:
                 "description": "Input is already per-cycle data (skip filtering and chunking)",
                 "default": False,
             },
+            "cycle_counter": _cycle_counter_property(),
         },
         "required": ["log_path"],
     }
@@ -170,6 +179,7 @@ def _progressive_start_input_schema() -> dict[str, Any]:
                 "description": "Input is already a single ft_launcher cycle log",
                 "default": False,
             },
+            "cycle_counter": _cycle_counter_property(),
             "user": {
                 "type": "string",
                 "description": "Optional submitting user for observability",
@@ -372,6 +382,7 @@ def register_all_modules():
                 },
                 "exclude_nvrx_logs": {"type": "boolean", "default": False},
                 "is_per_cycle": {"type": "boolean", "default": False},
+                "cycle_counter": _cycle_counter_property(),
                 "pattern": {"type": "string", "default": "_dump_*"},
                 "verbose": {"type": "boolean", "default": False},
                 "health_check": {"type": "boolean", "default": False},

--- a/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import re
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from nvidia_resiliency_ext.attribution.coalescing import LogAnalysisCoalesced
@@ -34,7 +33,7 @@ from nvidia_resiliency_ext.attribution.trace_analyzer.trace_analyzer import Trac
 from .analysis_pipeline import AnalysisPipelineMode, run_attribution_pipeline
 from .config import MODULE_LOG_FR_ANALYZER, ErrorCode, LogSageExecutionConfig
 from .job import Job
-from .log_path_metadata import CYCLE_LOG_PATTERN
+from .log_path_metadata import CYCLE_NUM_PATTERN, extract_job_metadata
 from .progressive import (
     MODULE_LOG_ANALYZER_PROGRESSIVE_START,
     PROGRESSIVE_STATUS_UNSUPPORTED,
@@ -128,6 +127,16 @@ class LogSageRunner:
         """Run the in-process LogSage coroutine on this worker thread's event loop."""
         return asyncio.run(analyzer.run(dict(run_kwargs)))
 
+    @staticmethod
+    def _per_cycle_log_kwargs(path: str) -> Dict[str, Any]:
+        is_per_cycle = bool(CYCLE_NUM_PATTERN.search(path))
+        kwargs: Dict[str, Any] = {"is_per_cycle": is_per_cycle}
+        if is_per_cycle:
+            kwargs["cycle_counter"] = extract_job_metadata(
+                path, warn_on_missing_job_id=False
+            ).cycle_id
+        return kwargs
+
     async def _run_lib_log_analyzer_serialized(
         self, analyzer: Any, run_kwargs: Dict[str, Any]
     ) -> Any:
@@ -209,11 +218,10 @@ class LogSageRunner:
             return self._lib_log_analyzer
 
     async def _fetch_log_result_lib(self, path: str) -> Dict[str, Any]:
-        is_per_cycle = bool(re.search(CYCLE_LOG_PATTERN, path))
         run_kwargs = {
             "log_path": path,
             "exclude_nvrx_logs": False,
-            "is_per_cycle": is_per_cycle,
+            **self._per_cycle_log_kwargs(path),
             **self.config.llm_runtime_overrides(),
         }
         analyzer = await self._get_lib_log_analyzer(run_kwargs)
@@ -224,11 +232,10 @@ class LogSageRunner:
     async def _fetch_log_result_mcp(self, path: str) -> Dict[str, Any]:
         self._ensure_mcp_ready()
 
-        is_per_cycle = bool(re.search(CYCLE_LOG_PATTERN, path))
         run_kwargs = {
             "log_path": path,
             "exclude_nvrx_logs": False,
-            "is_per_cycle": is_per_cycle,
+            **self._per_cycle_log_kwargs(path),
             **self.config.llm_runtime_overrides(),
         }
 
@@ -265,10 +272,9 @@ class LogSageRunner:
         job_id: str | None = None,
     ) -> ProgressiveStartResult:
         self._ensure_mcp_ready()
-        is_per_cycle = bool(re.search(CYCLE_LOG_PATTERN, path))
         run_kwargs: Dict[str, Any] = {
             "log_path": path,
-            "is_per_cycle": is_per_cycle,
+            **self._per_cycle_log_kwargs(path),
             "user": user,
             **self.config.llm_runtime_overrides(),
         }
@@ -321,12 +327,11 @@ class LogSageRunner:
     ) -> Tuple[Dict[str, Any], Optional[FRAnalysisResult], Optional[str]]:
         """Single MCP ``log_fr_analyzer`` call: collect log+FR, optionally merge with LLM."""
         self._ensure_mcp_ready()
-        is_per_cycle = bool(re.search(CYCLE_LOG_PATTERN, log_path))
         kwargs: Dict[str, Any] = {
             "log_path": log_path,
             "fr_path": fr_dump_path,
             "exclude_nvrx_logs": False,
-            "is_per_cycle": is_per_cycle,
+            **self._per_cycle_log_kwargs(log_path),
             "pattern": "_dump_*",
             "verbose": False,
             "health_check": False,

--- a/src/nvidia_resiliency_ext/attribution/orchestration/log_path_metadata.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/log_path_metadata.py
@@ -18,8 +18,8 @@ from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
-# Per-cycle log files (e.g., foo_cycle3.log); raw string for re.search(), compiled for .search()
-CYCLE_LOG_PATTERN = r"_cycle(\d+)\.log$"
+# Per-cycle log files (e.g., foo_cycle3.log). Keep matching case-insensitive so all
+# path consumers agree with the launcher-side detector.
 CYCLE_NUM_PATTERN = re.compile(r"_cycle(\d+)\.log$", re.IGNORECASE)
 
 # Date/time in filename: *_date_YY-MM-DD_time_HH-MM-SS.log (for splitlog file sorting)
@@ -50,7 +50,7 @@ def extract_job_metadata(log_path: str, warn_on_missing_job_id: bool = True) -> 
     Extract job ID and cycle ID from log file path.
 
     Job ID: tried in order of specificity; see JOB_ID_PATTERNS (inline comments).
-    Cycle ID: from ..._cycle<N>.log (see CYCLE_LOG_PATTERN).
+    Cycle ID: from ..._cycle<N>.log (see CYCLE_NUM_PATTERN).
 
     Args:
         log_path: Path to the log file
@@ -70,7 +70,7 @@ def extract_job_metadata(log_path: str, warn_on_missing_job_id: bool = True) -> 
     if not job_id and warn_on_missing_job_id:
         logger.warning(f"Failed to extract job ID from path: {log_path}")
 
-    match = re.search(CYCLE_LOG_PATTERN, log_path)
+    match = CYCLE_NUM_PATTERN.search(log_path)
     if match:
         cycle_id = int(match.group(1))
     else:

--- a/tests/attribution/unit/test_combined_log_fr.py
+++ b/tests/attribution/unit/test_combined_log_fr.py
@@ -35,19 +35,68 @@ def _import_combined_log_fr_with_optional_dependency_stubs(monkeypatch):
     langchain_openai = _stub_module(monkeypatch, "langchain_openai")
     langchain_openai.ChatOpenAI = object
 
+    output_parsers = _stub_module(monkeypatch, "langchain_core.output_parsers")
+    output_parsers.StrOutputParser = object
+    prompts = _stub_module(monkeypatch, "langchain_core.prompts")
+    prompts.ChatPromptTemplate = types.SimpleNamespace(
+        from_template=lambda *_args, **_kwargs: object()
+    )
+    runnables = _stub_module(monkeypatch, "langchain_core.runnables")
+    runnables.RunnablePassthrough = object
+
     _stub_module(monkeypatch, "logsage")
     _stub_module(monkeypatch, "logsage.auto_resume_policy")
     attribution_classes = _stub_module(
         monkeypatch, "logsage.auto_resume_policy.attribution_classes"
     )
+    stub_attribution = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_STEP_CANCELLED="SLURM_STEP_CANCELLED",
+        SLURM_STEP_CANCELLED_JOB_REQUEUE="SLURM_STEP_CANCELLED_JOB_REQUEUE",
+    )
+    stub_auto_resume = types.SimpleNamespace(
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        RESTART_IMMEDIATE="RESTART IMMEDIATE",
+        STOP_NO_RESTART="STOP - DONT RESTART IMMEDIATE",
+    )
+    stub_finished = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_CANCELLED="SLURM_CANCELLED",
+        SLURM_CANCELLED_JOB_REQUEUE="SLURM_CANCELLED_JOB_REQUEUE",
+        SLURM_CANCELLED_TIME_LIMIT="SLURM_CANCELLED_TIME_LIMIT",
+    )
     attribution_classes.ApplicationData = object
+    attribution_classes.Attribution = stub_attribution
+    attribution_classes.AutoResumeAction = stub_auto_resume
+    attribution_classes.ErrorAttribution = object
+    attribution_classes.FinishedStatus = stub_finished
     attribution_classes.LRUCache = object
 
     error_attribution = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_attribution")
+    error_attribution.CONTEXT_SIZE = 4096
+    error_attribution.get_attribution = lambda *args, **kwargs: (None, None, None, None)
+    error_attribution.get_auto_resume = lambda *args, **kwargs: ("", "")
     error_attribution.get_proposed_solution_cat = lambda *args, **kwargs: None
 
     error_extraction = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_extraction")
+    error_extraction.finished_validation = lambda _llm, data: data
     error_extraction.return_application_errors = lambda *args, **kwargs: []
+    error_extraction.return_application_errors_rt = lambda *args, **kwargs: types.SimpleNamespace(
+        checkpoint_saved=False
+    )
+
+    prompts_mod = _stub_module(monkeypatch, "logsage.auto_resume_policy.prompts")
+    prompts_mod.template_post_error_check = ""
+    util_postprocessing = _stub_module(
+        monkeypatch, "logsage.auto_resume_policy.util_postprocessing"
+    )
+    util_postprocessing.get_auto_resume_postprocessing = lambda *args, **kwargs: False
+    utils = _stub_module(monkeypatch, "logsage.auto_resume_policy.utils")
+    utils.chunk_indices = lambda *args, **kwargs: []
 
     return importlib.import_module(
         "nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr"
@@ -148,6 +197,153 @@ def test_log_fr_mcp_path_collects_without_merge_by_default(monkeypatch):
     assert payload["recommendation"] == {"action": "CONTINUE", "source": "log_analyzer"}
     assert payload["fr"]["state"] == "STOP"
     assert "llm_merged_summary" not in payload
+
+
+def test_log_fr_mcp_path_passes_cycle_counter_to_logsage(monkeypatch):
+    _import_combined_log_fr_with_optional_dependency_stubs(monkeypatch)
+    monkeypatch.delitem(
+        sys.modules,
+        "nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr_mcp",
+        raising=False,
+    )
+    module = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr_mcp"
+    )
+
+    raw_item = {
+        "raw_text": "runtime error",
+        "auto_resume": "RESTART IMMEDIATE",
+        "auto_resume_explanation": "",
+        "attribution_text": "",
+        "checkpoint_saved_flag": 1,
+        "action": "RESTART",
+        "primary_issues": [],
+        "secondary_issues": [],
+    }
+    captured_log_kwargs = {}
+
+    class FakeLogAnalyzer:
+        def __init__(self, kwargs):
+            captured_log_kwargs["init"] = dict(kwargs)
+
+        async def run(self, kwargs):
+            captured_log_kwargs["run"] = dict(kwargs)
+            return ([raw_item], AttributionState.CONTINUE)
+
+    class FakeFRAnalyzer:
+        def __init__(self, _kwargs):
+            pass
+
+        async def run(self, _kwargs):
+            return (None, AttributionState.CONTINUE)
+
+    class FakeCombinedLogFR:
+        def __init__(self, _kwargs):
+            raise AssertionError("merge LLM should not be constructed unless merge_llm=True")
+
+    monkeypatch.setattr(module, "NVRxLogAnalyzer", FakeLogAnalyzer)
+    monkeypatch.setattr(module, "CollectiveAnalyzer", FakeFRAnalyzer)
+    monkeypatch.setattr(module, "CombinedLogFR", FakeCombinedLogFR)
+    monkeypatch.setattr(module, "fr_path_resolvable_for_collective_analyzer", lambda _path: True)
+
+    async def run():
+        orchestrator = module.CombinedLogFRMCPOrchestrator()
+        return await orchestrator._run_from_paths(
+            {
+                "log_path": "/tmp/test_job_cycle3.log",
+                "fr_path": "/tmp/fr",
+                "is_per_cycle": True,
+                "cycle_counter": 3,
+            }
+        )
+
+    payload, state = asyncio.run(run())
+
+    assert state == AttributionState.CONTINUE
+    assert payload["recommendation"] == {"action": "RESTART", "source": "log_analyzer"}
+    assert captured_log_kwargs["init"]["is_per_cycle"] is True
+    assert captured_log_kwargs["init"]["cycle_counter"] == 3
+    assert captured_log_kwargs["run"]["is_per_cycle"] is True
+    assert captured_log_kwargs["run"]["cycle_counter"] == 3
+
+
+def test_log_fr_mcp_path_reuses_logsage_analyzer_across_cycles(monkeypatch):
+    _import_combined_log_fr_with_optional_dependency_stubs(monkeypatch)
+    monkeypatch.delitem(
+        sys.modules,
+        "nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr_mcp",
+        raising=False,
+    )
+    module = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr_mcp"
+    )
+
+    raw_item = {
+        "raw_text": "runtime error",
+        "auto_resume": "RESTART IMMEDIATE",
+        "auto_resume_explanation": "",
+        "attribution_text": "",
+        "checkpoint_saved_flag": 0,
+        "action": "RESTART",
+        "primary_issues": [],
+        "secondary_issues": [],
+    }
+    instances = []
+
+    class FakeLogAnalyzer:
+        def __init__(self, kwargs):
+            self.init_kwargs = dict(kwargs)
+            self.run_kwargs = []
+            instances.append(self)
+
+        async def run(self, kwargs):
+            self.run_kwargs.append(dict(kwargs))
+            return ([raw_item], AttributionState.CONTINUE)
+
+    class FakeFRAnalyzer:
+        def __init__(self, _kwargs):
+            pass
+
+        async def run(self, _kwargs):
+            return (None, AttributionState.CONTINUE)
+
+    class FakeCombinedLogFR:
+        def __init__(self, _kwargs):
+            raise AssertionError("merge LLM should not be constructed unless merge_llm=True")
+
+    monkeypatch.setattr(module, "NVRxLogAnalyzer", FakeLogAnalyzer)
+    monkeypatch.setattr(module, "CollectiveAnalyzer", FakeFRAnalyzer)
+    monkeypatch.setattr(module, "CombinedLogFR", FakeCombinedLogFR)
+    monkeypatch.setattr(module, "fr_path_resolvable_for_collective_analyzer", lambda _path: True)
+
+    async def run():
+        orchestrator = module.CombinedLogFRMCPOrchestrator()
+        await orchestrator._run_from_paths(
+            {
+                "log_path": "/tmp/test_job_cycle0.log",
+                "fr_path": "/tmp/fr",
+                "is_per_cycle": True,
+                "cycle_counter": 0,
+            }
+        )
+        await orchestrator._run_from_paths(
+            {
+                "log_path": "/tmp/test_job_cycle1.log",
+                "fr_path": "/tmp/fr",
+                "is_per_cycle": True,
+                "cycle_counter": 1,
+            }
+        )
+
+    asyncio.run(run())
+
+    assert len(instances) == 1
+    assert instances[0].init_kwargs["cycle_counter"] == 0
+    assert [kwargs["cycle_counter"] for kwargs in instances[0].run_kwargs] == [0, 1]
+    assert [kwargs["log_path"] for kwargs in instances[0].run_kwargs] == [
+        "/tmp/test_job_cycle0.log",
+        "/tmp/test_job_cycle1.log",
+    ]
 
 
 def test_log_fr_mcp_path_state_ignores_fr_and_merge_stop_when_merge_enabled(monkeypatch):

--- a/tests/attribution/unit/test_log_analyzer_observability.py
+++ b/tests/attribution/unit/test_log_analyzer_observability.py
@@ -405,3 +405,39 @@ def test_log_fr_analyzer_mcp_uses_top_level_log_contract(monkeypatch):
         assert merged_summary == "ignored unless merge_llm=true"
 
     asyncio.run(run())
+
+
+def test_log_fr_analyzer_mcp_uses_cycle_counter_for_per_cycle_log(monkeypatch):
+    _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    module = importlib.import_module("nvidia_resiliency_ext.attribution.orchestration.log_analyzer")
+    runner = object.__new__(module.LogSageRunner)
+    runner.config = LogSageExecutionConfig(use_lib_log_analysis=False)
+    runner._log_analysis_lock = asyncio.Lock()
+    captured: dict[str, Any] = {}
+
+    class FakeMCPClient:
+        session = object()
+
+        async def run_module_resilient(self, name: str, **kwargs: Any) -> dict[str, Any]:
+            captured["name"] = name
+            captured["kwargs"] = kwargs
+            return {
+                "module": "log_fr_analyzer",
+                "result": _log_result()["result"],
+                "recommendation": {"action": "RESTART", "source": "log_analyzer"},
+                "fr": {"result": None, "state": "CONTINUE"},
+            }
+
+    runner._mcp_client = FakeMCPClient()
+
+    async def run() -> None:
+        await runner.fetch_log_fr_analyzer_mcp(
+            "/tmp/train_cycle5.log",
+            "/tmp/fr",
+        )
+
+        assert captured["name"] == "log_fr_analyzer"
+        assert captured["kwargs"]["is_per_cycle"] is True
+        assert captured["kwargs"]["cycle_counter"] == 5
+
+    asyncio.run(run())

--- a/tests/attribution/unit/test_log_path_metadata.py
+++ b/tests/attribution/unit/test_log_path_metadata.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nvidia_resiliency_ext.attribution.orchestration.log_path_metadata import extract_job_metadata
+
+
+def test_extract_job_metadata_extracts_ft_cycle_id_case_insensitively():
+    assert (
+        extract_job_metadata("/mnt/logs/train_cycle3.log", warn_on_missing_job_id=False).cycle_id
+        == 3
+    )
+    assert (
+        extract_job_metadata("/mnt/logs/train_CYCLE4.log", warn_on_missing_job_id=False).cycle_id
+        == 4
+    )
+
+
+def test_extract_job_metadata_extracts_job_id_and_cycle_id():
+    metadata = extract_job_metadata(
+        "/mnt/logs/prefix_12345678_date_26-06-23_time_10-11-12_cycle7.log"
+    )
+
+    assert metadata.job_id == "12345678"
+    assert metadata.cycle_id == 7

--- a/tests/attribution/unit/test_nvrx_logsage_reason_code.py
+++ b/tests/attribution/unit/test_nvrx_logsage_reason_code.py
@@ -17,19 +17,68 @@ def _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch):
     langchain_openai = _stub_module(monkeypatch, "langchain_openai")
     langchain_openai.ChatOpenAI = object
 
+    output_parsers = _stub_module(monkeypatch, "langchain_core.output_parsers")
+    output_parsers.StrOutputParser = object
+    prompts = _stub_module(monkeypatch, "langchain_core.prompts")
+    prompts.ChatPromptTemplate = types.SimpleNamespace(
+        from_template=lambda *_args, **_kwargs: object()
+    )
+    runnables = _stub_module(monkeypatch, "langchain_core.runnables")
+    runnables.RunnablePassthrough = object
+
     _stub_module(monkeypatch, "logsage")
     _stub_module(monkeypatch, "logsage.auto_resume_policy")
     attribution_classes = _stub_module(
         monkeypatch, "logsage.auto_resume_policy.attribution_classes"
     )
+    stub_attribution = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_STEP_CANCELLED="SLURM_STEP_CANCELLED",
+        SLURM_STEP_CANCELLED_JOB_REQUEUE="SLURM_STEP_CANCELLED_JOB_REQUEUE",
+    )
+    stub_auto_resume = types.SimpleNamespace(
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        RESTART_IMMEDIATE="RESTART IMMEDIATE",
+        STOP_NO_RESTART="STOP - DONT RESTART IMMEDIATE",
+    )
+    stub_finished = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_CANCELLED="SLURM_CANCELLED",
+        SLURM_CANCELLED_JOB_REQUEUE="SLURM_CANCELLED_JOB_REQUEUE",
+        SLURM_CANCELLED_TIME_LIMIT="SLURM_CANCELLED_TIME_LIMIT",
+    )
     attribution_classes.ApplicationData = object
+    attribution_classes.Attribution = stub_attribution
+    attribution_classes.AutoResumeAction = stub_auto_resume
+    attribution_classes.ErrorAttribution = object
+    attribution_classes.FinishedStatus = stub_finished
     attribution_classes.LRUCache = object
 
     error_attribution = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_attribution")
+    error_attribution.CONTEXT_SIZE = 4096
+    error_attribution.get_attribution = lambda *args, **kwargs: (None, None, None, None)
+    error_attribution.get_auto_resume = lambda *args, **kwargs: ("", "")
     error_attribution.get_proposed_solution_cat = lambda *args, **kwargs: None
 
     error_extraction = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_extraction")
+    error_extraction.finished_validation = lambda _llm, data: data
     error_extraction.return_application_errors = lambda *args, **kwargs: []
+    error_extraction.return_application_errors_rt = lambda *args, **kwargs: types.SimpleNamespace(
+        checkpoint_saved=False
+    )
+
+    prompts_mod = _stub_module(monkeypatch, "logsage.auto_resume_policy.prompts")
+    prompts_mod.template_post_error_check = ""
+    util_postprocessing = _stub_module(
+        monkeypatch, "logsage.auto_resume_policy.util_postprocessing"
+    )
+    util_postprocessing.get_auto_resume_postprocessing = lambda *args, **kwargs: False
+    utils = _stub_module(monkeypatch, "logsage.auto_resume_policy.utils")
+    utils.chunk_indices = lambda *args, **kwargs: []
 
     return importlib.import_module(module_name)
 
@@ -39,6 +88,68 @@ def test_stop_no_restart_action_wins_over_restart_substring(monkeypatch):
 
     assert nvrx_logsage._action_from_logsage_head("STOP - DONT RESTART IMMEDIATE") == "STOP"
     assert nvrx_logsage._action_from_logsage_head("RESTART IMMEDIATE") == "RESTART"
+
+
+def test_cycle_counter_key_normalizes_ft_per_cycle_log_names(monkeypatch):
+    nvrx_logsage = _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch)
+
+    assert (
+        nvrx_logsage._cycle_counter_key("/mnt/logs/test_job_cycle0.log") == "/mnt/logs/test_job.log"
+    )
+    assert (
+        nvrx_logsage._cycle_counter_key("/mnt/logs/test_job_cycle4.log") == "/mnt/logs/test_job.log"
+    )
+    assert nvrx_logsage._cycle_counter_key("/mnt/logs/nvrx_4.log") == "/mnt/logs/nvrx.log"
+
+
+def test_per_cycle_non_progressive_path_applies_repeated_error_policy(monkeypatch):
+    nvrx_logsage = _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch)
+    analyzer = object.__new__(nvrx_logsage.NVRxLogAnalyzer)
+    analyzer._init_config = {
+        "log_path": "/mnt/logs/test_job_cycle2.log",
+        "is_per_cycle": True,
+        "cycle_counter": 2,
+    }
+    analyzer.is_per_cycle = True
+    analyzer.job_inline_data_dict = {}
+    analyzer.attribution_dict = {
+        "/mnt/logs/test_job_cycle1.log": "Primary issues: [OOM], Secondary issues: []"
+    }
+    analyzer.cycle_counter_dict = {"/mnt/logs/test_job.log": 2}
+    analyzer.repeated_amount = 3
+    analyzer.llm = object()
+
+    monkeypatch.setattr(
+        nvrx_logsage,
+        "get_proposed_solution_cat",
+        lambda *_args, **_kwargs: (
+            "RESTART IMMEDIATE",
+            "",
+            "Attribution: Primary issues: [OOM], Secondary issues: []",
+            "",
+            "False",
+        ),
+    )
+    monkeypatch.setattr(
+        nvrx_logsage,
+        "get_auto_resume_postprocessing",
+        lambda *_args, **_kwargs: True,
+    )
+    output = types.SimpleNamespace(
+        finished="RUNNING",
+        original_text=["RuntimeError: OOM"],
+        application_errors_list_full=[("RuntimeError: OOM", "", 0)],
+        checkpoint_saved=False,
+    )
+
+    fields = asyncio.run(analyzer.llm_analyze([output]))
+
+    assert fields[0][0] == "STOP - DONT RESTART IMMEDIATE"
+    assert fields[0][1] == "Stop job due to repeated issue"
+    assert analyzer.attribution_dict["/mnt/logs/test_job_cycle2.log"] == (
+        "Primary issues: [OOM], Secondary issues: []"
+    )
+    assert analyzer.cycle_counter_dict["/mnt/logs/test_job.log"] == 2
 
 
 def test_print_output_returns_structured_item_without_downstream_reparse(monkeypatch):

--- a/tests/attribution/unit/test_progressive_plumbing.py
+++ b/tests/attribution/unit/test_progressive_plumbing.py
@@ -43,19 +43,68 @@ def _import_analyzer_with_optional_dependency_stubs(monkeypatch):
     langchain_openai = _stub_module(monkeypatch, "langchain_openai")
     langchain_openai.ChatOpenAI = object
 
+    output_parsers = _stub_module(monkeypatch, "langchain_core.output_parsers")
+    output_parsers.StrOutputParser = object
+    prompts = _stub_module(monkeypatch, "langchain_core.prompts")
+    prompts.ChatPromptTemplate = types.SimpleNamespace(
+        from_template=lambda *_args, **_kwargs: object()
+    )
+    runnables = _stub_module(monkeypatch, "langchain_core.runnables")
+    runnables.RunnablePassthrough = object
+
     _stub_module(monkeypatch, "logsage")
     _stub_module(monkeypatch, "logsage.auto_resume_policy")
     attribution_classes = _stub_module(
         monkeypatch, "logsage.auto_resume_policy.attribution_classes"
     )
+    stub_attribution = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_STEP_CANCELLED="SLURM_STEP_CANCELLED",
+        SLURM_STEP_CANCELLED_JOB_REQUEUE="SLURM_STEP_CANCELLED_JOB_REQUEUE",
+    )
+    stub_auto_resume = types.SimpleNamespace(
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        RESTART_IMMEDIATE="RESTART IMMEDIATE",
+        STOP_NO_RESTART="STOP - DONT RESTART IMMEDIATE",
+    )
+    stub_finished = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_CANCELLED="SLURM_CANCELLED",
+        SLURM_CANCELLED_JOB_REQUEUE="SLURM_CANCELLED_JOB_REQUEUE",
+        SLURM_CANCELLED_TIME_LIMIT="SLURM_CANCELLED_TIME_LIMIT",
+    )
     attribution_classes.ApplicationData = object
+    attribution_classes.Attribution = stub_attribution
+    attribution_classes.AutoResumeAction = stub_auto_resume
+    attribution_classes.ErrorAttribution = object
+    attribution_classes.FinishedStatus = stub_finished
     attribution_classes.LRUCache = object
 
     error_attribution = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_attribution")
+    error_attribution.CONTEXT_SIZE = 4096
+    error_attribution.get_attribution = lambda *args, **kwargs: (None, None, None, None)
+    error_attribution.get_auto_resume = lambda *args, **kwargs: ("", "")
     error_attribution.get_proposed_solution_cat = lambda *args, **kwargs: None
 
     error_extraction = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_extraction")
+    error_extraction.finished_validation = lambda _llm, data: data
     error_extraction.return_application_errors = lambda *args, **kwargs: []
+    error_extraction.return_application_errors_rt = lambda *args, **kwargs: types.SimpleNamespace(
+        checkpoint_saved=False
+    )
+
+    prompts_mod = _stub_module(monkeypatch, "logsage.auto_resume_policy.prompts")
+    prompts_mod.template_post_error_check = ""
+    util_postprocessing = _stub_module(
+        monkeypatch, "logsage.auto_resume_policy.util_postprocessing"
+    )
+    util_postprocessing.get_auto_resume_postprocessing = lambda *args, **kwargs: False
+    utils = _stub_module(monkeypatch, "logsage.auto_resume_policy.utils")
+    utils.chunk_indices = lambda *args, **kwargs: []
 
     httpx = _stub_module(monkeypatch, "httpx")
     httpx.post = lambda *args, **kwargs: types.SimpleNamespace(status_code=201, text="created")
@@ -389,7 +438,7 @@ def test_progressive_start_uses_mcp_loganalysis_tool(monkeypatch, tmp_path):
 
     async def run() -> ProgressiveStartResult:
         return await runner.start_progressive_analysis(
-            str(tmp_path / "train_cycle0.log"),
+            str(tmp_path / "train_cycle3.log"),
             user="alice",
             job_id="123",
         )
@@ -405,10 +454,44 @@ def test_progressive_start_uses_mcp_loganalysis_tool(monkeypatch, tmp_path):
             MODULE_LOG_ANALYZER_PROGRESSIVE_START,
             {
                 "max_attempts": 3,
-                "log_path": str(tmp_path / "train_cycle0.log"),
+                "log_path": str(tmp_path / "train_cycle3.log"),
                 "is_per_cycle": True,
+                "cycle_counter": 3,
                 "user": "alice",
                 "job_id": "123",
+            },
+        )
+    ]
+
+
+def test_terminal_log_analyzer_mcp_uses_cycle_counter(monkeypatch, tmp_path):
+    _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    module = importlib.import_module("nvidia_resiliency_ext.attribution.orchestration.log_analyzer")
+    fake_client = FakeMcpClient(
+        {
+            "module": "log_analyzer",
+            "result": [],
+            "recommendation": {"action": "RESTART", "source": "test"},
+        }
+    )
+    monkeypatch.setattr(module, "create_mcp_client", lambda **_kwargs: fake_client)
+    runner = module.LogSageRunner(LogSageExecutionConfig(use_lib_log_analysis=False))
+
+    async def run() -> dict[str, Any]:
+        return await runner.fetch_log_result(str(tmp_path / "train_CYCLE4.log"))
+
+    result = asyncio.run(run())
+
+    assert result["recommendation"]["action"] == "RESTART"
+    assert fake_client.calls == [
+        (
+            "log_analyzer",
+            {
+                "max_attempts": 3,
+                "log_path": str(tmp_path / "train_CYCLE4.log"),
+                "exclude_nvrx_logs": False,
+                "is_per_cycle": True,
+                "cycle_counter": 4,
             },
         )
     ]


### PR DESCRIPTION
## Summary

- Pass FT per-cycle `cycle_counter` through LogSage MCP calls, including progressive start, terminal log analysis, and combined log+FR path mode.
- Normalize LogSage repeated-error state keys for `*_cycle<N>.log` files so per-cycle logs share the same counter.
- Add unit coverage proving MCP kwargs carry the cycle index and FT cycle filenames collapse to one repeated-error key.

## Root Cause

Launcher-managed attrsvc detected per-cycle MCP logs but did not pass `cycle_counter`, so LogSage defaulted every cycle to `0`. Separately, repeated-error state keyed `test_job_cycle0.log`, `test_job_cycle1.log`, etc. independently because `_cycle_counter_key()` only stripped `_<digits>` suffixes.

## Validation

- `git diff --check`
- `PYTHONPATH=src poetry run pytest -q tests/attribution/unit/test_progressive_plumbing.py tests/attribution/unit/test_nvrx_logsage_reason_code.py`
- `poetry run black --check .`
- `poetry run ruff check` on changed files
- `poetry run isort --check-only` on changed files

Dev PDX validation is prepared in `nvrx-workspace`, but could not be submitted from this session because the documented login host closed SSH sessions immediately (`Connection closed by 10.86.160.9 port 22`).
