### PR TITLE
[codex] Recover exited managed attribution service

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -26,8 +26,10 @@ logger = logging.getLogger(LogConfig.name)
 
 DEFAULT_ATTRIBUTION_PORT = 50050
 DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT = 20.0
+DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS = 2
 _ATTRIBUTION_STOP_TIMEOUT = 5.0
 _ATTRIBUTION_READY_POLL_INTERVAL = 0.5
+_ATTRIBUTION_READY_HTTP_TIMEOUT = 1.0
 _MANAGED_ATTRIBUTION_ENDPOINT = "localhost"
 _EXTERNAL_ATTRIBUTION_SCHEMES = {"http", "grpc"}
 _ATTRSVC_EXPORT_URL_ENV = "NVRX_ATTRSVC_EXPORT_URL"
@@ -193,15 +195,25 @@ class AttributionManager:
         if not self.is_store_host:
             return None
 
+        return self._start_managed_process(restarting=False)
+
+    def _start_managed_process(
+        self,
+        *,
+        restarting: bool,
+        ready_deadline: Optional[float] = None,
+    ) -> AttributionEndpoint:
         assert self.cfg.applog_dir is not None
         assert self.cfg.log_file is not None
         api_key_file = self._resolve_api_key_file()
         env = self._child_env(api_key_file)
         cmd = _attribution_command()
+        action = "Restarting" if restarting else "Starting"
 
         logger.info(
-            "Starting managed attribution service on localhost:%s "
+            "%s managed attribution service on localhost:%s "
             "(applog_dir=%s, log_file=%s, startup_timeout=%.1fs, decision_timeout=%s)",
+            action,
             DEFAULT_ATTRIBUTION_PORT,
             self.cfg.applog_dir,
             self.cfg.log_file,
@@ -213,7 +225,7 @@ class AttributionManager:
             ),
         )
 
-        log_fd = open(self.cfg.log_file, "w")
+        log_fd = open(self.cfg.log_file, "a" if restarting else "w")
         try:
             self.process = subprocess.Popen(  # nosec B603
                 cmd,
@@ -226,13 +238,17 @@ class AttributionManager:
             log_fd.close()
 
         try:
-            self._wait_until_ready()
+            self._wait_until_ready(deadline=ready_deadline)
         except Exception:
             self.stop()
             raise
 
+        ready_subject = (
+            "Restarted managed attribution service" if restarting else "Managed attribution service"
+        )
         logger.info(
-            "Managed attribution service is ready: PID=%s endpoint=http://localhost:%s",
+            "%s is ready: PID=%s endpoint=http://localhost:%s",
+            ready_subject,
             self.process.pid if self.process else None,
             DEFAULT_ATTRIBUTION_PORT,
         )
@@ -273,6 +289,61 @@ class AttributionManager:
         )
         self.process = None
 
+    def recover_exited_managed_process(self) -> bool:
+        """Reap and restart an unexpectedly exited launcher-managed attrsvc process.
+
+        Returns:
+            True when a managed child had exited and was restarted; False when
+            no launcher-owned attrsvc process needed action.
+        """
+        if not self.cfg.is_enabled or not self.cfg.is_managed or not self.is_store_host:
+            return False
+
+        proc = self.process
+        if proc is None:
+            return False
+
+        returncode = proc.poll()
+        if returncode is None:
+            return False
+
+        logger.error(
+            "Managed attribution service PID=%s exited unexpectedly with returncode=%s; "
+            "attempting restart",
+            proc.pid,
+            returncode,
+        )
+        self.process = None
+        if DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS < 1:
+            raise RuntimeError("managed attribution service restart attempts must be at least 1")
+
+        ready_deadline = time.monotonic() + self.cfg.startup_timeout
+        for attempt in range(1, DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS + 1):
+            try:
+                self._start_managed_process(
+                    restarting=True,
+                    ready_deadline=ready_deadline,
+                )
+                return True
+            except Exception:
+                if attempt >= DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS:
+                    logger.warning(
+                        "Managed attribution service recovery exhausted after %d attempts "
+                        "for PID=%s; attribution service will remain unavailable",
+                        DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS,
+                        proc.pid,
+                        exc_info=True,
+                    )
+                    raise
+                logger.warning(
+                    "Failed to restart managed attribution service after PID=%s exited "
+                    "(attempt %d/%d); retrying",
+                    proc.pid,
+                    attempt,
+                    DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS,
+                    exc_info=True,
+                )
+
     def _resolve_api_key_file(self) -> str:
         raw = self.cfg.llm_api_key_file or os.getenv("LLM_API_KEY_FILE")
         if not raw:
@@ -305,9 +376,10 @@ class AttributionManager:
         _set_if_not_none(env, _ATTRSVC_EXPORT_URL_ENV, self.cfg.export_url)
         return env
 
-    def _wait_until_ready(self) -> None:
+    def _wait_until_ready(self, *, deadline: Optional[float] = None) -> None:
         assert self.process is not None
-        deadline = time.monotonic() + self.cfg.startup_timeout
+        if deadline is None:
+            deadline = time.monotonic() + self.cfg.startup_timeout
         url = f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}/healthz"
         last_error = "not probed"
 
@@ -319,7 +391,10 @@ class AttributionManager:
                     f"(returncode={rc}, log_file={self.cfg.log_file})"
                 )
             try:
-                with urllib.request.urlopen(url, timeout=1.0) as resp:  # nosec B310
+                with urllib.request.urlopen(  # nosec B310
+                    url,
+                    timeout=_ATTRIBUTION_READY_HTTP_TIMEOUT,
+                ) as resp:
                     if 200 <= resp.status < 300:
                         return
                     last_error = f"HTTP status {resp.status}"
@@ -332,7 +407,8 @@ class AttributionManager:
         raise TimeoutError(
             f"managed attribution service did not become ready within "
             f"{self.cfg.startup_timeout:.1f}s "
-            f"at {url} (last_error={last_error}, log_file={self.cfg.log_file})"
+            f"at {url} "
+            f"(last_error={last_error}, log_file={self.cfg.log_file})"
         )
 
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -163,6 +163,16 @@ def _shutdown_cycle_info_reporter_safely(rdzv_handler: Any) -> None:
         logger.warning("Failed to shut down cycle info reporter", exc_info=True)
 
 
+def _recover_exited_managed_attribution_service() -> None:
+    manager = _ATTRIBUTION_MANAGER
+    if manager is None:
+        return
+    try:
+        manager.recover_exited_managed_process()
+    except Exception:
+        logger.warning("Failed to recover managed attribution service process", exc_info=True)
+
+
 def init_node_health_check(endpoint: Optional[str]) -> None:
     global _NODE_HEALTH_CHECK_INSTANCE
     if endpoint:
@@ -630,6 +640,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         while True:
             assert self._worker_group.state != WorkerState.INIT
             time.sleep(monitor_interval)
+            _recover_exited_managed_attribution_service()
             run_result = self._monitor_workers(self._worker_group)
             state = run_result.state
             self._worker_group.state = state

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import sys
 from types import SimpleNamespace
 
@@ -8,12 +9,14 @@ import pytest
 
 from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
     DEFAULT_ATTRIBUTION_PORT,
+    DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS,
     AttributionConfig,
     AttributionManager,
     _attribution_command,
 )
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
 from nvidia_resiliency_ext.shared_utils.health_check import AttributionService
+from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
 
 
 def _args(**overrides):
@@ -33,11 +36,24 @@ def _args(**overrides):
 
 
 class _FakeProcess:
-    def __init__(self, returncode=None):
+    def __init__(self, returncode=None, *, pid=123):
         self.returncode = returncode
-        self.pid = 123
+        self.pid = pid
+        self.terminated = False
+        self.killed = False
 
     def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout=None):
         return self.returncode
 
 
@@ -504,3 +520,186 @@ def test_wait_until_ready_raises_when_process_exits_early(tmp_path):
 
     with pytest.raises(RuntimeError, match="returncode=1"):
         manager._wait_until_ready()
+
+
+def test_recover_exited_managed_process_restarts_dead_child(tmp_path, monkeypatch, caplog):
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=True)
+    old_process = _FakeProcess(returncode=-9, pid=111)
+    new_process = _FakeProcess(returncode=None, pid=222)
+    manager.process = old_process
+    api_key_file = tmp_path / "llm.key"
+    api_key_file.write_text("dummy-key\n")
+    monkeypatch.setenv("LLM_API_KEY_FILE", str(api_key_file))
+
+    popen_calls = []
+
+    def fake_popen(*args, **kwargs):
+        popen_calls.append(kwargs)
+        return new_process
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.subprocess.Popen",
+        fake_popen,
+    )
+    monkeypatch.setattr(
+        AttributionManager,
+        "_wait_until_ready",
+        lambda self, *, deadline=None: None,
+    )
+
+    with caplog.at_level(logging.INFO, logger=LogConfig.name):
+        recovered = manager.recover_exited_managed_process()
+
+    assert recovered is True
+    assert manager.process is new_process
+    assert len(popen_calls) == 1
+    assert popen_calls[0]["stdout"].mode == "a"
+    assert "exited unexpectedly with returncode=-9" in caplog.text
+    assert "attempting restart" in caplog.text
+    assert "Restarted managed attribution service is ready" in caplog.text
+
+
+def test_recover_exited_managed_process_waits_for_healthz(tmp_path, monkeypatch):
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=True)
+    old_process = _FakeProcess(returncode=-9, pid=111)
+    new_process = _FakeProcess(returncode=None, pid=222)
+    manager.process = old_process
+    api_key_file = tmp_path / "llm.key"
+    api_key_file.write_text("dummy-key\n")
+    monkeypatch.setenv("LLM_API_KEY_FILE", str(api_key_file))
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.subprocess.Popen",
+        lambda *args, **kwargs: new_process,
+    )
+    healthz_requests = []
+
+    def fake_urlopen(url, *, timeout):
+        healthz_requests.append((url, timeout))
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.urllib.request.urlopen",
+        fake_urlopen,
+    )
+
+    recovered = manager.recover_exited_managed_process()
+
+    assert recovered is True
+    assert manager.process is new_process
+    assert healthz_requests == [(f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}/healthz", 1.0)]
+
+
+def test_recover_exited_managed_process_leaves_live_child(tmp_path):
+    process = _FakeProcess(returncode=None)
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=True)
+    manager.process = process
+
+    assert manager.recover_exited_managed_process() is False
+    assert manager.process is process
+
+
+def test_recover_exited_managed_process_retries_once_after_failed_restart(
+    tmp_path, monkeypatch, caplog
+):
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=True)
+    old_process = _FakeProcess(returncode=-9, pid=111)
+    failed_restart = _FakeProcess(returncode=None, pid=222)
+    successful_restart = _FakeProcess(returncode=None, pid=333)
+    manager.process = old_process
+    api_key_file = tmp_path / "llm.key"
+    api_key_file.write_text("dummy-key\n")
+    monkeypatch.setenv("LLM_API_KEY_FILE", str(api_key_file))
+    popen_processes = iter([failed_restart, successful_restart])
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.subprocess.Popen",
+        lambda *args, **kwargs: next(popen_processes),
+    )
+    ready_calls = 0
+    ready_deadlines = []
+
+    def flaky_ready(self, *, deadline=None):
+        nonlocal ready_calls
+        ready_calls += 1
+        ready_deadlines.append(deadline)
+        if ready_calls == 1:
+            raise TimeoutError("not ready yet")
+
+    monkeypatch.setattr(AttributionManager, "_wait_until_ready", flaky_ready)
+
+    with caplog.at_level(logging.WARNING, logger=LogConfig.name):
+        recovered = manager.recover_exited_managed_process()
+
+    assert recovered is True
+    assert manager.process is successful_restart
+    assert failed_restart.terminated is True
+    assert ready_calls == 2
+    assert ready_deadlines[0] is not None
+    assert ready_deadlines[0] == ready_deadlines[1]
+    assert f"attempt 1/{DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS}" in caplog.text
+
+
+def test_recover_exited_managed_process_ignores_non_store_host(tmp_path):
+    process = _FakeProcess(returncode=-9)
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=False)
+    manager.process = process
+
+    assert manager.recover_exited_managed_process() is False
+    assert manager.process is process
+
+
+def test_recover_exited_managed_process_ignores_external_attribution(tmp_path):
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="http://attribution.external:50123"),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(),
+    )
+    process = _FakeProcess(returncode=-9)
+    manager = AttributionManager(cfg, is_store_host=True)
+    manager.process = process
+
+    assert manager.recover_exited_managed_process() is False
+    assert manager.process is process
+
+
+def test_recover_exited_managed_process_clears_process_when_restart_fails(
+    tmp_path, monkeypatch, caplog
+):
+    manager = AttributionManager(_managed_cfg(tmp_path), is_store_host=True)
+    old_process = _FakeProcess(returncode=-9, pid=111)
+    new_process = _FakeProcess(returncode=None, pid=222)
+    manager.process = old_process
+    api_key_file = tmp_path / "llm.key"
+    api_key_file.write_text("dummy-key\n")
+    monkeypatch.setenv("LLM_API_KEY_FILE", str(api_key_file))
+
+    popen_calls = []
+
+    def fake_popen(*args, **kwargs):
+        popen_calls.append(kwargs)
+        return new_process
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.fault_tolerance.attribution_manager.subprocess.Popen",
+        fake_popen,
+    )
+
+    def fail_ready(self, *, deadline=None):
+        raise TimeoutError("not ready")
+
+    monkeypatch.setattr(AttributionManager, "_wait_until_ready", fail_ready)
+
+    with (
+        caplog.at_level(logging.WARNING, logger=LogConfig.name),
+        pytest.raises(TimeoutError, match="not ready"),
+    ):
+        manager.recover_exited_managed_process()
+
+    assert manager.process is None
+    assert new_process.terminated is True
+    assert len(popen_calls) == DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS
+    assert (
+        f"recovery exhausted after {DEFAULT_ATTRIBUTION_RESTART_ATTEMPTS} attempts"
+    ) in caplog.text
+    assert "attribution service will remain unavailable" in caplog.text

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -551,6 +551,59 @@ class TestLauncherRunBehavior(unittest.TestCase):
         self.assertEqual(result.state, WorkerState.FAILED)
         self.assertEqual(result.failures, failures)
 
+    def test_invoke_run_recovers_managed_attribution_on_monitor_tick(self):
+        """The worker monitor cadence also polls launcher-managed attrsvc lifecycle."""
+        from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
+
+        from nvidia_resiliency_ext.fault_tolerance import launcher
+        from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
+
+        spec = _make_agent_spec(rdzv_round=1)
+        spec.role = "trainer"
+        spec.monitor_interval = 0
+        agent = LocalElasticAgent(
+            spec=spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
+        )
+        agent._worker_group.state = WorkerState.HEALTHY
+
+        with (
+            patch.object(agent, '_initialize_workers'),
+            patch.object(
+                agent,
+                '_monitor_workers',
+                return_value=RunResult(state=WorkerState.SUCCEEDED),
+            ),
+            patch.object(agent, '_exit_barrier'),
+            patch.object(launcher, '_recover_exited_managed_attribution_service') as mock_recover,
+            patch.object(launcher, 'put_metric'),
+            patch.object(launcher.time, 'sleep'),
+        ):
+            result = agent._invoke_run_with_any_failed_policy()
+
+        self.assertEqual(result.state, WorkerState.SUCCEEDED)
+        mock_recover.assert_called_once_with()
+
+    def test_recover_exited_managed_attribution_service_logs_failure(self):
+        """Attrsvc recovery failures are fail-open for the launcher monitor loop."""
+        from nvidia_resiliency_ext.fault_tolerance import launcher
+
+        manager = MagicMock()
+        manager.recover_exited_managed_process.side_effect = RuntimeError("restart failed")
+
+        with (
+            patch.object(launcher, '_ATTRIBUTION_MANAGER', manager),
+            self.assertLogs(launcher.logger, level='WARNING') as logs,
+        ):
+            launcher._recover_exited_managed_attribution_service()
+
+        manager.recover_exited_managed_process.assert_called_once_with()
+        self.assertIn(
+            "Failed to recover managed attribution service process",
+            "\n".join(logs.output),
+        )
+
 
 class TestHandleRestartDecision(unittest.TestCase):
     """Unit tests for _handle_restart_decision() and _open_rendezvous_for_restart()."""


### PR DESCRIPTION
## Summary

- Reap launcher-managed `nvrx-attrsvc` if it exits during the launcher monitor loop.
- Restart the managed attrsvc after the dead child is reaped, reusing the same localhost endpoint.
- Wait for launcher-managed attrsvc `/healthz` readiness using a 1s per-request timeout inside the existing `--ft-attribution-startup-timeout` deadline.
- Retry managed attrsvc restart twice per observed outage with an internal default; no CLI/YAML knob.
- Keep mid-run attrsvc recovery fail-open for training: if restart recovery exhausts, the launcher logs the failure once and continues monitoring workers.
- Preserve startup fail-closed behavior: attrsvc startup failure before cycle 0 still fails the launcher.
- Add unit coverage and a PDX dev recovery suite covering reap, restart, retry, fail-open, fail-closed, healthz readiness, and post-restart client behavior.

## Root Cause

When `ft_launcher` starts a managed attrsvc process, it only cleaned that child up during normal shutdown. If attrsvc exited mid-run, the parent kept the `Popen` object but did not poll/reap it on the monitor cadence. That could leave a zombie process and stop attribution for later cycles.

## Behavior

The launcher monitor cadence now asks the `AttributionManager` to recover an exited managed child before worker monitoring. The manager polls the child, which reaps a zombie, then starts a replacement attrsvc through the same managed startup path.

Managed startup/restart readiness checks the existing `/healthz` route on `127.0.0.1:50050`. Each HTTP probe has a 1s timeout so a slow or unavailable child cannot block the monitor indefinitely; the existing `--ft-attribution-startup-timeout` still bounds the total wait and retry window. This keeps `/healthz` as the semantic app-readiness signal while avoiding the longer MCP health guardrail in the launcher restart path.

Recovery exceptions are caught at the launcher boundary so training is not failed by mid-run attrsvc loss. Initial startup remains fail-closed because cycle 0 has not started yet.

## Validation

- `git diff --check`
- `PYTHONPATH=/private/tmp/black-24.10.0 python3 -m black --check src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py tests/fault_tolerance/unit/test_attribution_manager.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/nvrx_pycache python3 -m py_compile src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py src/nvidia_resiliency_ext/fault_tolerance/cli_args.py tests/fault_tolerance/unit/test_attribution_manager.py`
- `bash -n ops/slurm/run_ft_attrsvc_managed_recovery_suite_pdx.sh`
- PDX dev Slurm recovery suite: job `3145`, `suite_rc=0`
  - Script: `ops/slurm/run_ft_attrsvc_managed_recovery_suite_pdx.sh`
  - Focused pytest: 11 recovery/readiness tests passed, including the restart path using the real `_wait_until_ready()` with mocked `/healthz`
  - Recovery retry unit coverage asserts attempts share one readiness deadline
  - Process recovery: old PID reached `State: Z (zombie)`, old PID gone, new PID live, `/healthz` returned OK: `health={'status': 'ok', 'pid': 1754765}`
  - Launcher monitor recovery: helper recovered dead attrsvc and continued monitor flow
  - Client-after-restart smoke: `AttributionService` POST/GET succeeded after replacement attrsvc started
  - Restart failure fail-open: two restart attempts failed, recovery exhaustion was logged once, and launcher helper returned without failing training flow
  - Startup failure fail-closed: initial managed attrsvc startup failure raised before workers would run

Companion dev suite committed and pushed separately in `nvrx-workspace`: `5b90592`.
