### PR TITLE
Bind launcher-managed attribution service to 127.0.0.1

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -232,7 +232,7 @@ class AttributionManager:
             raise
 
         logger.info(
-            "Managed attribution service is ready: PID=%s endpoint=http://localhost:%s",
+            "Managed attribution service is ready: PID=%s endpoint=http://127.0.0.1:%s",
             self.process.pid if self.process else None,
             DEFAULT_ATTRIBUTION_PORT,
         )
@@ -341,7 +341,7 @@ def is_managed_attribution_endpoint(endpoint: str) -> bool:
 
 
 def _managed_attribution_client_endpoint() -> str:
-    return f"http://localhost:{DEFAULT_ATTRIBUTION_PORT}"
+    return f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}"
 
 
 def _attribution_command() -> list[str]:

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -93,7 +93,7 @@ def test_managed_attribution_config_derives_applog_dir_and_log_file(tmp_path):
     )
 
     assert cfg.endpoint == "localhost"
-    assert cfg.client_endpoint.endpoint == f"http://localhost:{DEFAULT_ATTRIBUTION_PORT}"
+    assert cfg.client_endpoint.endpoint == f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}"
     assert cfg.applog_dir == str(tmp_path / "logs")
     assert cfg.log_file == str(tmp_path / "logs" / "train_attribution.log")
     assert cfg.client_endpoint.decision_timeout is None
@@ -194,7 +194,7 @@ def test_attribution_config_maps_launcher_args(tmp_path):
 
     env = AttributionManager(cfg, is_store_host=True)._child_env(str(api_key_file))
     assert env["LLM_API_KEY_FILE"] == str(api_key_file)
-    assert env["NVRX_ATTRSVC_ENDPOINT"] == f"http://localhost:{DEFAULT_ATTRIBUTION_PORT}"
+    assert env["NVRX_ATTRSVC_ENDPOINT"] == f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}"
     assert env["NVRX_ATTRSVC_ALLOWED_ROOT"] == str(applog_dir)
     assert env["NVRX_ATTRSVC_LLM_BASE_URL"] == "https://llm.example/v1"
     assert env["NVRX_ATTRSVC_LLM_MODEL"] == "model-a"
@@ -366,7 +366,7 @@ def test_child_env_overrides_inherited_attrsvc_endpoint(tmp_path, monkeypatch):
 
     env = AttributionManager(cfg, is_store_host=True)._child_env(str(api_key_file))
 
-    assert env["NVRX_ATTRSVC_ENDPOINT"] == f"http://localhost:{DEFAULT_ATTRIBUTION_PORT}"
+    assert env["NVRX_ATTRSVC_ENDPOINT"] == f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}"
 
 
 def test_child_env_preserves_existing_pythonpath(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

With launcher-managed attribution (`--ft-attribution-endpoint localhost`), ft_launcher spawns `nvrx-attrsvc` with `NVRX_ATTRSVC_ENDPOINT=http://localhost:50050`. uvicorn/asyncio's `create_server(host="localhost")` resolves every address `localhost` maps to and requires all of them to bind. On hosts whose `/etc/hosts` maps `::1` to `localhost` (Debian/Ubuntu convention) while IPv6 is administratively disabled via sysctl, `bind(::1)` fails:

```
INFO:     Application startup complete.
ERROR:    [Errno 99] error while attempting to bind on address ('::1', 50050, 0, 0): cannot assign requested address
```

The service exits during startup and the launcher exits within seconds — the whole training job is killed at startup, deterministically. Managed mode validates the endpoint to be the literal `localhost`, so no CLI/env workaround exists today.

Minimal reproducer (same bind path, any host matching the conditions above):

```python
import asyncio
loop = asyncio.new_event_loop()
loop.run_until_complete(loop.create_server(asyncio.Protocol, "localhost", 50050))
# OSError: [Errno 99] error while attempting to bind on address ('::1', 50050, 0, 0)
```

## Fix

`_managed_attribution_client_endpoint()` now returns `http://127.0.0.1:50050` instead of `http://localhost:50050`. This feeds both the spawned service's bind address (`NVRX_ATTRSVC_ENDPOINT`) and the launcher-side client endpoint. The launcher's readiness probe already polls `http://127.0.0.1:50050/healthz`, so this aligns the bind address with the probe — the set of working environments strictly grows. Managed mode is same-host loopback by design, so semantics are unchanged; external (non-managed) endpoints are unaffected.

## Testing

- `tests/fault_tolerance/unit/test_attribution_manager.py` — 42/42 pass (assertions updated to lock the new endpoint).
- A/B validation on two clusters: on an affected B200 cluster (sysctl-disabled IPv6 + Ubuntu-style hosts file) the managed attrsvc previously died at startup with Errno 99 and now serves the full E2E attribution decision flow; on an unaffected H100 cluster the same E2E case passes before and after the change (no regression).
