### PR TITLE
Enable progressive MCP log analysis

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/controller.py
+++ b/src/nvidia_resiliency_ext/attribution/controller.py
@@ -58,6 +58,7 @@ class AttributionAnalysisConfig:
     llm_temperature: float | None = None
     llm_top_p: float | None = None
     llm_max_tokens: int | None = None
+    progressive_chunks_per_time: float | None = None
 
 
 @dataclass(frozen=True)
@@ -166,6 +167,7 @@ class AttributionController:
             llm_temperature=config.analysis.llm_temperature,
             llm_top_p=config.analysis.llm_top_p,
             llm_max_tokens=config.analysis.llm_max_tokens,
+            progressive_chunks_per_time=config.analysis.progressive_chunks_per_time,
         )
 
         self._analyzer = Analyzer(

--- a/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
+++ b/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
@@ -681,7 +681,7 @@ class NVRxLogAnalyzer(NVRxAttribution):
         self.logs_minutes_before_job_end = int(
             self._init_config.get("logs_minutes_before_job_end", 20)
         )
-        self.chunks_per_time = int(self._init_config.get("chunks_per_time", 5))
+        self.chunks_per_time = float(self._init_config.get("chunks_per_time", 5))
         super().__init__(
             preprocess_input=self.analyze_logs,
             attribution=self.llm_analyze,
@@ -703,7 +703,10 @@ class NVRxLogAnalyzer(NVRxAttribution):
             return max(int(self.logs_minutes_before_job_end / self.chunks_per_time), 1)
         return 1
 
-    async def analyze_logs_rt_start(self) -> dict[str, str | None]:
+    async def analyze_logs_rt_start(
+        self,
+        args: Mapping[str, Any] | None = None,
+    ) -> dict[str, str | None]:
         """Run the progressive-analysis start phase for the configured log path.
 
         This is a non-result-producing phase: it polls the log file, reconciling
@@ -718,7 +721,11 @@ class NVRxLogAnalyzer(NVRxAttribution):
             payload (``status`` / ``message`` / ``handle``) describing the start outcome.
             The ``module`` key is added by the calling MCP tool.
         """
-        cfg = effective_run_or_init_config(self._init_config)
+        cfg = (
+            normalize_attribution_args(args)
+            if args is not None
+            else effective_run_or_init_config(self._init_config)
+        )
         path = cfg["log_path"]
 
         llm = self.llm
@@ -732,9 +739,10 @@ class NVRxLogAnalyzer(NVRxAttribution):
         if path not in self.temporal_cache_dict:
             self.temporal_cache_dict[path] = {}
         state = self.job_inline_data_dict.get(path)
-        if not isinstance(state, _ProgressiveLogState):
+        if not isinstance(state, _ProgressiveLogState) or state.closed:
             state = _ProgressiveLogState(self._history_window())
             self.job_inline_data_dict[path] = state
+        state.poller_task = asyncio.current_task()
         file_offset = 0
         empty_logs_stop = self.stop_accumulating_count
 

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_server.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_server.py
@@ -233,10 +233,29 @@ class NVRxMCPServer:
         """Execute a single attribution module."""
         # Apply default values from input schema
         arguments_with_defaults = self.registry.apply_defaults(module_name, arguments)
+        tool_arguments = (
+            self._progressive_start_arguments(arguments_with_defaults)
+            if module_name == MODULE_LOG_ANALYZER_PROGRESSIVE_START
+            else arguments_with_defaults
+        )
 
         # Get or create module instance
         if module_name not in self.module_instances:
-            instance = self.registry.create_instance(module_name, arguments_with_defaults)
+            constructor_kwargs: Dict[str, Any] = {}
+            if module_name == MODULE_LOG_ANALYZER_PROGRESSIVE_START:
+                analyzer = self._get_or_create_log_analyzer(tool_arguments)
+                if analyzer is not None:
+                    constructor_kwargs["analyzer"] = analyzer
+            instance_args = (
+                self._log_analyzer_constructor_args(tool_arguments)
+                if module_name == LOG_ANALYZER_MODULE
+                else tool_arguments
+            )
+            instance = self.registry.create_instance(
+                module_name,
+                instance_args,
+                constructor_kwargs=constructor_kwargs,
+            )
             self.module_instances[module_name] = instance
         else:
             instance = self.module_instances[module_name]
@@ -244,14 +263,12 @@ class NVRxMCPServer:
         logger.info(
             "module=%s argument_keys=%s",
             module_name,
-            sorted(arguments_with_defaults.keys()),
+            sorted(tool_arguments.keys()),
         )
-        logger.debug(
-            "module=%s arguments=%s", module_name, bounded_log_value(arguments_with_defaults)
-        )
+        logger.debug("module=%s arguments=%s", module_name, bounded_log_value(tool_arguments))
 
         # Run the attribution with defaults applied
-        result = await instance.run(arguments_with_defaults)
+        result = await instance.run(tool_arguments)
 
         if module_name == MODULE_LOG_ANALYZER_PROGRESSIVE_START:
             response = dict(result) if isinstance(result, dict) else {"status": str(result)}
@@ -301,6 +318,29 @@ class NVRxMCPServer:
         self.registry.cache_result_by_id(module_name, result_id, response)
 
         return [TextContent(type="text", text=serialize_result(response))]
+
+    @staticmethod
+    def _log_analyzer_constructor_args(arguments: dict) -> dict:
+        """Drop NVRx orchestration-only request metadata before constructing LogSage."""
+        return {key: value for key, value in arguments.items() if key not in {"user", "job_id"}}
+
+    @staticmethod
+    def _progressive_start_arguments(arguments: dict) -> dict:
+        """Keep NVRx request/reporting metadata out of the MCP progressive tool."""
+        return {key: value for key, value in arguments.items() if key not in {"user", "job_id"}}
+
+    def _get_or_create_log_analyzer(self, arguments: dict) -> Optional[Any]:
+        """Return the shared LogSage analyzer instance for progressive and terminal MCP tools."""
+        if LOG_ANALYZER_MODULE in self.module_instances:
+            return self.module_instances[LOG_ANALYZER_MODULE]
+        if self.registry.get_module_metadata(LOG_ANALYZER_MODULE) is None:
+            return None
+        analyzer = self.registry.create_instance(
+            LOG_ANALYZER_MODULE,
+            self._log_analyzer_constructor_args(arguments),
+        )
+        self.module_instances[LOG_ANALYZER_MODULE] = analyzer
+        return analyzer
 
     async def run(self):
         """Run the MCP server."""

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
@@ -164,6 +164,13 @@ def _log_analyzer_input_schema() -> dict[str, Any]:
                 "default": False,
             },
             "cycle_counter": _cycle_counter_property(),
+            "chunks_per_time": {
+                "type": "number",
+                "description": (
+                    "Progressive log-analysis polling interval in minutes; omit to use analyzer default"
+                ),
+                "exclusiveMinimum": 0,
+            },
         },
         "required": ["log_path"],
     }
@@ -180,14 +187,12 @@ def _progressive_start_input_schema() -> dict[str, Any]:
                 "default": False,
             },
             "cycle_counter": _cycle_counter_property(),
-            "user": {
-                "type": "string",
-                "description": "Optional submitting user for observability",
-                "default": "unknown",
-            },
-            "job_id": {
-                "type": "string",
-                "description": "Optional scheduler job id for observability",
+            "chunks_per_time": {
+                "type": "number",
+                "description": (
+                    "Progressive log-analysis polling interval in minutes; omit to use analyzer default"
+                ),
+                "exclusiveMinimum": 0,
             },
             **_llm_runtime_properties(
                 model_description="LLM model to bind to the progressive session"

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/registry.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/registry.py
@@ -117,14 +117,20 @@ class AttributionModuleRegistry:
         """Get metadata for all registered modules."""
         return list(self._modules.values())
 
-    def create_instance(self, name: str, args: Any) -> MCPModule:
+    def create_instance(
+        self,
+        name: str,
+        args: Any,
+        *,
+        constructor_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> MCPModule:
         """Create an instance of a registered module."""
         metadata = self._modules.get(name)
         if not metadata:
             raise ValueError(f"Module '{name}' not registered")
 
         # Create instance
-        instance = metadata.module_class(args)
+        instance = metadata.module_class(args, **(constructor_kwargs or {}))
         self._instances[name] = instance
         return instance
 

--- a/src/nvidia_resiliency_ext/attribution/orchestration/config.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/config.py
@@ -65,6 +65,7 @@ class LogSageExecutionConfig:
     llm_temperature: float | None = None
     llm_top_p: float | None = None
     llm_max_tokens: int | None = None
+    progressive_chunks_per_time: float | None = None
 
     def llm_runtime_overrides(self) -> dict[str, Any]:
         """LLM kwargs for LogSage/MCP/runtime calls, omitting unset overrides."""
@@ -96,6 +97,10 @@ class LogSageExecutionConfig:
                 "llm_max_tokens": self.llm_max_tokens,
             }
         )
+
+    def logsage_constructor_overrides(self) -> dict[str, Any]:
+        """LogSage construction kwargs, omitting unset overrides."""
+        return drop_none_values({"chunks_per_time": self.progressive_chunks_per_time})
 
 
 def drop_none_values(values: dict[str, Any]) -> dict[str, Any]:

--- a/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
@@ -223,6 +223,7 @@ class LogSageRunner:
             "exclude_nvrx_logs": False,
             **self._per_cycle_log_kwargs(path),
             **self.config.llm_runtime_overrides(),
+            **self.config.logsage_constructor_overrides(),
         }
         analyzer = await self._get_lib_log_analyzer(run_kwargs)
         result = await self._run_lib_log_analyzer_serialized(analyzer, run_kwargs)
@@ -237,6 +238,7 @@ class LogSageRunner:
             "exclude_nvrx_logs": False,
             **self._per_cycle_log_kwargs(path),
             **self.config.llm_runtime_overrides(),
+            **self.config.logsage_constructor_overrides(),
         }
 
         async with self._log_analysis_lock:
@@ -272,14 +274,13 @@ class LogSageRunner:
         job_id: str | None = None,
     ) -> ProgressiveStartResult:
         self._ensure_mcp_ready()
+        _ = (user, job_id)
         run_kwargs: Dict[str, Any] = {
             "log_path": path,
             **self._per_cycle_log_kwargs(path),
-            "user": user,
             **self.config.llm_runtime_overrides(),
+            **self.config.logsage_constructor_overrides(),
         }
-        if job_id:
-            run_kwargs["job_id"] = job_id
 
         async with self._log_analysis_lock:
             response = await self._mcp_client.run_module_resilient(

--- a/src/nvidia_resiliency_ext/attribution/orchestration/progressive.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/progressive.py
@@ -4,15 +4,18 @@
 """Progressive log-analysis boundary for attribution orchestration.
 
 This module defines the NVRx-owned request shape for starting progressive log
-analysis. The concrete LogSage behavior is intentionally not implemented here
-yet; until that shared contract exists, the MCP/tool entry point reports
-``unsupported``.
+analysis. When the MCP server binds a LogSage analyzer, the tool schedules the
+poller in the background and returns status metadata immediately.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import asdict, dataclass
 from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
 
 ANALYSIS_INTENT_TRACK_ONLY = "track_only"
 ANALYSIS_INTENT_PROGRESSIVE = "progressive"
@@ -74,11 +77,11 @@ def progressive_start_result_from_mcp_response(
 
 
 class ProgressiveLogAnalysisStartTool:
-    """MCP tool stub for starting progressive log analysis.
+    """MCP tool for starting progressive log analysis.
 
-    This is deliberately a non-result-producing tool. It advertises the
-    NVRx-owned loganalysis boundary now, while the LogSage progressive API is
-    still being defined.
+    This is deliberately a non-result-producing tool. It starts LogSage
+    progressive polling when the MCP server binds a shared analyzer, then
+    returns status metadata without waiting for terminal attribution.
     """
 
     def __init__(
@@ -88,13 +91,14 @@ class ProgressiveLogAnalysisStartTool:
         analyzer: Any = None,
     ):
         self._analyzer = analyzer
+        self._tasks: dict[str, asyncio.Task[Any]] = {}
 
     async def run(self, _arguments: Mapping[str, Any]) -> dict[str, str | None] | None:
         """Run the progressive start phase.
 
         With no analyzer bound, returns the ``unsupported`` status payload.
-        With an analyzer bound, delegates to
-        ``NVRxLogAnalyzer.analyze_logs_rt_start``.
+        With an analyzer bound, schedules
+        ``NVRxLogAnalyzer.analyze_logs_rt_start`` and returns immediately.
         """
         if self._analyzer is None:
             payload = ProgressiveStartResult(
@@ -102,14 +106,47 @@ class ProgressiveLogAnalysisStartTool:
                 message="LogSage progressive start API is not configured",
             ).as_payload()
         else:
-            result = await self._analyzer.analyze_logs_rt_start()
-            if isinstance(result, Mapping):
-                payload = dict(result)
+            path = str(_arguments.get("log_path") or "")
+            if not path:
+                raise ValueError("log_path is required")
+
+            task = self._tasks.get(path)
+            if task is None or task.done():
+                task = asyncio.create_task(
+                    self._analyzer.analyze_logs_rt_start(dict(_arguments)),
+                    name=f"nvrx-progressive-log-analysis:{path}",
+                )
+                self._tasks[path] = task
+                task.add_done_callback(
+                    lambda done_task, task_path=path: self._handle_task_done(
+                        task_path,
+                        done_task,
+                    )
+                )
+                message = f"progressive analysis started for {path}"
             else:
-                payload = ProgressiveStartResult(
-                    status=PROGRESSIVE_STATUS_FAILED,
-                    message="progressive start returned no payload",
-                ).as_payload()
+                message = f"progressive analysis already running for {path}"
+
+            payload = ProgressiveStartResult(
+                status=PROGRESSIVE_STATUS_STARTED,
+                message=message,
+                handle=path,
+            ).as_payload()
 
         payload["module"] = MODULE_LOG_ANALYZER_PROGRESSIVE_START
         return payload
+
+    def _handle_task_done(self, path: str, task: asyncio.Task[Any]) -> None:
+        if self._tasks.get(path) is task:
+            self._tasks.pop(path, None)
+        if task.cancelled():
+            logger.debug("Progressive log analysis poller cancelled for %s", path)
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "Progressive log analysis poller failed for %s: %s",
+                path,
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )

--- a/src/nvidia_resiliency_ext/attribution/orchestration/types.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/types.py
@@ -161,6 +161,7 @@ class LogAnalyzerConfig:
     llm_temperature: Optional[float] = None
     llm_top_p: Optional[float] = None
     llm_max_tokens: Optional[int] = None
+    progressive_chunks_per_time: Optional[float] = None
     use_lib_log_analysis: bool = False
     #: How LogSage and NCCL flight-recorder analysis are combined; see
     #: :class:`~nvidia_resiliency_ext.attribution.orchestration.analysis_pipeline.AnalysisPipelineMode`.
@@ -183,6 +184,7 @@ class LogAnalyzerConfig:
             llm_temperature=self.llm_temperature,
             llm_top_p=self.llm_top_p,
             llm_max_tokens=self.llm_max_tokens,
+            progressive_chunks_per_time=self.progressive_chunks_per_time,
         )
 
 

--- a/src/nvidia_resiliency_ext/services/attrsvc/config.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/config.py
@@ -160,6 +160,12 @@ class Settings(BaseSettings):
     )
     LLM_TOP_P: float | None = Field(default=None, description="LLM top-p for nucleus sampling")
     LLM_MAX_TOKENS: int | None = Field(default=None, description="Max tokens for LLM response")
+    PROGRESSIVE_CHUNKS_PER_TIME: float | None = Field(
+        default=None,
+        description=(
+            "Progressive log-analysis polling interval in minutes; None keeps the analyzer default"
+        ),
+    )
 
     # Log + FR analysis backend: "lib" = in-process, "mcp" = subprocess MCP (same stdio client)
     ANALYSIS_BACKEND: str = Field(
@@ -284,10 +290,11 @@ class Settings(BaseSettings):
         "LLM_TEMPERATURE",
         "LLM_TOP_P",
         "LLM_MAX_TOKENS",
+        "PROGRESSIVE_CHUNKS_PER_TIME",
         mode="before",
     )
     @classmethod
-    def normalize_llm_override(cls, v: object) -> object:
+    def normalize_optional_override(cls, v: object) -> object:
         return _normalize_optional_override(v)
 
     @field_validator("LLM_TEMPERATURE")
@@ -309,6 +316,13 @@ class Settings(BaseSettings):
     def validate_llm_max_tokens(cls, v: int | None) -> int | None:
         if v is not None and v <= 0:
             raise ValueError(f"LLM_MAX_TOKENS must be positive, got {v}")
+        return v
+
+    @field_validator("PROGRESSIVE_CHUNKS_PER_TIME")
+    @classmethod
+    def validate_progressive_chunks_per_time(cls, v: float | None) -> float | None:
+        if v is not None and v <= 0:
+            raise ValueError(f"PROGRESSIVE_CHUNKS_PER_TIME must be positive, got {v}")
         return v
 
     @field_validator("ALLOWED_ROOT")

--- a/src/nvidia_resiliency_ext/services/attrsvc/service.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/service.py
@@ -63,6 +63,7 @@ def _controller_config_from_settings(cfg: Settings) -> AttributionControllerConf
             llm_temperature=cfg.LLM_TEMPERATURE,
             llm_top_p=cfg.LLM_TOP_P,
             llm_max_tokens=cfg.LLM_MAX_TOKENS,
+            progressive_chunks_per_time=cfg.PROGRESSIVE_CHUNKS_PER_TIME,
         ),
         cache=AttributionCacheConfig(
             compute_timeout=cfg.COMPUTE_TIMEOUT,

--- a/tests/attribution/unit/test_attrsvc_settings.py
+++ b/tests/attribution/unit/test_attrsvc_settings.py
@@ -10,11 +10,13 @@ Settings = attrsvc_config.Settings
 def test_attrsvc_llm_settings_are_override_only(tmp_path, monkeypatch):
     monkeypatch.delenv("NVRX_ATTRSVC_LLM_MODEL", raising=False)
     monkeypatch.delenv("NVRX_ATTRSVC_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("NVRX_ATTRSVC_PROGRESSIVE_CHUNKS_PER_TIME", raising=False)
 
     cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
 
     assert cfg.LLM_MODEL is None
     assert cfg.LLM_BASE_URL is None
+    assert cfg.PROGRESSIVE_CHUNKS_PER_TIME is None
 
 
 def test_attrsvc_llm_settings_accept_env_overrides(tmp_path, monkeypatch):
@@ -33,6 +35,7 @@ def test_attrsvc_llm_empty_env_values_are_unset(tmp_path, monkeypatch):
     monkeypatch.setenv("NVRX_ATTRSVC_LLM_TEMPERATURE", "")
     monkeypatch.setenv("NVRX_ATTRSVC_LLM_TOP_P", "")
     monkeypatch.setenv("NVRX_ATTRSVC_LLM_MAX_TOKENS", "")
+    monkeypatch.setenv("NVRX_ATTRSVC_PROGRESSIVE_CHUNKS_PER_TIME", "")
 
     cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
 
@@ -41,6 +44,22 @@ def test_attrsvc_llm_empty_env_values_are_unset(tmp_path, monkeypatch):
     assert cfg.LLM_TEMPERATURE is None
     assert cfg.LLM_TOP_P is None
     assert cfg.LLM_MAX_TOKENS is None
+    assert cfg.PROGRESSIVE_CHUNKS_PER_TIME is None
+
+
+def test_attrsvc_progressive_chunks_per_time_accepts_float_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("NVRX_ATTRSVC_PROGRESSIVE_CHUNKS_PER_TIME", "0.01")
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.PROGRESSIVE_CHUNKS_PER_TIME == 0.01
+
+
+def test_attrsvc_progressive_chunks_per_time_must_be_positive(tmp_path, monkeypatch):
+    monkeypatch.setenv("NVRX_ATTRSVC_PROGRESSIVE_CHUNKS_PER_TIME", "0")
+
+    with pytest.raises(ValueError, match="PROGRESSIVE_CHUNKS_PER_TIME must be positive"):
+        Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
 
 
 def test_attrsvc_analysis_backend_uses_current_env_name_only(tmp_path, monkeypatch):

--- a/tests/attribution/unit/test_mcp_server_cache.py
+++ b/tests/attribution/unit/test_mcp_server_cache.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 import sys
 import types
@@ -81,8 +82,10 @@ if PY310_PLUS:
         )
         from nvidia_resiliency_ext.attribution.orchestration.progressive import (
             MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            PROGRESSIVE_STATUS_STARTED,
             PROGRESSIVE_STATUS_UNSUPPORTED,
             ProgressiveLogAnalysisStartTool,
+            ProgressiveStartResult,
         )
         from nvidia_resiliency_ext.attribution.orchestration.types import (
             AttributionRecommendation,
@@ -101,8 +104,10 @@ if PY310_PLUS:
         )
         from nvidia_resiliency_ext.attribution.orchestration.progressive import (
             MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            PROGRESSIVE_STATUS_STARTED,
             PROGRESSIVE_STATUS_UNSUPPORTED,
             ProgressiveLogAnalysisStartTool,
+            ProgressiveStartResult,
         )
         from nvidia_resiliency_ext.attribution.orchestration.types import (
             AttributionRecommendation,
@@ -131,6 +136,27 @@ class FakeLogAnalyzer:
             ),
             AttributionState.STOP,
         )
+
+
+class SharedFakeLogAnalyzer(FakeLogAnalyzer):
+    instances = []
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.init_args = dict(args)
+        self.progressive_args = []
+        self.run_args = []
+        self.progressive_started = asyncio.Event()
+        self.__class__.instances.append(self)
+
+    async def analyze_logs_rt_start(self, args=None):
+        self.progressive_args.append(dict(args or {}))
+        self.progressive_started.set()
+        return ProgressiveStartResult(status=PROGRESSIVE_STATUS_STARTED).as_payload()
+
+    async def run(self, arguments):
+        self.run_args.append(dict(arguments))
+        return await super().run(arguments)
 
 
 class FakeFrAnalyzer:
@@ -195,6 +221,33 @@ class TestMCPServerCache(unittest.IsolatedAsyncioTestCase):
             module_class=ProgressiveLogAnalysisStartTool,
             description="progressive start",
             input_schema={"type": "object", "properties": {}, "required": []},
+            output_schema={"type": "object"},
+        )
+        return NVRxMCPServer(registry=registry)
+
+    def _server_with_shared_progressive_log_analyzer(self):
+        SharedFakeLogAnalyzer.instances = []
+        registry = AttributionModuleRegistry()
+        registry.register(
+            name="log_analyzer",
+            module_class=SharedFakeLogAnalyzer,
+            description="shared fake log analyzer",
+            input_schema={
+                "type": "object",
+                "properties": {"log_path": {"type": "string"}},
+                "required": ["log_path"],
+            },
+            output_schema={"type": "object"},
+        )
+        registry.register(
+            name=MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            module_class=ProgressiveLogAnalysisStartTool,
+            description="progressive start",
+            input_schema={
+                "type": "object",
+                "properties": {"log_path": {"type": "string"}},
+                "required": ["log_path"],
+            },
             output_schema={"type": "object"},
         )
         return NVRxMCPServer(registry=registry)
@@ -273,6 +326,48 @@ class TestMCPServerCache(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("recommendation", response)
         self.assertNotIn("result_id", response)
         self.assertEqual(server.registry.count_results_cache_entries(), 0)
+
+    async def test_progressive_start_reuses_terminal_log_analyzer_instance(self):
+        server = self._server_with_shared_progressive_log_analyzer()
+
+        # Direct MCP callers may still send obsolete orchestration metadata.
+        # Progressive start should ignore it rather than leaking it into LogSage.
+        content = await server._handle_module_execution(
+            MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            {
+                "log_path": "/tmp/job_cycle0.log",
+                "user": "alice",
+                "job_id": "123",
+            },
+        )
+        response = json.loads(content[0].text)
+        analyzer = server.module_instances["log_analyzer"]
+
+        if not analyzer.progressive_args:
+            await asyncio.wait_for(analyzer.progressive_started.wait(), timeout=0.5)
+
+        self.assertEqual(response["module"], MODULE_LOG_ANALYZER_PROGRESSIVE_START)
+        self.assertEqual(response["status"], PROGRESSIVE_STATUS_STARTED)
+        self.assertIs(
+            server.module_instances[MODULE_LOG_ANALYZER_PROGRESSIVE_START]._analyzer,
+            analyzer,
+        )
+        self.assertEqual(
+            analyzer.progressive_args,
+            [{"log_path": "/tmp/job_cycle0.log"}],
+        )
+        self.assertEqual(analyzer.init_args, {"log_path": "/tmp/job_cycle0.log"})
+
+        await server._handle_module_execution(
+            "log_analyzer",
+            {"log_path": "/tmp/job_cycle0.log"},
+        )
+
+        self.assertEqual(len(SharedFakeLogAnalyzer.instances), 1)
+        self.assertEqual(
+            analyzer.run_args,
+            [{"log_path": "/tmp/job_cycle0.log"}],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/attribution/unit/test_progressive_plumbing.py
+++ b/tests/attribution/unit/test_progressive_plumbing.py
@@ -16,6 +16,7 @@ from nvidia_resiliency_ext.attribution.orchestration.progressive import (
     ANALYSIS_INTENT_PROGRESSIVE,
     ANALYSIS_INTENT_TERMINAL,
     MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+    PROGRESSIVE_STATUS_STARTED,
     PROGRESSIVE_STATUS_UNSUPPORTED,
     ProgressiveLogAnalysisStartTool,
     ProgressiveStartResult,
@@ -350,6 +351,55 @@ def test_terminal_get_nonblocking_reports_in_flight_without_joining(monkeypatch,
     asyncio.run(run())
 
 
+def test_dev_progressive_submit_then_terminal_get_records_evidence(monkeypatch, tmp_path):
+    Analyzer = _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    log_analyzer = FakeLogAnalyzer()
+    analyzer = Analyzer(
+        allowed_root=str(tmp_path),
+        log_analyzer=log_analyzer,
+        progressive_analysis_enabled=True,
+    )
+    log_path = str(tmp_path / "train_cycle0.log")
+
+    async def run() -> dict[str, Any]:
+        log_analyzer.progressive_started = asyncio.Event()
+        log_analyzer.progressive_release = asyncio.Event()
+
+        post_result = await asyncio.wait_for(
+            analyzer.submit(
+                log_path,
+                user="dev",
+                analysis_intent=ANALYSIS_INTENT_PROGRESSIVE,
+            ),
+            timeout=0.5,
+        )
+        await asyncio.wait_for(log_analyzer.progressive_started.wait(), timeout=0.5)
+
+        terminal_result = await asyncio.wait_for(analyzer.analyze(log_path), timeout=0.5)
+        log_analyzer.progressive_release.set()
+        await asyncio.sleep(0)
+
+        return {
+            "post_submitted": post_result.submitted,
+            "post_mode": post_result.mode,
+            "progressive_starts": list(log_analyzer.progressive_starts),
+            "terminal_runs": list(log_analyzer.terminal_runs),
+            "terminal_status": terminal_result.status,
+            "recommendation_action": terminal_result.recommendation["action"],
+        }
+
+    evidence = asyncio.run(run())
+
+    assert evidence == {
+        "post_submitted": True,
+        "post_mode": JobMode.SINGLE.value,
+        "progressive_starts": [(log_path, "dev", None)],
+        "terminal_runs": [(log_path, "dev", None)],
+        "terminal_status": "completed",
+        "recommendation_action": "RESTART",
+    }
+
+
 def test_nonblocking_get_does_not_start_analysis_on_pending_result(monkeypatch, tmp_path):
     Analyzer = _import_analyzer_with_optional_dependency_stubs(monkeypatch)
     log_analyzer = FakeLogAnalyzer()
@@ -422,6 +472,100 @@ def test_progressive_start_tool_returns_unsupported_without_final_result():
     }
 
 
+def test_progressive_start_tool_schedules_analyzer_without_waiting():
+    calls: list[dict[str, Any]] = []
+
+    async def run() -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        class BlockingAnalyzer:
+            async def analyze_logs_rt_start(
+                self,
+                args: dict[str, Any] | None = None,
+            ) -> dict[str, str | None]:
+                calls.append(dict(args or {}))
+                started.set()
+                await release.wait()
+                return ProgressiveStartResult(status=PROGRESSIVE_STATUS_STARTED).as_payload()
+
+        tool = ProgressiveLogAnalysisStartTool({}, analyzer=BlockingAnalyzer())
+        result = await asyncio.wait_for(
+            tool.run({"log_path": "/tmp/train_cycle0.log", "is_per_cycle": True}),
+            timeout=0.1,
+        )
+
+        assert result == {
+            "module": MODULE_LOG_ANALYZER_PROGRESSIVE_START,
+            "status": PROGRESSIVE_STATUS_STARTED,
+            "message": "progressive analysis started for /tmp/train_cycle0.log",
+            "handle": "/tmp/train_cycle0.log",
+        }
+
+        await asyncio.wait_for(started.wait(), timeout=0.5)
+        task = next(iter(tool._tasks.values()))
+        release.set()
+        await asyncio.wait_for(task, timeout=0.5)
+        await asyncio.sleep(0)
+        assert tool._tasks == {}
+
+    asyncio.run(run())
+
+    assert calls == [{"log_path": "/tmp/train_cycle0.log", "is_per_cycle": True}]
+
+
+def test_progressive_start_replaces_closed_state(monkeypatch, tmp_path):
+    _import_analyzer_with_optional_dependency_stubs(monkeypatch)
+    nvrx_logsage = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage"
+    )
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    monkeypatch.setattr(nvrx_logsage, "ChatOpenAI", lambda **_kwargs: object())
+    monkeypatch.setattr(nvrx_logsage, "LRUCache", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        nvrx_logsage,
+        "return_application_errors_rt",
+        lambda *_args, **_kwargs: types.SimpleNamespace(
+            finished=nvrx_logsage.FINISHED_STATUS_APPLICATION_DONE,
+            checkpoint_saved=False,
+        ),
+    )
+
+    log_path = tmp_path / "train_cycle0.log"
+    log_path.write_text("cycle output\n", encoding="utf-8")
+    analyzer = nvrx_logsage.NVRxLogAnalyzer(
+        {
+            "log_path": str(log_path),
+            "chunks_per_time": 0,
+            "stop_accumulating_count": 1,
+        }
+    )
+    stale_state = nvrx_logsage._ProgressiveLogState(analyzer._history_window())
+    stale_state.request_close()
+    analyzer.job_inline_data_dict[str(log_path)] = stale_state
+
+    async def run() -> dict[str, str | None]:
+        return await analyzer.analyze_logs_rt_start({"log_path": str(log_path)})
+
+    result = asyncio.run(run())
+    fresh_state = analyzer.job_inline_data_dict[str(log_path)]
+    evidence = {
+        "stale_state_was_closed": stale_state.closed,
+        "result_status": result["status"],
+        "fresh_state_replaced_stale": fresh_state is not stale_state,
+        "fresh_state_poll_count": fresh_state.poll_count,
+        "fresh_state_closed": fresh_state.closed,
+    }
+
+    assert evidence == {
+        "stale_state_was_closed": True,
+        "result_status": PROGRESSIVE_STATUS_STARTED,
+        "fresh_state_replaced_stale": True,
+        "fresh_state_poll_count": 1,
+        "fresh_state_closed": False,
+    }
+
+
 def test_progressive_start_uses_mcp_loganalysis_tool(monkeypatch, tmp_path):
     _import_analyzer_with_optional_dependency_stubs(monkeypatch)
     module = importlib.import_module("nvidia_resiliency_ext.attribution.orchestration.log_analyzer")
@@ -434,7 +578,9 @@ def test_progressive_start_uses_mcp_loganalysis_tool(monkeypatch, tmp_path):
         }
     )
     monkeypatch.setattr(module, "create_mcp_client", lambda **_kwargs: fake_client)
-    runner = module.LogSageRunner(LogSageExecutionConfig(use_lib_log_analysis=False))
+    runner = module.LogSageRunner(
+        LogSageExecutionConfig(use_lib_log_analysis=False, progressive_chunks_per_time=0.01)
+    )
 
     async def run() -> ProgressiveStartResult:
         return await runner.start_progressive_analysis(
@@ -457,8 +603,7 @@ def test_progressive_start_uses_mcp_loganalysis_tool(monkeypatch, tmp_path):
                 "log_path": str(tmp_path / "train_cycle3.log"),
                 "is_per_cycle": True,
                 "cycle_counter": 3,
-                "user": "alice",
-                "job_id": "123",
+                "chunks_per_time": 0.01,
             },
         )
     ]
@@ -475,7 +620,9 @@ def test_terminal_log_analyzer_mcp_uses_cycle_counter(monkeypatch, tmp_path):
         }
     )
     monkeypatch.setattr(module, "create_mcp_client", lambda **_kwargs: fake_client)
-    runner = module.LogSageRunner(LogSageExecutionConfig(use_lib_log_analysis=False))
+    runner = module.LogSageRunner(
+        LogSageExecutionConfig(use_lib_log_analysis=False, progressive_chunks_per_time=0.01)
+    )
 
     async def run() -> dict[str, Any]:
         return await runner.fetch_log_result(str(tmp_path / "train_CYCLE4.log"))
@@ -492,6 +639,7 @@ def test_terminal_log_analyzer_mcp_uses_cycle_counter(monkeypatch, tmp_path):
                 "exclude_nvrx_logs": False,
                 "is_per_cycle": True,
                 "cycle_counter": 4,
+                "chunks_per_time": 0.01,
             },
         )
     ]


### PR DESCRIPTION
## Summary

- Bind `log_analyzer_progressive_start` to the same cached `NVRxLogAnalyzer` instance used by terminal `log_analyzer` runs.
- Start progressive LogSage polling as a background task and return `started` immediately.
- Replace stale closed progressive state before a new progressive cycle on the same path.
- Remove NVRx-only `user` / `job_id` metadata from LogSage construction and keep per-request observability metadata in NVRx orchestration.
- Add optional attrsvc startup config `NVRX_ATTRSVC_PROGRESSIVE_CHUNKS_PER_TIME` so dev/e2e runs can shorten progressive polling without changing production defaults.

## Root Cause

The MCP registry constructed `ProgressiveLogAnalysisStartTool` with only request args, so it never received an analyzer and always returned `unsupported`.

Even if progressive start had created its own analyzer, terminal attribution would still use a different cached `log_analyzer` object, so the progressive `job_inline_data_dict` state would not be visible to the terminal read.

A second progressive start on the same path after terminal attribution could also reuse a closed state and report `started` while doing no polling.

## Validation

- `PYTHONPATH=src /private/tmp/nvrx6405833-py312/bin/python -m pytest tests/attribution/unit/test_attrsvc_settings.py tests/attribution/unit/test_progressive_plumbing.py tests/attribution/unit/test_mcp_server_cache.py` -> 31 passed
- `/private/tmp/nvrx6405833-py312/bin/black --check .` -> passed