### PR TITLE
Move attribution log submission to rendezvous control host

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -67,6 +67,20 @@ WriteBucket = Tuple[str, str, Tuple[list, list]]  # represents writes to a singl
 _results_queue = None
 
 
+def _wrap_exception_for_gather(exc: BaseException) -> WRAPPED_EXCEPTION:
+    wrapped_exception = _wrap_exception(exc)
+    _, stack_summary = wrapped_exception
+
+    # Python 3.13+ traceback FrameSummary may hold a code object in _code.
+    # Code objects are not pickleable, but dist.gather_object pickles the
+    # wrapped exception before sending it to the coordinator.
+    for frame in stack_summary:
+        if hasattr(frame, "_code"):
+            object.__setattr__(frame, "_code", None)
+
+    return wrapped_exception
+
+
 class ConsistentDataIdentifier:
     """Identifier for consistent data structure stored in worker cache.
 
@@ -1186,7 +1200,7 @@ class FileSystemWriterAsync(FileSystemWriter):
             try:
                 write_results_or_exc = self.results_queue.get_nowait()
             except queue.Empty:
-                return _wrap_exception(RuntimeError('results_queue should not be empty'))
+                return _wrap_exception_for_gather(RuntimeError('results_queue should not be empty'))
 
         if isinstance(write_results_or_exc, Exception):
             # Worker failed — its data cache may have been lost (e.g. after a restart).
@@ -1200,10 +1214,10 @@ class FileSystemWriterAsync(FileSystemWriter):
                     f'Worker failure: {write_results_or_exc}'
                 ) from write_results_or_exc
             except Exception as e:
-                return _wrap_exception(e)
+                return _wrap_exception_for_gather(e)
         write_results: dict = write_results_or_exc
         if self.has_data_to_write and len(write_results) == 0:
-            return _wrap_exception(
+            return _wrap_exception_for_gather(
                 RuntimeError(
                     'Worker returned empty results despite having data to write.'
                     ' This probably indicates a worker failure.'

--- a/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
@@ -43,10 +43,7 @@ from nvidia_resiliency_ext.fault_tolerance.cli_args import (
     str_to_bool,
 )
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
-from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import (
-    CycleInfoReporter,
-    cycle_log_file,
-)
+from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import CycleInfoReporter
 from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import (
     _NodeDescGenerator,
     _RendezvousBarrierState,
@@ -234,6 +231,7 @@ def _run_control_rendezvous_loop(
         join_timeout_seconds=join_timeout,
         last_call_timeout_seconds=last_call_timeout,
         segment=segment,
+        cycle_log_prefix=args.ft_per_cycle_applog_prefix,
     )
     node = _NodeDescGenerator().generate(args.local_addr)
 
@@ -248,8 +246,6 @@ def _run_control_rendezvous_loop(
     state._attribution_service = services.attribution_service
 
     while not stop_event.is_set():
-        if services.attribution_service is not None:
-            services.attribution_service.request_terminal_analysis()
         try:
             closed_round = state.close_current_round_as_host(
                 node,
@@ -260,13 +256,11 @@ def _run_control_rendezvous_loop(
             )
         except (RendezvousGracefulExitError, RendezvousClosedError) as exc:
             logger.info("nvrx-control rendezvous loop exiting: %s", exc)
-            return
+            break
 
         logger.info("nvrx-control closed rendezvous round %s", closed_round)
-        if services.attribution_service is not None and args.ft_per_cycle_applog_prefix:
-            services.attribution_service._submit_log(
-                cycle_log_file(args.ft_per_cycle_applog_prefix, closed_round)
-            )
+
+    state._request_terminal_attribution_for_submitted_cycle()
 
 
 def run(args: argparse.Namespace) -> None:

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -67,7 +67,7 @@ from ..shared_utils.profiling import (
     record_profiling_event,
     set_profiling_cycle,
 )
-from .cycle_info_writer import CycleInfoReporter, CycleInfoRoundSnapshot
+from .cycle_info_writer import CycleInfoReporter, CycleInfoRoundSnapshot, cycle_log_file
 from .data import WorkloadAction
 from .ipc_connector import IpcConnector
 from .launcher import FT_LAUNCHER_IPC_SOCKET, UnhealthyNodeException, get_node_health_check
@@ -582,6 +582,8 @@ class _RendezvousBarrierState:
         stale_check_interval: How often (in seconds) to check for stale rounds.
             Default is 10 seconds. Lower values increase store load but reduce
             detection latency. Higher values reduce store load but increase latency.
+        cycle_log_prefix: Base per-cycle application log path used by the
+            rendezvous host to submit cycle logs for attribution.
 
     This design trades some synchronization guarantees for better fault tolerance
     and operational flexibility in production environments.
@@ -597,6 +599,7 @@ class _RendezvousBarrierState:
         segment: Optional[int] = None,
         replacement_group_size: Optional[int] = None,
         stale_check_interval: float = 10.0,
+        cycle_log_prefix: Optional[str] = None,
     ):
         self.store = store
         self.run_id = run_id
@@ -620,6 +623,7 @@ class _RendezvousBarrierState:
         # Group ranks of active nodes, parallel to _active_node_addrs (same slot order)
         self._active_ranks: Optional[List[int]] = None
         self._cycle_info_reporter: Optional[CycleInfoReporter] = None
+        self._cycle_log_prefix = cycle_log_prefix
 
         # Reference to agent (set via set_agent() method in handler)
         # Will be set by handler via set_agent() method
@@ -634,7 +638,9 @@ class _RendezvousBarrierState:
         # Permanent shutdown reason: empty means open; non-empty means no further rounds.
         self.shutdown_key = f"{self.prefix}:shutdown"
         self._attribution_service: Optional[AttributionService] = None
-        self._attribution_settled_for_round: int = -1
+        self._attribution_gate_settled_round: int = -1
+        self._attribution_cycle_log_submitted: Optional[int] = None
+        self._attribution_terminal_requested_cycle: Optional[int] = None
         # Job-level unhealthy counter; persists across all rounds.
         self.unhealthy_count_key = f"{self.prefix}:unhealthy_count"
         # Latest closed round's active membership. This is host-local by design:
@@ -1377,7 +1383,19 @@ class _RendezvousBarrierState:
         if self._attribution_service is None or self._round == 0:
             return True
 
-        if self._attribution_settled_for_round == self._round:
+        if self._attribution_gate_settled_round == self._round:
+            return True
+
+        expected_submitted_round = self._round - 1
+        if self._attribution_cycle_log_submitted != expected_submitted_round:
+            log.warning(
+                "Attribution gate for round %s has no submitted log for cycle %s "
+                "(last submitted cycle: %s); failing open without polling a stale log",
+                self._round,
+                expected_submitted_round,
+                self._attribution_cycle_log_submitted,
+            )
+            self._attribution_gate_settled_round = self._round
             return True
 
         result = self._attribution_service.get_last_result(node_id=node_desc)
@@ -1394,7 +1412,7 @@ class _RendezvousBarrierState:
             self.set_shutdown(RDZV_SHUTDOWN_REASON_FAILURE)
             raise RendezvousGracefulExitError(msg)
 
-        self._attribution_settled_for_round = self._round
+        self._attribution_gate_settled_round = self._round
         return True
 
     def _host_close_round(
@@ -1425,6 +1443,8 @@ class _RendezvousBarrierState:
         mismatch_first_seen: Optional[float] = None
         close_gate = self._make_previous_active_last_call_gate(min_nodes, max_nodes)
         last_call_logged_deadline: Optional[float] = None
+        if self._round > 0:
+            self._request_terminal_attribution_for_round(self._round - 1)
 
         while True:
             if stop_event is not None and stop_event.is_set():
@@ -1628,9 +1648,53 @@ class _RendezvousBarrierState:
                 active_candidate_participants=complete_replacement_group_participants,
                 standby_only_participants=incomplete_replacement_group_participants,
             )
-            self._report_cycle_start_as_host(self._round)
+            closed_round = self._round
+            self._report_cycle_start_as_host(closed_round)
             self.store.set(self.round_done_key, "1".encode('utf-8'))
+            # Do not hold the rendezvous release on attribution I/O. The submit helper
+            # records the cycle before issuing the bounded attrsvc POST.
+            self._submit_attribution_log_for_round(closed_round)
             return
+
+    def _submit_attribution_log_for_round(self, round_id: int) -> None:
+        """Submit the just-started cycle log from the rendezvous control host."""
+        if self._attribution_service is None:
+            return
+        if not self._cycle_log_prefix:
+            log.warning(
+                "Attribution is enabled but no cycle log prefix is configured; "
+                "skipping attribution submit for cycle %s",
+                round_id,
+            )
+            return
+
+        log_path = cycle_log_file(self._cycle_log_prefix, round_id)
+        self._attribution_cycle_log_submitted = round_id
+        self._attribution_service._submit_log(log_path)
+
+    def _request_terminal_attribution_for_submitted_cycle(self) -> None:
+        """Request terminal analysis for the last cycle submitted by this control host."""
+        if self._attribution_cycle_log_submitted is None:
+            return
+        self._request_terminal_attribution_for_round(self._attribution_cycle_log_submitted)
+
+    def _request_terminal_attribution_for_round(self, round_id: int) -> None:
+        """Request terminal analysis for a previously submitted cycle log."""
+        if self._attribution_service is None:
+            return
+        if self._attribution_terminal_requested_cycle == round_id:
+            return
+        if self._attribution_cycle_log_submitted != round_id:
+            log.warning(
+                "Attribution terminal request for cycle %s skipped: no submitted log "
+                "(last submitted cycle: %s)",
+                round_id,
+                self._attribution_cycle_log_submitted,
+            )
+            return
+
+        self._attribution_service.request_terminal_analysis()
+        self._attribution_terminal_requested_cycle = round_id
 
     def _report_cycle_start_as_host(self, round_id: int) -> None:
         """Report cycle start from the rendezvous-host rank assignment snapshot."""
@@ -2388,6 +2452,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             settings.segment,
             settings.replacement_group_size,
             stale_check_interval=10.0,  # Check for stale rounds every 10 seconds
+            cycle_log_prefix=cycle_log_prefix,
         )
         self._cycle_info_reporter: Optional[CycleInfoReporter] = None
         if is_store_host and cycle_info_dir:

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -590,7 +590,6 @@ class LocalElasticAgent(SimpleElasticAgent):
             True if restart was initiated (caller should continue monitoring loop)
             False if no restart (caller should stop workers and return failure)
         """
-        self._request_terminal_attribution()
         self._progress_tracker.analyze_previous_cycle()
         should_terminate_early = self._progress_tracker.should_terminate_early()
 
@@ -915,10 +914,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         """Ask attrsvc to start final analysis for the last submitted cycle log."""
         if not self._is_store_host:
             return
-        attribution_service = getattr(self._rdzv_handler, "_attribution_service", None)
-        if attribution_service is None:
-            return
-        attribution_service.request_terminal_analysis()
+        self._rdzv_handler._barrier_state._request_terminal_attribution_for_submitted_cycle()
 
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.
@@ -1002,7 +998,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         # Get the current cycle number from the rendezvous handler
         # At this point, rendezvous has completed and we're about to start workers.
         # The cycle number is used for profiling and environment variable setting.
-        current_cycle = restart_count = self._get_global_cycle_number()
+        restart_count = self._get_global_cycle_number()
 
         # Send current cycle number to rank monitors for logging
         self._send_cycle_to_rank_monitors(restart_count)
@@ -1034,15 +1030,6 @@ class LocalElasticAgent(SimpleElasticAgent):
             f"[group_rank={worker_group.group_rank}] with "
             f"MASTER_ADDR={master_addr}, MASTER_PORT={master_port}"
         )
-
-        # Submit current cycle's log to attribution service (master node only, before workers start)
-        if (
-            self._is_store_host
-            and self._rdzv_handler._attribution_service is not None
-            and hasattr(self._logs_specs, 'get_cycle_log_file')
-        ):
-            cycle_log_file = self._logs_specs.get_cycle_log_file(current_cycle)
-            self._rdzv_handler._attribution_service._submit_log(cycle_log_file)
 
         current_cycle_info_path = self._current_cycle_info_path()
 
@@ -1697,8 +1684,7 @@ def launch_agent(
         # permanent-close signaling; it cannot keep the store alive after process exit.
         if is_store_host:
             # Trigger attribution service analysis for final cycle
-            if agent._rdzv_handler._attribution_service is not None:
-                agent._rdzv_handler._attribution_service()
+            agent._request_terminal_attribution()
 
             _shutdown_cycle_info_reporter_safely(agent._rdzv_handler)
 

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -1823,7 +1823,7 @@ class AttributionService:
         """
         Request terminal analysis for the previously submitted log.
 
-        Note: _submit_log() should be called first (from launcher) to set _last_submitted.
+        Note: _submit_log() should be called first (from the control host) to set _last_submitted.
         """
         self.request_terminal_analysis()
 

--- a/tests/checkpointing/unit/test_async_writer.py
+++ b/tests/checkpointing/unit/test_async_writer.py
@@ -31,6 +31,7 @@ from torch.distributed.checkpoint import (
 )
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
+from nvidia_resiliency_ext.checkpointing.async_ckpt import filesystem_async
 from nvidia_resiliency_ext.checkpointing.async_ckpt.core import (
     AsyncCallsQueue,
     AsyncRequest,
@@ -47,6 +48,11 @@ from tests.checkpointing.unit import TempNamedDir
 from tests.checkpointing.unit.test_utilities import Model, Utils
 
 
+class _FrameWithCode:
+    def __init__(self):
+        self._code = (lambda: None).__code__
+
+
 def mock_open(
     self,
     path: str,
@@ -54,6 +60,18 @@ def mock_open(
 ) -> IO[Any]:
     """Function matching the system open() signature that always raises an error."""
     raise OSError('worker critical failure during open()')
+
+
+def test_wrap_exception_for_gather_sanitizes_code_objects(monkeypatch):
+    def fake_wrap_exception(exc):
+        return exc, [_FrameWithCode()]
+
+    monkeypatch.setattr(filesystem_async, "_wrap_exception", fake_wrap_exception)
+
+    wrapped_exception = filesystem_async._wrap_exception_for_gather(RuntimeError("test"))
+
+    assert wrapped_exception[1][0]._code is None
+    pickle.dumps(wrapped_exception)
 
 
 class TestAsyncSave:

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -286,7 +286,8 @@ class BarrierStateBasicTest(BaseRendezvousTest):
         state._round = 1
         state._attribution_service = MagicMock()
         state._attribution_service.get_last_result.return_value = True
-        state._attribution_settled_for_round = -1
+        state._attribution_gate_settled_round = -1
+        state._attribution_cycle_log_submitted = 0
         state.set_shutdown = MagicMock()
 
         with self.assertRaises(RendezvousGracefulExitError):
@@ -296,6 +297,19 @@ class BarrierStateBasicTest(BaseRendezvousTest):
         state.set_shutdown.assert_called_once_with(
             ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_FAILURE
         )
+
+    def test_attribution_gate_does_not_poll_stale_submitted_log(self):
+        """A missing previous-cycle submit fails open without polling an older log."""
+        state = object.__new__(_RendezvousBarrierState)
+        state._round = 2
+        state._attribution_service = MagicMock()
+        state._attribution_gate_settled_round = -1
+        state._attribution_cycle_log_submitted = 0
+
+        self.assertTrue(state._attribution_gate("node-a"))
+
+        state._attribution_service.get_last_result.assert_not_called()
+        self.assertEqual(state._attribution_gate_settled_round, 2)
 
     def test_join_increments_join_count(self):
         """Test that joining increments join_count atomically."""
@@ -909,6 +923,7 @@ class Step2CompletionTest(BaseRendezvousTest):
         state._get_unhealthy_count = MagicMock(return_value=0)
         state._attribution_service = MagicMock()
         state._attribution_service.get_last_result.side_effect = [None, False]
+        state._attribution_cycle_log_submitted = 0
         state.get_all_participants = MagicMock(wraps=state.get_all_participants)
 
         participants = [
@@ -926,6 +941,7 @@ class Step2CompletionTest(BaseRendezvousTest):
         )
 
         self.assertEqual(state._attribution_service.get_last_result.call_count, 2)
+        state._attribution_service.request_terminal_analysis.assert_called_once_with()
         self.assertEqual(state._get_unhealthy_count.call_count, 2)
         state.get_all_participants.assert_called_once()
         self.assertEqual(self.store.get(state.round_done_key).decode("utf-8"), "1")
@@ -1470,6 +1486,61 @@ class GroupRankAssignmentTest(TestCase):
         self.assertEqual(snapshot.active_node_addrs, ["node_a", "node_b"])
         self.assertEqual(snapshot.standby_node_addrs, [])
         self.assertEqual(snapshot.active_ranks, [0, 1])
+
+    def test_control_host_submits_attribution_log_when_round_closes(self):
+        """The control host submits the just-started cycle log at round close."""
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+            cycle_log_prefix="/tmp/train.log",
+        )
+        state._attribution_service = MagicMock()
+
+        def assert_submitted_cycle_recorded(_log_path):
+            self.assertEqual(state._attribution_cycle_log_submitted, 0)
+
+        state._attribution_service._submit_log.side_effect = assert_submitted_cycle_recorded
+
+        join_count_key = state.join_count_key
+        prefix = state.prefix
+        train_0 = _NodeDesc("node_a", 100, 0)
+        train_1 = _NodeDesc("node_b", 101, 0)
+
+        self.store.add(join_count_key, 1)
+        self.store.add(join_count_key, 1)
+        self.store.set(
+            f"{prefix}:slot_1",
+            state._pack_participant_value(train_0, 0, "none", 0),
+        )
+        self.store.set(
+            f"{prefix}:slot_2",
+            state._pack_participant_value(train_1, 1, "none", 0),
+        )
+
+        closed_round = state.close_current_round_as_host(
+            _NodeDesc("control", 10, 0),
+            min_nodes=2,
+            max_nodes=2,
+            segment_check_interval=_test_segment_check_interval(),
+        )
+
+        self.assertEqual(closed_round, 0)
+        state._attribution_service._submit_log.assert_called_once_with("/tmp/train_cycle0.log")
+        self.assertEqual(state._attribution_cycle_log_submitted, 0)
+
+    def test_terminal_attribution_requests_last_submitted_cycle(self):
+        """Final-cycle terminal analysis targets the last cycle this control host submitted."""
+        state = object.__new__(_RendezvousBarrierState)
+        state._attribution_service = MagicMock()
+        state._attribution_cycle_log_submitted = 2
+        state._attribution_terminal_requested_cycle = None
+
+        state._request_terminal_attribution_for_submitted_cycle()
+
+        state._attribution_service.request_terminal_analysis.assert_called_once_with()
+        self.assertEqual(state._attribution_terminal_requested_cycle, 2)
 
     def test_open_rendezvous_reports_cycle_end_when_round_created(self):
         """Opening the next round closes the store-host's current cycle."""

--- a/tests/fault_tolerance/unit/test_control_plane.py
+++ b/tests/fault_tolerance/unit/test_control_plane.py
@@ -198,7 +198,7 @@ def test_control_parser_uses_launcher_config_file_alias(tmp_path):
     assert args.ft_cfg_path == str(cfg_path)
 
 
-def test_control_rendezvous_loop_submits_attribution_and_reports_cycle_info(tmp_path):
+def test_control_rendezvous_loop_wires_attribution_to_barrier_state(tmp_path):
     args = SimpleNamespace(
         nnodes="2",
         rdzv_conf="",
@@ -221,9 +221,12 @@ def test_control_rendezvous_loop_submits_attribution_and_reports_cycle_info(tmp_
             states.append(self)
             self._rounds = iter([0, 1])
             self._cycle_info_reporter = None
+            self._attribution_service = None
+            self._cycle_log_prefix = kwargs.get("cycle_log_prefix")
             self._active_node_addrs = ["node-a", "node-b"]
             self._standby_node_addrs = ["node-c"]
             self._active_ranks = [0, 1]
+            self.final_terminal_requested = False
 
         def close_current_round_as_host(self, *args, **kwargs):
             try:
@@ -240,6 +243,9 @@ def test_control_rendezvous_loop_submits_attribution_and_reports_cycle_info(tmp_
                 )
             )
             return round_id
+
+        def _request_terminal_attribution_for_submitted_cycle(self):
+            self.final_terminal_requested = True
 
     node_generator = MagicMock()
     node_generator.generate.return_value = object()
@@ -262,5 +268,7 @@ def test_control_rendezvous_loop_submits_attribution_and_reports_cycle_info(tmp_
     ]
     assert reported_rounds == [0, 1]
     assert states[0]._cycle_info_reporter is services.cycle_info_reporter
-    attribution_service._submit_log.assert_any_call(str(tmp_path / "train_cycle0.log"))
-    attribution_service._submit_log.assert_any_call(str(tmp_path / "train_cycle1.log"))
+    assert states[0]._attribution_service is attribution_service
+    assert states[0]._cycle_log_prefix == str(tmp_path / "train.log")
+    assert states[0].final_terminal_requested
+    attribution_service._submit_log.assert_not_called()

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -588,7 +588,7 @@ class TestHandleRestartDecision(unittest.TestCase):
             )
 
         self.assertFalse(result)
-        agent._rdzv_handler._attribution_service.request_terminal_analysis.assert_called_once_with()
+        agent._rdzv_handler._attribution_service.request_terminal_analysis.assert_not_called()
         mock_restart.assert_not_called()
         mock_open.assert_not_called()
 
@@ -612,17 +612,14 @@ class TestHandleRestartDecision(unittest.TestCase):
         mock_restart.assert_called_once()
         mock_open.assert_not_called()
 
-    def test_handle_restart_decision_requests_terminal_attribution_before_restart(self):
-        """Starts terminal attribution before local restart decisions and keeps moving."""
+    def test_handle_restart_decision_leaves_terminal_attribution_to_rendezvous_close(self):
+        """Terminal attribution is owned by the rendezvous control-host close path."""
         agent = self._make_agent()
         agent._is_store_host = True
         agent._progress_tracker = MagicMock()
         agent._remaining_restarts = 2
         agent._rdzv_handler._attribution_service = MagicMock()
         calls = []
-        agent._rdzv_handler._attribution_service.request_terminal_analysis.side_effect = (
-            lambda: calls.append("terminal")
-        )
         agent._progress_tracker.analyze_previous_cycle.side_effect = lambda: calls.append("analyze")
         agent._progress_tracker.should_terminate_early.side_effect = (
             lambda: calls.append("progress-check") or False
@@ -636,11 +633,12 @@ class TestHandleRestartDecision(unittest.TestCase):
             )
 
         self.assertTrue(result)
-        self.assertEqual(calls, ["terminal", "analyze", "progress-check", "restart"])
+        self.assertEqual(calls, ["analyze", "progress-check", "restart"])
+        agent._rdzv_handler._attribution_service.request_terminal_analysis.assert_not_called()
         agent._rdzv_handler._attribution_service.get_last_result.assert_not_called()
 
     def test_handle_restart_decision_no_restarts_left(self):
-        """Returns False when _remaining_restarts is 0 after requesting terminal attribution."""
+        """Returns False when _remaining_restarts is 0."""
         agent = self._make_agent()
         agent._is_store_host = True
         agent._progress_tracker = MagicMock()
@@ -654,8 +652,21 @@ class TestHandleRestartDecision(unittest.TestCase):
             )
 
         self.assertFalse(result)
-        agent._rdzv_handler._attribution_service.request_terminal_analysis.assert_called_once_with()
+        agent._rdzv_handler._attribution_service.request_terminal_analysis.assert_not_called()
         mock_restart.assert_not_called()
+
+    def test_request_terminal_attribution_uses_barrier_state_helper(self):
+        """Final-cycle terminal requests share the barrier attribution helper."""
+        agent = self._make_agent()
+        agent._is_store_host = True
+        agent._rdzv_handler._barrier_state = MagicMock()
+
+        agent._request_terminal_attribution()
+
+        helper = (
+            agent._rdzv_handler._barrier_state._request_terminal_attribution_for_submitted_cycle
+        )
+        helper.assert_called_once_with()
 
     def test_handle_restart_decision_open_rendezvous_called_when_requested(self):
         """Calls _open_rendezvous_for_restart() when open_rendezvous=True."""
@@ -729,7 +740,8 @@ def test_rendezvous_host_sets_failure_shutdown_when_attribution_says_stop():
     state._round = 1
     state._attribution_service = MagicMock()
     state._attribution_service.get_last_result.return_value = True
-    state._attribution_settled_for_round = -1
+    state._attribution_gate_settled_round = -1
+    state._attribution_cycle_log_submitted = 0
     state.set_shutdown = MagicMock()
 
     with pytest.raises(RendezvousGracefulExitError):
@@ -746,13 +758,14 @@ def test_rendezvous_host_retries_close_round_when_attribution_pending():
     state._round = 1
     state._attribution_service = MagicMock()
     state._attribution_service.get_last_result.return_value = None
-    state._attribution_settled_for_round = -1
+    state._attribution_gate_settled_round = -1
+    state._attribution_cycle_log_submitted = 0
 
     should_close = state._attribution_gate("node-a")
 
     assert should_close is False
     state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
-    assert state._attribution_settled_for_round == -1
+    assert state._attribution_gate_settled_round == -1
 
 
 def test_rendezvous_host_skips_attribution_gate_for_initial_round():
@@ -761,7 +774,8 @@ def test_rendezvous_host_skips_attribution_gate_for_initial_round():
     state = object.__new__(_RendezvousBarrierState)
     state._round = 0
     state._attribution_service = MagicMock()
-    state._attribution_settled_for_round = -1
+    state._attribution_gate_settled_round = -1
+    state._attribution_cycle_log_submitted = None
 
     assert state._attribution_gate("node-a") is True
     state._attribution_service.get_last_result.assert_not_called()
@@ -774,12 +788,13 @@ def test_rendezvous_host_closes_round_when_attribution_allows_restart():
     state._round = 1
     state._attribution_service = MagicMock()
     state._attribution_service.get_last_result.return_value = False
-    state._attribution_settled_for_round = -1
+    state._attribution_gate_settled_round = -1
+    state._attribution_cycle_log_submitted = 0
 
     should_close = state._attribution_gate("node-a")
 
     assert should_close is True
-    assert state._attribution_settled_for_round == 1
+    assert state._attribution_gate_settled_round == 1
     state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
 
 


### PR DESCRIPTION
Submit per-cycle attribution logs from the rendezvous round-close path instead of the store-host launcher worker-start path. This makes cycle log submission independent of whether the colocated store-host launcher is active or standby for the round.

Track the submitted cycle and terminal-requested cycle in the barrier state so the attribution gate only polls results for the expected previous cycle, and fails open with a warning instead of polling a stale log.