### PR TITLE
Fix flaky caplog assertions on the 'nvrx' logger

### DIFF
--- a/tests/fault_tolerance/unit/conftest.py
+++ b/tests/fault_tolerance/unit/conftest.py
@@ -14,6 +14,34 @@ shutdown, so pytest can hang after the session. On successful sessions we call
 import logging
 import os
 
+import pytest
+
+
+@pytest.fixture
+def capture_nvrx_logs(caplog):
+    """Capture 'nvrx' logger records via caplog, independent of log propagation.
+
+    The shared LogConfig handler sets the 'nvrx' logger ``propagate = False``
+    (log_manager.py) once NVRx logging is initialized (by any earlier test), so its
+    records otherwise never reach caplog's root handler — making log-content
+    assertions order-dependent (pass in isolation, fail in the full/sharded suite).
+
+    Attach caplog's handler directly to the 'nvrx' logger so capture works no matter
+    what ``propagate`` is, and pin ``propagate = False`` for the duration so the
+    record is captured exactly once (never also via the root handler).
+    """
+    from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
+
+    nvrx_logger = logging.getLogger(LogConfig.name)
+    prev_propagate = nvrx_logger.propagate
+    nvrx_logger.addHandler(caplog.handler)
+    nvrx_logger.propagate = False
+    try:
+        yield
+    finally:
+        nvrx_logger.removeHandler(caplog.handler)
+        nvrx_logger.propagate = prev_propagate
+
 
 def pytest_configure():
     logging.basicConfig(

--- a/tests/fault_tolerance/unit/test_cycle_info_writer.py
+++ b/tests/fault_tolerance/unit/test_cycle_info_writer.py
@@ -239,7 +239,9 @@ def test_cycle_info_reporter_defaults_missing_restart_count_to_zero(tmp_dir):
     assert call_kw["attempt_index"] == 0
 
 
-def test_cycle_info_reporter_invalid_restart_count_falls_back_to_zero(tmp_dir, caplog):
+def test_cycle_info_reporter_invalid_restart_count_falls_back_to_zero(
+    tmp_dir, caplog, capture_nvrx_logs
+):
     writer = MagicMock()
     reporter = CycleInfoReporter(tmp_dir, writer=writer)
 

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -1259,7 +1259,7 @@ def _make_launch_agent_config(**overrides):
     return SimpleNamespace(**values)
 
 
-def test_shutdown_cycle_info_reporter_safely_logs_reporter_exception(caplog):
+def test_shutdown_cycle_info_reporter_safely_logs_reporter_exception(caplog, capture_nvrx_logs):
     from types import SimpleNamespace
 
     from nvidia_resiliency_ext.fault_tolerance import launcher


### PR DESCRIPTION
## What

Fixes an order-dependent (flaky) unit-test failure, e.g. `test_cycle_info_reporter_invalid_restart_count_falls_back_to_zero`, which fails in the full/sharded suite but passes in isolation.

## Why

The `nvrx` logger gets `propagate = False` from `LogConfig.setup_logger()` (`log_manager.py`) the first time NVRx logging is initialized. After that, `caplog`'s root handler never receives its records, so any test asserting on `nvrx` log output sees an empty `caplog.text` — but only once some earlier test has triggered `setup_logger()`. Hence: passes alone, fails in the suite / under sharding, and behaves differently across pytest versions (8.1.1 respects `propagate=False`; 9.1.1 captures regardless).

## How

Add a shared `capture_nvrx_logs` fixture in `tests/fault_tolerance/unit/conftest.py` that:
- attaches `caplog.handler` directly to the `nvrx` logger, so capture works no matter what `propagate` is, and
- pins `propagate = False` for the test so the record is captured exactly once (never also via root), restoring both on teardown.

Applied to the two fragile tests that assert on the `nvrx` logger:
- `test_cycle_info_writer.py::test_cycle_info_reporter_invalid_restart_count_falls_back_to_zero`
- `test_launcher.py::test_shutdown_cycle_info_reporter_safely_logs_reporter_exception`

Other caplog tests capture `getLogger(__name__)` / `"LogAggregationServer"` loggers (which propagate) and are unaffected.

## Verification

- Reproduced the capture mechanism in isolation on **pytest 8.1.1** (the CI version) and **9.1.1**: message captured exactly once, whether or not `setup_logger()` had run; `caplog.handler` is stable across setup/call phases on both.
- `py_compile` clean on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)