### PR TITLE
[codex] Use grouped DCAHC checks for nvhcd

### DIFF
--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -50,6 +50,14 @@ from nvidia_resiliency_ext.shared_utils.profiling import ProfilingEvent, record_
 logger = logging.getLogger(LogConfig.name)
 
 _ATTRIBUTION_REQUEST_TIMEOUT_SECONDS = 2.0
+_DEFAULT_NODE_HEALTH_CHECK_ARGS = (
+    "--no-slurm",
+    "--group",
+    "prolog",
+    "epilog",
+    "logs",
+    "gpu",
+)
 
 
 # -----------------------------
@@ -1423,7 +1431,7 @@ class NodeHealthCheck:
     ):
         self.socket_path = socket_path
         self.endpoint = endpoint
-        self.args = args or []
+        self.args = list(args) if args is not None else list(_DEFAULT_NODE_HEALTH_CHECK_ARGS)
         self.interval = interval
         self.on_failure = on_failure
         self.request_timeout_sec = request_timeout_sec
@@ -1511,7 +1519,8 @@ class NodeHealthCheck:
         try:
             with self._grpc.insecure_channel(target) as channel:
                 stub = self._pb2_grpc.HealthCheckServiceStub(channel)
-                request = self._pb2.HealthCheckRequest(args=["--no-slurm"])
+                logger.debug("Node health check request args: %s", list(self.args))
+                request = self._pb2.HealthCheckRequest(args=list(self.args))
                 if self.request_timeout_sec is not None:
                     response = stub.RunHealthCheck(request, timeout=self.request_timeout_sec)
                 else:

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -17,11 +17,13 @@
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, mock_open, patch
 
 from nvidia_resiliency_ext.shared_utils.health_check import (
     AttributionService,
     NicHealthCheck,
+    NodeHealthCheck,
     NVLHealthCheck,
     PciMixin,
     PynvmlMixin,
@@ -560,6 +562,57 @@ class TestNVLHealthCheck(unittest.TestCase):
                 result = checker._perform_health_check()
                 self.assertTrue(result)
                 mock_check.assert_called_once_with(0)
+
+
+class TestNodeHealthCheck(unittest.TestCase):
+
+    def _checker_with_mocked_grpc(self, args=None):
+        checker = NodeHealthCheck(args=args)
+        checker._channel_target = "unix:///tmp/nvhcd.sock"
+
+        channel = MagicMock()
+        channel_context = MagicMock()
+        channel_context.__enter__.return_value = channel
+        channel_context.__exit__.return_value = None
+        checker._grpc = MagicMock()
+        checker._grpc.insecure_channel.return_value = channel_context
+
+        response = MagicMock()
+        response.success = True
+        response.output = '{"fail_count": 0}'
+        stub = MagicMock()
+        stub.RunHealthCheck.return_value = response
+        checker._pb2_grpc = MagicMock()
+        checker._pb2_grpc.HealthCheckServiceStub.return_value = stub
+
+        checker._pb2 = MagicMock()
+        checker._pb2.HealthCheckRequest.side_effect = lambda args: SimpleNamespace(args=args)
+        return checker, stub
+
+    def test_perform_health_check_uses_default_dcahc_groups(self):
+        checker, stub = self._checker_with_mocked_grpc()
+
+        result = checker._perform_health_check()
+
+        self.assertTrue(result)
+        checker._pb2.HealthCheckRequest.assert_called_once_with(
+            args=["--no-slurm", "--group", "prolog", "epilog", "logs", "gpu"]
+        )
+        request = stub.RunHealthCheck.call_args.args[0]
+        self.assertEqual(
+            request.args,
+            ["--no-slurm", "--group", "prolog", "epilog", "logs", "gpu"],
+        )
+
+    def test_perform_health_check_preserves_custom_args(self):
+        checker, stub = self._checker_with_mocked_grpc(args=["--group", "epilog"])
+
+        result = checker._perform_health_check()
+
+        self.assertTrue(result)
+        checker._pb2.HealthCheckRequest.assert_called_once_with(args=["--group", "epilog"])
+        request = stub.RunHealthCheck.call_args.args[0]
+        self.assertEqual(request.args, ["--group", "epilog"])
 
 
 class TestAttributionService(unittest.TestCase):


### PR DESCRIPTION
## Summary

Update the default `NodeHealthCheck` nvhcd request args from `--no-slurm` alone to Donald's narrowed DCAHC group selection:

```text
--no-slurm --group prolog epilog logs gpu
```

`--no-slurm` is still needed for the nvhcd/NVRx path, but by itself it bypasses the Slurm module's filtering and can run broader/full checks. Adding the explicit groups keeps the health check aligned with the intended lifecycle coverage while avoiding checks outside the requested group set.
See https://jirasw.nvidia.com/browse/AIDOT-900

## Changes

- Add `_DEFAULT_NODE_HEALTH_CHECK_ARGS` for the grouped nvhcd DCAHC request.
- Make `NodeHealthCheck(args=...)` preserve explicit caller args, while `args=None` uses the grouped default.
- Add unit coverage for the default request payload and custom-args override.

## Validation

=== nvhcd DCAHC check selection diff ===
no_slurm_count=102
grouped_count=41
common_count=41
only_no_slurm_count=61
only_grouped_count=0

=== checks only with --no-slurm ===
hw_drv_gpu_average_power_draw
hw_drv_gpu_check_bridge
hw_drv_gpu_count
hw_drv_gpu_fw_inforom
hw_drv_gpu_fw_vbios
hw_drv_gpu_nvlink_bandwidth_count_speed
hw_drv_gpu_nvlink_error_counters
hw_drv_gpu_nvlink_fabric
hw_drv_mbd_fw_bios
hw_drv_net_ib_ber
hw_drv_net_ib_config
hw_drv_stor_nvme_num
hw_drv_stor_nvme_smart
hw_sys_cpu_count
hw_sys_cpu_numa_cores
hw_sys_mem_dimm_count
hw_sys_net_ib_dev_exist_cx6
hw_sys_net_ib_dev_exist_cx7
hw_sys_net_ib_dev_speed_cx6
hw_sys_net_ib_dev_speed_cx7
hw_sys_net_ib_dev_width_cx5
hw_sys_net_rdma_gid
hw_sys_pci_acs_support
hw_sys_pci_assigned_buses
hw_sys_pci_dev_health
hw_sys_pci_unassigned_mem_io
hw_sys_smbios_l0
hw_sys_smbios_l1
hw_sys_smbios_l2
hw_sys_smbios_t0
hw_sys_smbios_t0optional
hw_sys_smbios_t1
hw_sys_smbios_t13
hw_sys_smbios_t16
hw_sys_smbios_t17
hw_sys_smbios_t19
hw_sys_smbios_t2
hw_sys_smbios_t3
hw_sys_smbios_t32
hw_sys_smbios_t39optional
hw_sys_smbios_t41optional
hw_sys_smbios_t45
hw_sys_smbios_t8
hw_sys_stor_nvme_dev_speed
hw_sys_stor_nvme_dev_width
sw_drv_fs_lustre_lnet
sw_drv_fs_lustre_params
sw_sys_config_nv_container_cli
sw_sys_config_services
sw_sys_fs_lustre_tcp
sw_sys_fs_part_free
sw_sys_fwts_acpiinfo
sw_sys_fwts_srat
sw_sys_logs_fabric_mngr_not_present
sw_sys_module_loaded
sw_sys_module_versions
sw_sys_net_eth_curl
sw_sys_net_eth_hostname
sw_sys_net_eth_link_state
sw_sys_net_eth_ping
sw_sys_net_eth_resolve

=== checks only with grouped args ===
=== checks in both ===
hw_drv_gpu_clock_idle
hw_drv_gpu_compute_apps
hw_drv_gpu_driver_version
hw_drv_gpu_ecc_error
hw_drv_gpu_ecc_remapped_rows
hw_drv_gpu_ecc_retired_pages
hw_drv_gpu_imex_topo
hw_drv_gpu_link_capability
hw_drv_gpu_nvlink_active
hw_drv_gpu_power_limit
hw_drv_gpu_power_state
hw_drv_gpu_sensor_temp_alloc
hw_drv_gpu_sensor_temp_idle
hw_drv_gpu_sensor_throttle
hw_drv_gpu_topo_m
hw_drv_gpu_topology
hw_drv_net_ib_devinfo_cx6
hw_drv_net_ib_devinfo_cx7
hw_drv_net_ib_fw_cx6
hw_drv_net_ib_fw_cx7
hw_sys_gpu_dev_exist
sw_drv_config_nvidia_params
sw_drv_config_nvidia_smi
sw_sys_fs_nfs_mounts
sw_sys_fs_raid_dev
sw_sys_fs_raid_mounts
sw_sys_logs_aer
sw_sys_logs_bmc_health
sw_sys_logs_gpu_missing
sw_sys_logs_hca_fw_error
sw_sys_logs_ib_firmware_bug
sw_sys_logs_mce_errors
sw_sys_logs_numa_oom
sw_sys_logs_nvidia_fabricmanager
sw_sys_logs_nvidia_persistenced
sw_sys_logs_nvidia_xid
sw_sys_logs_nvlink
sw_sys_logs_rdma_linkflap_fatal
sw_sys_logs_rminit_adapter
sw_sys_net_arp_flux
sw_sys_net_ib_ip


Note that checks such as average_power_draw are no longer included in the grouped list. Some IB/storage checks that would be useful during restart-time validation are also missing, because they are not tagged for prolog/epilog; they only run alongside the job-running path.