### PR TITLE
[codex] Fix LogSage LLM failure status mapping

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
+++ b/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
@@ -18,7 +18,6 @@ from logsage.auto_resume_policy.attribution_classes import (
     Attribution,
     AutoResumeAction,
     ErrorAttribution,
-    FinishedStatus,
     LRUCache,
 )
 from logsage.auto_resume_policy.error_attribution import (
@@ -258,9 +257,9 @@ def attribution_from_finished_status(
     """Build ErrorAttribution when no application errors were found,
     based solely on app_data.finished status.
     """
-    finished = app_data.finished
+    finished = _finished_status_name(app_data.finished)
 
-    if finished == FinishedStatus.LLM_FAILURE:
+    if finished == FINISHED_STATUS_LLM_FAILURE:
         logger.info("LLM failure")
         return ErrorAttribution(
             application_errors_full=[],
@@ -274,7 +273,7 @@ def attribution_from_finished_status(
             cor_category="",
         )
 
-    if finished == FinishedStatus.SLURM_CANCELLED:
+    if finished == FINISHED_STATUS_SLURM_CANCELLED:
         logger.info("Slurm cancelled")
         return ErrorAttribution(
             application_errors_full=[],
@@ -288,7 +287,7 @@ def attribution_from_finished_status(
             cor_category="",
         )
 
-    if finished == FinishedStatus.SLURM_CANCELLED_JOB_REQUEUE:
+    if finished == FINISHED_STATUS_SLURM_CANCELLED_JOB_REQUEUE:
         logger.info("Slurm cancelled due to job requeue")
         return ErrorAttribution(
             application_errors_full=[],
@@ -302,7 +301,7 @@ def attribution_from_finished_status(
             cor_category="",
         )
 
-    if FinishedStatus.SLURM_CANCELLED_TIME_LIMIT in finished:
+    if FINISHED_STATUS_SLURM_CANCELLED_TIME_LIMIT in finished:
         logger.info("Slurm cancelled due to time limit")
         return ErrorAttribution(
             application_errors_full=[],
@@ -316,7 +315,7 @@ def attribution_from_finished_status(
             cor_category="",
         )
 
-    if finished == FinishedStatus.APPLICATION_DONE:
+    if finished == FINISHED_STATUS_APPLICATION_DONE:
         logger.info(Attribution.APPLICATION_DONE)
         return ErrorAttribution(
             application_errors_full=[],
@@ -418,7 +417,14 @@ def _log_analysis_retry_config() -> tuple[int, float, float, float]:
 
 
 def _finished_status_name(status: Any) -> str:
-    return getattr(status, "name", status)
+    status_name = getattr(status, "name", None)
+    if status_name is None:
+        status_name = getattr(status, "value", status)
+    if not isinstance(status_name, str):
+        status_name = str(status_name)
+    if "." in status_name:
+        status_name = status_name.rsplit(".", 1)[-1]
+    return status_name.strip().upper().replace(" ", "_")
 
 
 def _sleep_with_backoff(
@@ -941,7 +947,8 @@ class NVRxLogAnalyzer(NVRxAttribution):
         result = []
         logger.info("output_list_size: %s", str(len(output_list)))
         for output in output_list:
-            if output.finished == FINISHED_STATUS_APPLICATION_DONE:
+            finished = _finished_status_name(output.finished)
+            if finished == FINISHED_STATUS_APPLICATION_DONE:
                 result.append(
                     (
                         STOP_NO_RESTART,
@@ -990,7 +997,7 @@ class NVRxLogAnalyzer(NVRxAttribution):
                         )
                     result.append(fields)
                 else:
-                    if output.finished == FINISHED_STATUS_LLM_FAILURE:
+                    if finished == FINISHED_STATUS_LLM_FAILURE:
                         result.append(
                             (
                                 ATTR_LLM_FAILURE,
@@ -1000,7 +1007,7 @@ class NVRxLogAnalyzer(NVRxAttribution):
                                 str(output.checkpoint_saved),
                             )
                         )
-                    elif output.finished == FINISHED_STATUS_SLURM_CANCELLED:
+                    elif finished == FINISHED_STATUS_SLURM_CANCELLED:
                         result.append(
                             (
                                 RESTART_IMMEDIATE,
@@ -1010,7 +1017,7 @@ class NVRxLogAnalyzer(NVRxAttribution):
                                 str(output.checkpoint_saved),
                             )
                         )
-                    elif output.finished == FINISHED_STATUS_SLURM_CANCELLED_JOB_REQUEUE:
+                    elif finished == FINISHED_STATUS_SLURM_CANCELLED_JOB_REQUEUE:
                         result.append(
                             (
                                 RESTART_IMMEDIATE,
@@ -1020,12 +1027,12 @@ class NVRxLogAnalyzer(NVRxAttribution):
                                 str(output.checkpoint_saved),
                             )
                         )
-                    elif FINISHED_STATUS_SLURM_CANCELLED_TIME_LIMIT in output.finished:
+                    elif FINISHED_STATUS_SLURM_CANCELLED_TIME_LIMIT in finished:
                         result.append(
                             (
                                 STOP_NO_RESTART,
                                 "",
-                                f"""Attribution: Primary issues: [{output.finished.replace("_", " ")}], Secondary issues: []""",
+                                f"""Attribution: Primary issues: [{finished.replace("_", " ")}], Secondary issues: []""",
                                 "",
                                 str(output.checkpoint_saved),
                             )
@@ -1209,7 +1216,7 @@ class NVRxLogAnalyzer(NVRxAttribution):
 
         if (
             len(last_with_errors.application_errors_list_full) == 0
-            or last_with_errors.finished == FinishedStatus.APPLICATION_DONE
+            or _finished_status_name(last_with_errors.finished) == FINISHED_STATUS_APPLICATION_DONE
         ):
             return attribution_from_finished_status(
                 last_with_errors, last_with_errors.application_errors_list_unique

--- a/tests/attribution/unit/test_nvrx_logsage_reason_code.py
+++ b/tests/attribution/unit/test_nvrx_logsage_reason_code.py
@@ -3,11 +3,23 @@ import importlib
 import sys
 import types
 
+import pytest
+
 
 def _stub_module(monkeypatch, name):
     module = types.ModuleType(name)
     monkeypatch.setitem(sys.modules, name, module)
     return module
+
+
+class _EnumStyleStatus:
+    def __init__(self, *, name=None, value=None, text=""):
+        self.name = name
+        self.value = value
+        self._text = text
+
+    def __str__(self):
+        return self._text
 
 
 def _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch):
@@ -16,7 +28,6 @@ def _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch):
 
     langchain_openai = _stub_module(monkeypatch, "langchain_openai")
     langchain_openai.ChatOpenAI = object
-
     output_parsers = _stub_module(monkeypatch, "langchain_core.output_parsers")
     output_parsers.StrOutputParser = object
     prompts = _stub_module(monkeypatch, "langchain_core.prompts")
@@ -31,6 +42,11 @@ def _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch):
     attribution_classes = _stub_module(
         monkeypatch, "logsage.auto_resume_policy.attribution_classes"
     )
+
+    class StubErrorAttribution:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
     stub_attribution = types.SimpleNamespace(
         APPLICATION_DONE="APPLICATION_DONE",
         ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
@@ -39,8 +55,8 @@ def _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch):
         SLURM_STEP_CANCELLED_JOB_REQUEUE="SLURM_STEP_CANCELLED_JOB_REQUEUE",
     )
     stub_auto_resume = types.SimpleNamespace(
-        ERRORS_NOT_FOUND="ERRORS_NOT_FOUND",
-        LLM_FAILURE="LLM_FAILURE",
+        ERRORS_NOT_FOUND="ERRORS NOT FOUND",
+        LLM_FAILURE="LLM FAILURE",
         RESTART_IMMEDIATE="RESTART IMMEDIATE",
         STOP_NO_RESTART="STOP - DONT RESTART IMMEDIATE",
     )
@@ -54,7 +70,7 @@ def _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch):
     attribution_classes.ApplicationData = object
     attribution_classes.Attribution = stub_attribution
     attribution_classes.AutoResumeAction = stub_auto_resume
-    attribution_classes.ErrorAttribution = object
+    attribution_classes.ErrorAttribution = StubErrorAttribution
     attribution_classes.FinishedStatus = stub_finished
     attribution_classes.LRUCache = object
 
@@ -70,7 +86,6 @@ def _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch):
     error_extraction.return_application_errors_rt = lambda *args, **kwargs: types.SimpleNamespace(
         checkpoint_saved=False
     )
-
     prompts_mod = _stub_module(monkeypatch, "logsage.auto_resume_policy.prompts")
     prompts_mod.template_post_error_check = ""
     util_postprocessing = _stub_module(
@@ -81,6 +96,31 @@ def _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch):
     utils.chunk_indices = lambda *args, **kwargs: []
 
     return importlib.import_module(module_name)
+
+
+def _fake_log_analyzer():
+    return types.SimpleNamespace(
+        _init_config={},
+        is_per_cycle=False,
+        job_inline_data_dict={},
+    )
+
+
+def _application_data(*, finished, original_text=None):
+    return types.SimpleNamespace(
+        finished=finished,
+        application_errors_list_full=[],
+        original_text=original_text if original_text is not None else ["training failed"],
+        checkpoint_saved=False,
+    )
+
+
+def _run_single_output(nvrx_logsage, output):
+    result = asyncio.run(nvrx_logsage.NVRxLogAnalyzer.llm_analyze(_fake_log_analyzer(), [output]))
+    analysis_result, state = asyncio.run(
+        nvrx_logsage.NVRxLogAnalyzer.print_output(object(), result)
+    )
+    return result, analysis_result, state
 
 
 def test_stop_no_restart_action_wins_over_restart_substring(monkeypatch):
@@ -227,3 +267,63 @@ def test_logsage_tuple_parser_falls_back_when_issue_literal_recurses(monkeypatch
 
     assert item.primary_issues == ["NCCL TIMEOUT"]
     assert item.secondary_issues == []
+
+
+@pytest.mark.parametrize(
+    "finished",
+    [
+        "LLM_FAILURE",
+        "LLM FAILURE",
+        "FinishedStatus.LLM_FAILURE",
+        _EnumStyleStatus(name="LLM_FAILURE", text="FinishedStatus.LLM_FAILURE"),
+        _EnumStyleStatus(value="LLM_FAILURE", text="FinishedStatus.LLM_FAILURE"),
+    ],
+)
+def test_llm_analyze_maps_llm_failure_status_representations_to_unknown(monkeypatch, finished):
+    nvrx_logsage = _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch)
+
+    output = _application_data(
+        finished=finished,
+        original_text=["logsage.auto_resume_policy.utils ERROR - LLM ENDPOINT FAILED"],
+    )
+
+    result, analysis_result, state = _run_single_output(nvrx_logsage, output)
+
+    assert result == [
+        (
+            nvrx_logsage.ATTR_LLM_FAILURE,
+            nvrx_logsage.ATTR_LLM_FAILURE,
+            nvrx_logsage.ATTR_LLM_FAILURE,
+            nvrx_logsage.ATTR_LLM_FAILURE,
+            "False",
+        )
+    ]
+    assert state.name == "CONTINUE"
+    assert analysis_result.recommendation.action == "UNKNOWN"
+    assert analysis_result.items[0].auto_resume == nvrx_logsage.ATTR_LLM_FAILURE
+
+
+def test_llm_analyze_preserves_errors_not_found_fallback_for_unknown_status(monkeypatch):
+    nvrx_logsage = _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch)
+
+    result, analysis_result, _state = _run_single_output(
+        nvrx_logsage,
+        _application_data(finished="RUNNING", original_text=["training finished cleanly"]),
+    )
+
+    assert result[0][0] == nvrx_logsage.ATTR_ERRORS_NOT_FOUND
+    assert analysis_result.recommendation.action == "CONTINUE"
+
+
+def test_llm_analyze_maps_stringified_slurm_time_limit_status(monkeypatch):
+    nvrx_logsage = _import_nvrx_logsage_with_optional_dependency_stubs(monkeypatch)
+
+    result, analysis_result, state = _run_single_output(
+        nvrx_logsage,
+        _application_data(finished="FinishedStatus.SLURM_CANCELLED_TIME_LIMIT"),
+    )
+
+    assert result[0][0] == nvrx_logsage.STOP_NO_RESTART
+    assert "SLURM CANCELLED TIME LIMIT" in result[0][2]
+    assert state.name == "STOP"
+    assert analysis_result.recommendation.action == "STOP"


### PR DESCRIPTION
## Summary

Fixes the LogSage/MCP attribution path so enum-like finished statuses are normalized before terminal-status branching. This prevents an LLM endpoint failure from falling through to the generic `ERRORS NOT FOUND` result, which incorrectly produced a `CONTINUE` recommendation.

## Root Cause

The retry path already normalized `ApplicationData.finished`, but the final LogSage result shaping compared `finished` directly against string constants. When the MCP subprocess received an enum-like `LLM_FAILURE`, it did not match the raw string branch and was treated as no errors found.

## Changes

- Normalize finished statuses via `.name`, `.value`, or string form before branching.
- Apply the same normalization in the no-errors helper and per-cycle result shaping.
- Add a regression test covering enum-style `LLM_FAILURE` mapping to `LLM FAILURE` and final recommendation `UNKNOWN`.

## Validation

- `PYTHONPATH=src /private/tmp/nvrx-pytest-311/bin/python -m pytest tests/attribution/unit/test_nvrx_logsage_reason_code.py tests/attribution/unit/test_nvrx_logsage_retry.py tests/attribution/unit/test_orchestration_utils.py` — 7 passed, 1 skipped
- `PYTHONPATH=src /private/tmp/nvrx-pytest-311/bin/python -m pytest tests/attribution/unit/test_llm_output.py tests/attribution/unit/test_mcp_server_cache.py tests/attribution/unit/test_analysis_pipeline_trace_only.py` — 19 passed

NVBugs: https://nvbugspro.nvidia.com/bug/6301888