### PR TITLE
[codex] Filter stale FR dumps by Pstart time

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
+++ b/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
@@ -326,7 +326,12 @@ class Analyzer:
         except ValueError as e:
             return LogAnalyzerError(error_code=ErrorCode.INVALID_PARAMETER, message=str(e))
 
-        result = await self._log.submit(log_path, user=user, job_id=job_id)
+        result = await self._log.submit(
+            log_path,
+            user=user,
+            job_id=job_id,
+            record_submission_time=(intent != ANALYSIS_INTENT_TERMINAL),
+        )
         if isinstance(result, LogAnalyzerError):
             return result
 

--- a/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py
+++ b/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py
@@ -217,6 +217,8 @@ class CombinedLogFRMCPOrchestrator:
             "llm_analyze": bool(arguments.get("llm_analyze", False)),
             "threshold": arguments.get("threshold"),
         }
+        if arguments.get("fr_min_mtime") is not None:
+            fr_kw["fr_min_mtime"] = float(arguments["fr_min_mtime"])
 
         log_analyzer = NVRxLogAnalyzer(log_kw)
         fr_analyzer = CollectiveAnalyzer(fr_kw)

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
@@ -300,6 +300,10 @@ def register_all_modules():
                     "description": "File pattern to match",
                     "default": "_dump_*",
                 },
+                "fr_min_mtime": {
+                    "type": "number",
+                    "description": "Optional lower-bound file mtime for FR dump freshness filtering",
+                },
             },
             "required": ["fr_path"],
         },
@@ -373,6 +377,10 @@ def register_all_modules():
                 "exclude_nvrx_logs": {"type": "boolean", "default": False},
                 "is_per_cycle": {"type": "boolean", "default": False},
                 "pattern": {"type": "string", "default": "_dump_*"},
+                "fr_min_mtime": {
+                    "type": "number",
+                    "description": "Optional lower-bound file mtime for FR dump freshness filtering",
+                },
                 "verbose": {"type": "boolean", "default": False},
                 "health_check": {"type": "boolean", "default": False},
                 "llm_analyze": {"type": "boolean", "default": False},

--- a/src/nvidia_resiliency_ext/attribution/orchestration/job.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/job.py
@@ -65,6 +65,8 @@ class Job:
     user: str  # Job owner (for dataflow posting)
     mode: JobMode = JobMode.PENDING  # Job mode
     created_at: float = field(default_factory=time.monotonic)
+    # time.time() from the Pstart POST; comparable to file mtimes.
+    submitted_at_wall: Optional[float] = None
 
     # Optional job_id (provided in POST for splitlog detection)
     job_id: Optional[str] = None
@@ -106,6 +108,7 @@ class Job:
         """Promote a pending job to splitlog mode."""
         self.mode = JobMode.SPLITLOG
         self.logs_dir = logs_dir
+        self.submitted_at_wall = None
 
     def demote_to_single(self) -> None:
         """Demote a pending job to single-file mode (fallback)."""

--- a/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
@@ -295,29 +295,49 @@ class LogSageRunner:
             return await self._start_progressive_analysis_lib(path, user=user, job_id=job_id)
         return await self._start_progressive_analysis_mcp(path, user=user, job_id=job_id)
 
-    async def _fetch_fr_result_mcp(self, dump_path: str) -> Optional[FRAnalysisResult]:
+    async def _fetch_fr_result_mcp(
+        self,
+        dump_path: str,
+        *,
+        fr_min_mtime: Optional[float] = None,
+    ) -> Optional[FRAnalysisResult]:
         self._ensure_mcp_ready()
+        kwargs: Dict[str, Any] = {
+            "fr_path": dump_path,
+            "pattern": "_dump_*",
+            "verbose": False,
+            "health_check": False,
+            "llm_analyze": False,
+            **self.config.llm_endpoint_overrides(),
+        }
+        if fr_min_mtime is not None:
+            kwargs["fr_min_mtime"] = fr_min_mtime
         async with self._log_analysis_lock:
             resp = await self._mcp_client.run_module_resilient(
                 "fr_analyzer",
                 max_attempts=3,
-                fr_path=dump_path,
-                pattern="_dump_*",
-                verbose=False,
-                health_check=False,
-                llm_analyze=False,
-                **self.config.llm_endpoint_overrides(),
+                **kwargs,
             )
         return fr_result_from_mcp_module_response(resp)
 
-    async def fetch_fr_result(self, dump_path: str) -> Optional[FRAnalysisResult]:
+    async def fetch_fr_result(
+        self,
+        dump_path: str,
+        *,
+        fr_min_mtime: Optional[float] = None,
+    ) -> Optional[FRAnalysisResult]:
         """Run flight-recorder analysis (lib or MCP) for ``dump_path``."""
         if self.config.use_lib_log_analysis:
-            return await analyze_fr_dump(dump_path)
-        return await self._fetch_fr_result_mcp(dump_path)
+            return await analyze_fr_dump(dump_path, fr_min_mtime=fr_min_mtime)
+        return await self._fetch_fr_result_mcp(dump_path, fr_min_mtime=fr_min_mtime)
 
     async def fetch_log_fr_analyzer_mcp(
-        self, log_path: str, fr_dump_path: str, *, merge_llm: bool = False
+        self,
+        log_path: str,
+        fr_dump_path: str,
+        *,
+        merge_llm: bool = False,
+        fr_min_mtime: Optional[float] = None,
     ) -> Tuple[Dict[str, Any], Optional[FRAnalysisResult], Optional[str]]:
         """Single MCP ``log_fr_analyzer`` call: collect log+FR, optionally merge with LLM."""
         self._ensure_mcp_ready()
@@ -335,6 +355,8 @@ class LogSageRunner:
             "threshold": 0,
             **self.config.llm_runtime_overrides(),
         }
+        if fr_min_mtime is not None:
+            kwargs["fr_min_mtime"] = fr_min_mtime
 
         async with self._log_analysis_lock:
             resp = await self._mcp_client.run_module_resilient(
@@ -438,6 +460,11 @@ class LogAnalyzer:
             )
             return None
         return discovered
+
+    def _fr_min_mtime_for_path(self, path: str) -> Optional[float]:
+        """Return recorded Pstart wall time for FR freshness filtering, if any."""
+        job = self.get_job(path)
+        return job.submitted_at_wall if job is not None else None
 
     def read_file_preview(
         self, log_path: str, max_bytes: int = 4096
@@ -592,13 +619,26 @@ class LogAnalyzer:
         mode = self._analysis_pipeline_mode
         cfg = self._runner.config
         pipeline_kw: Dict[str, Any] = {}
+        fr_min_mtime = self._fr_min_mtime_for_path(path)
         if self._trace_analyzer is not None:
             pipeline_kw["discover_fr_dump_path"] = self._discover_fr_dump_path
-            pipeline_kw["run_fr_analysis"] = (
-                self._trace_analyzer.analyze_fr_dump
-                if cfg.use_lib_log_analysis
-                else self._runner.fetch_fr_result
-            )
+            if cfg.use_lib_log_analysis:
+
+                async def _run_fr_analysis(fd: str) -> Optional[FRAnalysisResult]:
+                    return await self._trace_analyzer.analyze_fr_dump(
+                        fd,
+                        fr_min_mtime=fr_min_mtime,
+                    )
+
+            else:
+
+                async def _run_fr_analysis(fd: str) -> Optional[FRAnalysisResult]:
+                    return await self._runner.fetch_fr_result(
+                        fd,
+                        fr_min_mtime=fr_min_mtime,
+                    )
+
+            pipeline_kw["run_fr_analysis"] = _run_fr_analysis
             if not cfg.use_lib_log_analysis:
 
                 async def _mcp_combined(
@@ -608,6 +648,7 @@ class LogAnalyzer:
                         lp,
                         fd,
                         merge_llm=(mode == AnalysisPipelineMode.LOG_AND_TRACE_WITH_LLM),
+                        fr_min_mtime=fr_min_mtime,
                     )
 
                 pipeline_kw["run_log_fr_analyzer_mcp"] = _mcp_combined
@@ -713,6 +754,8 @@ class LogAnalyzer:
         log_path: str,
         user: str = "unknown",
         job_id: Optional[str] = None,
+        *,
+        record_submission_time: bool = True,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
         """Submit a log path for tracking (splitlog / pending / single)."""
         if not log_path:
@@ -734,4 +777,9 @@ class LogAnalyzer:
         if existing_job:
             return self._tracked.handle_existing_job(existing_job, validated)
 
-        return await self._tracked.create_new_job(validated, user, job_id)
+        return await self._tracked.create_new_job(
+            validated,
+            user,
+            job_id,
+            record_submission_time=record_submission_time,
+        )

--- a/src/nvidia_resiliency_ext/attribution/orchestration/tracked_jobs.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/tracked_jobs.py
@@ -28,6 +28,7 @@ from .config import (
     ErrorCode,
 )
 from .job import Job, JobMode
+from .log_path_metadata import CYCLE_NUM_PATTERN
 from .slurm_parser import read_and_parse_slurm_output
 from .splitlog import SplitlogTracker
 from .types import LogAnalyzerError, LogAnalyzerSubmitResult
@@ -36,6 +37,10 @@ logger = logging.getLogger(__name__)
 
 # Fire-and-forget: (log_path, user, job_id)
 FireAndForgetAnalyze = Callable[[str, str, Optional[str]], None]
+
+
+def _is_direct_app_log_path(path: str) -> bool:
+    return bool(CYCLE_NUM_PATTERN.search(path))
 
 
 class TrackedJobs:
@@ -92,7 +97,11 @@ class TrackedJobs:
         self._total_permission_errors += 1
         self._file_permission_errors += 1
 
-    def handle_existing_job(self, job: Job, validated: str) -> LogAnalyzerSubmitResult:
+    def handle_existing_job(
+        self,
+        job: Job,
+        validated: str,
+    ) -> LogAnalyzerSubmitResult:
         if job.is_splitlog():
             self._splitlog_tracker.poll_now()
             return LogAnalyzerSubmitResult(
@@ -126,10 +135,21 @@ class TrackedJobs:
         )
 
     async def create_new_job(
-        self, validated: str, user: str, job_id: Optional[str]
+        self,
+        validated: str,
+        user: str,
+        job_id: Optional[str],
+        *,
+        record_submission_time: bool = True,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
-        if job_id:
-            logger.debug("create_new_job: job_id=%s, checking for splitlog mode", job_id)
+        is_direct_app_log = _is_direct_app_log_path(validated)
+        if job_id and is_direct_app_log:
+            logger.debug(
+                "create_new_job: path is a direct app log, using SINGLE mode: %s",
+                validated,
+            )
+        elif job_id:
+            logger.debug("create_new_job: job_id=%s, checking splitlog/pending mode", job_id)
             info = read_and_parse_slurm_output(validated)
             logger.debug(
                 "create_new_job: slurm parse - logs_dir=%s, cycle_count=%s",
@@ -191,11 +211,18 @@ class TrackedJobs:
                 mode=JobMode.PENDING.value,
             )
 
+        submitted_at_wall = time.time() if record_submission_time and is_direct_app_log else None
         self._total_single += 1
-        job = Job(path=validated, user=user, mode=JobMode.SINGLE)
+        job = Job(
+            path=validated,
+            user=user,
+            mode=JobMode.SINGLE,
+            job_id=job_id,
+            submitted_at_wall=submitted_at_wall,
+        )
         with self._jobs_lock:
             self._jobs[validated] = job
-        logger.debug("Created SINGLE job (no job_id): path=%s", validated)
+        logger.debug("Created SINGLE job: path=%s, job_id=%s", validated, job_id)
         await self._track_submission(validated)
         return LogAnalyzerSubmitResult(
             submitted=True,

--- a/src/nvidia_resiliency_ext/attribution/trace_analyzer/fr_attribution.py
+++ b/src/nvidia_resiliency_ext/attribution/trace_analyzer/fr_attribution.py
@@ -43,6 +43,41 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
+def _optional_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _filter_files_by_min_mtime(filepaths: List[str], min_mtime: Optional[float]) -> List[str]:
+    if min_mtime is None:
+        return filepaths
+
+    kept = []
+    filtered_stale = 0
+    skipped_unavailable = 0
+    for filepath in filepaths:
+        try:
+            file_mtime = os.path.getmtime(filepath)
+        except OSError:
+            skipped_unavailable += 1
+            logger.debug("Skipping FR dump with unavailable mtime: %s", filepath)
+            continue
+        if file_mtime >= min_mtime:
+            kept.append(filepath)
+        else:
+            filtered_stale += 1
+    logger.info(
+        "FR min-mtime filter applied: min_mtime=%.6f, kept=%d, "
+        "filtered_stale=%d, skipped_unavailable=%d",
+        min_mtime,
+        len(kept),
+        filtered_stale,
+        skipped_unavailable,
+    )
+    return kept
+
+
 def _parse_rank_list(rank_text: str) -> List[int]:
     ranks = []
     for token in rank_text.split(','):
@@ -209,10 +244,12 @@ class CollectiveAnalyzer(NVRxAttribution):
         logger.info("FR args: %s", bounded_log_value(cfg))
         file_paths = [cfg["fr_path"]]
         pattern = cfg.get("pattern", "_dump_*")
+        fr_min_mtime = _optional_float(cfg.get("fr_min_mtime"))
         logger.info(
-            "file_paths: %s, pattern: %s",
+            "file_paths: %s, pattern: %s, fr_min_mtime: %s",
             file_paths,
             pattern,
+            fr_min_mtime,
         )
         processed_files = 0
         # Process all input paths
@@ -226,6 +263,7 @@ class CollectiveAnalyzer(NVRxAttribution):
             else:
                 # Path prefix (not a directory / not an existing file): match _dump_<rank> siblings.
                 json_files = glob.glob(path + "*")
+            json_files = _filter_files_by_min_mtime(json_files, fr_min_mtime)
             logger.info("json_files: %s", bounded_log_value(json_files))
             json_files.sort()
             for filepath in json_files:

--- a/src/nvidia_resiliency_ext/attribution/trace_analyzer/fr_support.py
+++ b/src/nvidia_resiliency_ext/attribution/trace_analyzer/fr_support.py
@@ -261,7 +261,11 @@ def fr_result_from_mcp_module_response(resp: Any) -> Optional[FRAnalysisResult]:
     return None
 
 
-async def analyze_fr_dump(dump_path: str) -> Optional[FRAnalysisResult]:
+async def analyze_fr_dump(
+    dump_path: str,
+    *,
+    fr_min_mtime: Optional[float] = None,
+) -> Optional[FRAnalysisResult]:
     """Run CollectiveAnalyzer on a flight recorder dump (deterministic table analysis only)."""
     try:
         from nvidia_resiliency_ext.attribution.trace_analyzer.fr_attribution import (
@@ -277,6 +281,8 @@ async def analyze_fr_dump(dump_path: str) -> Optional[FRAnalysisResult]:
             "llm_analyze": False,
             "threshold": None,
         }
+        if fr_min_mtime is not None:
+            args["fr_min_mtime"] = fr_min_mtime
 
         def _run_sync() -> FRAnalysisResult:
             try:

--- a/src/nvidia_resiliency_ext/attribution/trace_analyzer/trace_analyzer.py
+++ b/src/nvidia_resiliency_ext/attribution/trace_analyzer/trace_analyzer.py
@@ -26,6 +26,11 @@ class TraceAnalyzer:
         """Return path to NCCL FR dump referenced by the job log, or ``None``."""
         return extract_fr_dump_path(log_path, allowed_root=self._allowed_root)
 
-    async def analyze_fr_dump(self, dump_path: str) -> Optional[FRAnalysisResult]:
+    async def analyze_fr_dump(
+        self,
+        dump_path: str,
+        *,
+        fr_min_mtime: Optional[float] = None,
+    ) -> Optional[FRAnalysisResult]:
         """Analyze a single FR dump file."""
-        return await analyze_fr_dump(dump_path)
+        return await analyze_fr_dump(dump_path, fr_min_mtime=fr_min_mtime)

--- a/tests/attribution/unit/test_combined_log_fr.py
+++ b/tests/attribution/unit/test_combined_log_fr.py
@@ -35,19 +35,67 @@ def _import_combined_log_fr_with_optional_dependency_stubs(monkeypatch):
     langchain_openai = _stub_module(monkeypatch, "langchain_openai")
     langchain_openai.ChatOpenAI = object
 
+    output_parsers = _stub_module(monkeypatch, "langchain_core.output_parsers")
+    output_parsers.StrOutputParser = object
+    prompts = _stub_module(monkeypatch, "langchain_core.prompts")
+    prompts.ChatPromptTemplate = types.SimpleNamespace(
+        from_template=lambda *_args, **_kwargs: object()
+    )
+    runnables = _stub_module(monkeypatch, "langchain_core.runnables")
+    runnables.RunnablePassthrough = object
+
     _stub_module(monkeypatch, "logsage")
     _stub_module(monkeypatch, "logsage.auto_resume_policy")
     attribution_classes = _stub_module(
         monkeypatch, "logsage.auto_resume_policy.attribution_classes"
     )
+    stub_attribution = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_STEP_CANCELLED="SLURM_STEP_CANCELLED",
+        SLURM_STEP_CANCELLED_JOB_REQUEUE="SLURM_STEP_CANCELLED_JOB_REQUEUE",
+    )
+    stub_auto_resume = types.SimpleNamespace(
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        RESTART_IMMEDIATE="RESTART IMMEDIATE",
+        STOP_NO_RESTART="STOP - DONT RESTART IMMEDIATE",
+    )
+    stub_finished = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_CANCELLED="SLURM_CANCELLED",
+        SLURM_CANCELLED_JOB_REQUEUE="SLURM_CANCELLED_JOB_REQUEUE",
+        SLURM_CANCELLED_TIME_LIMIT="SLURM_CANCELLED_TIME_LIMIT",
+    )
     attribution_classes.ApplicationData = object
+    attribution_classes.Attribution = stub_attribution
+    attribution_classes.AutoResumeAction = stub_auto_resume
+    attribution_classes.ErrorAttribution = object
+    attribution_classes.FinishedStatus = stub_finished
     attribution_classes.LRUCache = object
 
     error_attribution = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_attribution")
+    error_attribution.CONTEXT_SIZE = 4096
+    error_attribution.get_attribution = lambda *args, **kwargs: (None, None, None, None)
+    error_attribution.get_auto_resume = lambda *args, **kwargs: ("", "")
     error_attribution.get_proposed_solution_cat = lambda *args, **kwargs: None
 
     error_extraction = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_extraction")
+    error_extraction.finished_validation = lambda _llm, data: data
     error_extraction.return_application_errors = lambda *args, **kwargs: []
+    error_extraction.return_application_errors_rt = lambda *args, **kwargs: types.SimpleNamespace(
+        checkpoint_saved=False
+    )
+    prompts_mod = _stub_module(monkeypatch, "logsage.auto_resume_policy.prompts")
+    prompts_mod.template_post_error_check = ""
+    util_postprocessing = _stub_module(
+        monkeypatch, "logsage.auto_resume_policy.util_postprocessing"
+    )
+    util_postprocessing.get_auto_resume_postprocessing = lambda *args, **kwargs: False
+    utils = _stub_module(monkeypatch, "logsage.auto_resume_policy.utils")
+    utils.chunk_indices = lambda *args, **kwargs: []
 
     return importlib.import_module(
         "nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr"

--- a/tests/attribution/unit/test_fr_mtime_filter.py
+++ b/tests/attribution/unit/test_fr_mtime_filter.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+
+from nvidia_resiliency_ext.attribution.base import NVRxAttribution
+from nvidia_resiliency_ext.attribution.trace_analyzer import fr_attribution
+from nvidia_resiliency_ext.attribution.trace_analyzer.fr_attribution import (
+    CollectiveAnalyzer,
+    _filter_files_by_min_mtime,
+)
+
+
+def test_collective_analyzer_filters_dump_files_older_than_fr_min_mtime(
+    tmp_path,
+    monkeypatch,
+):
+    old_dump = tmp_path / "_dump_0"
+    fresh_dump = tmp_path / "_dump_1"
+    old_dump.write_text("old\n", encoding="utf-8")
+    fresh_dump.write_text("fresh\n", encoding="utf-8")
+    os.utime(old_dump, (100.0, 100.0))
+    os.utime(fresh_dump, (200.0, 200.0))
+
+    analyzer = CollectiveAnalyzer(
+        {
+            "fr_path": str(tmp_path),
+            "pattern": "_dump_*",
+            "verbose": False,
+            "health_check": False,
+            "llm_analyze": False,
+            "threshold": None,
+            "fr_min_mtime": 150.0,
+        }
+    )
+    processed: list[str] = []
+
+    monkeypatch.setattr(
+        analyzer,
+        "process_file",
+        lambda filepath: processed.append(os.path.basename(filepath)) or True,
+    )
+    monkeypatch.setattr(analyzer, "group_collectives_by_windows", lambda: {})
+    monkeypatch.setattr(analyzer, "analyze_matches", lambda verbose=False: ({}, {}))
+
+    try:
+        analyzer._loop.run_until_complete(analyzer.preprocess_FR_dumps())
+    finally:
+        NVRxAttribution.reset_thread_event_loop()
+
+    assert processed == ["_dump_1"]
+
+
+def test_fr_min_mtime_filter_reports_stale_and_unavailable_mtime_separately(
+    tmp_path,
+    caplog,
+):
+    old_dump = tmp_path / "_dump_0"
+    fresh_dump = tmp_path / "_dump_1"
+    missing_dump = tmp_path / "_dump_2"
+    old_dump.write_text("old\n", encoding="utf-8")
+    fresh_dump.write_text("fresh\n", encoding="utf-8")
+    os.utime(old_dump, (100.0, 100.0))
+    os.utime(fresh_dump, (200.0, 200.0))
+
+    caplog.set_level(logging.INFO, logger=fr_attribution.__name__)
+
+    kept = _filter_files_by_min_mtime(
+        [str(old_dump), str(fresh_dump), str(missing_dump)],
+        150.0,
+    )
+
+    assert kept == [str(fresh_dump)]
+    assert "filtered_stale=1" in caplog.text
+    assert "skipped_unavailable=1" in caplog.text

--- a/tests/attribution/unit/test_log_analyzer_observability.py
+++ b/tests/attribution/unit/test_log_analyzer_observability.py
@@ -145,6 +145,267 @@ def _log_result() -> Dict[str, Any]:
     }
 
 
+def test_submit_records_pstart_wall_time_only_on_create(tmp_path, monkeypatch):
+    LogAnalyzer = _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    tracked_jobs = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.orchestration.tracked_jobs"
+    )
+    log_path = tmp_path / "train_cycle0.log"
+    log_path.write_text("training started\n", encoding="utf-8")
+    times = iter([111.0])
+    monkeypatch.setattr(tracked_jobs.time, "time", lambda: next(times))
+
+    analyzer = LogAnalyzer(
+        allowed_root=str(tmp_path),
+        log_sage=LogSageExecutionConfig(use_lib_log_analysis=True),
+        track_submission=_track_submission,
+        trace_analyzer=None,
+        analysis_pipeline_mode=AnalysisPipelineMode.LOG_ONLY,
+        runner=_FakeRunner(_log_result()),
+    )
+
+    async def run() -> None:
+        await analyzer.submit(str(log_path), record_submission_time=True)
+        job = analyzer.get_job(str(log_path))
+        assert job is not None
+        assert job.submitted_at_wall == 111.0
+
+        await analyzer.submit(str(log_path), record_submission_time=False)
+        assert job.submitted_at_wall == 111.0
+
+        await analyzer.submit(str(log_path), record_submission_time=True)
+        assert job.submitted_at_wall == 111.0
+
+    asyncio.run(run())
+
+
+def test_run_attribution_for_exact_job_passes_pstart_to_fr(tmp_path, monkeypatch):
+    LogAnalyzer = _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    tracked_jobs = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.orchestration.tracked_jobs"
+    )
+    log_path = tmp_path / "train_cycle2.log"
+    log_path.write_text("TORCH_FR_DUMP_TEMP_FILE=/container/_dump_\n", encoding="utf-8")
+    fr_dir = tmp_path / "checkpoints"
+    fr_dir.mkdir()
+    monkeypatch.setattr(tracked_jobs.time, "time", lambda: 123.0)
+
+    class FakeTraceAnalyzer:
+        def __init__(self) -> None:
+            self.fr_min_mtimes: list[float | None] = []
+
+        def discover_fr_dump_path(self, _log_path: str) -> str:
+            return str(fr_dir)
+
+        async def analyze_fr_dump(
+            self,
+            _dump_path: str,
+            *,
+            fr_min_mtime: float | None = None,
+        ) -> None:
+            self.fr_min_mtimes.append(fr_min_mtime)
+            return None
+
+    trace_analyzer = FakeTraceAnalyzer()
+    analyzer = LogAnalyzer(
+        allowed_root=str(tmp_path),
+        log_sage=LogSageExecutionConfig(use_lib_log_analysis=True),
+        track_submission=_track_submission,
+        trace_analyzer=trace_analyzer,
+        analysis_pipeline_mode=AnalysisPipelineMode.LOG_AND_TRACE,
+        runner=_FakeRunner(_log_result()),
+    )
+    analyzer._schedule_post_analysis_results = lambda *args, **kwargs: None
+
+    async def run() -> None:
+        await analyzer.submit(str(log_path))
+        await analyzer.run_attribution_for_path(str(log_path), user="alice", job_id="123")
+
+    asyncio.run(run())
+
+    assert trace_analyzer.fr_min_mtimes == [123.0]
+
+
+def test_submit_does_not_record_pstart_for_non_cycle_single_file(tmp_path, monkeypatch):
+    LogAnalyzer = _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    tracked_jobs = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.orchestration.tracked_jobs"
+    )
+    log_path = tmp_path / "job.log"
+    log_path.write_text("training started\n", encoding="utf-8")
+
+    def fail_time_call() -> None:
+        raise AssertionError("non-cycle single-file submits should not record a Pstart time")
+
+    monkeypatch.setattr(tracked_jobs.time, "time", fail_time_call)
+
+    analyzer = LogAnalyzer(
+        allowed_root=str(tmp_path),
+        log_sage=LogSageExecutionConfig(use_lib_log_analysis=True),
+        track_submission=_track_submission,
+        trace_analyzer=None,
+        analysis_pipeline_mode=AnalysisPipelineMode.LOG_ONLY,
+        runner=_FakeRunner(_log_result()),
+    )
+
+    async def run() -> None:
+        result = await analyzer.submit(str(log_path), record_submission_time=True)
+        job = analyzer.get_job(str(log_path))
+        assert result.mode == "single"
+        assert job is not None
+        assert job.is_single()
+        assert job.submitted_at_wall is None
+
+    asyncio.run(run())
+
+
+def test_submit_does_not_record_pstart_for_splitlog_job(tmp_path, monkeypatch):
+    LogAnalyzer = _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    tracked_jobs = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.orchestration.tracked_jobs"
+    )
+    log_path = tmp_path / "slurm.out"
+    log_path.write_text("LOGS_DIR=/unused\n", encoding="utf-8")
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    monkeypatch.setattr(
+        tracked_jobs,
+        "read_and_parse_slurm_output",
+        lambda _path: types.SimpleNamespace(logs_dir=str(logs_dir), cycle_count=1),
+    )
+
+    analyzer = LogAnalyzer(
+        allowed_root=str(tmp_path),
+        log_sage=LogSageExecutionConfig(use_lib_log_analysis=True),
+        track_submission=_track_submission,
+        trace_analyzer=None,
+        analysis_pipeline_mode=AnalysisPipelineMode.LOG_ONLY,
+        runner=_FakeRunner(_log_result()),
+    )
+
+    async def run() -> None:
+        result = await analyzer.submit(str(log_path), job_id="123")
+        job = analyzer.get_job(str(log_path))
+        assert result.mode == "splitlog"
+        assert job is not None
+        assert job.is_splitlog()
+        assert job.submitted_at_wall is None
+
+    asyncio.run(run())
+
+
+def test_submit_records_pstart_for_per_cycle_app_log_with_job_id(tmp_path, monkeypatch):
+    LogAnalyzer = _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    tracked_jobs = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.orchestration.tracked_jobs"
+    )
+    log_path = tmp_path / "train_Cycle7.log"
+    log_path.write_text("TORCH_FR_DUMP_TEMP_FILE=/container/_dump_\n", encoding="utf-8")
+    monkeypatch.setattr(tracked_jobs.time, "time", lambda: 333.0)
+
+    def fail_slurm_parse(_path: str) -> None:
+        raise AssertionError("direct app logs should not be parsed as slurm output")
+
+    monkeypatch.setattr(tracked_jobs, "read_and_parse_slurm_output", fail_slurm_parse)
+
+    analyzer = LogAnalyzer(
+        allowed_root=str(tmp_path),
+        log_sage=LogSageExecutionConfig(use_lib_log_analysis=True),
+        track_submission=_track_submission,
+        trace_analyzer=None,
+        analysis_pipeline_mode=AnalysisPipelineMode.LOG_ONLY,
+        runner=_FakeRunner(_log_result()),
+    )
+
+    async def run() -> None:
+        result = await analyzer.submit(str(log_path), job_id="123")
+        job = analyzer.get_job(str(log_path))
+        assert result.mode == "single"
+        assert job is not None
+        assert job.is_single()
+        assert job.job_id == "123"
+        assert job.submitted_at_wall == 333.0
+
+    asyncio.run(run())
+
+
+def test_terminal_create_does_not_record_pstart_for_app_log(tmp_path, monkeypatch):
+    LogAnalyzer = _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    tracked_jobs = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.orchestration.tracked_jobs"
+    )
+    log_path = tmp_path / "train_cycle8.log"
+    log_path.write_text("TORCH_FR_DUMP_TEMP_FILE=/container/_dump_\n", encoding="utf-8")
+
+    def fail_time_call() -> None:
+        raise AssertionError("terminal create should not record a Pstart wall time")
+
+    def fail_slurm_parse(_path: str) -> None:
+        raise AssertionError("direct app logs should not be parsed as slurm output")
+
+    monkeypatch.setattr(tracked_jobs.time, "time", fail_time_call)
+    monkeypatch.setattr(tracked_jobs, "read_and_parse_slurm_output", fail_slurm_parse)
+
+    analyzer = LogAnalyzer(
+        allowed_root=str(tmp_path),
+        log_sage=LogSageExecutionConfig(use_lib_log_analysis=True),
+        track_submission=_track_submission,
+        trace_analyzer=None,
+        analysis_pipeline_mode=AnalysisPipelineMode.LOG_ONLY,
+        runner=_FakeRunner(_log_result()),
+    )
+
+    async def run() -> None:
+        result = await analyzer.submit(
+            str(log_path),
+            job_id="123",
+            record_submission_time=False,
+        )
+        job = analyzer.get_job(str(log_path))
+        assert result.mode == "single"
+        assert job is not None
+        assert job.is_single()
+        assert job.submitted_at_wall is None
+
+    asyncio.run(run())
+
+
+def test_submit_does_not_record_pstart_for_pending_job(tmp_path, monkeypatch):
+    LogAnalyzer = _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    tracked_jobs = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.orchestration.tracked_jobs"
+    )
+    log_path = tmp_path / "slurm.out"
+    log_path.write_text("no logs dir yet\n", encoding="utf-8")
+    monkeypatch.setattr(
+        tracked_jobs,
+        "read_and_parse_slurm_output",
+        lambda _path: types.SimpleNamespace(logs_dir=None, cycle_count=0),
+    )
+
+    analyzer = LogAnalyzer(
+        allowed_root=str(tmp_path),
+        log_sage=LogSageExecutionConfig(use_lib_log_analysis=True),
+        track_submission=_track_submission,
+        trace_analyzer=None,
+        analysis_pipeline_mode=AnalysisPipelineMode.LOG_ONLY,
+        runner=_FakeRunner(_log_result()),
+    )
+
+    async def run() -> None:
+        result = await analyzer.submit(str(log_path), job_id="123")
+        job = analyzer.get_job(str(log_path))
+        assert result.mode == "pending"
+        assert job is not None
+        assert job.is_pending()
+        assert job.submitted_at_wall is None
+
+        await analyzer.submit(str(log_path), job_id="123")
+        assert job.submitted_at_wall is None
+
+    asyncio.run(run())
+
+
 def test_run_attribution_returns_before_observability_post_completes(tmp_path, monkeypatch):
     LogAnalyzer = _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
 
@@ -403,5 +664,12 @@ def test_log_fr_analyzer_mcp_uses_top_level_log_contract(monkeypatch):
         )
         assert captured["kwargs"]["merge_llm"] is True
         assert merged_summary == "ignored unless merge_llm=true"
+
+        await runner.fetch_log_fr_analyzer_mcp(
+            "/tmp/job.log",
+            "/tmp/fr",
+            fr_min_mtime=123.0,
+        )
+        assert captured["kwargs"]["fr_min_mtime"] == 123.0
 
     asyncio.run(run())

--- a/tests/attribution/unit/test_progressive_plumbing.py
+++ b/tests/attribution/unit/test_progressive_plumbing.py
@@ -43,19 +43,67 @@ def _import_analyzer_with_optional_dependency_stubs(monkeypatch):
     langchain_openai = _stub_module(monkeypatch, "langchain_openai")
     langchain_openai.ChatOpenAI = object
 
+    output_parsers = _stub_module(monkeypatch, "langchain_core.output_parsers")
+    output_parsers.StrOutputParser = object
+    prompts = _stub_module(monkeypatch, "langchain_core.prompts")
+    prompts.ChatPromptTemplate = types.SimpleNamespace(
+        from_template=lambda *_args, **_kwargs: object()
+    )
+    runnables = _stub_module(monkeypatch, "langchain_core.runnables")
+    runnables.RunnablePassthrough = object
+
     _stub_module(monkeypatch, "logsage")
     _stub_module(monkeypatch, "logsage.auto_resume_policy")
     attribution_classes = _stub_module(
         monkeypatch, "logsage.auto_resume_policy.attribution_classes"
     )
+    stub_attribution = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_STEP_CANCELLED="SLURM_STEP_CANCELLED",
+        SLURM_STEP_CANCELLED_JOB_REQUEUE="SLURM_STEP_CANCELLED_JOB_REQUEUE",
+    )
+    stub_auto_resume = types.SimpleNamespace(
+        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
+        LLM_FAILURE="LLM_FAILURE",
+        RESTART_IMMEDIATE="RESTART IMMEDIATE",
+        STOP_NO_RESTART="STOP - DONT RESTART IMMEDIATE",
+    )
+    stub_finished = types.SimpleNamespace(
+        APPLICATION_DONE="APPLICATION_DONE",
+        LLM_FAILURE="LLM_FAILURE",
+        SLURM_CANCELLED="SLURM_CANCELLED",
+        SLURM_CANCELLED_JOB_REQUEUE="SLURM_CANCELLED_JOB_REQUEUE",
+        SLURM_CANCELLED_TIME_LIMIT="SLURM_CANCELLED_TIME_LIMIT",
+    )
     attribution_classes.ApplicationData = object
+    attribution_classes.Attribution = stub_attribution
+    attribution_classes.AutoResumeAction = stub_auto_resume
+    attribution_classes.ErrorAttribution = object
+    attribution_classes.FinishedStatus = stub_finished
     attribution_classes.LRUCache = object
 
     error_attribution = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_attribution")
+    error_attribution.CONTEXT_SIZE = 4096
+    error_attribution.get_attribution = lambda *args, **kwargs: (None, None, None, None)
+    error_attribution.get_auto_resume = lambda *args, **kwargs: ("", "")
     error_attribution.get_proposed_solution_cat = lambda *args, **kwargs: None
 
     error_extraction = _stub_module(monkeypatch, "logsage.auto_resume_policy.error_extraction")
+    error_extraction.finished_validation = lambda _llm, data: data
     error_extraction.return_application_errors = lambda *args, **kwargs: []
+    error_extraction.return_application_errors_rt = lambda *args, **kwargs: types.SimpleNamespace(
+        checkpoint_saved=False
+    )
+    prompts_mod = _stub_module(monkeypatch, "logsage.auto_resume_policy.prompts")
+    prompts_mod.template_post_error_check = ""
+    util_postprocessing = _stub_module(
+        monkeypatch, "logsage.auto_resume_policy.util_postprocessing"
+    )
+    util_postprocessing.get_auto_resume_postprocessing = lambda *args, **kwargs: False
+    utils = _stub_module(monkeypatch, "logsage.auto_resume_policy.utils")
+    utils.chunk_indices = lambda *args, **kwargs: []
 
     httpx = _stub_module(monkeypatch, "httpx")
     httpx.post = lambda *args, **kwargs: types.SimpleNamespace(status_code=201, text="created")
@@ -67,6 +115,7 @@ def _import_analyzer_with_optional_dependency_stubs(monkeypatch):
 class FakeLogAnalyzer:
     def __init__(self) -> None:
         self.submissions: list[tuple[str, str, str | None]] = []
+        self.submission_record_flags: list[bool] = []
         self.progressive_starts: list[tuple[str, str, str | None]] = []
         self.progressive_started: asyncio.Event | None = None
         self.progressive_release: asyncio.Event | None = None
@@ -102,8 +151,11 @@ class FakeLogAnalyzer:
         log_path: str,
         user: str = "unknown",
         job_id: str | None = None,
+        *,
+        record_submission_time: bool = True,
     ) -> LogAnalyzerSubmitResult:
         self.submissions.append((log_path, user, job_id))
+        self.submission_record_flags.append(record_submission_time)
         self.jobs[log_path] = types.SimpleNamespace(
             mode=JobMode.SINGLE,
             user=user,
@@ -204,6 +256,7 @@ def test_progressive_submit_starts_backend_when_enabled(monkeypatch, tmp_path):
     asyncio.run(run())
 
     assert log_analyzer.submissions == [(str(tmp_path / "train_cycle0.log"), "alice", None)]
+    assert log_analyzer.submission_record_flags == [True]
     assert log_analyzer.progressive_starts == [(str(tmp_path / "train_cycle0.log"), "alice", None)]
 
 
@@ -264,6 +317,7 @@ def test_terminal_submit_starts_final_analysis_that_get_can_join(monkeypatch, tm
     asyncio.run(run())
 
     assert log_analyzer.terminal_runs == [(log_path, "alice", "123")]
+    assert log_analyzer.submission_record_flags == [False]
 
 
 def test_terminal_get_nonblocking_reports_in_flight_without_joining(monkeypatch, tmp_path):
@@ -299,6 +353,7 @@ def test_terminal_get_nonblocking_reports_in_flight_without_joining(monkeypatch,
         assert completed.status == "completed"
 
     asyncio.run(run())
+    assert log_analyzer.submission_record_flags == [False]
 
 
 def test_nonblocking_get_does_not_start_analysis_on_pending_result(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes the `ft_launcher` portion of [NVBug 6302348](https://nvbugspro.nvidia.com/bug/6302348): FR dump discovery can pick up stale `_dump_*` files from previous cycles when the same `TORCH_FR_DUMP_TEMP_FILE` prefix is reused.

This PR does not fully solve the service/splitlog case. In service splitlog mode, the submitted path can be a scheduler/slurm pointer file or log directory flow rather than the exact app log for a cycle, so there is not yet a reliable per-cycle Pstart timestamp to use as an FR lower-bound filter.

## Problem

`ft_launcher` runs repeated cycles and can reuse the same FR dump prefix across cycles. The FR analyzer currently discovers dump files by globbing the prefix, so stale files left behind from an older cycle can be included in the current cycle's analysis.

That can poison the result because FR analysis is then operating on a mixed set of dumps:

- old dump files from a previous cycle
- fresh dump files from the current cycle

For `ft_launcher`, the lifecycle gives us the useful timing anchor:

- `Pstart`: submit the exact per-cycle app log, for example `*_cycle<N>.log`
- `Pend`: terminal/end submit for that same cycle
- `Pget`: retrieve the result before the next cycle starts

The relevant lower bound is `Pstart`, not `Pend`.

## Fix

This PR records a wall-clock `submitted_at_wall` timestamp when a new non-terminal exact app-log job is created. During FR analysis, that timestamp is passed as `fr_min_mtime`, and FR dump discovery filters files with:

```text
dump_mtime >= Pstart
```

Direct per-cycle app logs matching `*_cycle<N>.log` are treated as exact app logs even when `job_id` is present, so the `ft_launcher` path does not get misclassified as pending splitlog/slurm mode.

Terminal-created jobs, pending jobs, and splitlog jobs leave `submitted_at_wall=None`, which preserves the existing no-filter behavior.

## Scope

Solved here:

- `ft_launcher` exact per-cycle app-log submissions
- stale FR dump files older than the cycle's `Pstart`
- lib FR analyzer path
- MCP FR analyzer path
- combined log+FR MCP path

Not solved here:

- service splitlog mode
- service submissions where the submitted path is only a slurm/pointer file and not the exact per-cycle app log
- per-cycle FR dump namespacing at the workload layer

For service mode, the current behavior remains intentionally conservative: if we cannot identify an exact per-cycle app-log Pstart, no mtime filter is generated.

## Validation

- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPATH=src uv run --no-project --python 3.11 --with pytest python -m pytest -q tests/attribution/unit/test_progressive_plumbing.py tests/attribution/unit/test_log_analyzer_observability.py tests/attribution/unit/test_fr_mtime_filter.py tests/attribution/unit/test_fr_mcp_result.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache PYTHONPATH=src uv run --no-project --python 3.11 --with pytest python -m pytest -q tests/attribution/unit/test_combined_log_fr.py tests/attribution/unit/test_mcp_server_cache.py tests/attribution/unit/test_fr_dump_path.py tests/attribution/unit/test_analysis_pipeline_trace_only.py`
- `black==24.10.0 black --check .`
- `isort==5.13.2 isort --check-only .`
- `ruff==0.8.3 ruff check .`
- `git diff --check`
