### PR TITLE
Add scheduler exclusion producer service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ nvrx-control = "nvidia_resiliency_ext.fault_tolerance.control_plane:main"
 nvrx-mcp-analysis = "nvidia_resiliency_ext.attribution.mcp_integration.server_launcher:main"
 nvrx-attrsvc = "nvidia_resiliency_ext.services.attrsvc.__main__:main"
 nvrx-smonsvc = "nvidia_resiliency_ext.services.smonsvc.__main__:main"
+nvrx-scheduler-exclusion-service = "nvidia_resiliency_ext.services.scheduler_exclusions.__main__:main"
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/services/README.md
+++ b/services/README.md
@@ -1,6 +1,6 @@
-# NVRX Attribution
+# NVRX Services
 
-Automated log analysis and failure attribution for distributed training jobs.
+Service entry points and deployment assets for NVRX.
 
 ## Components
 
@@ -8,12 +8,14 @@ Automated log analysis and failure attribution for distributed training jobs.
 |-----------|-------------|---------------|
 | **nvrx-attrsvc** | FastAPI server for LLM-based log analysis | [attrsvc/README.md](attrsvc/README.md) |
 | **nvrx-smonsvc** | SLURM job monitor for automatic log submission | [smonsvc/README.md](smonsvc/README.md) |
+| **nvrx-scheduler-exclusion-service** | Host-side Slurm monitor that publishes shared task-exclusion decisions | [scheduler_exclusions/README.md](scheduler_exclusions/README.md) |
 
-See component READMEs for quick start, configuration, and API details.
+See the linked documentation for each service's contract. Scheduler Exclusion
+build and deployment assets are in [`scheduler_exclusions/`](scheduler_exclusions/).
 
-## Combined Deployment
+## Combined Attribution Deployment
 
-Run both services together on SLURM:
+Run attrsvc and smonsvc together on SLURM:
 
 ```bash
 NVRX_ATTRSVC_ALLOWED_ROOT=/path/to/logs \
@@ -22,11 +24,11 @@ NVRX_ATTRSVC_ALLOWED_ROOT=/path/to/logs \
 
 This starts `nvrx-attrsvc` and `nvrx-smonsvc` in a single job with health monitoring.
 
-For individual deployment, see each component's `deploy/` directory.
+For individual attrsvc or smonsvc deployment, see its `deploy/` directory.
 
 ## Container Image
 
-Build an enroot squash image containing both services:
+Build an enroot squash image containing the attribution services:
 
 ```bash
 ./services/scripts/build_enroot_image.sh
@@ -39,7 +41,7 @@ See [scripts/build_enroot_image.sh](scripts/build_enroot_image.sh) for usage wit
 Periodically snapshot service endpoints for debugging:
 
 ```bash
-# Both services
+# Attribution services
 ./scripts/snapshot_services.sh hostname
 
 # Individual services (in respective directories)
@@ -55,6 +57,7 @@ Configure via environment: `SNAPSHOT_INTERVAL`, `SNAPSHOT_OUTPUT_DIR`.
 |------|-------------|
 | `attrsvc/` | Attribution service deployment docs and assets |
 | `smonsvc/` | SLURM monitor deployment docs and assets |
+| `scheduler_exclusions/` | Scheduler Exclusion producer build and deployment assets |
 | `scripts/` | Shell scripts ([README](scripts/README.md)) |
 
 ## Library Layer

--- a/services/scheduler_exclusions/README.md
+++ b/services/scheduler_exclusions/README.md
@@ -1,0 +1,73 @@
+# NVRx Scheduler Exclusion Service
+
+The NVRx Scheduler Exclusion Service is the host-side component of the
+Scheduler Exclusion feature. For an array job, the first allocated node of the
+lowest array task runs it outside the workload environment. Build it as a
+standalone Python zipapp so that host does not need an NVRx installation or
+virtual environment.
+
+## Build
+
+From the repository root:
+
+```bash
+python3 services/scheduler_exclusions/build_zipapp.py
+dist/nvrx-scheduler-exclusion-service.pyz --help
+```
+
+The builder packages only the Scheduler Exclusion modules and validates the
+artifact. It is an explicit build step: building the wheel does not create or
+publish the `.pyz`, and generated `dist/` output is not committed. The
+deployment owner builds it from the same NVRx revision as the workload, stores
+it at an immutable version or commit-based path, and stages it on storage
+visible to the service host.
+
+## Run
+
+The artifact is directly executable with Python 3.10 or newer:
+
+```bash
+/shared/nvrx/bin/nvrx-scheduler-exclusion-service.pyz \
+  --output-dir /shared/nvrx/scheduler-exclusions
+```
+
+It requires the Slurm CLI and configuration from the host environment. It has
+no third-party Python runtime dependencies.
+
+`deploy/run_service.sh` is an optional foreground launcher. Set
+`NVRX_SCHEDULER_EXCLUSION_ARTIFACT` when the artifact is outside the repository:
+
+```bash
+NVRX_SCHEDULER_EXCLUSION_ARTIFACT=/shared/nvrx/bin/nvrx-scheduler-exclusion-service.pyz \
+  services/scheduler_exclusions/deploy/run_service.sh \
+    --output-dir /shared/nvrx/scheduler-exclusions
+```
+
+`deploy/run_service.sh` stays in the foreground. The deployment owner provides
+process supervision, restart policy, log redirection, and shutdown.
+
+## Producer Contract
+
+The service monitors `SLURM_ARRAY_JOB_ID`, falling back to `SLURM_JOB_ID`, and
+refreshes scheduler state in the background. It atomically publishes
+`segment_health_check.<job-id>.state` under `--output-dir`. The compact first
+line contains excluded array-task IDs; detailed task, node, and observation
+records follow it:
+
+```text
+["7"]
+{"type":"decision","schema_version":1,"job_id":"12345","generated_at":"2026-08-04T19:00:00Z","scope":"array_task","excluded_array_tasks":[{"task_id":"7","restart_count":0,"valid_until":"2026-08-04T19:30:00Z"}]}
+{"type":"decision","schema_version":1,"job_id":"12345","generated_at":"2026-08-04T19:00:00Z","scope":"node","excluded_nodes":[{"node":"node-a","valid_until":"2026-08-04T19:30:00Z"}]}
+```
+
+The HTTP interface exposes `GET /healthz`, `GET /stats`, and
+`GET /scheduler-exclusions`. `POST /refresh` queues a nonblocking refresh.
+Run the artifact with `--help` for configuration defaults and Slurm overrides.
+
+## FT Consumer Integration
+
+`deploy/slurm_array.sbatch` is the combined lifecycle reference. It supervises
+the producer in the lowest array task, passes the shared output directory to
+`ft_launcher`, and terminates the supervisor during batch cleanup. The FT
+consumer remains independent of this service and depends only on the artifact
+contract above.

--- a/services/scheduler_exclusions/build_zipapp.py
+++ b/services/scheduler_exclusions/build_zipapp.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the NVRx Scheduler Exclusion Service as a standalone Python zipapp."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import zipapp
+from pathlib import Path
+
+_ARTIFACT_NAME = "nvrx-scheduler-exclusion-service.pyz"
+_ENTRY_POINT = "nvidia_resiliency_ext.services.scheduler_exclusions.__main__:main"
+_RUNTIME_FILES = (
+    "__init__.py",
+    "__main__.py",
+    "config.py",
+    "decision_file.py",
+    "monitor.py",
+    "server.py",
+)
+
+
+def _parser(repo_root: Path) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the standalone NVRx Scheduler Exclusion Service"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=repo_root / "dist" / _ARTIFACT_NAME,
+        help="Output .pyz path (default: %(default)s)",
+    )
+    return parser
+
+
+def build_zipapp(repo_root: Path, output: Path) -> Path:
+    """Build and validate a zipapp containing only the service runtime."""
+    source_root = repo_root / "src" / "nvidia_resiliency_ext"
+    service_source = source_root / "services" / "scheduler_exclusions"
+    missing = [name for name in _RUNTIME_FILES if not (service_source / name).is_file()]
+    if missing:
+        raise FileNotFoundError(f"missing Scheduler Exclusion sources: {missing}")
+
+    output = output.expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="nvrx-scheduler-exclusion-") as temp_dir:
+        staging = Path(temp_dir)
+        package_root = staging / "nvidia_resiliency_ext"
+        service_target = package_root / "services" / "scheduler_exclusions"
+        service_target.mkdir(parents=True)
+        shutil.copy2(source_root / "__init__.py", package_root / "__init__.py")
+        shutil.copy2(
+            source_root / "services" / "__init__.py",
+            package_root / "services" / "__init__.py",
+        )
+        for name in _RUNTIME_FILES:
+            shutil.copy2(service_source / name, service_target / name)
+
+        zipapp.create_archive(
+            staging,
+            target=output,
+            interpreter="/usr/bin/env python3",
+            main=_ENTRY_POINT,
+            compressed=True,
+        )
+
+    output.chmod(output.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    subprocess.run(  # nosec B603 - validates the artifact built above
+        [sys.executable, str(output), "--help"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    return output
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    args = _parser(repo_root).parse_args()
+    artifact = build_zipapp(repo_root, args.output)
+    print(artifact)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/scheduler_exclusions/deploy/run_service.sh
+++ b/services/scheduler_exclusions/deploy/run_service.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the standalone NVRx Scheduler Exclusion Service in the foreground. The batch
+# script owns backgrounding, restart policy, log redirection, and shutdown.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+ARTIFACT="${NVRX_SCHEDULER_EXCLUSION_ARTIFACT:-${REPO_ROOT}/dist/nvrx-scheduler-exclusion-service.pyz}"
+PYTHON="${NVRX_SCHEDULER_EXCLUSION_PYTHON:-python3}"
+
+if [[ ! -r "${ARTIFACT}" ]]; then
+    echo "Scheduler Exclusion artifact is not readable: ${ARTIFACT}" >&2
+    exit 1
+fi
+if ! command -v "${PYTHON}" >/dev/null 2>&1; then
+    echo "Scheduler Exclusion Python interpreter not found: ${PYTHON}" >&2
+    exit 1
+fi
+
+exec "${PYTHON}" "${ARTIFACT}" "$@"

--- a/services/scheduler_exclusions/deploy/slurm_array.sbatch
+++ b/services/scheduler_exclusions/deploy/slurm_array.sbatch
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reference lifecycle for one Scheduler Exclusion service per Slurm job array.
+# Supply the allocation directives through sbatch or adapt this file locally.
+
+#SBATCH --job-name=nvrx-scheduler-exclusion
+#SBATCH --no-requeue
+#SBATCH --output=slurm-%A_%a.out
+#SBATCH --error=slurm-%A_%a.err
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_SERVICE="${NVRX_SCHEDULER_EXCLUSION_RUN_SERVICE:-${SCRIPT_DIR}/run_service.sh}"
+SCHEDULER_EXCLUSION_DIR="${NVRX_SCHEDULER_EXCLUSION_DIR:?Set NVRX_SCHEDULER_EXCLUSION_DIR to a shared absolute path}"
+SERVICE_HOST="${NVRX_SCHEDULER_EXCLUSION_HOST:-127.0.0.1}"
+SERVICE_PORT="${NVRX_SCHEDULER_EXCLUSION_PORT:-18080}"
+SERVICE_PYTHON="${NVRX_SCHEDULER_EXCLUSION_PYTHON:-python3}"
+SERVICE_START_TIMEOUT_SECONDS="${NVRX_SCHEDULER_EXCLUSION_START_TIMEOUT_SECONDS:-60}"
+JOB_ID="${SLURM_ARRAY_JOB_ID:-${SLURM_JOB_ID:-manual}}"
+SERVICE_LOG="${SCHEDULER_EXCLUSION_DIR}/scheduler_exclusion_service.${JOB_ID}.log"
+
+if [[ $# -eq 0 ]]; then
+    echo "Pass ft_launcher arguments and its workload after the batch file." >&2
+    exit 2
+fi
+if [[ "${SCHEDULER_EXCLUSION_DIR}" != /* ]]; then
+    echo "NVRX_SCHEDULER_EXCLUSION_DIR must be absolute: ${SCHEDULER_EXCLUSION_DIR}" >&2
+    exit 2
+fi
+
+mkdir -p "${SCHEDULER_EXCLUSION_DIR}"
+
+supervisor_pid=""
+
+stop_supervisor() {
+    if [[ -n "${supervisor_pid}" ]]; then
+        kill "${supervisor_pid}" 2>/dev/null || true
+        wait "${supervisor_pid}" 2>/dev/null || true
+        supervisor_pid=""
+    fi
+}
+
+cleanup() {
+    local rc=$?
+    trap - EXIT INT TERM
+    stop_supervisor
+    exit "${rc}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+supervise_service() {
+    local child_pid=""
+    local delay=1
+    local rc=0
+
+    stop_child() {
+        if [[ -n "${child_pid}" ]]; then
+            kill "${child_pid}" 2>/dev/null || true
+            wait "${child_pid}" 2>/dev/null || true
+            child_pid=""
+        fi
+    }
+    trap 'stop_child; exit 0' INT TERM
+
+    while true; do
+        printf '%s starting Scheduler Exclusion service\n' \
+            "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"${SERVICE_LOG}"
+        "${RUN_SERVICE}" \
+            --host "${SERVICE_HOST}" \
+            --port "${SERVICE_PORT}" \
+            --output-dir "${SCHEDULER_EXCLUSION_DIR}" \
+            >>"${SERVICE_LOG}" 2>&1 &
+        child_pid=$!
+
+        set +e
+        wait "${child_pid}"
+        rc=$?
+        set -e
+        child_pid=""
+
+        printf '%s service exited rc=%s; restarting in %ss\n' \
+            "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "${rc}" "${delay}" >>"${SERVICE_LOG}"
+        sleep "${delay}" &
+        child_pid=$!
+        wait "${child_pid}"
+        child_pid=""
+        if (( delay < 8 )); then
+            delay=$((delay * 2))
+        fi
+    done
+}
+
+service_is_ready() {
+    "${SERVICE_PYTHON}" - "http://${SERVICE_HOST}:${SERVICE_PORT}/healthz" <<'PY'
+import sys
+import urllib.request
+
+try:
+    with urllib.request.urlopen(sys.argv[1], timeout=1) as response:
+        raise SystemExit(0 if response.status == 200 else 1)
+except Exception:
+    raise SystemExit(1)
+PY
+}
+
+wait_for_service() {
+    local deadline=$((SECONDS + SERVICE_START_TIMEOUT_SECONDS))
+    until service_is_ready; do
+        if ! kill -0 "${supervisor_pid}" 2>/dev/null; then
+            echo "Scheduler Exclusion supervisor exited during startup" >&2
+            return 1
+        fi
+        if (( SECONDS >= deadline )); then
+            echo "Scheduler Exclusion service did not become ready" >&2
+            tail -100 "${SERVICE_LOG}" >&2 || true
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+ARRAY_TASK_ID="${SLURM_ARRAY_TASK_ID:-0}"
+ARRAY_TASK_MIN="${SLURM_ARRAY_TASK_MIN:-0}"
+if [[ "${ARRAY_TASK_ID}" == "${ARRAY_TASK_MIN}" ]]; then
+    supervise_service &
+    supervisor_pid=$!
+    wait_for_service
+fi
+
+srun --kill-on-bad-exit=1 \
+    ft_launcher \
+    --ft-scheduler-exclusion-dir "${SCHEDULER_EXCLUSION_DIR}" \
+    "$@"

--- a/services/tests/test_scheduler_exclusion_service.py
+++ b/services/tests/test_scheduler_exclusion_service.py
@@ -1,0 +1,1342 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import http.client
+import json
+import logging
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Sequence
+from unittest.mock import MagicMock
+
+import pytest
+
+from nvidia_resiliency_ext.services.scheduler_exclusions.config import (
+    SchedulerExclusionServiceSettings,
+)
+from nvidia_resiliency_ext.services.scheduler_exclusions.decision_file import (
+    DecisionFileWriteError,
+    DecisionFileWriter,
+    DecisionObservation,
+    decision_file_path,
+)
+from nvidia_resiliency_ext.services.scheduler_exclusions.monitor import (
+    ArrayTaskGeneration,
+    JobIdentity,
+    LocalSlurmCommandRunner,
+    MalformedSchedulerResponse,
+    SchedulerExclusionConfig,
+    SchedulerExclusionError,
+    SchedulerExclusionMonitor,
+    discover_allocation,
+    job_identity_from_env,
+    query_scheduler_exclusions,
+)
+from nvidia_resiliency_ext.services.scheduler_exclusions.server import (
+    SchedulerExclusionHttpServer,
+    SchedulerExclusionRequestHandler,
+)
+
+
+class CallbackRunner:
+    def __init__(self, callback: Callable[[list[str]], str]):
+        self.callback = callback
+        self.calls: list[list[str]] = []
+
+    def run(self, argv: Sequence[str]) -> str:
+        call = list(argv)
+        self.calls.append(call)
+        return self.callback(call)
+
+
+def test_job_identity_prefers_array_parent():
+    identity = job_identity_from_env(
+        {
+            "SLURM_ARRAY_JOB_ID": "123",
+            "SLURM_JOB_ID": "123_7",
+        }
+    )
+
+    assert identity == JobIdentity(job_id="123", is_array=True)
+
+
+def test_job_identity_uses_regular_job_id():
+    assert job_identity_from_env({"SLURM_JOB_ID": "456"}) == JobIdentity(
+        job_id="456",
+        is_array=False,
+    )
+    assert job_identity_from_env({}) is None
+
+
+def test_decision_file_path_is_owned_by_component(tmp_path):
+    assert decision_file_path(tmp_path, "123") == tmp_path / "segment_health_check.123.state"
+
+    with pytest.raises(ValueError, match="invalid Slurm job ID"):
+        decision_file_path(tmp_path, "../123")
+
+
+def test_discover_array_allocation_groups_nodes_by_partition():
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "7|0|batch|node[01-02]\n" "8|2|batch|node[02-03]\n" "9|1|spare|node04\n"
+        if argv[-1] == "node[01-02]":
+            return "node01\nnode02\n"
+        if argv[-1] == "node[02-03]":
+            return "node02\nnode03\n"
+        if argv[-1] == "node04":
+            return "node04\n"
+        raise AssertionError(argv)
+
+    runner = CallbackRunner(callback)
+    allocation = discover_allocation(runner, JobIdentity(job_id="123", is_array=True))
+
+    assert allocation.nodes_by_partition == {
+        "batch": ("node01", "node02", "node03"),
+        "spare": ("node04",),
+    }
+    assert allocation.array_task_generations_by_node == {
+        "node01": (ArrayTaskGeneration("7", 0),),
+        "node02": (
+            ArrayTaskGeneration("7", 0),
+            ArrayTaskGeneration("8", 2),
+        ),
+        "node03": (ArrayTaskGeneration("8", 2),),
+        "node04": (ArrayTaskGeneration("9", 1),),
+    }
+    assert runner.calls[0] == [
+        "squeue",
+        "--noheader",
+        "--array",
+        "--jobs",
+        "123",
+        "--states=RUNNING",
+        "--Format=ArrayTaskID:64|,RestartCnt:16|,Partition:128|,NodeList:1024",
+    ]
+
+
+def test_discover_regular_allocation_has_no_array_task_ids():
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node01\n"
+        return "node01\n"
+
+    allocation = discover_allocation(
+        CallbackRunner(callback),
+        JobIdentity(job_id="123", is_array=False),
+    )
+
+    assert allocation.array_task_generations_by_node == {}
+
+
+def test_discover_allocation_rejects_empty_squeue():
+    runner = CallbackRunner(lambda _: "")
+
+    with pytest.raises(SchedulerExclusionError, match="no running allocations"):
+        discover_allocation(runner, JobIdentity(job_id="123", is_array=False))
+
+
+def test_discover_array_allocation_rejects_invalid_restart_count():
+    runner = CallbackRunner(lambda _: "7|invalid|batch|node01\n")
+
+    with pytest.raises(MalformedSchedulerResponse, match="invalid restart count"):
+        discover_allocation(runner, JobIdentity(job_id="123", is_array=True))
+
+
+@pytest.mark.parametrize(
+    "row, message",
+    [
+        ("7|0||node01\n", "no partition"),
+        ("7|0|batch|\n", "no nodelist"),
+    ],
+)
+def test_discover_array_allocation_rejects_incomplete_rows(row, message):
+    runner = CallbackRunner(lambda _: row)
+
+    with pytest.raises(MalformedSchedulerResponse, match=message):
+        discover_allocation(runner, JobIdentity(job_id="123", is_array=True))
+
+
+def test_discover_allocation_rejects_empty_nodelist_expansion():
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "7|0|batch|node01\n"
+        return ""
+
+    with pytest.raises(MalformedSchedulerResponse, match="returned no nodes"):
+        discover_allocation(
+            CallbackRunner(callback),
+            JobIdentity(job_id="123", is_array=True),
+        )
+
+
+def test_discover_allocation_stops_between_nodelist_expansions():
+    stop_requested = threading.Event()
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "7|0|batch|node01\n8|0|batch|node02\n"
+        stop_requested.set()
+        return "node01\n"
+
+    runner = CallbackRunner(callback)
+
+    with pytest.raises(SchedulerExclusionError, match="monitor is stopping"):
+        discover_allocation(
+            runner,
+            JobIdentity(job_id="123", is_array=True),
+            stop_requested=stop_requested.is_set,
+        )
+
+    assert [call[0] for call in runner.calls] == ["squeue", "scontrol"]
+
+
+def test_query_scheduler_exclusions_uses_one_filtered_sinfo_call():
+    runner = CallbackRunner(lambda _: "node01|drained|test drain\nnode02|down*|not responding\n")
+
+    records = query_scheduler_exclusions(runner)
+
+    assert records["node01"].excluded
+    assert records["node01"].state == "DRAINED"
+    assert records["node02"].excluded
+    assert records["node02"].state == "NO_RESPOND"
+    assert runner.calls == [
+        [
+            "sinfo",
+            "--noheader",
+            "--Node",
+            "--states=drain,down,fail,no_respond",
+            "--format=%N|%T|%E",
+        ]
+    ]
+
+
+def test_query_scheduler_exclusions_accepts_no_unavailable_nodes():
+    assert query_scheduler_exclusions(CallbackRunner(lambda _: "")) == {}
+
+
+def test_query_scheduler_exclusions_rejects_allocatable_rows():
+    runner = CallbackRunner(lambda _: "node01|idle|none\n")
+
+    with pytest.raises(MalformedSchedulerResponse, match="allocatable nodes: node01"):
+        query_scheduler_exclusions(runner)
+
+
+def test_query_scheduler_exclusions_treats_slurm_no_response_suffix_as_excluded():
+    runner = CallbackRunner(lambda _: "node01|idle*|Not responding\n")
+
+    records = query_scheduler_exclusions(runner)
+
+    assert records["node01"].excluded
+    assert records["node01"].state == "NO_RESPOND"
+
+
+@pytest.mark.parametrize("state", ["", "unknown", "UNKNOWN"])
+def test_query_scheduler_exclusions_rejects_unknown_state(state):
+    runner = CallbackRunner(lambda _: f"node01|{state}|no reliable state\n")
+
+    with pytest.raises(MalformedSchedulerResponse, match="(no|unknown) state"):
+        query_scheduler_exclusions(runner)
+
+
+def test_local_runner_uses_resolved_binary_and_inherited_environment(monkeypatch):
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="ok\n",
+        stderr="",
+    )
+    run = MagicMock(return_value=completed)
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.services.scheduler_exclusions.monitor.shutil.which",
+        lambda _: "/usr/bin/squeue",
+    )
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.services.scheduler_exclusions.monitor.subprocess.run",
+        run,
+    )
+    runner = LocalSlurmCommandRunner(timeout_seconds=12)
+
+    assert runner.run(["squeue", "--jobs", "123"]) == "ok\n"
+    assert run.call_args.args[0] == ["/usr/bin/squeue", "--jobs", "123"]
+    assert run.call_args.kwargs["timeout"] == 12
+    assert run.call_args.kwargs["env"]["PATH"]
+    assert "shell" not in run.call_args.kwargs
+
+
+def test_local_runner_applies_slurm_paths(monkeypatch):
+    run = MagicMock(
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="ok\n",
+            stderr="",
+        )
+    )
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.services.scheduler_exclusions.monitor.subprocess.run",
+        run,
+    )
+    runner = LocalSlurmCommandRunner(
+        slurm_bin_dir="/cm/shared/apps/slurm/current/bin",
+        slurm_conf="/cm/shared/apps/slurm/var/etc/slurm/slurm.conf",
+    )
+
+    assert runner.run(["squeue", "--format=%P|%N"]) == "ok\n"
+    assert run.call_args.args[0] == [
+        "/cm/shared/apps/slurm/current/bin/squeue",
+        "--format=%P|%N",
+    ]
+    assert (
+        run.call_args.kwargs["env"]["SLURM_CONF"]
+        == "/cm/shared/apps/slurm/var/etc/slurm/slurm.conf"
+    )
+
+
+def test_decision_file_starts_with_compact_task_ids_then_detailed_decisions(tmp_path):
+    path = tmp_path / "decision.jsonl"
+    writer = DecisionFileWriter(path)
+
+    assert writer.publish(
+        job_id="123",
+        generated_at=250.0,
+        cache_ttl_seconds=1800.0,
+        observations=[
+            DecisionObservation(
+                node="node01",
+                state="DRAINED",
+                reason="first",
+                observed_at=100.0,
+                array_tasks=(("7", 0),),
+            ),
+            DecisionObservation(
+                node="node02",
+                state="DOWN",
+                reason="second",
+                observed_at=200.0,
+                array_tasks=(("7", 0),),
+            ),
+            DecisionObservation(
+                node="node03",
+                state="NO_RESPOND",
+                reason="third",
+                observed_at=150.0,
+                array_tasks=(("8", 1),),
+            ),
+        ],
+    ) == (2, 3)
+
+    lines = path.read_text().splitlines()
+    assert lines[0] == '["7","8"]'
+    records = [json.loads(line) for line in lines]
+    assert records[0] == ["7", "8"]
+    assert [record["type"] for record in records[1:]] == [
+        "decision",
+        "decision",
+        "observation",
+        "observation",
+        "observation",
+    ]
+    assert records[1] == {
+        "type": "decision",
+        "schema_version": 1,
+        "job_id": "123",
+        "generated_at": "1970-01-01T00:04:10Z",
+        "scope": "array_task",
+        "excluded_array_tasks": [
+            {
+                "task_id": "7",
+                "restart_count": 0,
+                "valid_until": "1970-01-01T00:33:20Z",
+            },
+            {
+                "task_id": "8",
+                "restart_count": 1,
+                "valid_until": "1970-01-01T00:32:30Z",
+            },
+        ],
+    }
+    assert records[2] == {
+        "type": "decision",
+        "schema_version": 1,
+        "job_id": "123",
+        "generated_at": "1970-01-01T00:04:10Z",
+        "scope": "node",
+        "excluded_nodes": [
+            {"node": "node01", "valid_until": "1970-01-01T00:31:40Z"},
+            {"node": "node02", "valid_until": "1970-01-01T00:33:20Z"},
+            {"node": "node03", "valid_until": "1970-01-01T00:32:30Z"},
+        ],
+    }
+
+
+def test_decision_file_replace_failure_preserves_previous_artifact(tmp_path, monkeypatch):
+    path = tmp_path / "decision.jsonl"
+    path.write_text("previous\n", encoding="utf-8")
+    writer = DecisionFileWriter(path)
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.services.scheduler_exclusions.decision_file.os.replace",
+        MagicMock(side_effect=OSError("filesystem busy")),
+    )
+
+    with pytest.raises(DecisionFileWriteError, match="filesystem busy"):
+        writer.publish(
+            job_id="123",
+            generated_at=100.0,
+            cache_ttl_seconds=1800.0,
+            observations=[],
+        )
+
+    assert path.read_text(encoding="utf-8") == "previous\n"
+    assert list(tmp_path.glob(".decision.jsonl.*.tmp")) == []
+
+
+def test_monitor_refreshes_preserves_and_expires_unavailable_observations():
+    now = [100.0]
+    fail_sinfo = [False]
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node[01-02]\n"
+        if argv[0] == "scontrol":
+            return "node01\nnode02\n"
+        if fail_sinfo[0]:
+            raise SchedulerExclusionError("controller busy")
+        return "node01|drained|test drain\n"
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(
+            cache_ttl_seconds=1800,
+        ),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: now[0],
+    )
+
+    assert monitor.poll_once()
+    snapshot = monitor.snapshot()
+    assert snapshot["excluded_nodes"] == ["node01"]
+    assert snapshot["observations"]["node01"]["state"] == "DRAINED"
+    assert snapshot["observations"]["node01"]["array_tasks"] == []
+    assert snapshot["stats"]["cache_quality"] == "complete"
+
+    now[0] = 200.0
+    fail_sinfo[0] = True
+    assert not monitor.poll_once()
+    assert monitor.snapshot()["excluded_nodes"] == ["node01"]
+
+    now[0] = 1901.0
+    snapshot = monitor.snapshot()
+    assert snapshot["excluded_nodes"] == []
+    assert snapshot["stats"]["cache_quality"] == "unavailable"
+
+
+def test_monitor_snapshot_does_not_wait_for_mutable_state_lock():
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(lambda argv: pytest.fail(f"unexpected scheduler call: {argv}")),
+        clock=lambda: 100.0,
+    )
+    snapshot_ready = threading.Event()
+    result: list[dict] = []
+
+    def read_snapshot() -> None:
+        result.append(monitor.snapshot())
+        snapshot_ready.set()
+
+    reader = threading.Thread(target=read_snapshot)
+    monitor._lock.acquire()
+    try:
+        reader.start()
+        assert snapshot_ready.wait(timeout=1)
+    finally:
+        monitor._lock.release()
+        reader.join(timeout=1)
+
+    assert result[0]["job_id"] == "123"
+    assert result[0]["excluded_nodes"] == []
+
+
+def test_monitor_reports_current_array_task_generation_for_excluded_nodes():
+    array_task_id = ["7"]
+    restart_count = [0]
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return f"{array_task_id[0]}|{restart_count[0]}|batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        return "node01|drained|test drain\n"
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_ARRAY_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    assert monitor.snapshot()["observations"]["node01"]["array_tasks"] == [
+        {"task_id": "7", "restart_count": 0}
+    ]
+
+    restart_count[0] = 1
+    assert monitor.poll_once()
+    assert monitor.snapshot()["observations"]["node01"]["array_tasks"] == [
+        {"task_id": "7", "restart_count": 1}
+    ]
+
+
+def test_monitor_replaces_decision_for_new_task_generation_and_clears_it(tmp_path):
+    restart_count = [0]
+    state = ["drained"]
+    fail_allocation = [False]
+    decision_path = decision_file_path(tmp_path, "123")
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            if fail_allocation[0]:
+                raise SchedulerExclusionError("controller busy")
+            return f"7|{restart_count[0]}|batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        if any(arg.startswith("--nodes=") for arg in argv):
+            return "node01|allocated|none\n" if state[0] == "idle" else ""
+        return "node01|drained|reason\n" if state[0] == "drained" else ""
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(scheduler_exclusion_dir=str(tmp_path)),
+        env={"SLURM_ARRAY_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    first = decision_path.read_text(encoding="utf-8")
+    first_records = [json.loads(line) for line in first.splitlines()]
+    assert first_records[0] == ["7"]
+    first_decision = first_records[1]
+    node_decision = first_records[2]
+    response = monitor.scheduler_exclusions()
+    assert response is not None
+    assert response["excluded_array_tasks"] == first_decision["excluded_array_tasks"]
+    assert response["excluded_nodes"] == node_decision["excluded_nodes"]
+    assert first_decision["excluded_array_tasks"] == [
+        {
+            "task_id": "7",
+            "restart_count": 0,
+            "valid_until": "1970-01-01T00:31:40Z",
+        }
+    ]
+    assert node_decision["excluded_nodes"] == [
+        {"node": "node01", "valid_until": "1970-01-01T00:31:40Z"}
+    ]
+
+    fail_allocation[0] = True
+    assert not monitor.poll_once()
+    assert decision_path.read_text(encoding="utf-8") == first
+
+    fail_allocation[0] = False
+    restart_count[0] = 1
+    assert monitor.poll_once()
+    records = [json.loads(line) for line in decision_path.read_text().splitlines()]
+    assert records[0] == ["7"]
+    current_decision = records[1]
+    response = monitor.scheduler_exclusions()
+    assert response is not None
+    assert response["excluded_array_tasks"] == current_decision["excluded_array_tasks"]
+    assert response["excluded_nodes"] == records[2]["excluded_nodes"]
+    assert current_decision["excluded_array_tasks"] == [
+        {
+            "task_id": "7",
+            "restart_count": 1,
+            "valid_until": "1970-01-01T00:31:40Z",
+        }
+    ]
+
+    state[0] = "idle"
+    assert monitor.poll_once()
+    records = [json.loads(line) for line in decision_path.read_text().splitlines()]
+    assert records[0] == []
+    current_decision = records[1]
+    assert current_decision["excluded_array_tasks"] == []
+    assert records[2]["excluded_nodes"] == []
+    assert monitor.scheduler_exclusions() == {
+        "type": "decision",
+        "schema_version": 1,
+        "job_id": "123",
+        "generated_at": "1970-01-01T00:01:40Z",
+        "excluded_array_tasks": [],
+        "excluded_nodes": [],
+    }
+    assert monitor.snapshot()["last_decision_write"] == "1970-01-01T00:01:40Z"
+    assert monitor.snapshot()["stats"]["decision_write_failures"] == 0
+
+
+def test_monitor_publishes_node_decision_for_regular_job(tmp_path):
+    decision_path = decision_file_path(tmp_path, "123")
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        return "node01|drained|reason\n"
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(scheduler_exclusion_dir=str(tmp_path)),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    records = [json.loads(line) for line in decision_path.read_text().splitlines()]
+    assert records[0] == []
+    assert records[1]["scope"] == "array_task"
+    assert records[1]["excluded_array_tasks"] == []
+    assert records[2] == {
+        "type": "decision",
+        "schema_version": 1,
+        "job_id": "123",
+        "generated_at": "1970-01-01T00:01:40Z",
+        "scope": "node",
+        "excluded_nodes": [{"node": "node01", "valid_until": "1970-01-01T00:31:40Z"}],
+    }
+    assert records[3]["node"] == "node01"
+    assert records[3]["array_tasks"] == []
+    response = monitor.scheduler_exclusions()
+    assert response is not None
+    assert response["excluded_array_tasks"] == []
+    assert response["excluded_nodes"] == records[2]["excluded_nodes"]
+
+
+def test_failed_filtered_query_does_not_remap_stale_evidence_to_requeued_task(tmp_path):
+    restart_count = [0]
+    fail_node01 = [False]
+    decision_path = decision_file_path(tmp_path, "123")
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return f"7|{restart_count[0]}|batch|node01\n" "8|0|batch|node02\n"
+        if argv[0] == "scontrol":
+            return f"{argv[-1]}\n"
+        if fail_node01[0]:
+            raise SchedulerExclusionError("controller busy")
+        return "node01|drained|reason\n"
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(scheduler_exclusion_dir=str(tmp_path)),
+        env={"SLURM_ARRAY_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    restart_count[0] = 1
+    fail_node01[0] = True
+    assert not monitor.poll_once()
+
+    records = [json.loads(line) for line in decision_path.read_text().splitlines()]
+    assert records[0] == ["7"]
+    decision = records[1]
+    assert decision["excluded_array_tasks"] == [
+        {
+            "task_id": "7",
+            "restart_count": 0,
+            "valid_until": "1970-01-01T00:31:40Z",
+        }
+    ]
+
+
+def test_monitor_records_decision_publication_failure(tmp_path):
+    blocked_parent = tmp_path / "not-a-directory"
+    blocked_parent.write_text("blocked", encoding="utf-8")
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "7|0|batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        return "node01|drained|reason\n"
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(scheduler_exclusion_dir=str(blocked_parent)),
+        env={"SLURM_ARRAY_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    snapshot = monitor.snapshot()
+    assert snapshot["last_decision_write"] is None
+    assert snapshot["last_decision_error"]
+    assert snapshot["stats"]["decision_write_failures"] == 1
+
+
+def test_monitor_removes_node_after_explicit_good_observation(caplog):
+    now = [100.0]
+    state = ["drained"]
+    caplog.set_level(logging.INFO)
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        if any(arg.startswith("--nodes=") for arg in argv):
+            return "node01|allocated|none\n"
+        return "node01|drained|reason\n" if state[0] == "drained" else ""
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: now[0],
+    )
+
+    assert monitor.poll_once()
+    assert monitor.snapshot()["excluded_nodes"] == ["node01"]
+
+    now[0] = 200.0
+    state[0] = "idle"
+    assert monitor.poll_once()
+    assert monitor.snapshot()["excluded_nodes"] == []
+    assert "excluded=1" in caplog.text
+    assert "newly_excluded=['node01']" in caplog.text
+    assert "became_allocatable=['node01']" in caplog.text
+
+
+def test_monitor_distinguishes_excluded_node_leaving_allocation(caplog):
+    allocated_node = ["node01"]
+    caplog.set_level(logging.INFO)
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return f"batch|{allocated_node[0]}\n"
+        if argv[0] == "scontrol":
+            return f"{allocated_node[0]}\n"
+        if allocated_node[0] == "node01":
+            return "node01|drained|reason\n"
+        return ""
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    allocated_node[0] = "node02"
+    assert monitor.poll_once()
+
+    assert "left_allocation=['node01']" in caplog.text
+    assert "became_allocatable=['node01']" not in caplog.text
+
+
+def test_monitor_preserves_complete_cache_when_filtered_query_fails():
+    fail_sinfo = [False]
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node[01-02]\n"
+        if argv[0] == "scontrol":
+            return "node01\nnode02\n"
+        if fail_sinfo[0]:
+            raise SchedulerExclusionError("controller busy")
+        return "node01|drained|reason\n"
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    fail_sinfo[0] = True
+    assert not monitor.poll_once()
+    snapshot = monitor.snapshot()
+    assert snapshot["excluded_nodes"] == ["node01"]
+    assert snapshot["stats"]["cache_quality"] == "complete"
+    assert "controller busy" in snapshot["last_error"]
+
+
+def test_monitor_rejects_unexpected_allocatable_filtered_row():
+    sinfo_calls = 0
+
+    def callback(argv: list[str]) -> str:
+        nonlocal sinfo_calls
+        if argv[0] == "squeue":
+            return "batch|node[01-02]\n"
+        if argv[0] == "scontrol":
+            return "node01\nnode02\n"
+        sinfo_calls += 1
+        return "node01|idle|none\n"
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert not monitor.poll_once()
+    assert sinfo_calls == 1
+    snapshot = monitor.snapshot()
+    assert snapshot["excluded_nodes"] == []
+    assert snapshot["stats"]["cache_quality"] == "unavailable"
+    assert "allocatable nodes" in snapshot["last_error"]
+
+
+def test_monitor_replaces_complete_unavailable_snapshot():
+    excluded_nodes = ["node01", "node02"]
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node[01-02]\n"
+        if argv[0] == "scontrol":
+            return "node01\nnode02\n"
+        if any(arg.startswith("--nodes=") for arg in argv):
+            return "node01|allocated|none\n"
+        return "".join(f"{node}|drained|reason\n" for node in excluded_nodes)
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    assert monitor.snapshot()["excluded_nodes"] == ["node01", "node02"]
+
+    excluded_nodes[:] = ["node02"]
+    assert monitor.poll_once()
+    assert monitor.snapshot()["excluded_nodes"] == ["node02"]
+
+
+def test_monitor_clears_explicitly_recovered_node_and_retains_missing_node():
+    now = [100.0]
+    first_poll = [True]
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node[01-02]\n"
+        if argv[0] == "scontrol":
+            return "node01\nnode02\n"
+        if any(arg.startswith("--nodes=") for arg in argv):
+            return "node01|allocated|none\n"
+        if first_poll[0]:
+            return "node01|drained|reason\nnode02|drained|reason\n"
+        return ""
+
+    runner = CallbackRunner(callback)
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=runner,
+        clock=lambda: now[0],
+    )
+
+    assert monitor.poll_once()
+    first_poll[0] = False
+    now[0] = 200.0
+    assert monitor.poll_once()
+
+    snapshot = monitor.snapshot()
+    assert snapshot["excluded_nodes"] == ["node02"]
+    assert snapshot["observations"]["node02"]["observed_at"] == "1970-01-01T00:01:40Z"
+    assert [call for call in runner.calls if call[0] == "sinfo"][-1] == [
+        "sinfo",
+        "--noheader",
+        "--Node",
+        "--nodes=node01,node02",
+        "--format=%N|%T|%E",
+    ]
+
+
+def test_monitor_retains_recovery_candidates_when_verification_fails():
+    filtered_poll = [0]
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        if any(arg.startswith("--nodes=") for arg in argv):
+            raise SchedulerExclusionError("controller busy")
+        filtered_poll[0] += 1
+        return "node01|drained|reason\n" if filtered_poll[0] == 1 else ""
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    assert monitor.poll_once()
+    assert monitor.snapshot()["excluded_nodes"] == ["node01"]
+
+
+def test_monitor_refreshes_candidate_still_unavailable_during_verification():
+    now = [100.0]
+    filtered_poll = [0]
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        if any(arg.startswith("--nodes=") for arg in argv):
+            return "node01|down|still unavailable\n"
+        filtered_poll[0] += 1
+        return "node01|drained|initial\n" if filtered_poll[0] == 1 else ""
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: now[0],
+    )
+
+    assert monitor.poll_once()
+    now[0] = 200.0
+    assert monitor.poll_once()
+    observation = monitor.snapshot()["observations"]["node01"]
+    assert observation["state"] == "DOWN"
+    assert observation["reason"] == "still unavailable"
+    assert observation["observed_at"] == "1970-01-01T00:03:20Z"
+
+
+def test_monitor_skips_recovery_verification_above_candidate_limit(caplog):
+    filtered_poll = [0]
+    nodes = [f"node{index:02d}" for index in range(1, 18)]
+    caplog.set_level(logging.WARNING)
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "batch|node[01-17]\n"
+        if argv[0] == "scontrol":
+            return "".join(f"{node}\n" for node in nodes)
+        if any(arg.startswith("--nodes=") for arg in argv):
+            raise AssertionError("large candidate set must not be queried")
+        filtered_poll[0] += 1
+        if filtered_poll[0] == 1:
+            return "".join(f"{node}|drained|reason\n" for node in nodes)
+        return ""
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    assert monitor.poll_once()
+    assert monitor.snapshot()["excluded_nodes"] == nodes
+    assert "recovery verification skipped" in caplog.text
+    assert "candidates=17 limit=16" in caplog.text
+
+
+def test_monitor_stop_during_filtered_query_returns_without_retry():
+    monitor = None
+    sinfo_calls = 0
+
+    def callback(argv: list[str]) -> str:
+        nonlocal sinfo_calls
+        if argv[0] == "squeue":
+            return "batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        sinfo_calls += 1
+        assert monitor is not None
+        monitor._stop_event.set()
+        raise SchedulerExclusionError("controller busy")
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert not monitor.poll_once()
+    assert sinfo_calls == 1
+
+
+def test_monitor_stop_retains_a_live_worker_reference():
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=CallbackRunner(lambda _: ""),
+    )
+    worker = MagicMock()
+    worker.is_alive.return_value = True
+    monitor._thread = worker
+
+    monitor.stop()
+    monitor.start()
+
+    assert monitor._thread is worker
+    worker.join.assert_called_once()
+    assert monitor._stop_event.is_set()
+
+
+def test_refresh_hint_wakes_worker_and_coalesces_while_polling():
+    squeue_calls = 0
+    second_poll_started = threading.Event()
+    release_second_poll = threading.Event()
+
+    def callback(argv: list[str]) -> str:
+        nonlocal squeue_calls
+        if argv[0] == "squeue":
+            squeue_calls += 1
+            if squeue_calls == 2:
+                second_poll_started.set()
+                assert release_second_poll.wait(timeout=2)
+            return "batch|node01\n"
+        if argv[0] == "scontrol":
+            return "node01\n"
+        return ""
+
+    runner = CallbackRunner(callback)
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(
+            refresh_interval_seconds=3600,
+            jitter_fraction=0,
+        ),
+        env={"SLURM_JOB_ID": "123"},
+        runner=runner,
+    )
+    monitor.start()
+    try:
+        deadline = time.monotonic() + 2
+        while monitor.snapshot()["stats"]["polls_completed"] < 1:
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+
+        deadline = time.monotonic() + 2
+        while not monitor.request_refresh():
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+        assert second_poll_started.wait(timeout=2)
+        assert not monitor.request_refresh()
+    finally:
+        release_second_poll.set()
+        monitor.stop()
+
+    assert squeue_calls == 2
+
+
+def test_refresh_hint_does_not_run_scheduler_io():
+    runner = CallbackRunner(lambda argv: pytest.fail(f"unexpected scheduler call: {argv}"))
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_JOB_ID": "123"},
+        runner=runner,
+    )
+
+    assert not monitor.request_refresh()
+    assert runner.calls == []
+
+
+def test_monitor_uses_one_filtered_sinfo_query_for_5000_allocated_nodes():
+    nodes = [f"node{i:04d}" for i in range(5000)]
+    sinfo_calls: list[list[str]] = []
+
+    def callback(argv: list[str]) -> str:
+        if argv[0] == "squeue":
+            return "7|0|batch|all-nodes\n"
+        if argv[0] == "scontrol":
+            return "\n".join(nodes)
+        sinfo_calls.append(argv)
+        return "node4999|drained|test drain\nnode-outside|down|other job\n"
+
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={"SLURM_ARRAY_JOB_ID": "123"},
+        runner=CallbackRunner(callback),
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.poll_once()
+    assert len(sinfo_calls) == 1
+    assert "--nodes" not in sinfo_calls[0]
+    assert monitor.snapshot()["excluded_nodes"] == ["node4999"]
+
+
+def test_monitor_without_job_identity_is_unavailable():
+    monitor = SchedulerExclusionMonitor(
+        SchedulerExclusionConfig(),
+        env={},
+        clock=lambda: 100.0,
+    )
+
+    assert monitor.snapshot() == {
+        "job_id": None,
+        "last_complete_poll": None,
+        "last_poll_attempt": None,
+        "last_decision_write": None,
+        "excluded_nodes": [],
+        "observations": {},
+        "last_error": "Slurm job identity is unavailable",
+        "last_decision_error": None,
+        "stats": {
+            "polls_attempted": 0,
+            "polls_completed": 0,
+            "decision_write_failures": 0,
+            "current_nodes": 0,
+            "current_excluded_nodes": 0,
+            "cache_quality": "unavailable",
+        },
+    }
+
+
+def test_settings_use_scheduler_exclusion_environment_prefix():
+    settings = SchedulerExclusionServiceSettings.from_env(
+        {
+            "NVRX_SCHEDULER_EXCLUSION_HOST": "0.0.0.0",
+            "NVRX_SCHEDULER_EXCLUSION_PORT": "19090",
+            "NVRX_SCHEDULER_EXCLUSION_SLURM_BIN_DIR": "/opt/slurm/bin",
+            "NVRX_SCHEDULER_EXCLUSION_SLURM_CONF": "/etc/slurm/slurm.conf",
+            "NVRX_SCHEDULER_EXCLUSION_DIR": "/shared/scheduler-exclusions",
+            "NVRX_SCHEDULER_EXCLUSION_REFRESH_INTERVAL_SECONDS": "30",
+            "NVRX_SCHEDULER_EXCLUSION_CACHE_TTL_SECONDS": "90",
+            "NVRX_SCHEDULER_EXCLUSION_QUERY_TIMEOUT_SECONDS": "4",
+        }
+    )
+
+    assert settings.host == "0.0.0.0"
+    assert settings.port == 19090
+    assert settings.monitor_config() == SchedulerExclusionConfig(
+        slurm_bin_dir="/opt/slurm/bin",
+        slurm_conf="/etc/slurm/slurm.conf",
+        scheduler_exclusion_dir="/shared/scheduler-exclusions",
+        refresh_interval_seconds=30,
+        cache_ttl_seconds=90,
+        query_timeout_seconds=4,
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("PORT", "not-a-port"),
+        ("REFRESH_INTERVAL_SECONDS", "often"),
+        ("CACHE_TTL_SECONDS", "later"),
+        ("QUERY_TIMEOUT_SECONDS", "slow"),
+    ],
+)
+def test_settings_name_invalid_numeric_environment_values(name, value):
+    variable = f"NVRX_SCHEDULER_EXCLUSION_{name}"
+
+    with pytest.raises(ValueError, match=rf"{variable}: '{value}'"):
+        SchedulerExclusionServiceSettings.from_env({variable: value})
+
+
+@pytest.mark.parametrize("field", ["slurm_bin_dir", "slurm_conf", "scheduler_exclusion_dir"])
+def test_local_slurm_paths_must_be_absolute(field):
+    with pytest.raises(ValueError, match="absolute path"):
+        SchedulerExclusionServiceSettings(**{field: "relative/path"})
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "refresh_interval_seconds",
+        "cache_ttl_seconds",
+        "query_timeout_seconds",
+    ],
+)
+def test_numeric_settings_must_be_positive(field):
+    with pytest.raises(ValueError, match="positive"):
+        SchedulerExclusionServiceSettings(**{field: 0})
+
+
+def _http_json(method: str, url: str) -> tuple[int, dict]:
+    request = urllib.request.Request(url, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=2) as response:  # nosec B310
+            return response.status, json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
+def test_http_server_exposes_cache_and_nonblocking_refresh():
+    monitor = MagicMock()
+    monitor.snapshot.return_value = {
+        "job_id": "123",
+        "last_complete_poll": "2026-07-30T12:40:00Z",
+        "last_poll_attempt": "2026-07-30T12:41:00Z",
+        "last_decision_write": "2026-07-30T12:40:31Z",
+        "excluded_nodes": ["node01"],
+        "observations": {
+            "node01": {
+                "state": "DRAIN",
+                "reason": "test",
+                "observed_at": "2026-07-30T12:40:00Z",
+                "array_tasks": [{"task_id": "7", "restart_count": 0}],
+            }
+        },
+        "last_error": None,
+        "last_decision_error": None,
+        "stats": {
+            "polls_attempted": 4,
+            "polls_completed": 3,
+            "decision_write_failures": 0,
+            "current_nodes": 5000,
+            "current_excluded_nodes": 1,
+            "cache_quality": "complete",
+        },
+    }
+    monitor.scheduler_exclusions.return_value = {
+        "type": "decision",
+        "schema_version": 1,
+        "job_id": "123",
+        "generated_at": "2026-07-30T12:40:30Z",
+        "excluded_array_tasks": [
+            {
+                "task_id": "7",
+                "restart_count": 0,
+                "valid_until": "2026-07-30T13:10:00Z",
+            }
+        ],
+        "excluded_nodes": [
+            {
+                "node": "node01",
+                "valid_until": "2026-07-30T13:10:00Z",
+            }
+        ],
+    }
+    monitor.request_refresh.return_value = True
+    server = SchedulerExclusionHttpServer(("127.0.0.1", 0), monitor)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.server_port}"
+    try:
+        status, health = _http_json("GET", f"{endpoint}/healthz")
+        assert status == 200
+        assert health["service"] == "nvrx-scheduler-exclusion-service"
+
+        status, body = _http_json("GET", f"{endpoint}/scheduler-exclusions")
+        assert status == 200
+        assert body == monitor.scheduler_exclusions.return_value
+
+        status, stats = _http_json("GET", f"{endpoint}/stats")
+        assert status == 200
+        assert stats == {
+            "job_id": "123",
+            "last_complete_poll": "2026-07-30T12:40:00Z",
+            "last_poll_attempt": "2026-07-30T12:41:00Z",
+            "last_decision_write": "2026-07-30T12:40:31Z",
+            "last_error": None,
+            "last_decision_error": None,
+            "polls_attempted": 4,
+            "polls_completed": 3,
+            "decision_write_failures": 0,
+            "current_nodes": 5000,
+            "current_excluded_nodes": 1,
+            "cache_quality": "complete",
+        }
+
+        status, body = _http_json("GET", f"{endpoint}/allocation-state")
+        assert status == 404
+        assert body == {"error": "not_found"}
+
+        status, body = _http_json("GET", f"{endpoint}/allocation-state/stats")
+        assert status == 404
+        assert body == {"error": "not_found"}
+
+        status, refresh = _http_json("POST", f"{endpoint}/refresh")
+        assert status == 202
+        assert refresh == {"accepted": True}
+        monitor.request_refresh.assert_called_once_with()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_http_server_reports_scheduler_exclusions_unavailable_before_first_poll():
+    monitor = MagicMock()
+    monitor.scheduler_exclusions.return_value = None
+    server = SchedulerExclusionHttpServer(("127.0.0.1", 0), monitor)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.server_port}"
+    try:
+        status, body = _http_json("GET", f"{endpoint}/scheduler-exclusions")
+        assert status == 503
+        assert body == {"error": "scheduler_exclusions_unavailable"}
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_http_server_consumes_post_body_on_persistent_connection(monkeypatch):
+    monitor = MagicMock()
+    monitor.snapshot.return_value = {
+        "job_id": "123",
+        "last_complete_poll": None,
+        "last_poll_attempt": None,
+        "last_decision_write": None,
+        "excluded_nodes": [],
+        "observations": {},
+        "last_error": None,
+        "last_decision_error": None,
+        "stats": {
+            "polls_attempted": 0,
+            "polls_completed": 0,
+            "decision_write_failures": 0,
+            "current_nodes": 0,
+            "current_excluded_nodes": 0,
+            "cache_quality": "unavailable",
+        },
+    }
+    monitor.request_refresh.return_value = True
+    monkeypatch.setattr(SchedulerExclusionRequestHandler, "protocol_version", "HTTP/1.1")
+    server = SchedulerExclusionHttpServer(("127.0.0.1", 0), monitor)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=2)
+    try:
+        connection.request(
+            "POST",
+            "/missing",
+            body=b"{}",
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        assert response.status == 404
+        assert json.loads(response.read()) == {"error": "not_found"}
+
+        connection.request(
+            "POST",
+            "/refresh",
+            body=b"{}",
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        assert response.status == 202
+        assert json.loads(response.read()) == {"accepted": True}
+
+        connection.request("GET", "/stats")
+        response = connection.getresponse()
+        assert response.status == 200
+        assert json.loads(response.read())["cache_quality"] == "unavailable"
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)

--- a/services/tests/test_scheduler_exclusion_zipapp.py
+++ b/services/tests/test_scheduler_exclusion_zipapp.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+
+def test_builds_minimal_standalone_zipapp(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    builder = repo_root / "services" / "scheduler_exclusions" / "build_zipapp.py"
+    artifact = tmp_path / "scheduler-exclusion.pyz"
+
+    subprocess.run(  # nosec B603
+        [sys.executable, str(builder), "--output", str(artifact)],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    assert artifact.stat().st_mode & stat.S_IXUSR
+    with zipfile.ZipFile(artifact) as archive:
+        names = set(archive.namelist())
+    assert "__main__.py" in names
+    assert "nvidia_resiliency_ext/services/scheduler_exclusions/decision_file.py" in names
+    assert "nvidia_resiliency_ext/services/scheduler_exclusions/monitor.py" in names
+    assert not any("fault_tolerance" in name for name in names)
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(  # nosec B603
+        [str(artifact), "--help"],
+        check=True,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert "NVRx Scheduler Exclusion Service" in result.stdout
+    assert "--output-dir" in result.stdout
+    assert "--scheduler-exclusion-dir" not in result.stdout
+
+    env["NVRX_SCHEDULER_EXCLUSION_ARTIFACT"] = str(artifact)
+    env["NVRX_SCHEDULER_EXCLUSION_PYTHON"] = sys.executable
+    launcher = repo_root / "services" / "scheduler_exclusions" / "deploy" / "run_service.sh"
+    result = subprocess.run(  # nosec B603
+        [str(launcher), "--help"],
+        check=True,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert "NVRx Scheduler Exclusion Service" in result.stdout

--- a/src/nvidia_resiliency_ext/services/scheduler_exclusions/__init__.py
+++ b/src/nvidia_resiliency_ext/services/scheduler_exclusions/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVRx Scheduler Exclusion Service."""
+
+from .config import SchedulerExclusionServiceSettings
+from .monitor import SchedulerExclusionMonitor
+from .server import SchedulerExclusionHttpServer
+
+__all__ = [
+    "SchedulerExclusionHttpServer",
+    "SchedulerExclusionMonitor",
+    "SchedulerExclusionServiceSettings",
+]

--- a/src/nvidia_resiliency_ext/services/scheduler_exclusions/__main__.py
+++ b/src/nvidia_resiliency_ext/services/scheduler_exclusions/__main__.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI for the NVRx Scheduler Exclusion Service."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import signal
+import threading
+
+from .config import SchedulerExclusionServiceSettings
+from .monitor import SchedulerExclusionMonitor
+from .server import SchedulerExclusionHttpServer
+
+
+def _parser(defaults: SchedulerExclusionServiceSettings) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the NVRx Scheduler Exclusion Service")
+    parser.add_argument("--host", default=defaults.host)
+    parser.add_argument("--port", type=int, default=defaults.port)
+    parser.add_argument("--slurm-bin-dir", default=defaults.slurm_bin_dir)
+    parser.add_argument("--slurm-conf", default=defaults.slurm_conf)
+    parser.add_argument(
+        "--output-dir",
+        dest="scheduler_exclusion_dir",
+        default=defaults.scheduler_exclusion_dir,
+        help="Shared directory in which to publish scheduler-exclusion artifacts.",
+    )
+    parser.add_argument(
+        "--refresh-interval-seconds",
+        type=float,
+        default=defaults.refresh_interval_seconds,
+    )
+    parser.add_argument(
+        "--cache-ttl-seconds",
+        type=float,
+        default=defaults.cache_ttl_seconds,
+    )
+    parser.add_argument(
+        "--query-timeout-seconds",
+        type=float,
+        default=defaults.query_timeout_seconds,
+    )
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+def main() -> None:
+    defaults = SchedulerExclusionServiceSettings.from_env()
+    args = _parser(defaults).parse_args()
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    settings = SchedulerExclusionServiceSettings(
+        host=args.host,
+        port=args.port,
+        slurm_bin_dir=args.slurm_bin_dir,
+        slurm_conf=args.slurm_conf,
+        scheduler_exclusion_dir=args.scheduler_exclusion_dir,
+        refresh_interval_seconds=args.refresh_interval_seconds,
+        cache_ttl_seconds=args.cache_ttl_seconds,
+        query_timeout_seconds=args.query_timeout_seconds,
+    )
+    monitor = SchedulerExclusionMonitor(settings.monitor_config())
+    server = SchedulerExclusionHttpServer((settings.host, settings.port), monitor)
+    stop_event = threading.Event()
+
+    def request_stop(_signum: int, _frame: object) -> None:
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+    server.timeout = 0.5
+    monitor.start()
+    host, port = server.server_address[:2]
+    logging.getLogger(__name__).info("Listening on http://%s:%s", host, port)
+    try:
+        while not stop_event.is_set():
+            server.handle_request()
+    finally:
+        server.server_close()
+        monitor.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nvidia_resiliency_ext/services/scheduler_exclusions/config.py
+++ b/src/nvidia_resiliency_ext/services/scheduler_exclusions/config.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration for the NVRx Scheduler Exclusion Service."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import TypeVar
+
+from .monitor import (
+    DEFAULT_CACHE_TTL_SECONDS,
+    DEFAULT_QUERY_TIMEOUT_SECONDS,
+    DEFAULT_REFRESH_INTERVAL_SECONDS,
+    SchedulerExclusionConfig,
+)
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 18080
+ENV_PREFIX = "NVRX_SCHEDULER_EXCLUSION_"
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class SchedulerExclusionServiceSettings:
+    """Process and monitor settings loaded from CLI or environment."""
+
+    host: str = DEFAULT_HOST
+    port: int = DEFAULT_PORT
+    slurm_bin_dir: str = ""
+    slurm_conf: str = ""
+    scheduler_exclusion_dir: str = ""
+    refresh_interval_seconds: float = DEFAULT_REFRESH_INTERVAL_SECONDS
+    cache_ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS
+    query_timeout_seconds: float = DEFAULT_QUERY_TIMEOUT_SECONDS
+
+    def __post_init__(self) -> None:
+        if not self.host:
+            raise ValueError("host must not be empty")
+        if not 0 <= self.port <= 65535:
+            raise ValueError("port must be in [0, 65535]")
+        for name in ("slurm_bin_dir", "slurm_conf", "scheduler_exclusion_dir"):
+            value = getattr(self, name)
+            if value and not os.path.isabs(value):
+                raise ValueError(f"{name} must be an absolute path")
+        for name in (
+            "refresh_interval_seconds",
+            "cache_ttl_seconds",
+            "query_timeout_seconds",
+        ):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive")
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+    ) -> "SchedulerExclusionServiceSettings":
+        """Load settings from the ``NVRX_SCHEDULER_EXCLUSION_`` environment."""
+        values = os.environ if env is None else env
+
+        def get(name: str, default: object) -> str:
+            return str(values.get(f"{ENV_PREFIX}{name}", default)).strip()
+
+        def convert(name: str, default: object, parser: Callable[[str], _T]) -> _T:
+            raw = get(name, default)
+            try:
+                return parser(raw)
+            except ValueError as exc:
+                raise ValueError(f"Invalid value for {ENV_PREFIX}{name}: {raw!r}") from exc
+
+        return cls(
+            host=get("HOST", DEFAULT_HOST),
+            port=convert("PORT", DEFAULT_PORT, int),
+            slurm_bin_dir=get("SLURM_BIN_DIR", ""),
+            slurm_conf=get("SLURM_CONF", ""),
+            scheduler_exclusion_dir=get("DIR", ""),
+            refresh_interval_seconds=convert(
+                "REFRESH_INTERVAL_SECONDS",
+                DEFAULT_REFRESH_INTERVAL_SECONDS,
+                float,
+            ),
+            cache_ttl_seconds=convert(
+                "CACHE_TTL_SECONDS",
+                DEFAULT_CACHE_TTL_SECONDS,
+                float,
+            ),
+            query_timeout_seconds=convert(
+                "QUERY_TIMEOUT_SECONDS",
+                DEFAULT_QUERY_TIMEOUT_SECONDS,
+                float,
+            ),
+        )
+
+    def monitor_config(self) -> SchedulerExclusionConfig:
+        """Build the scheduler-query configuration."""
+        return SchedulerExclusionConfig(
+            slurm_bin_dir=self.slurm_bin_dir,
+            slurm_conf=self.slurm_conf,
+            scheduler_exclusion_dir=self.scheduler_exclusion_dir,
+            refresh_interval_seconds=self.refresh_interval_seconds,
+            cache_ttl_seconds=self.cache_ttl_seconds,
+            query_timeout_seconds=self.query_timeout_seconds,
+        )

--- a/src/nvidia_resiliency_ext/services/scheduler_exclusions/decision_file.py
+++ b/src/nvidia_resiliency_ext/services/scheduler_exclusions/decision_file.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Atomic shared-file publication for Scheduler Exclusion decisions."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+
+class DecisionFileWriteError(RuntimeError):
+    """Raised when a decision artifact cannot be published atomically."""
+
+
+def decision_file_path(directory: str | Path, job_id: str) -> Path:
+    """Return the component-owned decision filename for one Slurm job."""
+    clean_job_id = str(job_id).strip()
+    if not clean_job_id or Path(clean_job_id).name != clean_job_id:
+        raise ValueError(f"invalid Slurm job ID: {job_id!r}")
+    return Path(directory) / f"segment_health_check.{clean_job_id}.state"
+
+
+@dataclass(frozen=True)
+class DecisionObservation:
+    """One excluded-node observation included in a decision artifact."""
+
+    node: str
+    state: str
+    reason: str
+    observed_at: float
+    array_tasks: tuple[tuple[str, int], ...]
+
+
+def build_decision_records(
+    *,
+    job_id: str,
+    generated_at: float,
+    cache_ttl_seconds: float,
+    observations: Sequence[DecisionObservation],
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Build task- and node-scoped Scheduler Exclusion decisions."""
+    task_valid_until: dict[tuple[str, int], float] = {}
+    node_valid_until: dict[str, float] = {}
+    for observation in observations:
+        valid_until = observation.observed_at + cache_ttl_seconds
+        node_valid_until[observation.node] = valid_until
+        for task in observation.array_tasks:
+            task_valid_until[task] = max(task_valid_until.get(task, 0.0), valid_until)
+
+    excluded_tasks = [
+        {
+            "task_id": task_id,
+            "restart_count": restart_count,
+            "valid_until": _format_timestamp(valid_until),
+        }
+        for (task_id, restart_count), valid_until in sorted(
+            task_valid_until.items(), key=lambda item: _task_sort_key(item[0])
+        )
+    ]
+    excluded_nodes = [
+        {
+            "node": node,
+            "valid_until": _format_timestamp(valid_until),
+        }
+        for node, valid_until in sorted(node_valid_until.items())
+    ]
+    common = {
+        "type": "decision",
+        "schema_version": 1,
+        "job_id": job_id,
+        "generated_at": _format_timestamp(generated_at),
+    }
+    return (
+        {
+            **common,
+            "scope": "array_task",
+            "excluded_array_tasks": excluded_tasks,
+        },
+        {
+            **common,
+            "scope": "node",
+            "excluded_nodes": excluded_nodes,
+        },
+    )
+
+
+def build_decision_response(
+    *,
+    job_id: str,
+    generated_at: float,
+    cache_ttl_seconds: float,
+    observations: Sequence[DecisionObservation],
+) -> dict[str, object]:
+    """Build the combined HTTP representation of one decision snapshot."""
+    task_decision, node_decision = build_decision_records(
+        job_id=job_id,
+        generated_at=generated_at,
+        cache_ttl_seconds=cache_ttl_seconds,
+        observations=observations,
+    )
+    return {
+        "type": "decision",
+        "schema_version": task_decision["schema_version"],
+        "job_id": job_id,
+        "generated_at": task_decision["generated_at"],
+        "excluded_array_tasks": task_decision["excluded_array_tasks"],
+        "excluded_nodes": node_decision["excluded_nodes"],
+    }
+
+
+class DecisionFileWriter:
+    """Publish compact task exclusions plus detailed decision evidence as JSONL."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def publish(
+        self,
+        *,
+        job_id: str,
+        generated_at: float,
+        cache_ttl_seconds: float,
+        observations: Sequence[DecisionObservation],
+    ) -> tuple[int, int]:
+        """Atomically replace the artifact and return task and node counts."""
+        task_decision, node_decision = build_decision_records(
+            job_id=job_id,
+            generated_at=generated_at,
+            cache_ttl_seconds=cache_ttl_seconds,
+            observations=observations,
+        )
+        excluded_task_ids = list(
+            dict.fromkeys(entry["task_id"] for entry in task_decision["excluded_array_tasks"])
+        )
+        records: list[object] = [excluded_task_ids, task_decision, node_decision]
+        for observation in sorted(observations, key=lambda item: item.node):
+            records.append(
+                {
+                    "type": "observation",
+                    "node": observation.node,
+                    "state": observation.state,
+                    "reason": observation.reason,
+                    "observed_at": _format_timestamp(observation.observed_at),
+                    "valid_until": _format_timestamp(observation.observed_at + cache_ttl_seconds),
+                    "array_tasks": [
+                        {
+                            "task_id": task_id,
+                            "restart_count": restart_count,
+                        }
+                        for task_id, restart_count in sorted(
+                            observation.array_tasks, key=_task_sort_key
+                        )
+                    ],
+                }
+            )
+
+        self._atomic_write(records)
+        return (
+            len(task_decision["excluded_array_tasks"]),
+            len(node_decision["excluded_nodes"]),
+        )
+
+    def _atomic_write(self, records: Sequence[object]) -> None:
+        temporary_path: Path | None = None
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=f".{self.path.name}.",
+                suffix=".tmp",
+                dir=self.path.parent,
+            )
+            temporary_path = Path(temporary_name)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                for record in records:
+                    stream.write(json.dumps(record, separators=(",", ":")))
+                    stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary_path, self.path)
+        except OSError as exc:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+            raise DecisionFileWriteError(
+                f"could not publish Scheduler Exclusion decision to {self.path}: {exc}"
+            ) from exc
+
+
+def _task_sort_key(task: tuple[str, int]) -> tuple[int, int, str, int]:
+    task_id, restart_count = task
+    if task_id.isdigit():
+        return (0, int(task_id), task_id, restart_count)
+    return (1, 0, task_id, restart_count)
+
+
+def _format_timestamp(value: float) -> str:
+    return datetime.fromtimestamp(value, tz=timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/nvidia_resiliency_ext/services/scheduler_exclusions/monitor.py
+++ b/src/nvidia_resiliency_ext/services/scheduler_exclusions/monitor.py
@@ -1,0 +1,927 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scheduler exclusion monitoring and cache publication."""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+import re
+import shutil
+import subprocess  # nosec B404
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+from .decision_file import (
+    DecisionFileWriteError,
+    DecisionFileWriter,
+    DecisionObservation,
+    build_decision_response,
+    decision_file_path,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REFRESH_INTERVAL_SECONDS = 600.0
+DEFAULT_CACHE_TTL_SECONDS = 1800.0
+DEFAULT_QUERY_TIMEOUT_SECONDS = 30.0
+DEFAULT_JITTER_FRACTION = 0.1
+_LARGE_EXCLUDED_NODE_COUNT = 16
+_MAX_RECOVERY_VERIFICATION_CANDIDATES = 16
+_ARRAY_SQUEUE_FORMAT = "--Format=ArrayTaskID:64|,RestartCnt:16|,Partition:128|,NodeList:1024"
+_SINFO_EXCLUSION_FILTER = "drain,down,fail,no_respond"
+
+SCHEDULER_EXCLUSION_STATES = frozenset(
+    {
+        "down",
+        "drain",
+        "drained",
+        "draining",
+        "fail",
+        "failing",
+        "no_respond",
+    }
+)
+
+
+class SchedulerExclusionError(RuntimeError):
+    """Raised when scheduler state cannot be queried safely."""
+
+
+class MalformedSchedulerResponse(SchedulerExclusionError):
+    """Raised when Slurm returns a response that is unsafe to consume."""
+
+
+class CommandRunner(Protocol):
+    """Runs one command in the scheduler environment."""
+
+    def run(self, argv: Sequence[str]) -> str:
+        """Return stdout or raise :class:`SchedulerExclusionError`."""
+
+
+@dataclass(frozen=True)
+class JobIdentity:
+    """Slurm identity inherited by the Scheduler Exclusion Service."""
+
+    job_id: str
+    is_array: bool
+
+
+@dataclass(frozen=True)
+class SchedulerExclusionConfig:
+    """Configuration for one Scheduler Exclusion monitor."""
+
+    slurm_bin_dir: str = ""
+    slurm_conf: str = ""
+    scheduler_exclusion_dir: str = ""
+    refresh_interval_seconds: float = DEFAULT_REFRESH_INTERVAL_SECONDS
+    cache_ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS
+    query_timeout_seconds: float = DEFAULT_QUERY_TIMEOUT_SECONDS
+    jitter_fraction: float = DEFAULT_JITTER_FRACTION
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True)
+class NodeStateRecord:
+    """One scheduler response row."""
+
+    node: str
+    state: str
+    reason: str
+    excluded: bool
+
+
+@dataclass(frozen=True)
+class ExcludedNodeObservation:
+    """One cached Scheduler Exclusion observation."""
+
+    state: str
+    reason: str
+    observed_at: float
+    array_tasks: tuple[ArrayTaskGeneration, ...]
+
+
+@dataclass(frozen=True)
+class ArrayTaskGeneration:
+    """One running incarnation of a Slurm array task."""
+
+    task_id: str
+    restart_count: int
+
+
+@dataclass(frozen=True)
+class _PublishedSnapshot:
+    """Immutable cache view captured by HTTP readers."""
+
+    job_id: str | None
+    last_complete_poll: float | None
+    last_poll_attempt: float | None
+    observations: tuple[tuple[str, ExcludedNodeObservation], ...]
+    last_error: str | None
+    last_decision_write: float | None
+    last_decision_error: str | None
+    polls_attempted: int
+    polls_completed: int
+    decision_write_failures: int
+    current_nodes: int
+
+
+@dataclass(frozen=True)
+class AllocationSnapshot:
+    """Current Slurm allocation grouped by partition."""
+
+    nodes_by_partition: dict[str, tuple[str, ...]]
+    array_task_generations_by_node: dict[str, tuple[ArrayTaskGeneration, ...]]
+
+    @property
+    def nodes(self) -> set[str]:
+        return {
+            node for partition_nodes in self.nodes_by_partition.values() for node in partition_nodes
+        }
+
+
+def job_identity_from_env(env: Mapping[str, str] | None = None) -> JobIdentity | None:
+    """Resolve an array parent ID or regular job ID from the inherited environment."""
+    values = os.environ if env is None else env
+    array_job_id = str(values.get("SLURM_ARRAY_JOB_ID", "")).strip()
+    if array_job_id:
+        return JobIdentity(job_id=array_job_id, is_array=True)
+
+    job_id = str(values.get("SLURM_JOB_ID", "")).strip()
+    if job_id:
+        return JobIdentity(job_id=job_id, is_array=False)
+    return None
+
+
+class LocalSlurmCommandRunner:
+    """Execute fixed Slurm argv in the local batch-host environment."""
+
+    def __init__(
+        self,
+        *,
+        slurm_bin_dir: str = "",
+        slurm_conf: str = "",
+        timeout_seconds: float = DEFAULT_QUERY_TIMEOUT_SECONDS,
+    ) -> None:
+        self.slurm_bin_dir = slurm_bin_dir
+        self.slurm_conf = slurm_conf
+        self.timeout_seconds = float(timeout_seconds)
+
+    def run(self, argv: Sequence[str]) -> str:
+        if not argv:
+            raise ValueError("command must not be empty")
+        command = [str(arg) for arg in argv]
+        if self.slurm_bin_dir:
+            command[0] = os.path.join(self.slurm_bin_dir, command[0])
+        else:
+            resolved = shutil.which(command[0])
+            if resolved is None:
+                raise SchedulerExclusionError(f"{command[0]} command not found")
+            command[0] = resolved
+        env = os.environ.copy()
+        if self.slurm_conf:
+            env["SLURM_CONF"] = self.slurm_conf
+
+        try:
+            result = subprocess.run(  # nosec B603
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise SchedulerExclusionError(
+                f"{argv[0]} timed out after {self.timeout_seconds:.1f}s"
+            ) from exc
+        except OSError as exc:
+            raise SchedulerExclusionError(f"{argv[0]} could not be started: {exc}") from exc
+
+        if result.returncode != 0:
+            message = (result.stderr or result.stdout or f"{argv[0]} failed").strip()
+            raise SchedulerExclusionError(message)
+        return result.stdout
+
+
+def discover_allocation(
+    runner: CommandRunner,
+    identity: JobIdentity,
+    *,
+    stop_requested: Callable[[], bool] | None = None,
+) -> AllocationSnapshot:
+    """Discover current running nodes for a regular job or array parent."""
+    command = ["squeue", "--noheader"]
+    if identity.is_array:
+        command.append("--array")
+        # Long-format fields are truncated to their requested width by some
+        # supported Slurm releases. Leave enough room for compressed nodelists.
+        output_option = _ARRAY_SQUEUE_FORMAT
+    else:
+        output_option = "--format=%P|%N"
+    command.extend(
+        [
+            "--jobs",
+            identity.job_id,
+            "--states=RUNNING",
+            output_option,
+        ]
+    )
+    output = runner.run(command)
+    if stop_requested is not None and stop_requested():
+        raise SchedulerExclusionError("Scheduler Exclusion monitor is stopping")
+    allocation_rows = _parse_squeue_output(output, is_array=identity.is_array)
+    if not allocation_rows:
+        raise SchedulerExclusionError(
+            f"squeue returned no running allocations for job {identity.job_id}"
+        )
+
+    partition_nodes: dict[str, list[str]] = {}
+    array_task_generations_by_node: dict[str, set[ArrayTaskGeneration]] = {}
+    expanded_nodelists: dict[str, tuple[str, ...]] = {}
+    seen_nodes: set[str] = set()
+    # Expand each unique task nodelist separately to retain its node association.
+    for task_generation, partition, nodelist in allocation_rows:
+        nodes = expanded_nodelists.get(nodelist)
+        if nodes is None:
+            if stop_requested is not None and stop_requested():
+                raise SchedulerExclusionError("Scheduler Exclusion monitor is stopping")
+            expanded = runner.run(["scontrol", "show", "hostnames", nodelist])
+            if stop_requested is not None and stop_requested():
+                raise SchedulerExclusionError("Scheduler Exclusion monitor is stopping")
+            nodes = tuple(line.strip() for line in expanded.splitlines() if line.strip())
+            if not nodes:
+                raise MalformedSchedulerResponse(
+                    f"scontrol returned no nodes for nodelist {nodelist!r}"
+                )
+            expanded_nodelists[nodelist] = nodes
+        for node in nodes:
+            if task_generation is not None:
+                array_task_generations_by_node.setdefault(node, set()).add(task_generation)
+            if node not in seen_nodes:
+                seen_nodes.add(node)
+                partition_nodes.setdefault(partition, []).append(node)
+
+    nodes_by_partition = {
+        partition: tuple(nodes) for partition, nodes in partition_nodes.items() if nodes
+    }
+
+    if not nodes_by_partition:
+        raise SchedulerExclusionError(
+            f"allocation expansion returned no nodes for job {identity.job_id}"
+        )
+    return AllocationSnapshot(
+        nodes_by_partition=nodes_by_partition,
+        array_task_generations_by_node={
+            node: tuple(sorted(generations, key=_array_task_generation_sort_key))
+            for node, generations in array_task_generations_by_node.items()
+        },
+    )
+
+
+def query_scheduler_exclusions(
+    runner: CommandRunner,
+    *,
+    exclusion_states: frozenset[str] = SCHEDULER_EXCLUSION_STATES,
+) -> dict[str, NodeStateRecord]:
+    """Query scheduler-unavailable nodes across the cluster."""
+    output = runner.run(
+        [
+            "sinfo",
+            "--noheader",
+            "--Node",
+            f"--states={_SINFO_EXCLUSION_FILTER}",
+            "--format=%N|%T|%E",
+        ]
+    )
+    records = _parse_sinfo_output(output, exclusion_states)
+    unexpected = sorted(node for node, record in records.items() if not record.excluded)
+    if unexpected:
+        raise MalformedSchedulerResponse(
+            "filtered sinfo response contained allocatable nodes: " + ", ".join(unexpected)
+        )
+    return records
+
+
+def _query_recovery_candidates(
+    runner: CommandRunner,
+    nodes: Sequence[str],
+    *,
+    exclusion_states: frozenset[str] = SCHEDULER_EXCLUSION_STATES,
+) -> dict[str, NodeStateRecord]:
+    """Query full scheduler state for a bounded set of prior exclusions."""
+    requested_nodes = tuple(sorted(set(nodes)))
+    if not requested_nodes:
+        return {}
+    output = runner.run(
+        [
+            "sinfo",
+            "--noheader",
+            "--Node",
+            f"--nodes={','.join(requested_nodes)}",
+            "--format=%N|%T|%E",
+        ]
+    )
+    records = _parse_sinfo_output(output, exclusion_states)
+    unexpected = sorted(set(records) - set(requested_nodes))
+    if unexpected:
+        raise MalformedSchedulerResponse(
+            "recovery verification returned unrequested nodes: " + ", ".join(unexpected)
+        )
+    return records
+
+
+class SchedulerExclusionMonitor:
+    """Poll Slurm and publish copy-on-write snapshots of excluded nodes."""
+
+    def __init__(
+        self,
+        config: SchedulerExclusionConfig,
+        *,
+        env: Mapping[str, str] | None = None,
+        runner: CommandRunner | None = None,
+        clock: Callable[[], float] = time.time,
+        jitter: Callable[[float, float], float] = random.uniform,
+    ) -> None:
+        if config.refresh_interval_seconds <= 0:
+            raise ValueError("refresh_interval_seconds must be positive")
+        if config.cache_ttl_seconds <= 0:
+            raise ValueError("cache_ttl_seconds must be positive")
+        if config.query_timeout_seconds <= 0:
+            raise ValueError("query_timeout_seconds must be positive")
+        if config.scheduler_exclusion_dir and not os.path.isabs(config.scheduler_exclusion_dir):
+            raise ValueError("scheduler_exclusion_dir must be an absolute path")
+        if not 0 <= config.jitter_fraction < 1:
+            raise ValueError("jitter_fraction must be in [0, 1)")
+
+        self.config = config
+        self.identity = job_identity_from_env(env)
+        self._runner = runner
+        if self._runner is None:
+            self._runner = LocalSlurmCommandRunner(
+                slurm_bin_dir=config.slurm_bin_dir,
+                slurm_conf=config.slurm_conf,
+                timeout_seconds=config.query_timeout_seconds,
+            )
+        self._clock = clock
+        self._jitter = jitter
+        self._decision_writer = None
+        if config.scheduler_exclusion_dir and self.identity is not None:
+            path = decision_file_path(config.scheduler_exclusion_dir, self.identity.job_id)
+            self._decision_writer = DecisionFileWriter(path)
+        self._lock = threading.Lock()
+        self._snapshot_lock = threading.Lock()
+        self._refresh_condition = threading.Condition()
+        self._refresh_requested = False
+        self._poll_in_progress = False
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._excluded_nodes: dict[str, ExcludedNodeObservation] = {}
+        self._current_nodes: set[str] = set()
+        self._last_complete_poll: float | None = None
+        self._last_poll_attempt: float | None = None
+        self._last_error: str | None = None
+        self._last_decision_write: float | None = None
+        self._last_decision_error: str | None = None
+        self._polls_attempted = 0
+        self._polls_completed = 0
+        self._decision_write_failures = 0
+        self._state_version = 0
+        self._published_snapshot = _PublishedSnapshot(
+            job_id=self.identity.job_id if self.identity is not None else None,
+            last_complete_poll=None,
+            last_poll_attempt=None,
+            observations=(),
+            last_error=None,
+            last_decision_write=None,
+            last_decision_error=None,
+            polls_attempted=0,
+            polls_completed=0,
+            decision_write_failures=0,
+            current_nodes=0,
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return self.config.enabled
+
+    def start(self) -> None:
+        """Start one immediate poll followed by periodic refreshes."""
+        if not self.enabled:
+            return
+        if self.identity is None:
+            logger.warning(
+                "Scheduler Exclusion monitoring is enabled but SLURM_ARRAY_JOB_ID and "
+                "SLURM_JOB_ID are unset"
+            )
+            return
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        with self._refresh_condition:
+            self._refresh_requested = False
+            self._poll_in_progress = False
+        self._thread = threading.Thread(
+            target=self._run,
+            name="nvrx-scheduler-exclusion",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the polling worker."""
+        self._stop_event.set()
+        with self._refresh_condition:
+            self._refresh_condition.notify_all()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=self.config.query_timeout_seconds + 1.0)
+            if thread.is_alive():
+                logger.warning("Scheduler Exclusion polling worker is still stopping")
+                return
+        self._thread = None
+
+    def request_refresh(self) -> bool:
+        """Wake the existing worker without performing scheduler I/O."""
+        if not self.enabled or self.identity is None or self._stop_event.is_set():
+            return False
+        with self._refresh_condition:
+            if self._thread is None or not self._thread.is_alive():
+                return False
+            if self._poll_in_progress or self._refresh_requested:
+                return False
+            self._refresh_requested = True
+            self._refresh_condition.notify()
+        return True
+
+    def poll_once(self) -> bool:
+        """Run one allocation and node-state refresh."""
+        if not self.enabled or self.identity is None or self._runner is None:
+            return False
+
+        attempted_at = self._clock()
+        with self._lock:
+            self._last_poll_attempt = attempted_at
+            self._polls_attempted += 1
+            self._state_version += 1
+        self._publish_snapshot()
+
+        try:
+            allocation = discover_allocation(
+                self._runner,
+                self.identity,
+                stop_requested=self._stop_event.is_set,
+            )
+        except SchedulerExclusionError as exc:
+            if self._stop_event.is_set():
+                return False
+            self._record_error(f"allocation discovery failed: {exc}")
+            return False
+
+        if self._stop_event.is_set():
+            return False
+        try:
+            cluster_exclusions = query_scheduler_exclusions(self._runner)
+        except SchedulerExclusionError as exc:
+            if self._stop_event.is_set():
+                return False
+            self._record_error(f"scheduler-state query failed: {exc}")
+            return False
+
+        completed_at = self._clock()
+        current_nodes = allocation.nodes
+        staged_records = {
+            node: record for node, record in cluster_exclusions.items() if node in current_nodes
+        }
+        with self._lock:
+            recovery_candidates = sorted(
+                node
+                for node, observation in self._excluded_nodes.items()
+                if node in current_nodes
+                and node not in staged_records
+                and completed_at - observation.observed_at <= self.config.cache_ttl_seconds
+            )
+
+        retained_recovery_nodes = set(recovery_candidates)
+        verified_allocatable_nodes: set[str] = set()
+        if recovery_candidates:
+            if len(recovery_candidates) > _MAX_RECOVERY_VERIFICATION_CANDIDATES:
+                logger.warning(
+                    "Scheduler Exclusion recovery verification skipped job_id=%s "
+                    "candidates=%s limit=%s",
+                    self.identity.job_id,
+                    len(recovery_candidates),
+                    _MAX_RECOVERY_VERIFICATION_CANDIDATES,
+                )
+            else:
+                try:
+                    recovery_records = _query_recovery_candidates(
+                        self._runner,
+                        recovery_candidates,
+                    )
+                except SchedulerExclusionError as exc:
+                    logger.warning(
+                        "Scheduler Exclusion recovery verification failed job_id=%s "
+                        "candidates=%s: %s",
+                        self.identity.job_id,
+                        len(recovery_candidates),
+                        exc,
+                    )
+                else:
+                    for node, record in recovery_records.items():
+                        retained_recovery_nodes.discard(node)
+                        if record.excluded:
+                            staged_records[node] = record
+                        else:
+                            verified_allocatable_nodes.add(node)
+
+        if self._stop_event.is_set():
+            return False
+        completed_at = self._clock()
+        with self._lock:
+            previous_excluded = {
+                node for node in self._excluded_nodes if node in self._current_nodes
+            }
+            self._current_nodes = current_nodes
+            self._apply_records_locked(
+                staged_records,
+                current_nodes=current_nodes,
+                observed_at=completed_at,
+                array_task_generations_by_node=allocation.array_task_generations_by_node,
+                retained_nodes=retained_recovery_nodes,
+            )
+            self._last_complete_poll = completed_at
+            self._last_error = None
+            self._polls_completed += 1
+            self._evict_expired_locked(completed_at)
+            current_excluded = {
+                node for node in self._excluded_nodes if node in self._current_nodes
+            }
+            self._state_version += 1
+        self._publish_snapshot()
+        self._publish_decision_file(generated_at=completed_at)
+        logger.info(
+            "Scheduler Exclusion refresh completed job_id=%s nodes=%s "
+            "cluster_exclusions=%s excluded=%s duration_seconds=%.3f",
+            self.identity.job_id,
+            len(current_nodes),
+            len(cluster_exclusions),
+            len(current_excluded),
+            max(0.0, completed_at - attempted_at),
+        )
+        newly_excluded = sorted(current_excluded - previous_excluded)
+        cleared_exclusions = previous_excluded - current_excluded
+        became_allocatable_set = cleared_exclusions & verified_allocatable_nodes
+        left_allocation_set = cleared_exclusions - current_nodes
+        expired_exclusions = sorted(
+            cleared_exclusions - became_allocatable_set - left_allocation_set
+        )
+        became_allocatable = sorted(became_allocatable_set)
+        left_allocation = sorted(left_allocation_set)
+        if newly_excluded or became_allocatable or left_allocation or expired_exclusions:
+            logger.info(
+                "Scheduler Exclusion transitions job_id=%s newly_excluded=%s "
+                "became_allocatable=%s left_allocation=%s expired_exclusions=%s",
+                self.identity.job_id,
+                newly_excluded,
+                became_allocatable,
+                left_allocation,
+                expired_exclusions,
+            )
+        if len(current_excluded) > _LARGE_EXCLUDED_NODE_COUNT:
+            logger.warning(
+                "Scheduler Exclusion monitor found %s excluded nodes for job %s",
+                len(current_excluded),
+                self.identity.job_id,
+            )
+        return True
+
+    def snapshot(self) -> dict:
+        """Materialize the current immutable cache view without scheduler I/O."""
+        now = self._clock()
+        with self._snapshot_lock:
+            published = self._published_snapshot
+
+        observations = {
+            node: observation
+            for node, observation in published.observations
+            if now - observation.observed_at <= self.config.cache_ttl_seconds
+        }
+        last_error = published.last_error
+        if published.job_id is None:
+            last_error = "Slurm job identity is unavailable"
+
+        complete_cache_is_fresh = (
+            published.last_complete_poll is not None
+            and now - published.last_complete_poll <= self.config.cache_ttl_seconds
+        )
+        if complete_cache_is_fresh:
+            cache_quality = "complete"
+        else:
+            cache_quality = "unavailable"
+
+        return {
+            "job_id": published.job_id,
+            "last_complete_poll": _format_timestamp(published.last_complete_poll),
+            "last_poll_attempt": _format_timestamp(published.last_poll_attempt),
+            "last_decision_write": _format_timestamp(published.last_decision_write),
+            "excluded_nodes": sorted(observations),
+            "observations": {
+                node: {
+                    "state": observation.state,
+                    "reason": observation.reason,
+                    "observed_at": _format_timestamp(observation.observed_at),
+                    "array_tasks": [
+                        {
+                            "task_id": task.task_id,
+                            "restart_count": task.restart_count,
+                        }
+                        for task in observation.array_tasks
+                    ],
+                }
+                for node, observation in sorted(observations.items())
+            },
+            "last_error": last_error,
+            "last_decision_error": published.last_decision_error,
+            "stats": {
+                "polls_attempted": published.polls_attempted,
+                "polls_completed": published.polls_completed,
+                "decision_write_failures": published.decision_write_failures,
+                "current_nodes": published.current_nodes,
+                "current_excluded_nodes": len(observations),
+                "cache_quality": cache_quality,
+            },
+        }
+
+    def scheduler_exclusions(self) -> dict[str, object] | None:
+        """Return current task and node decisions without scheduler or file I/O."""
+        now = self._clock()
+        with self._snapshot_lock:
+            published = self._published_snapshot
+
+        if self.identity is None or published.last_complete_poll is None:
+            return None
+
+        observations = [
+            DecisionObservation(
+                node=node,
+                state=observation.state,
+                reason=observation.reason,
+                observed_at=observation.observed_at,
+                array_tasks=tuple(
+                    (task.task_id, task.restart_count) for task in observation.array_tasks
+                ),
+            )
+            for node, observation in published.observations
+            if now - observation.observed_at <= self.config.cache_ttl_seconds
+        ]
+        return build_decision_response(
+            job_id=self.identity.job_id,
+            generated_at=published.last_complete_poll,
+            cache_ttl_seconds=self.config.cache_ttl_seconds,
+            observations=observations,
+        )
+
+    def _publish_snapshot(self) -> None:
+        """Build outside locks and atomically publish the newest state version."""
+        while True:
+            with self._lock:
+                version = self._state_version
+                excluded_nodes = dict(self._excluded_nodes)
+                current_nodes = frozenset(self._current_nodes)
+                job_id = self.identity.job_id if self.identity is not None else None
+                last_complete_poll = self._last_complete_poll
+                last_poll_attempt = self._last_poll_attempt
+                last_error = self._last_error
+                last_decision_write = self._last_decision_write
+                last_decision_error = self._last_decision_error
+                polls_attempted = self._polls_attempted
+                polls_completed = self._polls_completed
+                decision_write_failures = self._decision_write_failures
+
+            published = _PublishedSnapshot(
+                job_id=job_id,
+                last_complete_poll=last_complete_poll,
+                last_poll_attempt=last_poll_attempt,
+                observations=tuple(
+                    (node, observation)
+                    for node, observation in sorted(excluded_nodes.items())
+                    if node in current_nodes
+                ),
+                last_error=last_error,
+                last_decision_write=last_decision_write,
+                last_decision_error=last_decision_error,
+                polls_attempted=polls_attempted,
+                polls_completed=polls_completed,
+                decision_write_failures=decision_write_failures,
+                current_nodes=len(current_nodes),
+            )
+
+            # Do not let an older build replace state changed while it was built.
+            with self._lock:
+                if version != self._state_version:
+                    continue
+                with self._snapshot_lock:
+                    self._published_snapshot = published
+                return
+
+    def _publish_decision_file(self, *, generated_at: float) -> None:
+        writer = self._decision_writer
+        identity = self.identity
+        if writer is None or identity is None:
+            return
+
+        with self._snapshot_lock:
+            published = self._published_snapshot
+        observations = [
+            DecisionObservation(
+                node=node,
+                state=observation.state,
+                reason=observation.reason,
+                observed_at=observation.observed_at,
+                array_tasks=tuple(
+                    (task.task_id, task.restart_count) for task in observation.array_tasks
+                ),
+            )
+            for node, observation in published.observations
+        ]
+        try:
+            excluded_tasks, excluded_nodes = writer.publish(
+                job_id=identity.job_id,
+                generated_at=generated_at,
+                cache_ttl_seconds=self.config.cache_ttl_seconds,
+                observations=observations,
+            )
+        except DecisionFileWriteError as exc:
+            with self._lock:
+                self._last_decision_error = str(exc)
+                self._decision_write_failures += 1
+                self._state_version += 1
+            self._publish_snapshot()
+            logger.warning("Scheduler Exclusion decision publication failed: %s", exc)
+            return
+
+        with self._lock:
+            self._last_decision_write = generated_at
+            self._last_decision_error = None
+            self._state_version += 1
+        self._publish_snapshot()
+        logger.info(
+            "Scheduler Exclusion decision published path=%s tasks=%s nodes=%s observations=%s",
+            writer.path,
+            excluded_tasks,
+            excluded_nodes,
+            len(observations),
+        )
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            with self._refresh_condition:
+                self._poll_in_progress = True
+                self._refresh_requested = False
+            try:
+                self.poll_once()
+            except Exception:
+                logger.exception("Unexpected Scheduler Exclusion polling failure")
+            finally:
+                with self._refresh_condition:
+                    self._poll_in_progress = False
+            jitter = self.config.refresh_interval_seconds * self.config.jitter_fraction
+            delay = self.config.refresh_interval_seconds + self._jitter(-jitter, jitter)
+            with self._refresh_condition:
+                self._refresh_condition.wait_for(
+                    lambda: self._stop_event.is_set() or self._refresh_requested,
+                    timeout=max(1.0, delay),
+                )
+
+    def _apply_records_locked(
+        self,
+        records: Mapping[str, NodeStateRecord],
+        *,
+        current_nodes: set[str],
+        observed_at: float,
+        array_task_generations_by_node: Mapping[str, tuple[ArrayTaskGeneration, ...]],
+        retained_nodes: set[str],
+    ) -> None:
+        for node in current_nodes:
+            record = records.get(node)
+            if record is not None:
+                self._excluded_nodes[node] = ExcludedNodeObservation(
+                    state=record.state,
+                    reason=record.reason,
+                    observed_at=observed_at,
+                    array_tasks=array_task_generations_by_node.get(node, ()),
+                )
+            elif node not in retained_nodes:
+                self._excluded_nodes.pop(node, None)
+
+    def _record_error(self, message: str) -> None:
+        with self._lock:
+            self._last_error = message
+            self._state_version += 1
+        self._publish_snapshot()
+        logger.warning("Scheduler Exclusion monitor: %s", message)
+
+    def _evict_expired_locked(self, now: float) -> None:
+        expired = [
+            node
+            for node, observation in self._excluded_nodes.items()
+            if now - observation.observed_at > self.config.cache_ttl_seconds
+        ]
+        for node in expired:
+            del self._excluded_nodes[node]
+
+
+def _parse_squeue_output(
+    output: str,
+    *,
+    is_array: bool,
+) -> list[tuple[ArrayTaskGeneration | None, str, str]]:
+    allocation_rows: list[tuple[ArrayTaskGeneration | None, str, str]] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = [part.strip() for part in line.split("|")]
+        expected_parts = 4 if is_array else 2
+        if len(parts) != expected_parts:
+            raise MalformedSchedulerResponse(f"invalid squeue row: {line!r}")
+        task_generation = None
+        if is_array:
+            array_task_id, restart_count_text = parts[:2]
+            if not array_task_id or array_task_id.lower() in {"(null)", "n/a"}:
+                raise MalformedSchedulerResponse(f"squeue row has no array task ID: {line!r}")
+            try:
+                restart_count = int(restart_count_text)
+            except ValueError as exc:
+                raise MalformedSchedulerResponse(
+                    f"squeue row has invalid restart count: {line!r}"
+                ) from exc
+            if restart_count < 0:
+                raise MalformedSchedulerResponse(f"squeue row has negative restart count: {line!r}")
+            task_generation = ArrayTaskGeneration(array_task_id, restart_count)
+        partition, nodelist = parts[-2:]
+        if not partition:
+            raise MalformedSchedulerResponse(f"squeue row has no partition: {line!r}")
+        if not nodelist or nodelist.lower() in {"(null)", "n/a"}:
+            raise MalformedSchedulerResponse(f"squeue row has no nodelist: {line!r}")
+        allocation_rows.append((task_generation, partition, nodelist))
+    return allocation_rows
+
+
+def _array_task_generation_sort_key(
+    task: ArrayTaskGeneration,
+) -> tuple[int, int, str, int]:
+    if task.task_id.isdigit():
+        return (0, int(task.task_id), task.task_id, task.restart_count)
+    return (1, 0, task.task_id, task.restart_count)
+
+
+def _parse_sinfo_output(
+    output: str,
+    exclusion_states: frozenset[str],
+) -> dict[str, NodeStateRecord]:
+    records: dict[str, NodeStateRecord] = {}
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("|", 2)
+        if len(parts) < 2:
+            raise MalformedSchedulerResponse(f"invalid sinfo row: {line!r}")
+        node = parts[0].strip()
+        raw_state = parts[1].strip()
+        reason = parts[2].strip() if len(parts) == 3 else ""
+        if not node:
+            raise MalformedSchedulerResponse(f"sinfo row has no node: {line!r}")
+        if not raw_state:
+            raise MalformedSchedulerResponse(f"sinfo row has no state: {line!r}")
+        normalized = "no_respond" if raw_state.endswith("*") else _normalize_state(raw_state)
+        if normalized == "unknown":
+            raise MalformedSchedulerResponse(f"sinfo row has unknown state: {line!r}")
+        records[node] = NodeStateRecord(
+            node=node,
+            state=normalized.upper(),
+            reason=reason,
+            excluded=normalized in exclusion_states,
+        )
+    return records
+
+
+def _normalize_state(raw_state: str) -> str:
+    normalized = raw_state.strip().lower()
+    normalized = re.sub(r"[\s-]+", "_", normalized)
+    normalized = re.sub(r"[^a-z0-9_]+", "", normalized)
+    return normalized or "unknown"
+
+
+def _format_timestamp(value: float | None) -> str | None:
+    if value is None:
+        return None
+    return datetime.fromtimestamp(value, timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/nvidia_resiliency_ext/services/scheduler_exclusions/server.py
+++ b/src/nvidia_resiliency_ext/services/scheduler_exclusions/server.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP interface for the NVRx Scheduler Exclusion Service."""
+
+from __future__ import annotations
+
+import json
+import logging
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+from .monitor import SchedulerExclusionMonitor
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerExclusionHttpServer(ThreadingHTTPServer):
+    """Threaded cache-only HTTP server."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        monitor: SchedulerExclusionMonitor,
+    ) -> None:
+        self.monitor = monitor
+        super().__init__(server_address, SchedulerExclusionRequestHandler)
+
+
+class SchedulerExclusionRequestHandler(BaseHTTPRequestHandler):
+    """Serve health, cache reads, and asynchronous refresh hints."""
+
+    server: SchedulerExclusionHttpServer
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        path = urlsplit(self.path).path
+        if path == "/healthz":
+            snapshot = self.server.monitor.snapshot()
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "service": "nvrx-scheduler-exclusion-service",
+                    "status": "ok",
+                    "job_id": snapshot["job_id"],
+                },
+            )
+            return
+        if path == "/stats":
+            snapshot = self.server.monitor.snapshot()
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "job_id": snapshot["job_id"],
+                    "last_complete_poll": snapshot["last_complete_poll"],
+                    "last_poll_attempt": snapshot["last_poll_attempt"],
+                    "last_decision_write": snapshot["last_decision_write"],
+                    "last_error": snapshot["last_error"],
+                    "last_decision_error": snapshot["last_decision_error"],
+                    **snapshot["stats"],
+                },
+            )
+            return
+        if path == "/scheduler-exclusions":
+            decision = self.server.monitor.scheduler_exclusions()
+            if decision is None:
+                self._send_json(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    {"error": "scheduler_exclusions_unavailable"},
+                )
+                return
+            self._send_json(HTTPStatus.OK, decision)
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if not self._discard_request_body():
+            return
+        path = urlsplit(self.path).path
+        if path != "/refresh":
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+        accepted = self.server.monitor.request_refresh()
+        self._send_json(HTTPStatus.ACCEPTED, {"accepted": accepted})
+
+    def log_message(self, format: str, *args: object) -> None:
+        logger.info("%s - %s", self.address_string(), format % args)
+
+    def _discard_request_body(self) -> bool:
+        raw_length = self.headers.get("Content-Length")
+        if raw_length is None:
+            return True
+        try:
+            length = int(raw_length)
+        except ValueError:
+            self.close_connection = True
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"error": "invalid_content_length"},
+            )
+            return False
+        if length < 0:
+            self.close_connection = True
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"error": "invalid_content_length"},
+            )
+            return False
+        if length:
+            self.rfile.read(length)
+        return True
+
+    def _send_json(self, status: HTTPStatus, payload: dict) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)


### PR DESCRIPTION
## Summary

Adds the host-side producer for Scheduler-Aware Node Exclusion.

- runs a standalone `nvrx-scheduler-exclusion-service` from the Slurm host environment
- discovers Slurm array-task generations or a regular-job allocation
- queries scheduler-unavailable node state with bounded retries and recovery verification
- refreshes every 10 minutes and retains validated unavailable-node observations for 30 minutes
- publishes the current decision through `GET /scheduler-exclusions` and an atomically replaced shared JSONL artifact
- writes a compact array-task control record followed by detailed task, node, and observation records
- exposes `/healthz`, `/stats`, `/scheduler-exclusions`, and nonblocking `POST /refresh`
- provides a standard-library-only Python 3.10+ zipapp and foreground launch helper

The FT consumer is intentionally split into a follow-up PR. This PR owns only scheduler polling, caching, publication, and the producer contract.

## Validation

- 59 scheduler-exclusion service, HTTP, decision-file, and zipapp tests passed
- Black, isort, shell syntax, and `git diff --check` passed
- PDX producer smoke validated `DRAIN -> publish -> RESUME -> clear`