### PR TITLE
[codex] Bound LogSage endpoint outer retries

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py
+++ b/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py
@@ -210,6 +210,9 @@ class CombinedLogFRMCPOrchestrator:
             "is_per_cycle": is_per_cycle,
             **llm_kwargs,
         }
+        for key in ("endpoint_outer_retries", "endpoint_outer_backoff_sec"):
+            if key in arguments:
+                log_kw[key] = arguments[key]
         if is_per_cycle:
             log_kw["cycle_counter"] = int(arguments.get("cycle_counter", 0))
         fr_kw: dict[str, Any] = {

--- a/src/nvidia_resiliency_ext/attribution/controller.py
+++ b/src/nvidia_resiliency_ext/attribution/controller.py
@@ -58,6 +58,8 @@ class AttributionAnalysisConfig:
     llm_temperature: float | None = None
     llm_top_p: float | None = None
     llm_max_tokens: int | None = None
+    endpoint_outer_retries: int | None = None
+    endpoint_outer_backoff_sec: float | None = None
 
 
 @dataclass(frozen=True)
@@ -166,6 +168,8 @@ class AttributionController:
             llm_temperature=config.analysis.llm_temperature,
             llm_top_p=config.analysis.llm_top_p,
             llm_max_tokens=config.analysis.llm_max_tokens,
+            endpoint_outer_retries=config.analysis.endpoint_outer_retries,
+            endpoint_outer_backoff_sec=config.analysis.endpoint_outer_backoff_sec,
         )
 
         self._analyzer = Analyzer(
@@ -178,7 +182,7 @@ class AttributionController:
         timeout_str = (
             f"{config.cache.compute_timeout}s" if config.cache.compute_timeout else "default"
         )
-        llm_overrides = [
+        analysis_overrides = [
             k
             for k, v in (
                 ("llm_model", config.analysis.llm_model),
@@ -186,26 +190,30 @@ class AttributionController:
                 ("llm_temperature", config.analysis.llm_temperature),
                 ("llm_top_p", config.analysis.llm_top_p),
                 ("llm_max_tokens", config.analysis.llm_max_tokens),
+                ("endpoint_outer_retries", config.analysis.endpoint_outer_retries),
+                ("endpoint_outer_backoff_sec", config.analysis.endpoint_outer_backoff_sec),
             )
             if v is not None
         ]
-        llm_str = f", llm_overrides={llm_overrides}" if llm_overrides else ""
+        analysis_str = f", analysis_overrides={analysis_overrides}" if analysis_overrides else ""
         logger.info(
             "Initialized AttributionController with allowed_root=%s, compute_timeout=%s, "
             "analysis_engine_backend=%s%s",
             config.allowed_root,
             timeout_str,
             self._engine_backend,
-            llm_str,
+            analysis_str,
         )
         logger.info(
             "Analyzer engine LLM wiring: model=%r base_url=%s temperature=%s top_p=%s "
-            "max_tokens=%s",
+            "max_tokens=%s endpoint_outer_retries=%s endpoint_outer_backoff_sec=%s",
             analyzer_engine.llm_model,
             analyzer_engine.llm_base_url,
             analyzer_engine.llm_temperature,
             analyzer_engine.llm_top_p,
             analyzer_engine.llm_max_tokens,
+            analyzer_engine.endpoint_outer_retries,
+            analyzer_engine.endpoint_outer_backoff_sec,
         )
 
     def shutdown(self) -> None:

--- a/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
+++ b/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
@@ -67,6 +67,9 @@ from nvidia_resiliency_ext.attribution.orchestration.types import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES = 0
+DEFAULT_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC = 60.0
+
 LogSageCycleFields = tuple[str, str, str, str, str]
 
 FINISHED_STATUS_LLM_FAILURE = "LLM_FAILURE"
@@ -417,6 +420,67 @@ def _log_analysis_retry_config() -> tuple[int, float, float, float]:
     return retries, initial_backoff, max_backoff, jitter
 
 
+def _int_config(values: Mapping[str, Any], key: str, default: int) -> int:
+    raw = values.get(key)
+    if raw is None or raw == "":
+        return default
+    try:
+        return max(int(raw), 0)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %d", key, raw, default)
+        return default
+
+
+def _float_config(values: Mapping[str, Any], key: str, default: float) -> float:
+    raw = values.get(key)
+    if raw is None or raw == "":
+        return default
+    try:
+        return max(float(raw), 0.0)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %.2f", key, raw, default)
+        return default
+
+
+def _endpoint_outer_retry_config(values: Mapping[str, Any]) -> tuple[int, float]:
+    retries = _int_config(
+        values,
+        "endpoint_outer_retries",
+        DEFAULT_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES,
+    )
+    backoff = _float_config(
+        values,
+        "endpoint_outer_backoff_sec",
+        DEFAULT_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC,
+    )
+    return retries, backoff
+
+
+def _is_endpoint_failed_result(result: Any) -> bool:
+    try:
+        fields = result[:4]
+    except (TypeError, IndexError):
+        return False
+    return any(field == LOGSAGE_LLM_ENDPOINT_FAILED for field in fields)
+
+
+def _endpoint_failed_tuple(
+    checkpoint_saved: bool, endpoint_outer_retries: int
+) -> LogSageCycleFields:
+    reason = (
+        "LogSage returned LLM ENDPOINT FAILED after its internal retries; "
+        "NVRx endpoint outer retries exhausted "
+        f"(configured additional retries: {endpoint_outer_retries})."
+    )
+    return (
+        ATTR_LLM_FAILURE,
+        reason,
+        f"Attribution: Primary issues: [{LOGSAGE_LLM_ENDPOINT_FAILED}], Secondary issues: []",
+        "",
+        str(checkpoint_saved),
+    )
+
+
 def _finished_status_name(status: Any) -> str:
     return getattr(status, "name", status)
 
@@ -489,8 +553,16 @@ def _retry_return_application_errors_rt(
     return app_data
 
 
-def _with_exponential_backoff(llm_call, checkpoint_saved: bool) -> tuple[str, str, str, str, str]:
+def _with_exponential_backoff(
+    llm_call,
+    checkpoint_saved: bool,
+    *,
+    endpoint_outer_retries: int = DEFAULT_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES,
+    endpoint_outer_backoff_sec: float = DEFAULT_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC,
+) -> tuple[str, str, str, str, str]:
     retries, initial_backoff, max_backoff, jitter = _log_analysis_retry_config()
+    endpoint_outer_retries = max(endpoint_outer_retries, 0)
+    endpoint_outer_backoff = max(endpoint_outer_backoff_sec, 0.0)
     backoff = initial_backoff
     last_error = "no attempts made (retries=0)"
     fallback = (
@@ -501,12 +573,45 @@ def _with_exponential_backoff(llm_call, checkpoint_saved: bool) -> tuple[str, st
         str(checkpoint_saved),
     )
 
-    for attempt in range(1, retries + 1):
+    if retries <= 0:
+        logger.error(
+            "Log-analysis LLM failed after %d attempts; last error: %s",
+            retries,
+            last_error,
+        )
+        return fallback
+
+    attempt = 1
+    endpoint_failures = 0
+    while attempt <= retries:
         try:
             result = llm_call()
-            if result and not any(field == LOGSAGE_LLM_ENDPOINT_FAILED for field in result[:4]):
+            if _is_endpoint_failed_result(result):
+                endpoint_failures += 1
+                last_error = LOGSAGE_LLM_ENDPOINT_FAILED
+                if endpoint_failures > endpoint_outer_retries:
+                    logger.error(
+                        "LogSage endpoint failure exhausted NVRx outer retry budget "
+                        "(configured additional retries: %d)",
+                        endpoint_outer_retries,
+                    )
+                    return _endpoint_failed_tuple(checkpoint_saved, endpoint_outer_retries)
+
+                logger.warning(
+                    "LogSage returned %s; retrying NVRx outer attribution attempt "
+                    "%d/%d in %.2fs",
+                    LOGSAGE_LLM_ENDPOINT_FAILED,
+                    endpoint_failures,
+                    endpoint_outer_retries,
+                    endpoint_outer_backoff,
+                )
+                time.sleep(endpoint_outer_backoff)
+                continue
+
+            if result:
                 return result
-            last_error = LOGSAGE_LLM_ENDPOINT_FAILED
+
+            last_error = "empty LLM result"
         except Exception as exc:
             last_error = str(exc)
             logger.warning("Log-analysis LLM attempt %d/%d failed: %s", attempt, retries, exc)
@@ -520,13 +625,7 @@ def _with_exponential_backoff(llm_call, checkpoint_saved: bool) -> tuple[str, st
             return fallback
 
         backoff = _sleep_with_backoff(attempt, retries, backoff, max_backoff, jitter)
-
-    logger.error(
-        "Log-analysis LLM failed after %d attempts; last error: %s",
-        retries,
-        last_error,
-    )
-    return fallback
+        attempt += 1
 
 
 class _ProgressiveLogState:
@@ -909,6 +1008,7 @@ class NVRxLogAnalyzer(NVRxAttribution):
         cfg = effective_run_or_init_config(self._init_config)
         path = cfg.get("log_path")
         is_per_cycle = bool(cfg.get("is_per_cycle", self.is_per_cycle))
+        endpoint_outer_retries, endpoint_outer_backoff_sec = _endpoint_outer_retry_config(cfg)
         if path and self.job_inline_data_dict.get(path) and len(output_list) == 1:
             rt_result = self._streaming_attribution(output_list[0], cfg, path)
             # Final attribution has consumed the progressive state (and already
@@ -969,6 +1069,8 @@ class NVRxLogAnalyzer(NVRxAttribution):
                     fields = _with_exponential_backoff(
                         lambda: get_proposed_solution_cat(self.llm, output),
                         checkpoint_saved=output.checkpoint_saved,
+                        endpoint_outer_retries=endpoint_outer_retries,
+                        endpoint_outer_backoff_sec=endpoint_outer_backoff_sec,
                     )
                     if path and is_per_cycle and len(output_list) == 1:
                         auto_resume_output, auto_resume_verbose = (
@@ -1306,6 +1408,18 @@ def main():
         type=int,
         default=DEFAULT_LLM_MAX_TOKENS,
         help='Max tokens for LLM',
+    )
+    parser.add_argument(
+        '--endpoint_outer_retries',
+        type=int,
+        default=DEFAULT_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES,
+        help='Additional NVRx retries when LogSage reports LLM ENDPOINT FAILED',
+    )
+    parser.add_argument(
+        '--endpoint_outer_backoff_sec',
+        type=float,
+        default=DEFAULT_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC,
+        help='Seconds between NVRx endpoint outer retries',
     )
     parser.add_argument(
         '--exclude_nvrx_logs', action='store_true', help='Exclude nvrx logs from the input data'

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
@@ -139,6 +139,23 @@ def _llm_runtime_properties(*, model_description: str) -> dict[str, dict[str, An
     }
 
 
+def _endpoint_retry_properties() -> dict[str, dict[str, Any]]:
+    """Input-schema properties for NVRx-owned final attribution endpoint retries."""
+    return {
+        "endpoint_outer_retries": {
+            "type": "integer",
+            "description": (
+                "Additional NVRx retries when LogSage returns LLM ENDPOINT FAILED "
+                "after its internal endpoint retries"
+            ),
+        },
+        "endpoint_outer_backoff_sec": {
+            "type": "number",
+            "description": "Seconds to wait between NVRx endpoint outer retries",
+        },
+    }
+
+
 def _cycle_counter_property() -> dict[str, Any]:
     return {
         "type": "integer",
@@ -153,6 +170,7 @@ def _log_analyzer_input_schema() -> dict[str, Any]:
         "properties": {
             "log_path": {"type": "string", "description": "Path to log files"},
             **_llm_runtime_properties(model_description="LLM model to use for analysis"),
+            **_endpoint_retry_properties(),
             "exclude_nvrx_logs": {
                 "type": "boolean",
                 "description": "Exclude NVRX internal logs",
@@ -374,6 +392,7 @@ def register_all_modules():
                 "temperature": {"type": "number", "default": DEFAULT_LLM_TEMPERATURE},
                 "top_p": {"type": "number", "default": DEFAULT_LLM_TOP_P},
                 "max_tokens": {"type": "integer", "default": DEFAULT_LLM_MAX_TOKENS},
+                **_endpoint_retry_properties(),
                 "threshold": {"type": "integer", "default": 0},
                 "merge_llm": {
                     "type": "boolean",

--- a/src/nvidia_resiliency_ext/attribution/orchestration/config.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/config.py
@@ -65,6 +65,8 @@ class LogSageExecutionConfig:
     llm_temperature: float | None = None
     llm_top_p: float | None = None
     llm_max_tokens: int | None = None
+    endpoint_outer_retries: int | None = None
+    endpoint_outer_backoff_sec: float | None = None
 
     def llm_runtime_overrides(self) -> dict[str, Any]:
         """LLM kwargs for LogSage/MCP/runtime calls, omitting unset overrides."""
@@ -74,6 +76,13 @@ class LogSageExecutionConfig:
             temperature=self.llm_temperature,
             top_p=self.llm_top_p,
             max_tokens=self.llm_max_tokens,
+        )
+
+    def endpoint_retry_overrides(self) -> dict[str, Any]:
+        """LogSage endpoint retry policy for final attribution calls."""
+        return endpoint_retry_overrides(
+            retries=self.endpoint_outer_retries,
+            backoff_sec=self.endpoint_outer_backoff_sec,
         )
 
     def llm_endpoint_overrides(self) -> dict[str, Any]:
@@ -121,6 +130,20 @@ def llm_runtime_overrides(
             "max_tokens": max_tokens,
         }
     )
+
+
+def endpoint_retry_overrides(
+    *,
+    retries: int | None = None,
+    backoff_sec: float | None = None,
+) -> dict[str, Any]:
+    """Final-attribution endpoint retry kwargs, omitting unset overrides."""
+    values: dict[str, Any] = {}
+    if retries is not None:
+        values["endpoint_outer_retries"] = max(int(retries), 0)
+    if backoff_sec is not None:
+        values["endpoint_outer_backoff_sec"] = max(float(backoff_sec), 0.0)
+    return values
 
 
 def _value_or_default(values: Mapping[str, Any], key: str, default: Any) -> Any:

--- a/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
@@ -223,6 +223,7 @@ class LogSageRunner:
             "exclude_nvrx_logs": False,
             **self._per_cycle_log_kwargs(path),
             **self.config.llm_runtime_overrides(),
+            **self.config.endpoint_retry_overrides(),
         }
         analyzer = await self._get_lib_log_analyzer(run_kwargs)
         result = await self._run_lib_log_analyzer_serialized(analyzer, run_kwargs)
@@ -237,6 +238,7 @@ class LogSageRunner:
             "exclude_nvrx_logs": False,
             **self._per_cycle_log_kwargs(path),
             **self.config.llm_runtime_overrides(),
+            **self.config.endpoint_retry_overrides(),
         }
 
         async with self._log_analysis_lock:
@@ -339,6 +341,7 @@ class LogSageRunner:
             "merge_llm": merge_llm,
             "threshold": 0,
             **self.config.llm_runtime_overrides(),
+            **self.config.endpoint_retry_overrides(),
         }
 
         async with self._log_analysis_lock:

--- a/src/nvidia_resiliency_ext/attribution/orchestration/types.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/types.py
@@ -161,6 +161,8 @@ class LogAnalyzerConfig:
     llm_temperature: Optional[float] = None
     llm_top_p: Optional[float] = None
     llm_max_tokens: Optional[int] = None
+    endpoint_outer_retries: Optional[int] = None
+    endpoint_outer_backoff_sec: Optional[float] = None
     use_lib_log_analysis: bool = False
     #: How LogSage and NCCL flight-recorder analysis are combined; see
     #: :class:`~nvidia_resiliency_ext.attribution.orchestration.analysis_pipeline.AnalysisPipelineMode`.
@@ -183,6 +185,8 @@ class LogAnalyzerConfig:
             llm_temperature=self.llm_temperature,
             llm_top_p=self.llm_top_p,
             llm_max_tokens=self.llm_max_tokens,
+            endpoint_outer_retries=self.endpoint_outer_retries,
+            endpoint_outer_backoff_sec=self.endpoint_outer_backoff_sec,
         )
 
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -58,6 +58,8 @@ class AttributionConfig:
     decision_timeout: Optional[float] = None
     log_level: Optional[str] = None
     export_url: Optional[str] = None
+    log_analysis_endpoint_outer_retries: Optional[int] = None
+    log_analysis_endpoint_outer_backoff_sec: Optional[float] = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -65,6 +67,18 @@ class AttributionConfig:
             "analysis_backend",
             _normalize_analysis_backend(self.analysis_backend),
         )
+        if (
+            self.log_analysis_endpoint_outer_retries is not None
+            and self.log_analysis_endpoint_outer_retries < 0
+        ):
+            raise ValueError("--ft-attribution-log-analysis-endpoint-outer-retries must be >= 0")
+        if (
+            self.log_analysis_endpoint_outer_backoff_sec is not None
+            and self.log_analysis_endpoint_outer_backoff_sec < 0
+        ):
+            raise ValueError(
+                "--ft-attribution-log-analysis-endpoint-outer-backoff-sec must be >= 0"
+            )
 
     @property
     def is_enabled(self) -> bool:
@@ -139,6 +153,16 @@ class AttributionConfig:
                 decision_timeout=decision_timeout,
                 log_level=getattr(args, "ft_attribution_log_level", None),
                 export_url=None,
+                log_analysis_endpoint_outer_retries=getattr(
+                    args,
+                    "ft_attribution_log_analysis_endpoint_outer_retries",
+                    None,
+                ),
+                log_analysis_endpoint_outer_backoff_sec=getattr(
+                    args,
+                    "ft_attribution_log_analysis_endpoint_outer_backoff_sec",
+                    None,
+                ),
             )
 
         applog_dir = os.path.dirname(os.path.realpath(os.path.abspath(base_log_file)))
@@ -168,6 +192,16 @@ class AttributionConfig:
             decision_timeout=decision_timeout,
             log_level=getattr(args, "ft_attribution_log_level", None),
             export_url=export_url,
+            log_analysis_endpoint_outer_retries=getattr(
+                args,
+                "ft_attribution_log_analysis_endpoint_outer_retries",
+                None,
+            ),
+            log_analysis_endpoint_outer_backoff_sec=getattr(
+                args,
+                "ft_attribution_log_analysis_endpoint_outer_backoff_sec",
+                None,
+            ),
         )
 
 
@@ -302,6 +336,16 @@ class AttributionManager:
         _set_if_not_none(env, "NVRX_ATTRSVC_LLM_MODEL", self.cfg.llm_model)
         _set_if_not_none(env, "NVRX_ATTRSVC_ANALYSIS_BACKEND", self.cfg.analysis_backend)
         _set_if_not_none(env, "NVRX_ATTRSVC_LOG_LEVEL", self.cfg.log_level)
+        _set_if_not_none(
+            env,
+            "NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES",
+            self.cfg.log_analysis_endpoint_outer_retries,
+        )
+        _set_if_not_none(
+            env,
+            "NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC",
+            self.cfg.log_analysis_endpoint_outer_backoff_sec,
+        )
         _set_if_not_none(env, _ATTRSVC_EXPORT_URL_ENV, self.cfg.export_url)
         return env
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -398,6 +398,28 @@ def _add_attribution_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--ft-attribution-log-analysis-endpoint-outer-retries",
+        "--ft_attribution_log_analysis_endpoint_outer_retries",
+        type=int,
+        default=None,
+        dest="ft_attribution_log_analysis_endpoint_outer_retries",
+        help=(
+            "Additional NVRx retries when LogSage reports LLM ENDPOINT FAILED after "
+            "its internal endpoint retries. Default: attrsvc default (0)."
+        ),
+    )
+    parser.add_argument(
+        "--ft-attribution-log-analysis-endpoint-outer-backoff-sec",
+        "--ft_attribution_log_analysis_endpoint_outer_backoff_sec",
+        type=float,
+        default=None,
+        dest="ft_attribution_log_analysis_endpoint_outer_backoff_sec",
+        help=(
+            "Seconds between NVRx log-analysis endpoint outer retries. "
+            "Default: attrsvc default (60)."
+        ),
+    )
+    parser.add_argument(
         "--ft-attribution-decision-timeout",
         "--ft_attribution_decision_timeout",
         type=float,

--- a/src/nvidia_resiliency_ext/services/attrsvc/config.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/config.py
@@ -15,7 +15,7 @@ import re
 from dataclasses import dataclass
 from urllib.parse import unquote, urlparse
 
-from pydantic import Field, field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Re-export ErrorCode from library layer so service consumers can use:
@@ -160,6 +160,25 @@ class Settings(BaseSettings):
     )
     LLM_TOP_P: float | None = Field(default=None, description="LLM top-p for nucleus sampling")
     LLM_MAX_TOKENS: int | None = Field(default=None, description="Max tokens for LLM response")
+    LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES: int | None = Field(
+        default=None,
+        description=(
+            "Additional NVRx retries when LogSage reports LLM ENDPOINT FAILED "
+            "after its internal endpoint retries"
+        ),
+        validation_alias=AliasChoices(
+            "NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES",
+            "NVRX_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES",
+        ),
+    )
+    LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC: float | None = Field(
+        default=None,
+        description="Seconds to wait between NVRx endpoint outer retries",
+        validation_alias=AliasChoices(
+            "NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC",
+            "NVRX_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC",
+        ),
+    )
 
     # Log + FR analysis backend: "lib" = in-process, "mcp" = subprocess MCP (same stdio client)
     ANALYSIS_BACKEND: str = Field(
@@ -309,6 +328,20 @@ class Settings(BaseSettings):
     def validate_llm_max_tokens(cls, v: int | None) -> int | None:
         if v is not None and v <= 0:
             raise ValueError(f"LLM_MAX_TOKENS must be positive, got {v}")
+        return v
+
+    @field_validator("LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES")
+    @classmethod
+    def validate_log_analysis_endpoint_outer_retries(cls, v: int | None) -> int | None:
+        if v is not None and v < 0:
+            raise ValueError(f"LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES must be >= 0, got {v}")
+        return v
+
+    @field_validator("LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC")
+    @classmethod
+    def validate_log_analysis_endpoint_outer_backoff_sec(cls, v: float | None) -> float | None:
+        if v is not None and v < 0:
+            raise ValueError(f"LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC must be >= 0, got {v}")
         return v
 
     @field_validator("ALLOWED_ROOT")

--- a/src/nvidia_resiliency_ext/services/attrsvc/service.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/service.py
@@ -63,6 +63,8 @@ def _controller_config_from_settings(cfg: Settings) -> AttributionControllerConf
             llm_temperature=cfg.LLM_TEMPERATURE,
             llm_top_p=cfg.LLM_TOP_P,
             llm_max_tokens=cfg.LLM_MAX_TOKENS,
+            endpoint_outer_retries=cfg.LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES,
+            endpoint_outer_backoff_sec=cfg.LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC,
         ),
         cache=AttributionCacheConfig(
             compute_timeout=cfg.COMPUTE_TIMEOUT,

--- a/tests/attribution/unit/test_attrsvc_settings.py
+++ b/tests/attribution/unit/test_attrsvc_settings.py
@@ -43,6 +43,62 @@ def test_attrsvc_llm_empty_env_values_are_unset(tmp_path, monkeypatch):
     assert cfg.LLM_MAX_TOKENS is None
 
 
+def test_attrsvc_log_analysis_endpoint_outer_retry_defaults(tmp_path, monkeypatch):
+    monkeypatch.delenv("NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES", raising=False)
+    monkeypatch.delenv("NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC", raising=False)
+    monkeypatch.delenv("NVRX_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES", raising=False)
+    monkeypatch.delenv("NVRX_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC", raising=False)
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES is None
+    assert cfg.LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC is None
+
+
+def test_attrsvc_log_analysis_endpoint_outer_retry_accepts_attrsvc_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES", "2")
+    monkeypatch.setenv("NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC", "3.5")
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES == 2
+    assert cfg.LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC == 3.5
+
+
+def test_attrsvc_log_analysis_endpoint_outer_retry_accepts_nvrx_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES", raising=False)
+    monkeypatch.delenv("NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC", raising=False)
+    monkeypatch.setenv("NVRX_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES", "1")
+    monkeypatch.setenv("NVRX_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC", "0")
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES == 1
+    assert cfg.LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC == 0.0
+
+
+def test_attrsvc_log_analysis_endpoint_outer_retry_rejects_negative(tmp_path, monkeypatch):
+    monkeypatch.setenv("NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES", "-1")
+
+    with pytest.raises(Exception):
+        Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+
+def test_attrsvc_settings_pass_endpoint_outer_retry_to_controller_config(tmp_path):
+    attrsvc_service = pytest.importorskip("nvidia_resiliency_ext.services.attrsvc.service")
+    cfg = Settings(
+        ALLOWED_ROOT=str(tmp_path),
+        LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES=4,
+        LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC=2.5,
+        _env_file=None,
+    )
+
+    controller_cfg = attrsvc_service._controller_config_from_settings(cfg)
+
+    assert controller_cfg.analysis.endpoint_outer_retries == 4
+    assert controller_cfg.analysis.endpoint_outer_backoff_sec == 2.5
+
+
 def test_attrsvc_analysis_backend_uses_current_env_name_only(tmp_path, monkeypatch):
     monkeypatch.setenv("NVRX_ATTRSVC_ANALYSIS_BACKEND", "lib")
     monkeypatch.setenv("NVRX_ATTRSVC_LOG_ANALYSIS_BACKEND", "mcp")

--- a/tests/attribution/unit/test_log_analyzer_observability.py
+++ b/tests/attribution/unit/test_log_analyzer_observability.py
@@ -12,7 +12,10 @@ from typing import Any, Dict
 
 from nvidia_resiliency_ext.attribution.coalescing.coalescer import RequestCoalescer
 from nvidia_resiliency_ext.attribution.orchestration.analysis_pipeline import AnalysisPipelineMode
-from nvidia_resiliency_ext.attribution.orchestration.config import LogSageExecutionConfig
+from nvidia_resiliency_ext.attribution.orchestration.config import (
+    LogSageExecutionConfig,
+    endpoint_retry_overrides,
+)
 
 
 def _stub_module(monkeypatch, name):
@@ -108,6 +111,16 @@ def _import_log_analyzer_with_optional_dependency_stubs(monkeypatch):
 
     module = importlib.import_module("nvidia_resiliency_ext.attribution.orchestration.log_analyzer")
     return module.LogAnalyzer
+
+
+def test_endpoint_retry_overrides_omits_unset_values():
+    assert endpoint_retry_overrides() == {}
+    assert endpoint_retry_overrides(retries=2) == {"endpoint_outer_retries": 2}
+    assert endpoint_retry_overrides(backoff_sec=3.5) == {"endpoint_outer_backoff_sec": 3.5}
+    assert endpoint_retry_overrides(retries=-1, backoff_sec=-1.0) == {
+        "endpoint_outer_retries": 0,
+        "endpoint_outer_backoff_sec": 0.0,
+    }
 
 
 class _FakeRunner:
@@ -225,6 +238,8 @@ def test_log_sage_runner_omits_unset_llm_overrides(monkeypatch):
         assert "temperature" not in kwargs
         assert "top_p" not in kwargs
         assert "max_tokens" not in kwargs
+        assert "endpoint_outer_retries" not in kwargs
+        assert "endpoint_outer_backoff_sec" not in kwargs
         assert kwargs["log_path"] == "/tmp/job.log"
         assert kwargs["exclude_nvrx_logs"] is False
 
@@ -266,6 +281,39 @@ def test_log_sage_runner_preserves_explicit_llm_overrides(monkeypatch):
         assert kwargs["temperature"] == 0.0
         assert kwargs["top_p"] == 0.0
         assert kwargs["max_tokens"] == 0
+
+
+def test_log_sage_runner_preserves_endpoint_retry_overrides(monkeypatch):
+    _import_log_analyzer_with_optional_dependency_stubs(monkeypatch)
+    module = importlib.import_module("nvidia_resiliency_ext.attribution.orchestration.log_analyzer")
+    runner = module.LogSageRunner(
+        LogSageExecutionConfig(
+            use_lib_log_analysis=True,
+            endpoint_outer_retries=2,
+            endpoint_outer_backoff_sec=3.5,
+        )
+    )
+    captured: dict[str, dict[str, Any]] = {}
+
+    class FakeLogAnalyzer:
+        async def run(self, kwargs: dict[str, Any]) -> list[Any]:
+            captured["run"] = dict(kwargs)
+            return []
+
+    async def fake_get_lib_log_analyzer(kwargs: dict[str, Any]) -> FakeLogAnalyzer:
+        captured["init"] = dict(kwargs)
+        return FakeLogAnalyzer()
+
+    runner._get_lib_log_analyzer = fake_get_lib_log_analyzer
+
+    async def run() -> None:
+        await runner._fetch_log_result_lib("/tmp/job.log")
+
+    asyncio.run(run())
+
+    for kwargs in captured.values():
+        assert kwargs["endpoint_outer_retries"] == 2
+        assert kwargs["endpoint_outer_backoff_sec"] == 3.5
 
 
 def test_log_sage_runner_lib_run_allows_coalescer_timeout(monkeypatch):

--- a/tests/attribution/unit/test_nvrx_logsage_retry.py
+++ b/tests/attribution/unit/test_nvrx_logsage_retry.py
@@ -31,6 +31,98 @@ class TestNVRxLogSageRetry(unittest.TestCase):
                 ),
             )
 
+    def test_endpoint_failure_is_not_retried_by_default(self):
+        calls = {"count": 0}
+
+        def llm_call():
+            calls["count"] += 1
+            return (
+                nvrx_logsage.LOGSAGE_LLM_ENDPOINT_FAILED,
+                "",
+                nvrx_logsage.LOGSAGE_LLM_ENDPOINT_FAILED,
+                "",
+                "False",
+            )
+
+        with patch.dict(
+            os.environ,
+            {
+                "NVRX_LOG_ANALYSIS_LLM_RETRIES": "3",
+            },
+        ):
+            result = nvrx_logsage._with_exponential_backoff(llm_call, checkpoint_saved=False)
+
+        self.assertEqual(calls["count"], 1)
+        self.assertEqual(result[0], nvrx_logsage.ATTR_LLM_FAILURE)
+        self.assertIn("configured additional retries: 0", result[1])
+        self.assertIn(nvrx_logsage.LOGSAGE_LLM_ENDPOINT_FAILED, result[2])
+
+    def test_endpoint_failure_uses_configured_outer_retry(self):
+        responses = [
+            (
+                nvrx_logsage.LOGSAGE_LLM_ENDPOINT_FAILED,
+                "",
+                nvrx_logsage.LOGSAGE_LLM_ENDPOINT_FAILED,
+                "",
+                "False",
+            ),
+            (
+                "RESTART IMMEDIATE",
+                "not a user failure",
+                "Attribution: Primary issues: [NCCL TIMEOUT], Secondary issues: []",
+                "",
+                "False",
+            ),
+        ]
+
+        def llm_call():
+            return responses.pop(0)
+
+        with patch.dict(
+            os.environ,
+            {
+                "NVRX_LOG_ANALYSIS_LLM_RETRIES": "3",
+            },
+        ):
+            result = nvrx_logsage._with_exponential_backoff(
+                llm_call,
+                checkpoint_saved=False,
+                endpoint_outer_retries=1,
+                endpoint_outer_backoff_sec=0,
+            )
+
+        self.assertEqual(len(responses), 0)
+        self.assertEqual(result[0], "RESTART IMMEDIATE")
+
+    def test_exceptions_still_use_llm_retry_budget(self):
+        calls = {"count": 0}
+
+        def llm_call():
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RuntimeError("temporary local failure")
+            return (
+                "RESTART IMMEDIATE",
+                "not a user failure",
+                "Attribution: Primary issues: [NCCL TIMEOUT], Secondary issues: []",
+                "",
+                "False",
+            )
+
+        with patch.dict(
+            os.environ,
+            {
+                "NVRX_LOG_ANALYSIS_LLM_RETRIES": "2",
+                "NVRX_LOG_ANALYSIS_LLM_INITIAL_BACKOFF_SEC": "0",
+                "NVRX_LOG_ANALYSIS_LLM_MAX_BACKOFF_SEC": "0",
+                "NVRX_LOG_ANALYSIS_LLM_JITTER_SEC": "0",
+            },
+        ):
+            result = nvrx_logsage._with_exponential_backoff(llm_call, checkpoint_saved=False)
+
+        self.assertEqual(calls["count"], 2)
+        self.assertEqual(result[0], "RESTART IMMEDIATE")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/attribution/unit/test_progressive_plumbing.py
+++ b/tests/attribution/unit/test_progressive_plumbing.py
@@ -495,3 +495,44 @@ def test_terminal_log_analyzer_mcp_uses_cycle_counter(monkeypatch, tmp_path):
             },
         )
     ]
+
+
+def test_terminal_log_analyzer_mcp_passes_endpoint_retry_overrides(monkeypatch, tmp_path):
+    _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    module = importlib.import_module("nvidia_resiliency_ext.attribution.orchestration.log_analyzer")
+    fake_client = FakeMcpClient(
+        {
+            "module": "log_analyzer",
+            "result": [],
+            "recommendation": {"action": "RESTART", "source": "test"},
+        }
+    )
+    monkeypatch.setattr(module, "create_mcp_client", lambda **_kwargs: fake_client)
+    runner = module.LogSageRunner(
+        LogSageExecutionConfig(
+            use_lib_log_analysis=False,
+            endpoint_outer_retries=2,
+            endpoint_outer_backoff_sec=3.5,
+        )
+    )
+
+    async def run() -> dict[str, Any]:
+        return await runner.fetch_log_result(str(tmp_path / "train_CYCLE4.log"))
+
+    result = asyncio.run(run())
+
+    assert result["recommendation"]["action"] == "RESTART"
+    assert fake_client.calls == [
+        (
+            "log_analyzer",
+            {
+                "max_attempts": 3,
+                "log_path": str(tmp_path / "train_CYCLE4.log"),
+                "exclude_nvrx_logs": False,
+                "is_per_cycle": True,
+                "cycle_counter": 4,
+                "endpoint_outer_retries": 2,
+                "endpoint_outer_backoff_sec": 3.5,
+            },
+        )
+    ]

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -27,6 +27,8 @@ def _args(**overrides):
         "ft_attribution_decision_timeout": None,
         "ft_attribution_log_level": None,
         "ft_attribution_export_url": None,
+        "ft_attribution_log_analysis_endpoint_outer_retries": None,
+        "ft_attribution_log_analysis_endpoint_outer_backoff_sec": None,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -184,6 +186,8 @@ def test_attribution_config_maps_launcher_args(tmp_path):
             ft_attribution_analysis_backend="mcp",
             ft_attribution_decision_timeout=12.5,
             ft_attribution_log_level="DEBUG",
+            ft_attribution_log_analysis_endpoint_outer_retries=2,
+            ft_attribution_log_analysis_endpoint_outer_backoff_sec=3.5,
             ft_attribution_export_url=(
                 "https://dataflow.example.test/dataflow2/example-index/posting"
             ),
@@ -201,6 +205,8 @@ def test_attribution_config_maps_launcher_args(tmp_path):
     assert env["NVRX_ATTRSVC_ANALYSIS_BACKEND"] == "mcp"
     assert cfg.client_endpoint.decision_timeout == 12.5
     assert env["NVRX_ATTRSVC_LOG_LEVEL"] == "DEBUG"
+    assert env["NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES"] == "2"
+    assert env["NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC"] == "3.5"
     assert (
         env["NVRX_ATTRSVC_EXPORT_URL"]
         == "https://dataflow.example.test/dataflow2/example-index/posting"
@@ -235,6 +241,28 @@ def test_attribution_decision_timeout_must_be_positive(tmp_path, value):
     with pytest.raises(ValueError, match="--ft-attribution-decision-timeout"):
         AttributionConfig.from_args(
             _args(ft_attribution_endpoint="localhost", ft_attribution_decision_timeout=value),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        (
+            "ft_attribution_log_analysis_endpoint_outer_retries",
+            "--ft-attribution-log-analysis-endpoint-outer-retries",
+        ),
+        (
+            "ft_attribution_log_analysis_endpoint_outer_backoff_sec",
+            "--ft-attribution-log-analysis-endpoint-outer-backoff-sec",
+        ),
+    ],
+)
+def test_attribution_endpoint_outer_retry_knobs_must_be_non_negative(tmp_path, field, message):
+    with pytest.raises(ValueError, match=message):
+        AttributionConfig.from_args(
+            _args(ft_attribution_endpoint="localhost", **{field: -1}),
             str(tmp_path / "train.log"),
             FaultToleranceConfig(),
         )


### PR DESCRIPTION
## Summary

This PR changes the NVRx outer retry behavior for LogSage final attribution endpoint failures.

- Defaults NVRx endpoint-result outer retries in `nvrx_logsage.py` to `0` additional retries, with a `60` second backoff if a deployment opts in.
- Keeps the existing retry budget for real exceptions around the LogSage call.
- Treats a normal LogSage result containing `LLM ENDPOINT FAILED` as having already consumed LogSage's internal LLM retry budget.
- Plumbs optional endpoint retry overrides through attrsvc/controller/orchestration and MCP call arguments instead of reading the new knobs directly inside `nvrx_logsage.py`.
- Keeps higher layers at `None` by default, so unset values are omitted until `NVRxLogAnalyzer` applies its runtime defaults.
- Adds service env support for `NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_RETRIES` and `NVRX_ATTRSVC_LOG_ANALYSIS_ENDPOINT_OUTER_BACKOFF_SEC`; attrsvc also accepts the shorter `NVRX_LOG_ANALYSIS_ENDPOINT_OUTER_*` aliases.
- Adds launcher-managed attrsvc CLI knobs:
  - `--ft-attribution-log-analysis-endpoint-outer-retries`
  - `--ft-attribution-log-analysis-endpoint-outer-backoff-sec`

## Root Cause

For NVBug 6368845, one final attribution attempt was already taking about 15-16 minutes because LogSage and the lower-level LLM client both retried endpoint timeouts. NVRx then retried the same endpoint-failed attribution result three times, producing roughly 48 minutes of wall-clock time before returning `LLM FAILURE` / `UNKNOWN`.

## Impact

By default, NVRx no longer immediately repeats the full final attribution path after LogSage returns `LLM ENDPOINT FAILED`. Deployments that want an additional delayed retry can opt in through attrsvc env or launcher CLI config.

Prompt/evidence compaction is intentionally not handled in NVRx; that belongs inside LogSage.

## Validation

- `PYTHONPATH=src .venv/bin/python -m pytest tests/attribution/unit/test_nvrx_logsage_retry.py tests/attribution/unit/test_nvrx_logsage_reason_code.py tests/attribution/unit/test_attrsvc_settings.py tests/attribution/unit/test_log_analyzer_observability.py tests/attribution/unit/test_progressive_plumbing.py -q`
- `PYTHONPATH=src .venv/bin/python -m py_compile src/nvidia_resiliency_ext/attribution/orchestration/config.py src/nvidia_resiliency_ext/attribution/controller.py src/nvidia_resiliency_ext/services/attrsvc/config.py src/nvidia_resiliency_ext/services/attrsvc/service.py src/nvidia_resiliency_ext/attribution/orchestration/types.py src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py src/nvidia_resiliency_ext/fault_tolerance/cli_args.py`
- `PYTHONPATH=src .venv/bin/python -m black --check .`
- `git diff --check`
