### PR TITLE
Persist attribution startup failures in NVRx log

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -212,6 +212,9 @@ def add_log_funnel_args(
         dest="ft_nvrx_logfile",
         help="Optional: Path for NVRx process logs (must be absolute path if specified). "
         "ft_launcher routes these logs through the same infrastructure as worker logs. "
+        "Before that infrastructure is ready, only the TCPStore host may append a managed-attribution "
+        "startup error directly. The caller is responsible for keeping this path available and "
+        "writable; no stderr fallback is provided if the path itself fails. "
         "nvrx-control also uses this path as a fallback source for gRPC server diagnostic logs. "
         "Example: --ft-nvrx-logfile /lustre/logs/launcher.log",
     )

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -134,6 +134,24 @@ _GRPC_SERVER_PROCESSES: List[subprocess.Popen] = []
 _ATTRIBUTION_MANAGER: Optional[AttributionManager] = None
 
 
+def _append_attribution_startup_failure(log_file: Optional[str], error: Exception) -> None:
+    """Best-effort direct append before the normal launcher log path is available."""
+    if not log_file:
+        return
+    record = (
+        f"{time.strftime('%Y-%m-%d %H:%M:%S')} [ERROR] [{socket.gethostname()}] "
+        f"Agent run ended with exception, e={error!r}. Agent's exit code = 1\n"
+    )
+    try:
+        with open(log_file, "a", encoding="utf-8") as stream:
+            stream.write(record)
+            stream.flush()
+    except Exception:
+        # The caller owns availability and integrity of --ft-nvrx-logfile. Never
+        # replace the original launcher failure with an emergency logging error.
+        pass
+
+
 def _shutdown_cycle_info_reporter_safely(rdzv_handler: Any) -> None:
     shutdown_cycle_info_reporter = getattr(rdzv_handler, "shutdown_cycle_info_reporter", None)
     if not callable(shutdown_cycle_info_reporter):
@@ -2998,19 +3016,25 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
         if getattr(args, 'ft_enable_log_server', False):
             log_funnel_ports = LogFunnelPorts.from_launcher_args(args)
 
-        attribution_cfg = AttributionConfig.from_args(args, base_log_file, fault_tol_cfg)
-        if log_funnel_ports is not None and attribution_cfg.is_managed:
-            _validate_managed_attribution_listen_port_not_in_log_funnel(
-                DEFAULT_ATTRIBUTION_PORT, log_funnel_ports
-            )
+        try:
+            attribution_cfg = AttributionConfig.from_args(args, base_log_file, fault_tol_cfg)
+            if log_funnel_ports is not None and attribution_cfg.is_managed:
+                _validate_managed_attribution_listen_port_not_in_log_funnel(
+                    DEFAULT_ATTRIBUTION_PORT, log_funnel_ports
+                )
 
-        attribution_manager = AttributionManager(
-            attribution_cfg,
-            is_store_host=is_tcp_store_host,
-        )
-        global _ATTRIBUTION_MANAGER
-        _ATTRIBUTION_MANAGER = attribution_manager
-        attribution_endpoint = attribution_manager.start_if_needed()
+            attribution_manager = AttributionManager(
+                attribution_cfg,
+                is_store_host=is_tcp_store_host,
+            )
+            global _ATTRIBUTION_MANAGER
+            _ATTRIBUTION_MANAGER = attribution_manager
+            attribution_endpoint = attribution_manager.start_if_needed()
+        except Exception as e:
+            if is_tcp_store_host:
+                _append_attribution_startup_failure(launcher_log_file, e)
+            raise
+
         if attribution_endpoint is not None:
             rdzv_configs['attribution_endpoint'] = attribution_endpoint.endpoint
             decision_timeout = getattr(attribution_endpoint, "decision_timeout", None)

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -1799,6 +1799,7 @@ class AttributionService:
     """
 
     DEFAULT_DECISION_TIMEOUT_SECONDS = 60.0
+    _RESULT_POLL_INTERVAL_SECONDS = 2.0
 
     def __init__(
         self,
@@ -1816,6 +1817,7 @@ class AttributionService:
         self._last_submitted: Optional[str] = None
         self._terminal_deadline: Optional[float] = None
         self._get_started_recorded = False
+        self._next_result_poll_time = 0.0
 
     def __call__(self) -> None:
         """
@@ -1859,6 +1861,11 @@ class AttributionService:
                 return False
             return result
 
+        now = time.monotonic()
+        if now < self._next_result_poll_time:
+            return None
+
+        self._next_result_poll_time = now + self._RESULT_POLL_INTERVAL_SECONDS
         result = self._get_results(log_path, timeout=_ATTRIBUTION_REQUEST_TIMEOUT_SECONDS)
 
         if result is None:
@@ -1896,6 +1903,7 @@ class AttributionService:
         self._last_submitted = log_path
         self._terminal_deadline = None
         self._get_started_recorded = False
+        self._next_result_poll_time = 0.0
         self._do_submit_log(log_path, analysis_intent=ANALYSIS_INTENT_PROGRESSIVE)
 
     def request_terminal_analysis(self) -> None:
@@ -1910,6 +1918,7 @@ class AttributionService:
             logger.debug("AttributionService terminal POST skipped: no submitted log path")
             return
         self._ensure_decision_deadline()
+        self._next_result_poll_time = 0.0
         self._do_submit_log(
             log_path,
             analysis_intent=ANALYSIS_INTENT_TERMINAL,
@@ -1968,14 +1977,10 @@ class AttributionService:
                 if resp.status_code == 200:
                     payload = resp.json() if resp.text else {}
                     attrsvc_result = parse_attrsvc_response(payload, log_path=log_path)
-                    logger.info(attrsvc_result.format_log_message())
                     if attrsvc_result.status.lower() != "completed":
-                        logger.debug(
-                            "AttributionService GET for %s returned status=%s; polling again",
-                            log_path,
-                            attrsvc_result.status,
-                        )
+                        logger.debug(attrsvc_result.format_log_message())
                         return None
+                    logger.info(attrsvc_result.format_log_message())
                     return attrsvc_result.should_stop
                 else:
                     logger.warning(

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -1138,6 +1138,83 @@ def test_nvrx_logfile_auto_enables_grpc_routing_to_rendezvous_host(tmp_path):
     assert config.logs_specs.grpc_server_address == "control.host:50051"
 
 
+def _managed_attribution_args(launcher, tmp_path):
+    return launcher.get_args_parser().parse_args(
+        [
+            "--nnodes",
+            "1",
+            "--nproc-per-node",
+            "1",
+            "--rdzv-endpoint",
+            "localhost:29500",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+            "--ft-nvrx-logfile",
+            str(tmp_path / "nvrx.log"),
+            "--ft-attribution-endpoint",
+            "localhost",
+            "--ft-attribution-llm-api-key-file",
+            "/no/such/missing_key",
+            "train.py",
+        ]
+    )
+
+
+def test_store_host_writes_attribution_startup_failure_to_nvrx_log(tmp_path):
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    args = _managed_attribution_args(launcher, tmp_path)
+    with (
+        patch.object(launcher, "_matches_machine_hostname", return_value=True),
+        pytest.raises(ValueError, match="is not a file"),
+    ):
+        launcher.config_from_args(args, launcher_log_file=args.ft_nvrx_logfile)
+
+    record = (tmp_path / "nvrx.log").read_text(encoding="utf-8")
+    assert "managed attribution service LLM API key file is not a file" in record
+    assert "Agent's exit code = 1" in record
+    launcher._ATTRIBUTION_MANAGER = None
+
+
+def test_non_store_host_does_not_write_attribution_startup_failure(tmp_path):
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    args = _managed_attribution_args(launcher, tmp_path)
+    with (
+        patch.object(launcher, "_matches_machine_hostname", return_value=False),
+        patch.object(
+            launcher.AttributionConfig,
+            "from_args",
+            side_effect=ValueError("bad attribution config"),
+        ),
+        pytest.raises(ValueError, match="bad attribution config"),
+    ):
+        launcher.config_from_args(args, launcher_log_file=args.ft_nvrx_logfile)
+
+    assert not (tmp_path / "nvrx.log").exists()
+
+
+def test_attribution_startup_log_failure_does_not_mask_original_error(tmp_path):
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    args = _managed_attribution_args(launcher, tmp_path)
+    original_error = ValueError("bad attribution config")
+    with (
+        patch.object(launcher, "_matches_machine_hostname", return_value=True),
+        patch.object(
+            launcher.AttributionManager,
+            "start_if_needed",
+            side_effect=original_error,
+        ),
+        patch("builtins.open", side_effect=OSError("network filesystem unavailable")),
+        pytest.raises(ValueError) as exc_info,
+    ):
+        launcher.config_from_args(args, launcher_log_file=args.ft_nvrx_logfile)
+
+    assert exc_info.value is original_error
+    launcher._ATTRIBUTION_MANAGER = None
+
+
 def _make_launch_agent_config(**overrides):
     from types import SimpleNamespace
 

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -1165,6 +1165,7 @@ def test_store_host_writes_attribution_startup_failure_to_nvrx_log(tmp_path):
 
     args = _managed_attribution_args(launcher, tmp_path)
     with (
+        patch.object(launcher, "_ATTRIBUTION_MANAGER", None),
         patch.object(launcher, "_matches_machine_hostname", return_value=True),
         pytest.raises(ValueError, match="is not a file"),
     ):
@@ -1173,7 +1174,6 @@ def test_store_host_writes_attribution_startup_failure_to_nvrx_log(tmp_path):
     record = (tmp_path / "nvrx.log").read_text(encoding="utf-8")
     assert "managed attribution service LLM API key file is not a file" in record
     assert "Agent's exit code = 1" in record
-    launcher._ATTRIBUTION_MANAGER = None
 
 
 def test_non_store_host_does_not_write_attribution_startup_failure(tmp_path):
@@ -1200,6 +1200,7 @@ def test_attribution_startup_log_failure_does_not_mask_original_error(tmp_path):
     args = _managed_attribution_args(launcher, tmp_path)
     original_error = ValueError("bad attribution config")
     with (
+        patch.object(launcher, "_ATTRIBUTION_MANAGER", None),
         patch.object(launcher, "_matches_machine_hostname", return_value=True),
         patch.object(
             launcher.AttributionManager,
@@ -1212,7 +1213,6 @@ def test_attribution_startup_log_failure_does_not_mask_original_error(tmp_path):
         launcher.config_from_args(args, launcher_log_file=args.ft_nvrx_logfile)
 
     assert exc_info.value is original_error
-    launcher._ATTRIBUTION_MANAGER = None
 
 
 def _make_launch_agent_config(**overrides):

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -18,7 +18,7 @@ import os
 import tempfile
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 from nvidia_resiliency_ext.shared_utils.health_check import (
     AttributionService,
@@ -688,11 +688,13 @@ class TestAttributionService(unittest.TestCase):
 
     def test_submit_log_posts_progressive_work_synchronously(self):
         service = AttributionService(endpoint="http://attr.example:8000/")
+        service._next_result_poll_time = 42.0
 
         with patch.object(service, "_do_submit_log") as mock_submit:
             service._submit_log("/tmp/train.log")
 
         self.assertEqual(service._last_submitted, "/tmp/train.log")
+        self.assertEqual(service._next_result_poll_time, 0.0)
         mock_submit.assert_called_once_with(
             "/tmp/train.log",
             analysis_intent="progressive",
@@ -701,6 +703,7 @@ class TestAttributionService(unittest.TestCase):
     def test_request_terminal_analysis_posts_terminal_work_synchronously(self):
         service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
         service._last_submitted = "/tmp/train.log"
+        service._next_result_poll_time = 42.0
 
         with (
             patch.object(service, "_do_submit_log") as mock_submit,
@@ -716,6 +719,7 @@ class TestAttributionService(unittest.TestCase):
             analysis_intent="terminal",
         )
         self.assertEqual(service._terminal_deadline, 17.0)
+        self.assertEqual(service._next_result_poll_time, 0.0)
 
     def test_request_terminal_analysis_skips_without_submitted_log(self):
         service = AttributionService(endpoint="http://attr.example:8000/")
@@ -749,6 +753,31 @@ class TestAttributionService(unittest.TestCase):
         self.assertFalse(should_stop)
         mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
 
+    def test_get_last_result_throttles_http_polling(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=20.0)
+        service._last_submitted = "/tmp/train.log"
+        service._terminal_deadline = 30.0
+
+        with (
+            patch.object(service, "_get_results", side_effect=[None, False]) as mock_get,
+            patch(
+                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
+                side_effect=[10.0, 10.0, 11.9, 11.9, 12.0, 12.0],
+            ),
+        ):
+            self.assertIsNone(service.get_last_result())
+            self.assertIsNone(service.get_last_result())
+            self.assertFalse(service.get_last_result())
+
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(
+            mock_get.call_args_list,
+            [
+                call("/tmp/train.log", timeout=2.0),
+                call("/tmp/train.log", timeout=2.0),
+            ],
+        )
+
     def test_terminal_analysis_does_not_extend_existing_decision_budget(self):
         service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
         service._last_submitted = "/tmp/train.log"
@@ -773,6 +802,7 @@ class TestAttributionService(unittest.TestCase):
         service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
         service._last_submitted = "/tmp/train.log"
         service._terminal_deadline = 20.0
+        service._next_result_poll_time = 30.0
 
         with (
             patch.object(service, "_get_results", return_value=True) as mock_get,
@@ -812,7 +842,7 @@ class TestAttributionService(unittest.TestCase):
             patch.object(service, "_get_results", side_effect=[None, True]),
             patch(
                 "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                return_value=10.0,
+                side_effect=[10.0, 10.0, 12.0, 12.0],
             ),
             patch(
                 "nvidia_resiliency_ext.shared_utils.health_check.record_profiling_event"
@@ -904,9 +934,11 @@ class TestAttributionService(unittest.TestCase):
         client.get.return_value = response
         service = AttributionService(endpoint="http://attr.example:8000/")
 
-        should_stop = service._get_results("/tmp/train.log")
+        with patch("nvidia_resiliency_ext.shared_utils.health_check.logger") as mock_logger:
+            should_stop = service._get_results("/tmp/train.log")
 
         self.assertTrue(should_stop)
+        mock_logger.info.assert_called_once()
         mock_client.assert_called_once_with(base_url="http://attr.example:8000", timeout=2.0)
         client.get.assert_called_once_with(
             "/logs",
@@ -956,9 +988,17 @@ class TestAttributionService(unittest.TestCase):
         client.get.return_value = response
         service = AttributionService(endpoint="http://attr.example:8000/")
 
-        should_stop = service._get_results("/tmp/train.log")
+        with patch("nvidia_resiliency_ext.shared_utils.health_check.logger") as mock_logger:
+            should_stop = service._get_results("/tmp/train.log")
 
         self.assertIsNone(should_stop)
+        mock_logger.info.assert_not_called()
+        self.assertTrue(
+            any(
+                "status=in_flight" in str(log_call.args[0])
+                for log_call in mock_logger.debug.call_args_list
+            )
+        )
 
     @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
     def test_get_results_maps_continue_recommendation_to_no_stop(self, mock_client):


### PR DESCRIPTION
Launcher-managed attribution can fail before the pipe/gRPC log reader is available, leaving its configuration error only in an unread stderr pipe. Append that failure directly to --ft-nvrx-logfile from the TCPStore host, while preserving the original exception if the logfile is unavailable.

Document the logfile availability contract and cover store-host ownership, missing API key diagnostics, and logfile write failures.