### PR TITLE
Keep attribution launcher summary on one line

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/orchestration/client_response.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/client_response.py
@@ -109,12 +109,17 @@ class AttrSvcResult:
     def format_log_message(self, *, preview_chars: int = 200) -> str:
         """Return a compact one-line summary suitable for launcher logs."""
         path = f" for {self.log_path}" if self.log_path else ""
+        preview = " | ".join(
+            line.strip()
+            for line in self.attribution_preview(preview_chars).splitlines()
+            if line.strip()
+        )
         return (
             f"AttrSvcResult{path}: status={self.status} "
             f"recommendation={self.recommendation.action} "
             f"reason={self.recommendation_reason} "
             f"should_stop={self.should_stop} "
-            f"result preview: {self.attribution_preview(preview_chars)}"
+            f"result preview: {preview}"
         )
 
 

--- a/tests/attribution/unit/test_client_response.py
+++ b/tests/attribution/unit/test_client_response.py
@@ -156,3 +156,26 @@ def test_attrsvc_result_formats_launcher_log_message():
         "recommendation=CONTINUE reason=training cycle still running "
         "should_stop=False result preview: ERRORS NOT FOUND"
     )
+
+
+def test_attrsvc_result_launcher_log_message_flattens_multiline_preview():
+    parsed = parse_attrsvc_response(
+        {
+            "status": "completed",
+            "recommendation": {
+                "action": "CONTINUE",
+                "reason": "",
+                "source": "log_analyzer",
+            },
+            "result": {
+                "module": "log_analyzer",
+                "result": [_item("ERRORS NOT FOUND\nERRORS NOT FOUND\nFalse", "CONTINUE")],
+            },
+        },
+        log_path="/tmp/train.log",
+    )
+
+    message = parsed.format_log_message()
+
+    assert "\n" not in message
+    assert message.endswith("result preview: ERRORS NOT FOUND | ERRORS NOT FOUND | False")


### PR DESCRIPTION
Flatten embedded newlines in attribution result previews with readable separators so completed launcher summaries do not spill across unprefixed log lines.