### PR TITLE
Merge origin/main into stable

### DIFF
--- a/docs/source/attribution/features/progressive-ft-launcher-attribution.rst
+++ b/docs/source/attribution/features/progressive-ft-launcher-attribution.rst
@@ -4,12 +4,18 @@ Progressive FT Launcher Attribution
 Summary
 -------
 
-Progressive FT launcher attribution reduces restart-decision latency by starting
-log analysis when a fault-tolerance cycle starts, while the workload is still
-running. When the cycle ends and ``ft_launcher`` asks attrsvc for a stop/restart
-decision, attrsvc should reuse the analysis work already completed for the same
-per-cycle application log and only perform the final missing work needed to
-return an authoritative decision.
+Progressive FT launcher attribution reduces the time to an authoritative
+stop/restart verdict by starting log analysis when a fault-tolerance cycle
+starts, while the workload is still running. When the cycle ends and
+``ft_launcher`` asks attrsvc for a stop/restart decision, attrsvc should reuse
+the analysis work already completed for the same per-cycle application log and
+only perform the final missing work needed to return an authoritative decision.
+
+Note that ``ft_launcher`` no longer blocks on that verdict. The rendezvous host
+requests terminal analysis and restarts the workload immediately; a background
+poller consumes the verdict and terminates the job if it is STOP, possibly
+several cycles later. Progressive analysis therefore shortens the window in which
+a doomed job keeps burning nodes, rather than shortening a restart stall.
 
 The feature is aimed at the ``ft_launcher`` integration path. The cluster-wide
 service path may expose progressive behavior for validation, but it is not a
@@ -26,13 +32,13 @@ LogSage calls over the file flow. Until the LogSage contract is available,
 Problem
 -------
 
-Today, ``ft_launcher`` submits a per-cycle log path near cycle start with
-``POST /logs`` and later requests attribution with ``GET /logs`` after the
-workload has stopped. The ``POST`` path records/tracks the log, but the
-``GET`` path triggers the full LogSage attribution pipeline. For large
-application logs this makes ``ft_launcher`` wait for parsing and LLM analysis
-after the workload has already died, increasing the time before the launcher can
-act on a stop/restart decision.
+``ft_launcher`` submits a per-cycle log path near cycle start with
+``POST /logs`` and later requests attribution with ``GET /logs`` once the cycle
+has ended. The ``POST`` path records/tracks the log, but the ``GET`` path
+triggers the full LogSage attribution pipeline. For large application logs, all
+of that parsing and LLM analysis begins only after the workload has already died,
+so a job that attribution would have stopped keeps restarting and consuming nodes
+until the verdict lands.
 
 The per-cycle log path is already a stable correlation key. Both calls refer to
 the same path produced by the cycle log naming convention, for example
@@ -72,11 +78,16 @@ User Flows
 2. Attrsvc recognizes the submission as an ``ft_launcher`` progressive-analysis
    request and starts non-blocking pre-analysis for the growing file.
 3. The workload runs and continues writing to the same log file.
-4. At cycle end, ``ft_launcher`` sends ``GET /logs`` for the same path.
-5. Attrsvc uses the progressive state to complete the normal stop/end analysis
+4. At cycle end, ``ft_launcher`` sends ``POST /logs`` with terminal intent and
+   restarts the workload without waiting.
+5. A background poller in the launcher sends ``GET /logs`` for the same path
+   until attrsvc returns a completed result.
+6. Attrsvc uses the progressive state to complete the normal stop/end analysis
    and returns the normal attribution payload with a normalized recommendation.
-6. If progressive state is missing or unusable, attrsvc computes the result with
+   If progressive state is missing or unusable, attrsvc computes the result with
    the existing terminal pipeline.
+7. A STOP recommendation terminates the job at that point, whichever cycle is
+   running by then. Anything else lets the job continue.
 
 Service mode
 ~~~~~~~~~~~~

--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -230,8 +230,8 @@ service dependencies.
   - ``--ft-attribution-llm-base-url <URL>`` (alias: ``--ft_attribution_llm_base_url``)
   - ``--ft-attribution-llm-model <MODEL>`` (alias: ``--ft_attribution_llm_model``)
   - ``--ft-attribution-analysis-backend mcp`` (alias: ``--ft_attribution_analysis_backend``)
+  - ``--ft-attribution-stop-action {log,no-restart}`` (alias: ``--ft_attribution_stop_action``), default ``log``
   - ``--ft-attribution-startup-timeout <SECONDS>`` (alias: ``--ft_attribution_startup_timeout``), default ``20``
-  - ``--ft-attribution-decision-timeout <SECONDS>`` (alias: ``--ft_attribution_decision_timeout``), default ``60``
   - ``--ft-attribution-export-url <URL>`` (alias: ``--ft_attribution_export_url``)
 
   The managed attribution app-log directory is derived from
@@ -250,9 +250,42 @@ service dependencies.
   left unset, which uses the service default, or set explicitly to ``mcp``. The in-process ``lib``
   backend is available only when running ``nvrx-attrsvc`` as a standalone service.
 
-  ``--ft-attribution-decision-timeout`` is the total launcher-side budget for one
-  attribution decision, measured from the terminal analysis request until the rendezvous
-  host fetches the STOP/RESTART recommendation.
+  Attribution never delays a restart. When a cycle ends, the rendezvous host requests
+  terminal analysis and immediately closes the next round, so the workload restarts while
+  analysis is still running. A background poller on the rendezvous host fetches the verdict
+  and, if attribution recommends stopping, terminates the job at that point -- even if the
+  workload has already advanced one or more cycles past the analyzed one. A verdict that
+  never arrives leaves the job running.
+
+  The stop decision is global, not per-cycle: the first STOP verdict observed ends the job
+  regardless of which cycle produced it.
+
+  Only one terminal analysis is in flight at a time. If further cycles fail while a verdict
+  is still outstanding, their terminal analysis is skipped rather than replacing the one
+  already running. This keeps a fast crash loop from repeatedly discarding an analysis
+  before it can finish, which would otherwise leave the job with no verdict at all.
+
+  **Acting on a STOP verdict is opt-in.** With the default
+  ``--ft-attribution-stop-action log``, attribution runs in full and every verdict is
+  polled, logged and recorded, but a STOP never terminates anything. Set
+  ``--ft-attribution-stop-action no-restart`` to make a STOP end the job.
+
+  The default is deliberate. Attribution verdicts come from an LLM, and the two kinds of
+  mistake are not equally expensive. A missed STOP is bounded: the job crash-loops until
+  ``--max-restarts`` runs out, and the progress tracker independently catches the stuck
+  case. An enforced false STOP is not bounded: the job ends with the no-restart exit code
+  and stays down until a human resubmits it. Run in ``log`` mode first, review the recorded
+  verdicts against what actually happened on your workloads, and enable ``no-restart``
+  once you trust the precision.
+
+  In ``log`` mode every failed cycle is analyzed, not just the first one that produces a
+  STOP, so the verdicts accumulate over the life of the job. Each unenforced STOP is logged
+  at ``ERROR``, says explicitly that it is not being enforced, and carries a running count
+  of how many STOP verdicts have been seen so far. Comparing that count against the number
+  of failed cycles is the measurement that tells you whether to enable ``no-restart``.
+
+  When enforcement is on, every launcher in the job exits with the no-restart exit code
+  rather than the generic failure code ``1``. See :ref:`ft-no-restart` below.
 
   ``ft_launcher`` sends job metadata with each attribution submission: ``user`` is read from
   ``SLURM_JOB_USER`` or ``USER``, and ``job_id`` is read from ``SLURM_ARRAY_JOB_ID`` or
@@ -280,6 +313,54 @@ service dependencies.
        --ft-per-cycle-applog-prefix /lustre/job123/train.log \
        --ft-attribution-endpoint http://attribution.service.internal:8000 \
        train.py
+
+.. _ft-no-restart:
+
+No restart: telling "do not requeue" apart from a failure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Two mechanisms let NVRx conclude that a job must not be restarted at all:
+
+* an attribution ``STOP`` verdict, when ``--ft-attribution-stop-action no-restart`` is
+  set (see the attribution section above; the default ``log`` never terminates), and
+* the progress tracker finding no progress across restarts
+  (``--ft-max-no-progress-cycles`` / ``max_no_progress_cycles``, default ``3``).
+
+The progress tracker reads the iteration from ``--ft-checkpoint-iteration-file``; without
+that file it stays inactive and logs a one-time warning. Raise the cycle threshold, or set
+it to ``0`` to disable tracking, for workloads that deliberately replay an iteration
+without advancing the checkpoint -- for example Megatron-LM's rerun state machine
+re-running a suspect result on different hardware to tell silent data corruption apart from
+a genuine data issue. Those replays look identical to a stuck job from the outside.
+
+Both answer the same scheduler-facing question, so both report the same result: every
+launcher in the job exits with ``--ft-no-restart-exit-code`` (default ``93``) instead of
+the generic failure code ``1``. Downstream tooling therefore needs a single rule -- exit
+code ``93`` means NVRx decided, do not requeue -- rather than one rule per cause.
+
+The specific cause is recorded in the rendezvous store shutdown key as ``attribution_stop``
+or ``no_progress``, and is named in the launcher logs, so the two remain distinguishable
+for diagnosis without complicating the scheduler contract.
+
+Running out of restarts is deliberately *not* one of these cases. Exhausting
+``--max-restarts`` means this launcher used up its retry budget, not that the job is
+unrecoverable, so it still exits ``1`` and leaves requeueing to your scheduler policy.
+The distinction is scope: a no-restart decision is a verdict about the job, while the
+restart budget is a limit on a single allocation.
+
+* CLI:
+
+  - ``--ft-no-restart-exit-code <CODE>`` (alias: ``--ft_no_restart_exit_code``),
+    default ``93``
+
+Note that SLURM reports the maximum exit code across tasks and that ``sacct`` derived exit
+codes are lossy, so treat this as a best-effort signal.
+
+Nodes other than the one that made the decision read the reason from the rendezvous store,
+so the store must outlive them. Both the store-host launcher and ``nvrx-control`` hold it
+open for a few seconds after shutting down, but a node that has not read the key by then
+exits ``1`` rather than the no-restart code. The job still stops either way.
+
 
 GPU Memory Reclaim
 ^^^^^^^^^^^^^^^^^^

--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -33,6 +33,13 @@ _EXTERNAL_ATTRIBUTION_SCHEMES = {"http", "grpc"}
 _ATTRSVC_EXPORT_URL_ENV = "NVRX_ATTRSVC_EXPORT_URL"
 _ATTRIBUTION_EXPORT_URL_CONFIG = "--ft-attribution-export-url / attribution_export_url"
 _EXPORT_URL_SCHEMES = {"http", "https"}
+# Acting on an attribution STOP is opt-in. "log" observes and records verdicts without
+# terminating anything, so a site can measure its own false-positive rate before enabling
+# "no-restart", which ends the job with the no-restart exit code.
+ATTRIBUTION_STOP_ACTION_LOG = "log"
+ATTRIBUTION_STOP_ACTION_NO_RESTART = "no-restart"
+ATTRIBUTION_STOP_ACTIONS = (ATTRIBUTION_STOP_ACTION_LOG, ATTRIBUTION_STOP_ACTION_NO_RESTART)
+DEFAULT_ATTRIBUTION_STOP_ACTION = ATTRIBUTION_STOP_ACTION_LOG
 
 
 @dataclass(frozen=True)
@@ -40,7 +47,7 @@ class AttributionEndpoint:
     """Endpoint used by the in-launcher attribution client."""
 
     endpoint: str
-    decision_timeout: Optional[float]
+    enforce_stop: bool = False
 
 
 @dataclass(frozen=True)
@@ -55,7 +62,7 @@ class AttributionConfig:
     llm_base_url: Optional[str] = None
     llm_model: Optional[str] = None
     analysis_backend: Optional[str] = None
-    decision_timeout: Optional[float] = None
+    stop_action: str = DEFAULT_ATTRIBUTION_STOP_ACTION
     log_level: Optional[str] = None
     export_url: Optional[str] = None
 
@@ -78,6 +85,10 @@ class AttributionConfig:
         return is_managed_attribution_endpoint(self.endpoint)
 
     @property
+    def enforce_stop(self) -> bool:
+        return self.stop_action == ATTRIBUTION_STOP_ACTION_NO_RESTART
+
+    @property
     def client_endpoint(self) -> AttributionEndpoint:
         if not self.is_enabled:
             raise ValueError("attribution endpoint requested while attribution service is disabled")
@@ -85,12 +96,9 @@ class AttributionConfig:
         if self.is_managed:
             return AttributionEndpoint(
                 endpoint=_managed_attribution_client_endpoint(),
-                decision_timeout=self.decision_timeout,
+                enforce_stop=self.enforce_stop,
             )
-        return AttributionEndpoint(
-            endpoint=self.endpoint,
-            decision_timeout=self.decision_timeout,
-        )
+        return AttributionEndpoint(endpoint=self.endpoint, enforce_stop=self.enforce_stop)
 
     @classmethod
     def from_args(
@@ -124,7 +132,7 @@ class AttributionConfig:
         if startup_timeout <= 0:
             raise ValueError("--ft-attribution-startup-timeout must be positive")
 
-        decision_timeout = _resolve_decision_timeout(args, ft_cfg)
+        stop_action = _resolve_stop_action(args, ft_cfg)
 
         if endpoint is None:
             return cls(
@@ -136,7 +144,7 @@ class AttributionConfig:
                 llm_base_url=getattr(args, "ft_attribution_llm_base_url", None),
                 llm_model=getattr(args, "ft_attribution_llm_model", None),
                 analysis_backend=getattr(args, "ft_attribution_analysis_backend", None),
-                decision_timeout=decision_timeout,
+                stop_action=stop_action,
                 log_level=getattr(args, "ft_attribution_log_level", None),
                 export_url=None,
             )
@@ -165,7 +173,7 @@ class AttributionConfig:
             llm_base_url=getattr(args, "ft_attribution_llm_base_url", None),
             llm_model=getattr(args, "ft_attribution_llm_model", None),
             analysis_backend=getattr(args, "ft_attribution_analysis_backend", None),
-            decision_timeout=decision_timeout,
+            stop_action=stop_action,
             log_level=getattr(args, "ft_attribution_log_level", None),
             export_url=export_url,
         )
@@ -201,16 +209,11 @@ class AttributionManager:
 
         logger.info(
             "Starting managed attribution service on localhost:%s "
-            "(applog_dir=%s, log_file=%s, startup_timeout=%.1fs, decision_timeout=%s)",
+            "(applog_dir=%s, log_file=%s, startup_timeout=%.1fs)",
             DEFAULT_ATTRIBUTION_PORT,
             self.cfg.applog_dir,
             self.cfg.log_file,
             self.cfg.startup_timeout,
-            (
-                f"{self.cfg.decision_timeout:.1f}s"
-                if self.cfg.decision_timeout is not None
-                else "default"
-            ),
         )
 
         log_fd = open(self.cfg.log_file, "w")
@@ -396,6 +399,21 @@ def _validate_attribution_endpoint(endpoint: str) -> None:
     _validate_attribution_endpoint_host(parsed.hostname)
 
 
+def _resolve_stop_action(args: Any, ft_cfg: FaultToleranceConfig) -> str:
+    value = getattr(args, "ft_attribution_stop_action", None)
+    if value is None:
+        value = getattr(ft_cfg, "attribution_stop_action", None)
+    if value is None:
+        return DEFAULT_ATTRIBUTION_STOP_ACTION
+    normalized = str(value).strip().lower()
+    if normalized not in ATTRIBUTION_STOP_ACTIONS:
+        raise ValueError(
+            f"--ft-attribution-stop-action must be one of {list(ATTRIBUTION_STOP_ACTIONS)}, "
+            f"got {value!r}"
+        )
+    return normalized
+
+
 def _resolve_export_url(args: Any, ft_cfg: FaultToleranceConfig) -> Optional[str]:
     value = getattr(args, "ft_attribution_export_url", None)
     if value is None:
@@ -407,18 +425,6 @@ def _resolve_export_url(args: Any, ft_cfg: FaultToleranceConfig) -> Optional[str
     if not value:
         return None
     _validate_export_url(value)
-    return value
-
-
-def _resolve_decision_timeout(args: Any, ft_cfg: FaultToleranceConfig) -> Optional[float]:
-    value = getattr(args, "ft_attribution_decision_timeout", None)
-    if value is None:
-        value = getattr(ft_cfg, "attribution_decision_timeout", None)
-    if value is None:
-        return None
-    value = float(value)
-    if value <= 0:
-        raise ValueError("--ft-attribution-decision-timeout must be positive")
     return value
 
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -9,9 +9,11 @@ import argparse
 from typing import Any, Callable, Optional, Sequence
 
 from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
+    ATTRIBUTION_STOP_ACTIONS,
     DEFAULT_ATTRIBUTION_STARTUP_TIMEOUT,
+    DEFAULT_ATTRIBUTION_STOP_ACTION,
 )
-from nvidia_resiliency_ext.shared_utils.health_check import AttributionService
+from nvidia_resiliency_ext.fault_tolerance.utils import DEFAULT_NO_RESTART_EXIT_CODE
 
 
 def str_to_bool(value: Any) -> bool:
@@ -138,6 +140,24 @@ def _add_ft_segment_arg(parser: argparse.ArgumentParser) -> None:
         "Domains with fewer than N nodes are excluded. From valid domains, complete segments are selected. "
         "min_nodes must be divisible by segment. "
         "Note: segment=None (default) is suitable for H100; segment=1 is similar but requires ClusterUUID.",
+    )
+
+
+def add_no_restart_args(parser: argparse.ArgumentParser) -> None:
+    """Register the exit code used when NVRx decides the job must not be restarted."""
+    parser.add_argument(
+        "--ft-no-restart-exit-code",
+        "--ft_no_restart_exit_code",
+        type=int,
+        default=None,
+        dest="ft_no_restart_exit_code",
+        help=(
+            "Process exit code reported by every launcher when NVRx decides the job must "
+            "not be restarted, either because attribution recommended stopping or because "
+            "the progress tracker saw no progress across restarts. Lets downstream tooling "
+            "tell 'do not requeue' apart from an ordinary failure. "
+            f"Default: {DEFAULT_NO_RESTART_EXIT_CODE}."
+        ),
     )
 
 
@@ -398,15 +418,18 @@ def _add_attribution_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
-        "--ft-attribution-decision-timeout",
-        "--ft_attribution_decision_timeout",
-        type=float,
+        "--ft-attribution-stop-action",
+        "--ft_attribution_stop_action",
+        type=str.lower,
         default=None,
-        dest="ft_attribution_decision_timeout",
+        dest="ft_attribution_stop_action",
+        choices=ATTRIBUTION_STOP_ACTIONS,
         help=(
-            "Total launcher-side attribution decision budget in seconds, measured from "
-            "terminal analysis request to rendezvous result fetch. "
-            f"Default: {AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS}."
+            "What to do when attribution recommends stopping the job. "
+            "'log' records the verdict without terminating anything, so a deployment can "
+            "measure how often attribution is right before trusting it. 'no-restart' ends "
+            "the job with the no-restart exit code and no requeue. "
+            f"Default: {DEFAULT_ATTRIBUTION_STOP_ACTION}."
         ),
     )
     parser.add_argument(
@@ -452,6 +475,7 @@ def add_cycle_info_args(parser: argparse.ArgumentParser) -> None:
 
 def add_control_services_args(parser: argparse.ArgumentParser) -> None:
     add_attribution_args(parser)
+    add_no_restart_args(parser)
     add_cycle_info_args(parser)
     parser.add_argument(
         "--ft-cycle-info-job-id",

--- a/src/nvidia_resiliency_ext/fault_tolerance/config.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/config.py
@@ -97,8 +97,8 @@ class FaultToleranceConfig:
       Default: 5. Can be overridden by workload (e.g., Megatron-LM via init_workload_monitoring).
     * Attribution service (optional, disabled unless `attribution_endpoint` is set):
       - `attribution_endpoint` [str] endpoint of the attribution service
-      - `attribution_decision_timeout` [float] launcher-side attribution decision
-        budget in seconds, measured from terminal analysis request to result fetch.
+      - `attribution_stop_action` [str] what to do with a STOP verdict: `log` (default,
+        record it without terminating) or `no-restart` (end the job, no requeue).
       - `attribution_export_url` [str] complete export posting URL for
         launcher-managed attribution service postprocessing.
 
@@ -138,7 +138,7 @@ class FaultToleranceConfig:
     check_remaining_processes: bool = False
     # Progress tracking configuration (controlled by max_no_progress_cycles)
     max_no_progress_cycles: int = (
-        2  # Max consecutive cycles (incl. cycle 0) without progress before early terminate
+        3  # Max consecutive cycles (incl. cycle 0) without progress before early terminate
     )
     min_progress_iterations: int = (
         1  # Min iteration increase to count as progress (default: any increase)
@@ -150,7 +150,7 @@ class FaultToleranceConfig:
     )
     # Attribution service configuration (optional)
     attribution_endpoint: Optional[str] = None
-    attribution_decision_timeout: Optional[float] = None
+    attribution_stop_action: Optional[str] = None
     attribution_export_url: Optional[str] = None
 
     # NVRx cycle info: base directory for cycle_info JSON files

--- a/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
@@ -16,6 +16,7 @@ import os
 import signal
 import sys
 import threading
+import time
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, Optional
@@ -177,8 +178,9 @@ def _start_control_services(
             if attribution_endpoint is not None:
                 services.attribution_service = AttributionService(
                     endpoint=attribution_endpoint.endpoint,
-                    decision_timeout=getattr(attribution_endpoint, "decision_timeout", None),
+                    enforce_stop=attribution_endpoint.enforce_stop,
                 )
+                services.attribution_service.start_poller()
 
         if args.ft_enable_log_server:
             assert log_funnel_ports is not None
@@ -197,6 +199,9 @@ def _start_control_services(
                     services.grpc_processes,
                     float(args.ft_log_server_graceful_shutdown_timeout),
                 )
+        with contextlib.suppress(Exception):
+            if services.attribution_service is not None:
+                services.attribution_service.stop_poller()
         with contextlib.suppress(Exception):
             if services.attribution_manager is not None:
                 services.attribution_manager.stop()
@@ -263,6 +268,29 @@ def _run_control_rendezvous_loop(
     state._request_terminal_attribution_for_submitted_cycle()
 
 
+# Peers read the recorded shutdown reason from the TCPStore to decide their exit code,
+# and this process owns that store: it dies when nvrx-control exits. Leaving too fast
+# downgrades a no-restart stop to a generic failure exit on nodes that had not read it
+# yet. The embedded launcher holds the same window open in launch_agent().
+_STORE_READ_GRACE_SECONDS = 3.0
+
+
+def _wait_for_store_read_grace(since: float) -> None:
+    """Keep the TCPStore alive until _STORE_READ_GRACE_SECONDS after the loop ended.
+
+    Teardown of the other owned services already consumes part of that window, so only
+    the remainder is waited out and a slow teardown costs nothing extra.
+    """
+    remaining = _STORE_READ_GRACE_SECONDS - (time.monotonic() - since)
+    if remaining <= 0:
+        return
+    logger.info(
+        "nvrx-control waiting %.1fs before exit so other nodes can read final " "TCPStore state",
+        remaining,
+    )
+    time.sleep(remaining)
+
+
 def run(args: argparse.Namespace) -> None:
     setup_logger(node_local_tmp_prefix="nvrxcontrol")
     ft_cfg = FaultToleranceConfig.from_args(args)
@@ -286,6 +314,7 @@ def run(args: argparse.Namespace) -> None:
         services = _start_control_services(args, ft_cfg)
         _run_control_rendezvous_loop(args, ft_cfg, store, services, stop_event)
     finally:
+        rendezvous_loop_ended = time.monotonic()
         with contextlib.suppress(Exception):
             if services.cycle_info_reporter is not None:
                 services.cycle_info_reporter.shutdown()
@@ -296,8 +325,17 @@ def run(args: argparse.Namespace) -> None:
                     float(args.ft_log_server_graceful_shutdown_timeout),
                 )
         with contextlib.suppress(Exception):
+            # Stop polling before the service being polled goes away, otherwise the
+            # daemon keeps issuing requests at attrsvc through its shutdown and logs
+            # connection failures. The embedded launcher does this from
+            # FtRendezvousBarrierHandler._close(); nvrx-control owns the client itself.
+            if services.attribution_service is not None:
+                services.attribution_service.stop_poller()
+        with contextlib.suppress(Exception):
             if services.attribution_manager is not None:
                 services.attribution_manager.stop()
+        with contextlib.suppress(Exception):
+            _wait_for_store_read_grace(rendezvous_loop_ended)
         for sig, handler in previous_handlers.items():
             signal.signal(sig, handler)
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -76,12 +76,19 @@ from .launcher import FT_LAUNCHER_IPC_SOCKET, UnhealthyNodeException, get_node_h
 if os.environ.get("NVRX_INJECT_GPU_FAILURE"):
     from ..testing_utils import health_check_injector
 
-from .utils import get_infrastructure_rank, is_slurm_job_array, parse_bool_env, slurm_sort_addrs
+from .utils import (  # noqa: F401  (shutdown reasons are re-exported for existing importers)
+    RDZV_NO_RESTART_REASONS,
+    RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP,
+    RDZV_SHUTDOWN_REASON_FAILURE,
+    RDZV_SHUTDOWN_REASON_GRACEFUL,
+    RDZV_SHUTDOWN_REASON_NO_PROGRESS,
+    get_infrastructure_rank,
+    is_slurm_job_array,
+    parse_bool_env,
+    slurm_sort_addrs,
+)
 
 log = logging.getLogger(LogConfig.name)
-
-RDZV_SHUTDOWN_REASON_GRACEFUL = "graceful"
-RDZV_SHUTDOWN_REASON_FAILURE = "failure"
 
 
 def _rdzv_signal_exception_handler(sig: int, frame: Optional[FrameType]) -> None:
@@ -638,7 +645,6 @@ class _RendezvousBarrierState:
         # Permanent shutdown reason: empty means open; non-empty means no further rounds.
         self.shutdown_key = f"{self.prefix}:shutdown"
         self._attribution_service: Optional[AttributionService] = None
-        self._attribution_gate_settled_round: int = -1
         self._attribution_cycle_log_submitted: Optional[int] = None
         self._attribution_terminal_requested_cycle: Optional[int] = None
         # Job-level unhealthy counter; persists across all rounds.
@@ -1327,6 +1333,12 @@ class _RendezvousBarrierState:
             if stop_event is not None and stop_event.is_set():
                 raise RendezvousGracefulExitError("Control rendezvous stop requested")
 
+            # This node owns the attribution poller (rendezvous store host). In the
+            # standalone control-plane deployment there is no agent monitor loop, so this
+            # wait is where the store host consumes a latched STOP verdict.
+            if self.attribution_stop_requested():
+                self.signal_no_restart(RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP)
+
             # Check for permanent shutdown (no further rounds)
             if self.is_shutdown():
                 msg = f"The node '{node_desc}' detected that rendezvous was permanently closed"
@@ -1374,46 +1386,32 @@ class _RendezvousBarrierState:
             wait_count += 1
             time.sleep(1.0)  # Poll every 1 second
 
-    def _attribution_gate(self, node_desc: _NodeDesc) -> bool:
-        """Return whether attribution permits closing the current round.
+    def attribution_stop_requested(self) -> bool:
+        """Return whether the background attribution poller has latched a STOP verdict.
 
-        Raises ``RendezvousGracefulExitError`` if attribution recommends stopping.
-        Returns ``False`` while attribution is still pending.
+        Local attribute read; performs no TCPStore or network I/O, so it is safe to call
+        from the agent monitor loop at its native interval.
         """
-        if self._attribution_service is None or self._round == 0:
-            return True
-
-        if self._attribution_gate_settled_round == self._round:
-            return True
-
-        expected_submitted_round = self._round - 1
-        if self._attribution_cycle_log_submitted != expected_submitted_round:
-            log.warning(
-                "Attribution gate for round %s has no submitted log for cycle %s "
-                "(last submitted cycle: %s); failing open without polling a stale log",
-                self._round,
-                expected_submitted_round,
-                self._attribution_cycle_log_submitted,
-            )
-            self._attribution_gate_settled_round = self._round
-            return True
-
-        result = self._attribution_service.get_last_result(node_id=node_desc)
-
-        if result is None:
+        if self._attribution_service is None:
             return False
+        return self._attribution_service.stop_requested()
 
-        if result is True:
-            msg = (
-                f"The node '{node_desc}' is closing rendezvous because attribution "
-                f"recommended stopping the job."
-            )
-            log.error(msg)
-            self.set_shutdown(RDZV_SHUTDOWN_REASON_FAILURE)
-            raise RendezvousGracefulExitError(msg)
+    def signal_no_restart(self, reason: str) -> None:
+        """Broadcast to every node that the job must not be restarted.
 
-        self._attribution_gate_settled_round = self._round
-        return True
+        Must be called from the thread that owns rendezvous state: ``open_rendezvous()``
+        reads ``self._round``, and the attribution poller runs on its own thread.
+
+        Two store writes carry the whole broadcast:
+          - the shutdown key records why the job is ending;
+          - opening the next round makes peers' existing ``is_next_round_open()`` poll
+            fire, so no node needs a new steady-state poll to learn about the stop.
+
+        The shutdown key is written with ``compare_set``, so the first reason recorded
+        wins and a later, less specific shutdown cannot overwrite it.
+        """
+        self.set_shutdown(reason)
+        self.open_rendezvous()
 
     def _host_close_round(
         self,
@@ -1450,6 +1448,11 @@ class _RendezvousBarrierState:
             if stop_event is not None and stop_event.is_set():
                 raise RendezvousGracefulExitError("Control rendezvous stop requested")
 
+            # A verdict for an earlier cycle can land while this round is still gathering
+            # participants. Honor it before admitting anyone into a round that will not run.
+            if self.attribution_stop_requested():
+                self.signal_no_restart(RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP)
+
             self._check_timeout_and_closure(node_desc)
 
             # Early termination: if too many nodes are unhealthy it is mathematically
@@ -1474,10 +1477,6 @@ class _RendezvousBarrierState:
 
             # Only attempt snapshot + constraint check when enough nodes have joined.
             if current_joined < min_nodes:
-                time.sleep(0.1)
-                continue
-
-            if not self._attribution_gate(node_desc):
                 time.sleep(0.1)
                 continue
 
@@ -2330,7 +2329,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         link_state_path_template: Optional[str] = None,
         storage_healthcheck_paths: Optional[list] = None,
         attribution_endpoint: Optional[str] = None,
-        attribution_decision_timeout: Optional[float] = None,
+        attribution_enforce_stop: bool = False,
         cycle_info_dir: Optional[str] = None,
         cycle_log_prefix: Optional[str] = None,
     ):
@@ -2367,8 +2366,8 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
                 List of storage paths to check for health.
             attribution_endpoint:
                 Endpoint of the attribution service.
-            attribution_decision_timeout:
-                Launcher-side attribution decision budget in seconds.
+            attribution_enforce_stop:
+                Whether a STOP verdict ends the job. False observes and logs only.
         """
         # We associate each handler instance with a unique node descriptor.
         node = cls._node_desc_generator.generate(local_addr)
@@ -2396,7 +2395,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             link_state_path_template=link_state_path_template,
             storage_healthcheck_paths=storage_healthcheck_paths,
             attribution_endpoint=attribution_endpoint,
-            attribution_decision_timeout=attribution_decision_timeout,
+            attribution_enforce_stop=attribution_enforce_stop,
             cycle_info_dir=cycle_info_dir,
             cycle_log_prefix=cycle_log_prefix,
         )
@@ -2413,7 +2412,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         link_state_path_template: Optional[str] = None,
         storage_healthcheck_paths: Optional[list] = None,
         attribution_endpoint: Optional[str] = None,
-        attribution_decision_timeout: Optional[float] = None,
+        attribution_enforce_stop: bool = False,
         cycle_info_dir: Optional[str] = None,
         cycle_log_prefix: Optional[str] = None,
     ) -> None:
@@ -2492,8 +2491,9 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         if is_store_host and attribution_endpoint:
             self._attribution_service = AttributionService(
                 endpoint=attribution_endpoint,
-                decision_timeout=attribution_decision_timeout,
+                enforce_stop=attribution_enforce_stop,
             )
+            self._attribution_service.start_poller(node_id=self._this_node)
         else:
             self._attribution_service = None
         self._barrier_state._attribution_service = self._attribution_service
@@ -2916,6 +2916,31 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
     def is_shutdown_due_to_failure(self) -> bool:
         return self._barrier_state.get_shutdown_reason() == RDZV_SHUTDOWN_REASON_FAILURE
 
+    def get_shutdown_reason(self) -> Optional[str]:
+        """Return the recorded shutdown reason, or None if the job is not shutting down.
+
+        Costs the same as ``is_shutdown()`` (one ``check`` plus one ``get``), so callers
+        that need to distinguish shutdown reasons should use this instead of calling both.
+        """
+        return self._barrier_state.get_shutdown_reason()
+
+    def no_restart_reason(self) -> Optional[str]:
+        """Return the reason NVRx decided this job must not be restarted, if any.
+
+        Returns ``None`` for a healthy job or for an ordinary failure shutdown. Costs one
+        ``check`` plus one ``get``, the same as ``is_shutdown()``.
+        """
+        reason = self._barrier_state.get_shutdown_reason()
+        return reason if reason in RDZV_NO_RESTART_REASONS else None
+
+    def attribution_stop_requested(self) -> bool:
+        """Return whether this node's attribution poller has latched a STOP verdict."""
+        return self._barrier_state.attribution_stop_requested()
+
+    def signal_no_restart(self, reason: str) -> None:
+        """Broadcast to the whole job that it must not be restarted."""
+        self._barrier_state.signal_no_restart(reason)
+
     def shutdown_cycle_info_reporter(self) -> None:
         if self._cycle_info_reporter is not None:
             self._cycle_info_reporter.shutdown()
@@ -2924,6 +2949,10 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         """Permanently shut down the rendezvous (no further rounds)."""
         self._barrier_state.set_shutdown(reason)
         self.shutdown_cycle_info_reporter()
+        if self._attribution_service is not None:
+            # No one will consume a verdict once the job is ending. The final cycle's
+            # terminal POST is still issued afterwards for post-mortem analysis.
+            self._attribution_service.stop_poller()
 
         msg = f"The node '{self._this_node}' has permanently closed the rendezvous '{self._settings.run_id}'."
         self._record(message=msg, node_state=NodeState.SUCCEEDED)
@@ -3040,9 +3069,9 @@ def create_handler(
         storage_healthcheck_paths = params.config.get('storage_healthcheck_paths', None)
         link_state_path_template = params.config.get('link_state_path_template', None)
         attribution_endpoint = params.config.get('attribution_endpoint', None)
-        attribution_decision_timeout = params.config.get('attribution_decision_timeout', None)
-        if attribution_decision_timeout is not None:
-            attribution_decision_timeout = float(attribution_decision_timeout)
+        attribution_enforce_stop = (
+            str(params.config.get('attribution_enforce_stop', '')).lower() == 'true'
+        )
         cycle_info_dir = params.config.get('cycle_info_dir', None)
         cycle_log_prefix = params.config.get('cycle_log_prefix', None)
 
@@ -3063,7 +3092,7 @@ def create_handler(
             link_state_path_template=link_state_path_template,
             storage_healthcheck_paths=storage_healthcheck_paths,
             attribution_endpoint=attribution_endpoint,
-            attribution_decision_timeout=attribution_decision_timeout,
+            attribution_enforce_stop=attribution_enforce_stop,
             cycle_info_dir=cycle_info_dir,
             cycle_log_prefix=cycle_log_prefix,
         )

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -61,7 +61,10 @@ from torch.distributed.elastic.multiprocessing import (
 from torch.distributed.elastic.multiprocessing.errors import ChildFailedError, record
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous import registry as rdzv_registry
-from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
+from torch.distributed.elastic.rendezvous.api import (
+    RendezvousClosedError,
+    RendezvousGracefulExitError,
+)
 from torch.distributed.elastic.rendezvous.utils import (
     _matches_machine_hostname,
     _parse_rendezvous_config,
@@ -79,6 +82,7 @@ from nvidia_resiliency_ext.fault_tolerance.cli_args import (
     add_cycle_info_args,
     add_ft_config_file_args,
     add_log_funnel_args,
+    add_no_restart_args,
     add_rendezvous_args,
 )
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
@@ -93,6 +97,9 @@ from nvidia_resiliency_ext.fault_tolerance.progress_tracker import TrainingProgr
 from nvidia_resiliency_ext.fault_tolerance.rank_monitor_server import RankMonitorServer
 from nvidia_resiliency_ext.fault_tolerance.rdzv_utils import rdzv_config_get_as_bool
 from nvidia_resiliency_ext.fault_tolerance.utils import (
+    DEFAULT_NO_RESTART_EXIT_CODE,
+    RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP,
+    RDZV_SHUTDOWN_REASON_NO_PROGRESS,
     get_log_aggregator_shard_index,
     get_processes_by_pgids,
     is_slurm_job_array,
@@ -234,6 +241,30 @@ class UnhealthyNodeException(Exception):
 
 class TerminalWorkerGroupFailure(Exception):
     """Raised when the worker group failed without local child failure details."""
+
+
+def _no_restart_exit_code(args: Any) -> int:
+    """Resolve the process exit code used when NVRx decides the job must not restart."""
+    value = getattr(args, "ft_no_restart_exit_code", None)
+    if value is None:
+        return DEFAULT_NO_RESTART_EXIT_CODE
+    return int(value)
+
+
+class NoRestartRequested(Exception):
+    """Raised when NVRx concluded the job must not be restarted.
+
+    Covers both causes that reach that conclusion -- an attribution STOP verdict and the
+    progress tracker finding no progress across restarts. Both exit with the same
+    dedicated code so downstream tooling gets one binary "do not requeue" signal; the
+    specific ``reason`` is recorded in the rendezvous store and the logs for diagnosis.
+
+    Every launcher in the job raises this, not just the node that made the decision.
+    """
+
+    def __init__(self, reason: str, message: Optional[str] = None):
+        self.reason = reason
+        super().__init__(message or f"NVRx decided the job must not be restarted ({reason})")
 
 
 def _wrap_entrypoint_with_numactl(
@@ -518,6 +549,23 @@ class LocalElasticAgent(SimpleElasticAgent):
     # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
     #  `torch.distributed.elastic.metrics.prof`.
     @prof
+    def _raise_if_no_restart(self, e: Exception) -> None:
+        """Re-raise a rendezvous closure as NoRestartRequested when NVRx decided the stop.
+
+        A closure reaches this node as either RendezvousGracefulExitError or
+        RendezvousClosedError depending on which rendezvous step it was in, and both must
+        map to the same exit code. Returns without raising for ordinary closures.
+        """
+        no_restart = self._rdzv_handler.no_restart_reason()
+        if no_restart is None:
+            return
+        msg = (
+            "Rendezvous closed because NVRx decided the job must not be restarted "
+            f"({no_restart})."
+        )
+        logger.error("%s Original rendezvous message: %s", msg, e)
+        raise NoRestartRequested(no_restart, msg) from e
+
     def run(self, role: str = DEFAULT_ROLE) -> RunResult:
         # Re-sync _remaining_restarts: _round=0 at __init__ time (store not yet synced).
         # set_agent() -> _complete_initialization() has corrected _round by now.
@@ -533,6 +581,10 @@ class LocalElasticAgent(SimpleElasticAgent):
             self._record_worker_events(result)
             return result
         except RendezvousGracefulExitError as e:
+            # Hot spares and nodes waiting for a round to open learn about the stop here
+            # rather than in the monitor loop. Without this they would exit 0 and report
+            # success while the rest of the job reports the no-restart exit code.
+            self._raise_if_no_restart(e)
             if self._rdzv_handler.is_shutdown_due_to_failure():
                 msg = (
                     "Rendezvous closed because another launcher reported "
@@ -542,6 +594,12 @@ class LocalElasticAgent(SimpleElasticAgent):
                 raise TerminalWorkerGroupFailure(msg) from e
             logger.info("Rendezvous gracefully exited: %s", e)
             return None
+        except RendezvousClosedError as e:
+            # Any node waiting for a round to close when the stop is broadcast takes the
+            # permanent-close path instead of the graceful one. Other closure reasons
+            # keep their existing behavior.
+            self._raise_if_no_restart(e)
+            raise
         except SignalException as e:
             logger.warning("Received %s death signal, shutting down workers, timeout %s sec.", e.sigval, self._term_timeout)
             if self._is_store_host:
@@ -597,9 +655,19 @@ class LocalElasticAgent(SimpleElasticAgent):
             logger.error(
                 "[%s] Progress tracker detected no progress across restarts. "
                 "No more restarts will be attempted.",
-                role
+                role,
             )
-            return False
+            # Same scheduler-facing meaning as an attribution STOP: NVRx decided, do not
+            # requeue. Reported through the shared no-restart path so both causes are
+            # indistinguishable to downstream tooling, rather than this one looking like
+            # an ordinary crash.
+            self._rdzv_handler.signal_no_restart(RDZV_SHUTDOWN_REASON_NO_PROGRESS)
+            self._stop_workers(self._worker_group)
+            self._worker_group.state = WorkerState.FAILED
+            raise NoRestartRequested(
+                RDZV_SHUTDOWN_REASON_NO_PROGRESS,
+                "Progress tracker detected no progress across restarts.",
+            )
         elif self._remaining_restarts > 0:
             logger.info(log_msg, role)
             self._remaining_restarts -= 1
@@ -645,7 +713,34 @@ class LocalElasticAgent(SimpleElasticAgent):
                 )
                 self._exit_barrier()
                 return run_result
-            elif state in {WorkerState.UNHEALTHY, WorkerState.FAILED}:
+
+            # An attribution STOP preempts any restart decision, in both healthy and
+            # failed states. Only the node that owns the attribution client can latch a
+            # verdict -- the store-host launcher when attribution runs colocated, and no
+            # launcher at all when it runs under a standalone nvrx-control process. This
+            # is a local attribute read, so it costs nothing at the monitor interval, and
+            # it runs before the store poll below so the stopping node skips a TCPStore
+            # round trip it no longer needs.
+            #
+            # Deliberately placed below SUCCEEDED: a workload that finished is not killed
+            # because an earlier cycle was later attributed as fatal.
+            if rdzv_handler.attribution_stop_requested():
+                logger.error(
+                    "[%s] Attribution recommended stopping the job; terminating workers "
+                    "and signalling the rest of the job.",
+                    role,
+                )
+                # Writes the shutdown reason and opens the next round, which is what peers
+                # already poll for. No node needs a new steady-state check.
+                rdzv_handler.signal_no_restart(RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP)
+                self._stop_workers(self._worker_group)
+                self._worker_group.state = WorkerState.FAILED
+                raise NoRestartRequested(
+                    RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP,
+                    "Attribution recommended stopping the job.",
+                )
+
+            if state in {WorkerState.UNHEALTHY, WorkerState.FAILED}:
                 # Record failure detection event
                 record_profiling_event(
                     ProfilingEvent.FAILURE_DETECTED,
@@ -675,6 +770,21 @@ class LocalElasticAgent(SimpleElasticAgent):
                 # open_rendezvous() sets round_done_{N+1}=0; this is both the spare-node
                 # wake-up signal and the peer-failure signal for healthy nodes here.
                 if rdzv_handler.is_next_round_open():
+                    # The round may have been opened to broadcast a no-restart decision rather
+                    # than to restart. One extra store read, only once, at the moment the
+                    # job is ending.
+                    no_restart = rdzv_handler.no_restart_reason()
+                    if no_restart is not None:
+                        logger.error(
+                            "[%s] Another launcher reported a no-restart decision (%s); "
+                            "terminating workers.",
+                            role,
+                            no_restart,
+                        )
+                        self._stop_workers(self._worker_group)
+                        self._worker_group.state = WorkerState.FAILED
+                        raise NoRestartRequested(no_restart)
+
                     group_rank = self._worker_group.group_rank
                     # Record failure detection event
                     record_profiling_event(
@@ -2576,6 +2686,7 @@ def get_args_parser() -> ArgumentParser:
     )
 
     add_attribution_args(parser)
+    add_no_restart_args(parser)
     add_cycle_info_args(parser)
 
     parser.add_argument(
@@ -2596,8 +2707,10 @@ def get_args_parser() -> ArgumentParser:
         default=None,
         dest="ft_max_no_progress_cycles",
         help="Maximum consecutive cycles (including initial cycle 0) without progress before early "
-        "termination. E.g. 2 = allow cycle 0 and 1 with no progress, then terminate before cycle 2. "
-        "Progress tracking is enabled when this value > 0. Set to 0 or -1 to disable. Default: 2.",
+        "termination. E.g. 3 = allow cycles 0, 1 and 2 with no progress, then terminate before "
+        "cycle 3. Raise this or disable tracking for workloads that deliberately replay an "
+        "iteration without advancing the checkpoint. Progress tracking is enabled when this value "
+        "> 0. Set to 0 or -1 to disable. Default: 3.",
     )
 
     parser.add_argument(
@@ -3008,11 +3121,9 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
 
         if attribution_endpoint is not None:
             rdzv_configs['attribution_endpoint'] = attribution_endpoint.endpoint
-            decision_timeout = getattr(attribution_endpoint, "decision_timeout", None)
-            if decision_timeout is not None:
-                rdzv_configs['attribution_decision_timeout'] = str(
-                    decision_timeout
-                )
+            rdzv_configs['attribution_enforce_stop'] = str(
+                attribution_endpoint.enforce_stop
+            )
 
         if getattr(args, 'ft_enable_log_server', False):
             assert log_funnel_ports is not None
@@ -3580,6 +3691,12 @@ def main(args=None):
     args = parse_args(args)
     try:
         run(args)
+    except NoRestartRequested as e:
+        exit_code = _no_restart_exit_code(args)
+        logger.error(
+            f"NVRx decided the job must not be restarted ({e.reason}): {e}. "
+            f"Agent's exit code = {exit_code}"
+        )
     except ChildFailedError as e:
         logger.error(
             f"Some rank(s) exited with non-zero exit code: {e.failures}. Agent's exit code = 1"

--- a/src/nvidia_resiliency_ext/fault_tolerance/progress_tracker.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/progress_tracker.py
@@ -53,7 +53,7 @@ class TrainingProgressTracker:
     def __init__(
         self,
         min_progress_iterations: int = 1,
-        max_no_progress_cycles: int = 2,
+        max_no_progress_cycles: int = 3,
         initial_cycle_number: int = 0,
         checkpoint_iteration_file: Optional[str] = None,
     ):
@@ -64,9 +64,14 @@ class TrainingProgressTracker:
             min_progress_iterations: Minimum iteration increase to consider as "making progress"
                                      (default 1 = any increase).
             max_no_progress_cycles: Max consecutive cycles (including cycle 0) without progress
-                                    before early termination. E.g. 2 = allow cycle 0 and 1 with
-                                    no progress, then terminate before starting cycle 2.
+                                    before early termination. E.g. 3 = allow cycles 0, 1 and 2
+                                    with no progress, then terminate before starting cycle 3.
                                     Set to <= 0 to disable progress tracking.
+                                    Workloads that deliberately replay an iteration without
+                                    advancing the checkpoint (for example Megatron-LM's rerun
+                                    state machine investigating a suspect result) need this
+                                    above the number of replay cycles they can take, or
+                                    tracking disabled.
             initial_cycle_number: Initial global cycle number (for job array replacement nodes)
                                   Cycle 0 = initial attempt, cycle 1 = first restart, etc.
             checkpoint_iteration_file: Optional path to file containing latest checkpoint iteration.
@@ -86,6 +91,8 @@ class TrainingProgressTracker:
         self._iterations_not_reported_warned = (
             False  # Track if we've warned about missing iterations
         )
+        # Track if we've warned about an unreadable checkpoint iteration file
+        self._iteration_unknown_warned = False
 
         # Training resumes from last checkpoint; use it as baseline for progress (don't assume 0)
         self._read_iteration_from_checkpoint_file()
@@ -113,24 +120,37 @@ class TrainingProgressTracker:
         """
         self.cycle_number = new_cycle_number
 
-    def _read_iteration_from_checkpoint_file(self) -> None:
-        """Read checkpoint iteration file and update current_max_iteration if present."""
+    def _read_iteration_from_checkpoint_file(self) -> bool:
+        """Read the checkpoint iteration file into current_max_iteration.
+
+        Returns whether a usable iteration value was obtained. Callers must distinguish
+        "the iteration is unknown" from "the iteration is 0": current_max_iteration is
+        reset to 0 after every cycle, so a failed read leaves it at 0 and would otherwise
+        be scored as the workload having gone backwards.
+        """
         if not self.checkpoint_iteration_file:
-            return
+            return False
         try:
             with open(self.checkpoint_iteration_file, "r") as f:
                 raw = f.read().strip()
-            if raw:
-                iteration = int(raw)
-                self.update_iteration(iteration)
+            if not raw:
+                return False
+            iteration = int(raw)
+            self.update_iteration(iteration)
+            return True
         except FileNotFoundError:
-            pass  # File may not exist yet
+            # Normal before the first checkpoint is written.
+            return False
         except (ValueError, OSError) as e:
-            logger.debug(
+            # Logged at warning rather than debug: this suppresses a progress check, and
+            # a transient filesystem error is most likely exactly when the tracker is
+            # relied upon.
+            logger.warning(
                 "Could not read checkpoint iteration file %s: %s",
                 self.checkpoint_iteration_file,
                 e,
             )
+            return False
 
     def analyze_previous_cycle(self):
         """
@@ -142,13 +162,37 @@ class TrainingProgressTracker:
 
         If no iteration source is available (no file and both current and last are 0),
         the progress check is skipped and a warning is logged once.
+
+        If a checkpoint iteration file is configured but cannot be read, the cycle is
+        skipped entirely and no tracking state is touched. Scoring it would be wrong in
+        both directions: the unknown iteration reads as 0, which counts as a large
+        backwards step now, and it also clears last_restart_iteration, so the following
+        successful read looks like a large jump forwards and resets no_progress_count on
+        a genuinely stuck job.
         """
         # Skip if tracking is disabled
         if self.max_no_progress_cycles <= 0:
             return
 
         # When using checkpoint file, read it now (before new workers start)
-        self._read_iteration_from_checkpoint_file()
+        iteration_known = self._read_iteration_from_checkpoint_file()
+        if self.checkpoint_iteration_file and not iteration_known:
+            # Logged once per run of unknowns so the expected pre-first-checkpoint phase
+            # does not warn on every cycle.
+            if not self._iteration_unknown_warned:
+                logger.warning(
+                    "Training cycle #%s progress check skipped: the checkpoint iteration "
+                    "is unknown (file: %s). Tracking state is left unchanged; consecutive "
+                    "cycles without progress remain at %s/%s.",
+                    self.cycle_number,
+                    self.checkpoint_iteration_file,
+                    self.no_progress_count,
+                    self.max_no_progress_cycles,
+                )
+                self._iteration_unknown_warned = True
+            self.cycle_number += 1
+            return
+        self._iteration_unknown_warned = False
 
         # Check if previous cycle made progress (includes cycle 0; last_restart_iteration starts at 0)
         if self.last_restart_iteration == 0 and self.current_max_iteration == 0:

--- a/src/nvidia_resiliency_ext/fault_tolerance/utils.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/utils.py
@@ -36,6 +36,26 @@ from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
 
 logger = logging.getLogger(LogConfig.name)
 
+# Rendezvous shutdown reasons. "graceful" and "failure" describe how the job ended;
+# RDZV_NO_RESTART_REASONS are the cases where NVRx itself concluded the job must not be
+# restarted, as opposed to "failure", which only says something broke and leaves the retry
+# policy to the scheduler. Every launcher reports DEFAULT_NO_RESTART_EXIT_CODE for those
+# so downstream tooling gets a binary "do not requeue" signal; the specific reason stays in
+# the rendezvous store for diagnosis.
+#
+# Defined here rather than in ft_rendezvous_barrier because that module imports launcher,
+# so launcher cannot import back from it.
+RDZV_SHUTDOWN_REASON_GRACEFUL = "graceful"
+RDZV_SHUTDOWN_REASON_FAILURE = "failure"
+RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP = "attribution_stop"
+RDZV_SHUTDOWN_REASON_NO_PROGRESS = "no_progress"
+RDZV_NO_RESTART_REASONS = frozenset(
+    {RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP, RDZV_SHUTDOWN_REASON_NO_PROGRESS}
+)
+# Chosen outside the ranges that already carry meaning: 0-2 (success / generic failure /
+# argparse), 64-78 (BSD sysexits.h), 126-165 (shell errors and 128+signal), and 255.
+DEFAULT_NO_RESTART_EXIT_CODE = 93
+
 _IPC_PICKLER = multiprocessing.reduction.ForkingPickler(open(os.devnull, mode='wb'))
 
 

--- a/src/nvidia_resiliency_ext/shared_utils/health_check.py
+++ b/src/nvidia_resiliency_ext/shared_utils/health_check.py
@@ -23,7 +23,6 @@ import os
 import subprocess  # nosec B404
 import sys
 import threading
-import time
 import traceback
 from collections import defaultdict, deque
 from functools import wraps
@@ -1795,29 +1794,40 @@ class AttributionService:
     Client that queries an external attribution service to analyze artifacts (e.g., logs).
     Behavior:
       - POSTs to submit for log analysis
-      - GETs results by the last submitted log_path
+      - a background poller GETs the verdict for the log with a pending terminal analysis
+
+    Nothing in the launcher waits on a verdict. The poller latches the first STOP
+    recommendation it observes; the rendezvous-owning thread reads that latch (a plain
+    attribute read, no I/O) and terminates the job. A verdict for cycle N is therefore
+    honored even when it arrives while cycle N+1 or N+2 is already running.
     """
 
-    DEFAULT_DECISION_TIMEOUT_SECONDS = 60.0
     _RESULT_POLL_INTERVAL_SECONDS = 2.0
 
-    def __init__(
-        self,
-        endpoint: str,
-        decision_timeout: Optional[float] = None,
-    ):
+    def __init__(self, endpoint: str, *, enforce_stop: bool = False):
         self.endpoint = endpoint.rstrip("/")
-        if decision_timeout is None:
-            decision_timeout = self.DEFAULT_DECISION_TIMEOUT_SECONDS
-        self.decision_timeout = float(decision_timeout)
-        if self.decision_timeout <= 0:
-            raise ValueError("attribution decision timeout must be positive")
+        # When False, a STOP verdict is still polled, logged and recorded, but never acted
+        # on. Attribution verdicts come from an LLM, and acting on a false positive costs
+        # far more than missing a true one -- a missed STOP is bounded by the restart
+        # budget, while an enforced false STOP needs a human to resubmit. So enforcement
+        # is opt-in and sites can measure their own precision first.
+        self._enforce_stop = enforce_stop
         self._unsupported_transport_warned = False
         # Track the most recent log_path we submitted
         self._last_submitted: Optional[str] = None
-        self._terminal_deadline: Optional[float] = None
+        # Log path with an outstanding terminal analysis. Distinct from _last_submitted:
+        # the latter advances every cycle, while a terminal verdict is only requested for
+        # cycles that actually failed and may still be pending when the next cycle starts.
+        self._terminal_pending: Optional[str] = None
+        self._stop_latched = False
+        # How many STOP verdicts have been observed. In log-only mode this is the
+        # number that decides whether the precision is good enough to enforce.
+        self._stop_verdict_count = 0
         self._get_started_recorded = False
-        self._next_result_poll_time = 0.0
+        self._lock = threading.Lock()
+        self._poll_stop_event = threading.Event()
+        self._poll_thread: Optional[threading.Thread] = None
+        self._poll_node_id: Optional[Any] = None
 
     def __call__(self) -> None:
         """
@@ -1827,83 +1837,150 @@ class AttributionService:
         """
         self.request_terminal_analysis()
 
-    def get_last_result(
-        self,
-        node_id: Optional[Any] = None,
-    ) -> Optional[bool]:
-        """Briefly join terminal analysis and fetch whether attribution recommends stopping.
+    def stop_requested(self) -> bool:
+        """Return whether the job should be stopped on attribution's recommendation.
 
-        Returns:
-          - True when attribution recommends stopping the job.
-          - False when attribution recommends continuing, or when the launcher-side
-            decision budget expires and restart should fail open.
-          - None when attribution is still pending within the decision budget.
+        Always False in log-only mode, even after a STOP verdict is observed. Use
+        ``stop_verdict_observed()`` for the raw verdict.
+
+        Local attribute read. Safe to call from a hot polling loop: it performs no
+        network, TCPStore, or filesystem I/O.
         """
-        log_path = self._last_submitted
+        with self._lock:
+            return self._stop_latched and self._enforce_stop
+
+    def stop_verdict_observed(self) -> bool:
+        """Return whether a STOP verdict was observed, regardless of enforcement mode."""
+        with self._lock:
+            return self._stop_latched
+
+    def stop_verdict_count(self) -> int:
+        """Return how many STOP verdicts have been observed across the job's cycles."""
+        with self._lock:
+            return self._stop_verdict_count
+
+    def start_poller(self, node_id: Optional[Any] = None) -> None:
+        """Start the background verdict poller on the rendezvous store host.
+
+        No-op for transports the in-job client cannot speak, where every GET would
+        fail and the poller would spin forever without ever reaching a verdict.
+        """
+        if self._poll_thread is not None:
+            return
+        if self._http_base_url() is None:
+            logger.info(
+                "AttributionService verdict poller not started: endpoint %s is not "
+                "reachable by the in-job HTTP client",
+                self.endpoint,
+            )
+            return
+        self._poll_node_id = node_id
+        self._poll_thread = threading.Thread(
+            target=self._poll_loop,
+            name="nvrx-attribution-poller",
+            daemon=True,
+        )
+        self._poll_thread.start()
+        logger.debug("AttributionService verdict poller started")
+
+    def stop_poller(self, timeout: float = 5.0) -> None:
+        """Signal the poller to exit and join it."""
+        self._poll_stop_event.set()
+        thread = self._poll_thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+            self._poll_thread = None
+
+    def _poll_loop(self) -> None:
+        while not self._poll_stop_event.is_set():
+            try:
+                self._poll_once()
+            except Exception as e:
+                logger.warning(
+                    "AttributionService poller iteration failed: %s: %s", type(e).__name__, e
+                )
+            # When enforcing, a verdict ends the job, so there is nothing further to
+            # learn. In log-only mode the job keeps running and keeps failing, and the
+            # point of the mode is to accumulate a verdict per failed cycle, so the poller
+            # must survive a STOP.
+            if self._enforce_stop and self.stop_verdict_observed():
+                return
+            self._poll_stop_event.wait(self._RESULT_POLL_INTERVAL_SECONDS)
+
+    def _poll_once(self) -> None:
+        with self._lock:
+            log_path = self._terminal_pending
         if not log_path:
-            logger.debug("AttributionService GET skipped: no submitted log path")
-            return False
+            return
 
-        self._start_get_profiling(node_id)
-        decision_remaining = self._remaining_decision_timeout()
-        if decision_remaining <= 0:
-            logger.warning(
-                "AttributionService decision budget exhausted for %s; attempting final "
-                "bounded GET",
-                log_path,
-            )
-            result = self._get_results(log_path, timeout=_ATTRIBUTION_REQUEST_TIMEOUT_SECONDS)
-            record_profiling_event(
-                ProfilingEvent.ATTRIBUTION_GET_COMPLETED,
-                node_id=node_id,
-            )
-            if result is None:
-                return False
-            return result
-
-        now = time.monotonic()
-        if now < self._next_result_poll_time:
-            return None
-
-        self._next_result_poll_time = now + self._RESULT_POLL_INTERVAL_SECONDS
+        self._start_get_profiling(self._poll_node_id)
         result = self._get_results(log_path, timeout=_ATTRIBUTION_REQUEST_TIMEOUT_SECONDS)
-
         if result is None:
-            return None
+            # Analysis still running, or attrsvc is unreachable. Keep polling; the job
+            # keeps running in the meantime.
+            return
 
         record_profiling_event(
             ProfilingEvent.ATTRIBUTION_GET_COMPLETED,
-            node_id=node_id,
+            node_id=self._poll_node_id,
         )
-        return result
+
+        with self._lock:
+            if result:
+                self._stop_latched = True
+                self._stop_verdict_count += 1
+                if self._enforce_stop:
+                    logger.error(
+                        "Attribution recommends stopping the job (analyzed log: %s); "
+                        "the job will be terminated",
+                        log_path,
+                    )
+                    # Leave the pending path in place: the job is ending, and keeping it
+                    # records which log produced the verdict.
+                    return
+                logger.error(
+                    "Attribution recommends stopping the job (analyzed log: %s), but the "
+                    "recommendation is NOT being enforced "
+                    "(--ft-attribution-stop-action=log). The job continues. This is STOP "
+                    "verdict %s so far. Set --ft-attribution-stop-action=no-restart to "
+                    "act on verdicts like this one.",
+                    log_path,
+                    self._stop_verdict_count,
+                )
+                # Log-only mode treats a STOP like any other completed verdict: free the
+                # slot so later failed cycles are analyzed too. Without this the first
+                # STOP would silently end all attribution for the rest of the job, which
+                # is the opposite of what this mode is for.
+                if self._terminal_pending == log_path:
+                    self._terminal_pending = None
+                    self._get_started_recorded = False
+                return
+            # Authoritative "keep going" for this log; stop polling it. A later failing
+            # cycle installs a new pending path.
+            if self._terminal_pending == log_path:
+                self._terminal_pending = None
+                self._get_started_recorded = False
+        logger.info("Attribution recommends continuing (analyzed log: %s)", log_path)
 
     def _start_get_profiling(self, node_id: Optional[Any]) -> None:
-        if self._get_started_recorded:
-            return
-        self._get_started_recorded = True
+        with self._lock:
+            if self._get_started_recorded:
+                return
+            self._get_started_recorded = True
         record_profiling_event(
             ProfilingEvent.ATTRIBUTION_GET_STARTED,
             node_id=node_id,
         )
 
-    def _ensure_decision_deadline(self) -> float:
-        if self._terminal_deadline is None:
-            self._terminal_deadline = time.monotonic() + self.decision_timeout
-        return self._terminal_deadline
-
-    def _remaining_decision_timeout(self) -> float:
-        """Return the remaining launcher-side budget for the current attribution decision."""
-        return self._ensure_decision_deadline() - time.monotonic()
-
     def _submit_log(self, log_path: str) -> None:
         """
         Submit a log file for progressive analysis via POST.
         The POST is synchronous but bounded to avoid delaying launcher progress.
+
+        Deliberately does not touch _terminal_pending: a terminal analysis requested for
+        an earlier cycle must keep being polled across cycle boundaries.
         """
         self._last_submitted = log_path
-        self._terminal_deadline = None
-        self._get_started_recorded = False
-        self._next_result_poll_time = 0.0
         self._do_submit_log(log_path, analysis_intent=ANALYSIS_INTENT_PROGRESSIVE)
 
     def request_terminal_analysis(self) -> None:
@@ -1911,29 +1988,94 @@ class AttributionService:
         Request terminal analysis for the last submitted workload log.
 
         The POST returns after attrsvc accepts the request and schedules final analysis.
-        Later GETs use non-blocking probes until a verdict is cached.
+        The background poller then probes for the verdict without blocking the launcher.
+
+        The pending slot is first-come-first-served. Replacing an unresolved analysis
+        would starve the verdict in a crash loop: if every cycle fails faster than attrsvc
+        can analyze the previous one, each in-flight analysis is discarded before it
+        completes and no verdict ever arrives -- in exactly the scenario attribution is
+        meant to catch. Keeping the oldest instead guarantees one analysis runs to
+        completion, and the stop decision is global, so whichever cycle produces it is
+        enough. When analysis finishes within a cycle, which is the normal case, the slot
+        is already free and this is indistinguishable from replacing.
         """
         log_path = self._last_submitted
         if not log_path:
             logger.debug("AttributionService terminal POST skipped: no submitted log path")
             return
-        self._ensure_decision_deadline()
-        self._next_result_poll_time = 0.0
-        self._do_submit_log(
-            log_path,
-            analysis_intent=ANALYSIS_INTENT_TERMINAL,
-        )
+        with self._lock:
+            in_flight = self._terminal_pending
+        if in_flight is not None:
+            # Skip the POST too: this result would never be polled, so requesting it only
+            # spends analysis budget and competes with the analysis already in flight.
+            #
+            # Dropping this cycle's analysis is the intended FCFS behavior, not a gap. The
+            # check is a snapshot, so it can also lose a benign race: _poll_once runs its
+            # GET outside the lock and only then clears the slot, so a cycle can be
+            # deferred microseconds before the slot frees. The outcome is the same either
+            # way -- this cycle is not analyzed, and the next failed cycle installs
+            # normally -- and the stop decision is global, so any cycle's verdict is
+            # enough.
+            #
+            # Promoting a deferred path when the poller clears the slot looks like the fix
+            # but is not: with several cycles deferred it needs a keep-newest/keep-oldest
+            # policy and still drops the rest, or it becomes a real queue that grows one
+            # entry per failed cycle in a crash loop -- the unbounded retention that
+            # choosing a single slot removed. It would also move POST submission and its
+            # failure handling into the poller thread and reopen a race against a
+            # concurrent terminal request.
+            logger.info(
+                "AttributionService terminal analysis for %s deferred: still awaiting a "
+                "verdict for %s",
+                log_path,
+                in_flight,
+            )
+            return
+
+        # Tell attrsvc before making the path pollable. Publishing the slot first would
+        # let the poller GET a path attrsvc has not yet been asked to analyze terminally,
+        # so whatever it returns for that path would be treated as the terminal verdict.
+        # attrsvc does not currently cache a result for a progressive-only submission, so
+        # such a GET just reports "not completed" -- but that is an attrsvc-side invariant
+        # this client cannot enforce, and the progressive design explicitly leaves room for
+        # terminal analysis to reuse progressive state later. Ordering the two removes the
+        # dependency entirely.
+        #
+        # Only the rendezvous-owning thread calls this, so reading the slot above and
+        # writing it below cannot interleave with another submitter. The poller only ever
+        # clears the slot, never fills it, so reaching here means the slot was free and is
+        # still free. (It can go the other way -- free just after we read it occupied --
+        # which is the benign deferral race described above.)
+        if not self._do_submit_log(log_path, analysis_intent=ANALYSIS_INTENT_TERMINAL):
+            # Leave the slot free. Installing a path attrsvc never accepted would pin the
+            # FCFS slot forever: its GET can never complete, so every later failed cycle
+            # would defer behind it and attribution would be dead for the rest of the job.
+            # Losing this one cycle's analysis is recoverable; losing all of them is not.
+            logger.warning(
+                "AttributionService terminal analysis for %s was not accepted; skipping "
+                "this cycle so a later failed cycle can still be analyzed",
+                log_path,
+            )
+            return
+        with self._lock:
+            self._terminal_pending = log_path
+            self._get_started_recorded = False
 
     def _do_submit_log(
         self,
         log_path: str,
         analysis_intent: str = ANALYSIS_INTENT_PROGRESSIVE,
         timeout: float = _ATTRIBUTION_REQUEST_TIMEOUT_SECONDS,
-    ) -> None:
-        """Perform the actual POST request."""
+    ) -> bool:
+        """Perform the actual POST request. Returns whether attrsvc accepted it.
+
+        Callers that reserve state on the strength of the submission must check this:
+        installing a pending terminal analysis that attrsvc never received would pin the
+        FCFS slot on a path whose GET can never complete.
+        """
         base_url = self._http_base_url()
         if base_url is None:
-            return
+            return False
         try:
             with httpx.Client(base_url=base_url, timeout=timeout) as client:
                 url = f"{base_url}{ROUTE_LOGS}"
@@ -1943,7 +2085,7 @@ class AttributionService:
                     log_path,
                     analysis_intent,
                 )
-                post_log(
+                resp = post_log(
                     client,
                     log_path,
                     user=job_user_from_env(),
@@ -1954,6 +2096,22 @@ class AttributionService:
             logger.warning(
                 "AttributionService POST %s failed: %s: %s", log_path, type(e).__name__, e
             )
+            return False
+
+        # httpx does not raise for error statuses, so a rejected submission would
+        # otherwise look identical to an accepted one.
+        status = getattr(resp, "status_code", None)
+        if not isinstance(status, int):
+            return True
+        if not 200 <= status < 300:
+            logger.warning(
+                "AttributionService POST %s (analysis_intent=%s) rejected: HTTP %s",
+                log_path,
+                analysis_intent,
+                status,
+            )
+            return False
+        return True
 
     def _get_results(
         self,
@@ -1963,8 +2121,12 @@ class AttributionService:
         """
         Get the stop decision for a previously submitted log file via GET.
 
-        Terminal analysis is triggered earlier via POST, so launcher uses a
-        non-blocking probe before rendezvous closes the next round.
+        Terminal analysis is triggered earlier via POST, so this is a non-blocking probe.
+
+        Returns:
+          - True/False when attrsvc has completed analysis: the normalized stop decision.
+          - None when there is no decision yet, either because analysis is still running
+            or because attrsvc could not be reached.
         """
         base_url = self._http_base_url()
         if base_url is None:

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -13,7 +13,6 @@ from nvidia_resiliency_ext.fault_tolerance.attribution_manager import (
     _attribution_command,
 )
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
-from nvidia_resiliency_ext.shared_utils.health_check import AttributionService
 
 
 def _args(**overrides):
@@ -24,7 +23,7 @@ def _args(**overrides):
         "ft_attribution_llm_base_url": None,
         "ft_attribution_llm_model": None,
         "ft_attribution_analysis_backend": None,
-        "ft_attribution_decision_timeout": None,
+        "ft_attribution_stop_action": None,
         "ft_attribution_log_level": None,
         "ft_attribution_export_url": None,
     }
@@ -96,8 +95,6 @@ def test_managed_attribution_config_derives_applog_dir_and_log_file(tmp_path):
     assert cfg.client_endpoint.endpoint == f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}"
     assert cfg.applog_dir == str(tmp_path / "logs")
     assert cfg.log_file == str(tmp_path / "logs" / "train_attribution.log")
-    assert cfg.client_endpoint.decision_timeout is None
-    assert AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS == 60.0
     assert cfg.is_enabled
     assert cfg.is_managed
 
@@ -182,7 +179,6 @@ def test_attribution_config_maps_launcher_args(tmp_path):
             ft_attribution_llm_base_url="https://llm.example/v1",
             ft_attribution_llm_model="model-a",
             ft_attribution_analysis_backend="mcp",
-            ft_attribution_decision_timeout=12.5,
             ft_attribution_log_level="DEBUG",
             ft_attribution_export_url=(
                 "https://dataflow.example.test/dataflow2/example-index/posting"
@@ -199,12 +195,55 @@ def test_attribution_config_maps_launcher_args(tmp_path):
     assert env["NVRX_ATTRSVC_LLM_BASE_URL"] == "https://llm.example/v1"
     assert env["NVRX_ATTRSVC_LLM_MODEL"] == "model-a"
     assert env["NVRX_ATTRSVC_ANALYSIS_BACKEND"] == "mcp"
-    assert cfg.client_endpoint.decision_timeout == 12.5
     assert env["NVRX_ATTRSVC_LOG_LEVEL"] == "DEBUG"
     assert (
         env["NVRX_ATTRSVC_EXPORT_URL"]
         == "https://dataflow.example.test/dataflow2/example-index/posting"
     )
+
+
+def test_attribution_stop_action_defaults_to_log_only(tmp_path):
+    """Enabling attribution must not implicitly enable acting on its verdicts."""
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(),
+    )
+
+    assert cfg.stop_action == "log"
+    assert cfg.enforce_stop is False
+    assert cfg.client_endpoint.enforce_stop is False
+
+
+def test_attribution_stop_action_no_restart_enables_enforcement(tmp_path):
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost", ft_attribution_stop_action="no-restart"),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(),
+    )
+
+    assert cfg.enforce_stop is True
+    assert cfg.client_endpoint.enforce_stop is True
+
+
+def test_yaml_attribution_stop_action_is_used(tmp_path):
+    cfg = AttributionConfig.from_args(
+        _args(ft_attribution_endpoint="localhost"),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(attribution_stop_action="no-restart"),
+    )
+
+    assert cfg.client_endpoint.enforce_stop is True
+
+
+@pytest.mark.parametrize("value", ["restart", "stop", ""])
+def test_attribution_stop_action_rejects_unknown_values(tmp_path, value):
+    with pytest.raises(ValueError, match="--ft-attribution-stop-action"):
+        AttributionConfig.from_args(
+            _args(ft_attribution_endpoint="localhost", ft_attribution_stop_action=value),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(),
+        )
 
 
 def test_attribution_config_rejects_lib_analysis_backend(tmp_path):
@@ -214,27 +253,6 @@ def test_attribution_config_rejects_lib_analysis_backend(tmp_path):
                 ft_attribution_endpoint="localhost",
                 ft_attribution_analysis_backend="lib",
             ),
-            str(tmp_path / "train.log"),
-            FaultToleranceConfig(),
-        )
-
-
-def test_yaml_attribution_decision_timeout_is_used(tmp_path):
-    cfg = AttributionConfig.from_args(
-        _args(ft_attribution_endpoint="localhost"),
-        str(tmp_path / "train.log"),
-        FaultToleranceConfig(attribution_decision_timeout=9.0),
-    )
-
-    assert cfg.decision_timeout == 9.0
-    assert cfg.client_endpoint.decision_timeout == 9.0
-
-
-@pytest.mark.parametrize("value", [0, -1])
-def test_attribution_decision_timeout_must_be_positive(tmp_path, value):
-    with pytest.raises(ValueError, match="--ft-attribution-decision-timeout"):
-        AttributionConfig.from_args(
-            _args(ft_attribution_endpoint="localhost", ft_attribution_decision_timeout=value),
             str(tmp_path / "train.log"),
             FaultToleranceConfig(),
         )

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -280,36 +280,34 @@ class BarrierStateBasicTest(BaseRendezvousTest):
             ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_FAILURE,
         )
 
-    def test_attribution_gate_sets_failure_shutdown_when_stop_recommended(self):
-        """Attribution-stop is a terminal failure reason, not a graceful shutdown."""
+    def test_attribution_stop_requested_reads_the_service_latch(self):
+        """The monitor loop polls this at its native interval, so it must stay local."""
         state = object.__new__(_RendezvousBarrierState)
-        state._round = 1
         state._attribution_service = MagicMock()
-        state._attribution_service.get_last_result.return_value = True
-        state._attribution_gate_settled_round = -1
-        state._attribution_cycle_log_submitted = 0
+        state._attribution_service.stop_requested.return_value = True
+
+        self.assertTrue(state.attribution_stop_requested())
+        state._attribution_service.stop_requested.assert_called_once_with()
+
+    def test_attribution_stop_requested_is_false_without_attribution(self):
+        """Only the rendezvous store host holds an attribution client."""
+        state = object.__new__(_RendezvousBarrierState)
+        state._attribution_service = None
+
+        self.assertFalse(state.attribution_stop_requested())
+
+    def test_signal_no_restart_records_reason_and_wakes_peers(self):
+        """Two store writes carry the whole broadcast; peers need no new steady-state poll."""
+        state = object.__new__(_RendezvousBarrierState)
         state.set_shutdown = MagicMock()
+        state.open_rendezvous = MagicMock()
 
-        with self.assertRaises(RendezvousGracefulExitError):
-            state._attribution_gate("node-a")
+        state.signal_no_restart(ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP)
 
-        state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
         state.set_shutdown.assert_called_once_with(
-            ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_FAILURE
+            ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP
         )
-
-    def test_attribution_gate_does_not_poll_stale_submitted_log(self):
-        """A missing previous-cycle submit fails open without polling an older log."""
-        state = object.__new__(_RendezvousBarrierState)
-        state._round = 2
-        state._attribution_service = MagicMock()
-        state._attribution_gate_settled_round = -1
-        state._attribution_cycle_log_submitted = 0
-
-        self.assertTrue(state._attribution_gate("node-a"))
-
-        state._attribution_service.get_last_result.assert_not_called()
-        self.assertEqual(state._attribution_gate_settled_round, 2)
+        state.open_rendezvous.assert_called_once_with()
 
     def test_join_increments_join_count(self):
         """Test that joining increments join_count atomically."""
@@ -908,8 +906,8 @@ class Step2CompletionTest(BaseRendezvousTest):
         finally:
             os.environ.pop("NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE", None)
 
-    def test_step2_rechecks_close_state_after_attribution_resolves(self):
-        """Restart attribution resolution forces one fresh close-loop pass."""
+    def test_step2_closes_round_without_waiting_for_an_attribution_verdict(self):
+        """Restart latency no longer includes attribution: the round closes immediately."""
         min_nodes = 2
         max_nodes = 2
         state = _RendezvousBarrierState(
@@ -922,7 +920,8 @@ class Step2CompletionTest(BaseRendezvousTest):
         state._compute_step2_poll_interval = lambda min_nodes, segment_check_interval: 0.0
         state._get_unhealthy_count = MagicMock(return_value=0)
         state._attribution_service = MagicMock()
-        state._attribution_service.get_last_result.side_effect = [None, False]
+        # Verdict never arrives; the poller keeps working in the background.
+        state._attribution_service.stop_requested.return_value = False
         state._attribution_cycle_log_submitted = 0
         state.get_all_participants = MagicMock(wraps=state.get_all_participants)
 
@@ -940,11 +939,36 @@ class Step2CompletionTest(BaseRendezvousTest):
             segment_check_interval=0.0,
         )
 
-        self.assertEqual(state._attribution_service.get_last_result.call_count, 2)
+        # Terminal analysis is still requested for the cycle that just failed.
         state._attribution_service.request_terminal_analysis.assert_called_once_with()
-        self.assertEqual(state._get_unhealthy_count.call_count, 2)
         state.get_all_participants.assert_called_once()
         self.assertEqual(self.store.get(state.round_done_key).decode("utf-8"), "1")
+
+    def test_step2_honors_a_latched_stop_before_admitting_participants(self):
+        """A verdict landing mid-round ends the job instead of opening a round nobody runs."""
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+        )
+        state._round = 1
+        state._attribution_service = MagicMock()
+        state._attribution_service.stop_requested.return_value = True
+
+        state._rendezvous_start_time = time.monotonic()
+        with self.assertRaises(RendezvousClosedError):
+            state._host_close_round(
+                _NodeDesc("control", 10, 0),
+                min_nodes=2,
+                max_nodes=2,
+                segment_check_interval=0.0,
+            )
+
+        self.assertEqual(
+            state.get_shutdown_reason(),
+            ft_rendezvous_barrier_module.RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP,
+        )
 
     def test_step2_waits_for_complete_replacement_group_before_segment_check(self):
         """Raw participants may satisfy segment while complete replacement groups do not."""
@@ -1497,6 +1521,7 @@ class GroupRankAssignmentTest(TestCase):
             cycle_log_prefix="/tmp/train.log",
         )
         state._attribution_service = MagicMock()
+        state._attribution_service.stop_requested.return_value = False
 
         def assert_submitted_cycle_recorded(_log_path):
             self.assertEqual(state._attribution_cycle_log_submitted, 0)

--- a/tests/fault_tolerance/unit/test_control_plane.py
+++ b/tests/fault_tolerance/unit/test_control_plane.py
@@ -5,8 +5,22 @@ import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from nvidia_resiliency_ext.fault_tolerance import control_plane
 from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import CycleInfoRoundSnapshot
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep():
+    """Keep the store-read grace period from actually sleeping in unit tests.
+
+    run() waits out the remainder of the grace window on every exit path, so without
+    this each test that calls run() would burn the full _STORE_READ_GRACE_SECONDS.
+    Tests that assert on the wait patch time.sleep themselves and shadow this.
+    """
+    with patch.object(control_plane.time, "sleep"):
+        yield
 
 
 def test_nvrx_control_starts_owned_services_without_worker_agent(tmp_path):
@@ -31,7 +45,10 @@ def test_nvrx_control_starts_owned_services_without_worker_agent(tmp_path):
         ]
     )
     manager = MagicMock()
-    manager.start_if_needed.return_value = SimpleNamespace(endpoint="http://localhost:50050")
+    # Mirror the real AttributionEndpoint dataclass, including the enforcement flag.
+    manager.start_if_needed.return_value = SimpleNamespace(
+        endpoint="http://localhost:50050", enforce_stop=False
+    )
     grpc_proc = MagicMock()
     cycle_reporter = MagicMock()
 
@@ -65,6 +82,162 @@ def test_nvrx_control_starts_owned_services_without_worker_agent(tmp_path):
     manager.stop.assert_called_once()
     cycle_reporter.shutdown.assert_called_once()
     assert not hasattr(control_plane, "LocalElasticAgent")
+
+
+def test_nvrx_control_stops_the_attribution_poller_before_the_service(tmp_path):
+    """nvrx-control owns the client, so nothing else will stop its poller thread.
+
+    The embedded launcher does this from FtRendezvousBarrierHandler._close(), which has
+    no equivalent here. Without it the daemon keeps polling attrsvc through its shutdown.
+    """
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--rdzv-id",
+            "job-a",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+            "--ft-attribution-endpoint",
+            "localhost",
+        ]
+    )
+    manager = MagicMock()
+    manager.start_if_needed.return_value = SimpleNamespace(
+        endpoint="http://localhost:50050", enforce_stop=False
+    )
+    service = MagicMock()
+    order = []
+    service.stop_poller.side_effect = lambda *a, **k: order.append("stop_poller")
+    manager.stop.side_effect = lambda *a, **k: order.append("manager_stop")
+
+    with (
+        patch.object(control_plane, "_create_tcp_store", return_value=object()),
+        patch.object(control_plane, "AttributionManager", return_value=manager),
+        patch.object(control_plane, "AttributionService", return_value=service),
+        patch.object(control_plane, "_run_control_rendezvous_loop"),
+    ):
+        control_plane.run(args)
+
+    service.start_poller.assert_called_once()
+    service.stop_poller.assert_called_once()
+    assert order == ["stop_poller", "manager_stop"]
+
+
+def test_nvrx_control_stops_the_poller_when_startup_fails(tmp_path):
+    """A later startup failure must not abandon an already-running poller thread."""
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--rdzv-id",
+            "job-a",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+            "--ft-attribution-endpoint",
+            "localhost",
+            "--ft-enable-log-server",
+            "true",
+        ]
+    )
+    manager = MagicMock()
+    manager.start_if_needed.return_value = SimpleNamespace(
+        endpoint="http://localhost:50050", enforce_stop=False
+    )
+    service = MagicMock()
+
+    with (
+        patch.object(control_plane, "_create_tcp_store", return_value=object()),
+        patch.object(control_plane, "AttributionManager", return_value=manager),
+        patch.object(control_plane, "AttributionService", return_value=service),
+        patch.object(control_plane, "_start_grpc_log_servers", return_value=[]),
+        patch.object(control_plane, "stop_grpc_log_servers"),
+        patch.object(control_plane, "_run_control_rendezvous_loop"),
+        pytest.raises(RuntimeError, match="log funnel"),
+    ):
+        control_plane.run(args)
+
+    service.stop_poller.assert_called_once()
+
+
+def test_store_read_grace_waits_out_the_remainder():
+    """Peers map the stored shutdown reason to their exit code, so the store must outlive them."""
+    with (
+        patch.object(control_plane.time, "monotonic", return_value=100.0),
+        patch.object(control_plane.time, "sleep") as sleep,
+    ):
+        control_plane._wait_for_store_read_grace(since=99.0)
+
+    sleep.assert_called_once()
+    assert sleep.call_args.args[0] == pytest.approx(2.0)
+
+
+def test_store_read_grace_is_skipped_when_teardown_was_already_slow():
+    """A slow gRPC or attrsvc shutdown already held the window open; do not add to it."""
+    with (
+        patch.object(control_plane.time, "monotonic", return_value=100.0),
+        patch.object(control_plane.time, "sleep") as sleep,
+    ):
+        control_plane._wait_for_store_read_grace(since=90.0)
+
+    sleep.assert_not_called()
+
+
+def test_nvrx_control_holds_the_store_open_before_exit(tmp_path):
+    """The grace wait must run after service teardown but before run() drops the store."""
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--rdzv-id",
+            "job-a",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+        ]
+    )
+
+    with (
+        patch.object(control_plane, "_create_tcp_store", return_value=object()),
+        patch.object(control_plane, "_run_control_rendezvous_loop"),
+        patch.object(control_plane, "_wait_for_store_read_grace") as grace,
+    ):
+        control_plane.run(args)
+
+    grace.assert_called_once()
+
+
+def test_nvrx_control_holds_the_store_open_even_when_the_loop_raises(tmp_path):
+    """An aborted control loop is exactly when peers still need to read the reason."""
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--rdzv-id",
+            "job-a",
+            "--ft-per-cycle-applog-prefix",
+            str(tmp_path / "train.log"),
+        ]
+    )
+
+    with (
+        patch.object(control_plane, "_create_tcp_store", return_value=object()),
+        patch.object(
+            control_plane, "_run_control_rendezvous_loop", side_effect=RuntimeError("boom")
+        ),
+        patch.object(control_plane, "_wait_for_store_read_grace") as grace,
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        control_plane.run(args)
+
+    grace.assert_called_once()
 
 
 def test_nvrx_control_does_not_start_attribution_without_endpoint(tmp_path):

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -26,9 +26,15 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
+from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
 
 from nvidia_resiliency_ext import fault_tolerance
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
+from nvidia_resiliency_ext.fault_tolerance.utils import (
+    DEFAULT_NO_RESTART_EXIT_CODE,
+    RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP,
+    RDZV_SHUTDOWN_REASON_NO_PROGRESS,
+)
 
 WORLD_SIZE = 4
 DEFAULT_TIMEOUT = 90
@@ -360,6 +366,10 @@ def _make_agent_spec(rdzv_round=1):
     spec.rdzv_handler.get_standby_node_addrs.return_value = ["node003"]
     spec.rdzv_handler.get_active_ranks.return_value = [0, 1]
     spec.rdzv_handler._attribution_service = None
+    # Only the rendezvous store host holds an attribution client, and a stop is the
+    # exception rather than the rule, so default both attribution probes to "no stop".
+    spec.rdzv_handler.attribution_stop_requested.return_value = False
+    spec.rdzv_handler.no_restart_reason.return_value = None
     spec.max_restarts = 3
     return spec
 
@@ -571,7 +581,13 @@ class TestHandleRestartDecision(unittest.TestCase):
         )
 
     def test_handle_restart_decision_progress_terminate(self):
-        """Returns False without restarting when progress tracker says terminate early."""
+        """No-progress is a no-restart decision, reported like an attribution STOP.
+
+        Both mean "NVRx decided, do not requeue", so they must be indistinguishable to
+        downstream tooling rather than this one looking like an ordinary crash.
+        """
+        from nvidia_resiliency_ext.fault_tolerance.launcher import NoRestartRequested
+
         agent = self._make_agent()
         agent._is_store_host = True
         agent._progress_tracker = MagicMock()
@@ -582,15 +598,23 @@ class TestHandleRestartDecision(unittest.TestCase):
         with (
             patch.object(agent, '_restart_workers') as mock_restart,
             patch.object(agent, '_open_rendezvous_for_restart') as mock_open,
+            patch.object(agent, '_stop_workers') as mock_stop,
         ):
-            result = agent._handle_restart_decision(
-                role="test", spec=self.spec, log_msg="[%s] restarting"
-            )
+            with self.assertRaises(NoRestartRequested) as ctx:
+                agent._handle_restart_decision(
+                    role="test", spec=self.spec, log_msg="[%s] restarting"
+                )
 
-        self.assertFalse(result)
+        self.assertEqual(ctx.exception.reason, RDZV_SHUTDOWN_REASON_NO_PROGRESS)
+        agent._rdzv_handler.signal_no_restart.assert_called_once_with(
+            RDZV_SHUTDOWN_REASON_NO_PROGRESS
+        )
+        mock_stop.assert_called_once_with(agent._worker_group)
         agent._rdzv_handler._attribution_service.request_terminal_analysis.assert_not_called()
         mock_restart.assert_not_called()
         mock_open.assert_not_called()
+        # The restart budget is untouched: this is a stop, not a consumed retry.
+        self.assertEqual(agent._remaining_restarts, 2)
 
     def test_handle_restart_decision_restarts_remaining(self):
         """Returns True and decrements _remaining_restarts when restarts are available."""
@@ -728,74 +752,229 @@ class TestHandleRestartDecision(unittest.TestCase):
         self.assertFalse(hasattr(legacy_rdzv, '_barrier_state'))
 
 
-def test_rendezvous_host_sets_failure_shutdown_when_attribution_says_stop():
-    from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
+def _healthy_agent(fault_tol_cfg, logs_specs, **rdzv_overrides):
+    """Agent wired so one monitor-loop pass runs against a HEALTHY worker group."""
+    from nvidia_resiliency_ext.fault_tolerance.launcher import LocalElasticAgent
 
-    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import (
-        RDZV_SHUTDOWN_REASON_FAILURE,
-        _RendezvousBarrierState,
+    spec = _make_agent_spec(rdzv_round=1)
+    spec.role = "trainer"
+    spec.monitor_interval = 0
+    for name, value in rdzv_overrides.items():
+        getattr(spec.rdzv_handler, name).return_value = value
+    agent = LocalElasticAgent(
+        spec=spec,
+        fault_tol_cfg=fault_tol_cfg,
+        logs_specs=logs_specs,
     )
-
-    state = object.__new__(_RendezvousBarrierState)
-    state._round = 1
-    state._attribution_service = MagicMock()
-    state._attribution_service.get_last_result.return_value = True
-    state._attribution_gate_settled_round = -1
-    state._attribution_cycle_log_submitted = 0
-    state.set_shutdown = MagicMock()
-
-    with pytest.raises(RendezvousGracefulExitError):
-        state._attribution_gate("node-a")
-
-    state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
-    state.set_shutdown.assert_called_once_with(RDZV_SHUTDOWN_REASON_FAILURE)
+    agent._worker_group.state = WorkerState.HEALTHY
+    agent._worker_group.group_rank = 0
+    return agent
 
 
-def test_rendezvous_host_retries_close_round_when_attribution_pending():
-    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import _RendezvousBarrierState
+class TestNoRestartTermination(unittest.TestCase):
+    """The monitor loop consumes a latched STOP verdict and ends the job."""
 
-    state = object.__new__(_RendezvousBarrierState)
-    state._round = 1
-    state._attribution_service = MagicMock()
-    state._attribution_service.get_last_result.return_value = None
-    state._attribution_gate_settled_round = -1
-    state._attribution_cycle_log_submitted = 0
+    def setUp(self):
+        self.fault_tol_cfg = FaultToleranceConfig()
+        self.logs_specs = MagicMock()
+        self.logs_specs.get_cycle_log_file.return_value = "/path/to/cycle_0.log"
 
-    should_close = state._attribution_gate("node-a")
+    def _run_one_monitor_pass(self, agent):
+        from nvidia_resiliency_ext.fault_tolerance import launcher
 
-    assert should_close is False
-    state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
-    assert state._attribution_gate_settled_round == -1
+        with (
+            patch.object(agent, '_initialize_workers'),
+            patch.object(
+                agent, '_monitor_workers', return_value=RunResult(state=WorkerState.HEALTHY)
+            ),
+            patch.object(agent, '_stop_workers') as stop_workers,
+            patch.object(launcher, 'record_profiling_event'),
+            patch.object(launcher, 'put_metric'),
+            patch.object(launcher.time, 'sleep'),
+        ):
+            try:
+                return agent._invoke_run_with_any_failed_policy(), stop_workers, None
+            except Exception as exc:  # noqa: BLE001 - the raised type is the assertion
+                return None, stop_workers, exc
+
+    def test_store_host_terminates_job_when_attribution_latches_stop(self):
+        """The latch is local, so acting on it needs no extra TCPStore poll."""
+        from nvidia_resiliency_ext.fault_tolerance.launcher import NoRestartRequested
+
+        agent = _healthy_agent(self.fault_tol_cfg, self.logs_specs, attribution_stop_requested=True)
+        rdzv_handler = agent._worker_group.spec.rdzv_handler
+
+        _, stop_workers, exc = self._run_one_monitor_pass(agent)
+
+        self.assertIsInstance(exc, NoRestartRequested)
+        rdzv_handler.signal_no_restart.assert_called_once_with(
+            RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP
+        )
+        stop_workers.assert_called_once_with(agent._worker_group)
+        # The latch is checked first, so the stopping node skips the round-open store read.
+        rdzv_handler.is_next_round_open.assert_not_called()
+
+    def test_store_host_terminates_job_when_latch_set_during_a_failed_cycle(self):
+        """The latch preempts the restart decision, not just the healthy path.
+
+        A verdict often lands while the group is FAILED rather than HEALTHY, especially in
+        a crash loop. Without preemption the node would spend a restart and a rendezvous
+        round trip before noticing.
+        """
+        from nvidia_resiliency_ext.fault_tolerance import launcher
+        from nvidia_resiliency_ext.fault_tolerance.launcher import NoRestartRequested
+
+        agent = _healthy_agent(self.fault_tol_cfg, self.logs_specs, attribution_stop_requested=True)
+        rdzv_handler = agent._worker_group.spec.rdzv_handler
+
+        with (
+            patch.object(agent, '_initialize_workers'),
+            patch.object(
+                agent, '_monitor_workers', return_value=RunResult(state=WorkerState.FAILED)
+            ),
+            patch.object(agent, '_stop_workers') as stop_workers,
+            patch.object(agent, '_handle_restart_decision') as restart_decision,
+            patch.object(launcher, 'record_profiling_event'),
+            patch.object(launcher, 'put_metric'),
+            patch.object(launcher.time, 'sleep'),
+        ):
+            with self.assertRaises(NoRestartRequested) as ctx:
+                agent._invoke_run_with_any_failed_policy()
+
+        self.assertEqual(ctx.exception.reason, RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP)
+        rdzv_handler.signal_no_restart.assert_called_once_with(
+            RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP
+        )
+        stop_workers.assert_called_once_with(agent._worker_group)
+        restart_decision.assert_not_called()
+
+    def test_successful_workers_are_not_killed_by_a_latched_stop(self):
+        """A workload that finished is not killed because an earlier cycle was fatal."""
+        from nvidia_resiliency_ext.fault_tolerance import launcher
+
+        agent = _healthy_agent(self.fault_tol_cfg, self.logs_specs, attribution_stop_requested=True)
+        rdzv_handler = agent._worker_group.spec.rdzv_handler
+        succeeded = RunResult(state=WorkerState.SUCCEEDED)
+
+        with (
+            patch.object(agent, '_initialize_workers'),
+            patch.object(agent, '_monitor_workers', return_value=succeeded),
+            patch.object(agent, '_exit_barrier'),
+            patch.object(agent, '_stop_workers') as stop_workers,
+            patch.object(launcher, 'record_profiling_event'),
+            patch.object(launcher, 'put_metric'),
+            patch.object(launcher.time, 'sleep'),
+        ):
+            result = agent._invoke_run_with_any_failed_policy()
+
+        self.assertEqual(result.state, WorkerState.SUCCEEDED)
+        rdzv_handler.signal_no_restart.assert_not_called()
+        stop_workers.assert_not_called()
+
+    def test_peer_terminates_job_when_round_opens_for_attribution_stop(self):
+        """Peers hold no attribution client; they learn about the stop from the store."""
+        from nvidia_resiliency_ext.fault_tolerance.launcher import NoRestartRequested
+
+        agent = _healthy_agent(
+            self.fault_tol_cfg,
+            self.logs_specs,
+            attribution_stop_requested=False,
+            is_next_round_open=True,
+            no_restart_reason=RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP,
+        )
+
+        with patch.object(agent, '_handle_restart_decision') as restart_decision:
+            _, stop_workers, exc = self._run_one_monitor_pass(agent)
+
+        self.assertIsInstance(exc, NoRestartRequested)
+        stop_workers.assert_called_once_with(agent._worker_group)
+        # A stop is not a restart: the restart budget must not be consumed.
+        restart_decision.assert_not_called()
+
+    def test_peer_restarts_normally_when_round_opens_without_attribution_stop(self):
+        """An ordinary peer failure keeps the existing restart path."""
+        agent = _healthy_agent(
+            self.fault_tol_cfg,
+            self.logs_specs,
+            attribution_stop_requested=False,
+            is_next_round_open=True,
+            no_restart_reason=None,
+        )
+
+        with patch.object(agent, '_handle_restart_decision', return_value=False) as decision:
+            result, _, exc = self._run_one_monitor_pass(agent)
+
+        self.assertIsNone(exc)
+        self.assertEqual(result.state, WorkerState.FAILED)
+        decision.assert_called_once()
+
+    def test_graceful_rendezvous_exit_maps_no_restart_to_dedicated_exception(self):
+        """Hot spares exit via rendezvous, not the monitor loop, and must not report success."""
+        from torch.distributed.elastic.rendezvous.api import RendezvousGracefulExitError
+
+        from nvidia_resiliency_ext.fault_tolerance.launcher import (
+            LocalElasticAgent,
+            NoRestartRequested,
+        )
+
+        spec = _make_agent_spec(rdzv_round=3)
+        spec.rdzv_handler.no_restart_reason.return_value = RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP
+        agent = LocalElasticAgent(
+            spec=spec,
+            fault_tol_cfg=self.fault_tol_cfg,
+            logs_specs=self.logs_specs,
+        )
+
+        with (
+            patch.object(
+                agent, '_invoke_run', side_effect=RendezvousGracefulExitError("round closed")
+            ),
+            patch.object(agent, '_shutdown'),
+        ):
+            with self.assertRaises(NoRestartRequested):
+                agent.run()
 
 
-def test_rendezvous_host_skips_attribution_gate_for_initial_round():
-    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import _RendezvousBarrierState
-
-    state = object.__new__(_RendezvousBarrierState)
-    state._round = 0
-    state._attribution_service = MagicMock()
-    state._attribution_gate_settled_round = -1
-    state._attribution_cycle_log_submitted = None
-
-    assert state._attribution_gate("node-a") is True
-    state._attribution_service.get_last_result.assert_not_called()
+def test_no_restart_exit_code_default_is_outside_reserved_ranges():
+    """Downstream tooling keys on this code to tell "do not requeue" from a failure."""
+    assert DEFAULT_NO_RESTART_EXIT_CODE == 93
+    assert DEFAULT_NO_RESTART_EXIT_CODE not in (0, 1, 2, 255)
+    assert not 64 <= DEFAULT_NO_RESTART_EXIT_CODE <= 78
+    assert not 126 <= DEFAULT_NO_RESTART_EXIT_CODE <= 165
 
 
-def test_rendezvous_host_closes_round_when_attribution_allows_restart():
-    from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import _RendezvousBarrierState
+def test_main_reports_same_exit_code_for_both_no_restart_reasons():
+    """Attribution STOP and no-progress are one binary signal to the scheduler."""
+    from nvidia_resiliency_ext.fault_tolerance.launcher import NoRestartRequested, main
 
-    state = object.__new__(_RendezvousBarrierState)
-    state._round = 1
-    state._attribution_service = MagicMock()
-    state._attribution_service.get_last_result.return_value = False
-    state._attribution_gate_settled_round = -1
-    state._attribution_cycle_log_submitted = 0
+    codes = []
+    for reason in (RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP, RDZV_SHUTDOWN_REASON_NO_PROGRESS):
+        with (
+            patch(
+                "nvidia_resiliency_ext.fault_tolerance.launcher.run",
+                side_effect=NoRestartRequested(reason),
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            main(['train.py'])
+        codes.append(excinfo.value.code)
 
-    should_close = state._attribution_gate("node-a")
+    assert codes == [DEFAULT_NO_RESTART_EXIT_CODE, DEFAULT_NO_RESTART_EXIT_CODE]
 
-    assert should_close is True
-    assert state._attribution_gate_settled_round == 1
-    state._attribution_service.get_last_result.assert_called_once_with(node_id="node-a")
+
+def test_main_honors_no_restart_exit_code_override():
+    from nvidia_resiliency_ext.fault_tolerance.launcher import NoRestartRequested, main
+
+    with (
+        patch(
+            "nvidia_resiliency_ext.fault_tolerance.launcher.run",
+            side_effect=NoRestartRequested(RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP),
+        ),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        main(['--ft-no-restart-exit-code', '17', 'train.py'])
+
+    assert excinfo.value.code == 17
 
 
 def test_ft_log_aggregator_count_rejects_negative():

--- a/tests/fault_tolerance/unit/test_progress_tracker.py
+++ b/tests/fault_tolerance/unit/test_progress_tracker.py
@@ -18,6 +18,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
 from nvidia_resiliency_ext.fault_tolerance.progress_tracker import TrainingProgressTracker
 
 
@@ -29,12 +30,19 @@ class TestTrainingProgressTracker(unittest.TestCase):
         self.min_progress_iterations = 200
         self.max_no_progress_cycles = 3
 
-    def test_initialization_default_min_progress(self):
-        """Test tracker default min_progress_iterations is 1 and default max_no_progress_cycles is 2."""
-        tracker = TrainingProgressTracker(max_no_progress_cycles=2)
+    def test_initialization_defaults(self):
+        """Defaults: any iteration increase counts as progress, 3 no-progress cycles allowed."""
+        tracker = TrainingProgressTracker()
         self.assertEqual(tracker.min_progress_iterations, 1)
-        self.assertEqual(tracker.max_no_progress_cycles, 2)
+        self.assertEqual(tracker.max_no_progress_cycles, 3)
         self.assertIsNone(tracker.checkpoint_iteration_file)
+
+    def test_default_matches_fault_tolerance_config(self):
+        """The dataclass default and the tracker default must not drift apart."""
+        self.assertEqual(
+            FaultToleranceConfig().max_no_progress_cycles,
+            TrainingProgressTracker().max_no_progress_cycles,
+        )
 
     def test_initialization(self):
         """Test tracker initialization with explicit values."""
@@ -69,6 +77,79 @@ class TestTrainingProgressTracker(unittest.TestCase):
             self.assertEqual(tracker.last_restart_iteration, 351500)
         finally:
             os.unlink(path)
+
+    def test_unreadable_iteration_file_does_not_count_as_no_progress(self):
+        """A failed read means the iteration is unknown, not that the job went backwards.
+
+        current_max_iteration is reset to 0 after every cycle, so without this an I/O
+        error scores as a large backwards step and burns a no-progress cycle.
+        """
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("351500\n")
+            path = f.name
+        try:
+            tracker = TrainingProgressTracker(
+                min_progress_iterations=1,
+                max_no_progress_cycles=3,
+                checkpoint_iteration_file=path,
+            )
+            tracker.last_restart_iteration = 351500
+            tracker.no_progress_count = 1
+
+            with patch("builtins.open", side_effect=OSError("stale file handle")):
+                tracker.analyze_previous_cycle()
+
+            self.assertEqual(tracker.no_progress_count, 1)  # not incremented
+            self.assertEqual(tracker.last_restart_iteration, 351500)  # baseline preserved
+            self.assertEqual(tracker.cycle_number, 1)  # cycle still advances
+        finally:
+            os.unlink(path)
+
+    def test_unreadable_iteration_file_does_not_reset_no_progress_count(self):
+        """The recovery read must not look like a huge jump forwards.
+
+        Clobbering the baseline to 0 on a failed read makes the next successful read score
+        as large progress, silently clearing the counter on a genuinely stuck job.
+        """
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("351500\n")
+            path = f.name
+        try:
+            tracker = TrainingProgressTracker(
+                min_progress_iterations=1,
+                max_no_progress_cycles=3,
+                checkpoint_iteration_file=path,
+            )
+            tracker.last_restart_iteration = 351500
+            tracker.no_progress_count = 2
+
+            # Transient failure, then the file becomes readable again at the same value:
+            # the job is still stuck, so the count must keep climbing to the threshold.
+            with patch("builtins.open", side_effect=OSError("stale file handle")):
+                tracker.analyze_previous_cycle()
+            tracker.analyze_previous_cycle()
+
+            self.assertEqual(tracker.no_progress_count, 3)
+            self.assertTrue(tracker.should_terminate_early())
+        finally:
+            os.unlink(path)
+
+    def test_missing_iteration_file_warns_once_not_every_cycle(self):
+        """The pre-first-checkpoint phase is expected and must not warn on every cycle."""
+        tracker = TrainingProgressTracker(
+            min_progress_iterations=1,
+            max_no_progress_cycles=3,
+            checkpoint_iteration_file="/nonexistent/latest_checkpointed_iteration.txt",
+        )
+
+        with self.assertLogs("nvrx", level="WARNING") as captured:
+            tracker.analyze_previous_cycle()
+            tracker.analyze_previous_cycle()
+            tracker.analyze_previous_cycle()
+
+        skips = [r for r in captured.records if "progress check skipped" in r.getMessage()]
+        self.assertEqual(len(skips), 1)
+        self.assertEqual(tracker.no_progress_count, 0)
 
     def test_update_iteration(self):
         """Test that iteration updates track maximum value."""

--- a/tests/fault_tolerance/unit/utils.py
+++ b/tests/fault_tolerance/unit/utils.py
@@ -111,9 +111,18 @@ def distributed_worker(
 
     ready_flag.set()
 
-    worker_fn(**kwargs)
-
-    torch.distributed.destroy_process_group()
+    try:
+        worker_fn(**kwargs)
+    finally:
+        # Must run even when worker_fn exits via sys.exit(), which most of them do.
+        # SystemExit propagates out of the call, so an unguarded destroy here is simply
+        # never reached and the process group survives into interpreter shutdown. Gloo
+        # then tears its background threads down during static destruction, the process
+        # aborts with "terminate called without an active exception", and the rank
+        # returns -6. It is timing dependent, so it surfaces as a flaky subset of ranks
+        # failing rather than a consistent error.
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
 
     sys.exit(0)
 

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -18,7 +18,7 @@ import os
 import tempfile
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 from nvidia_resiliency_ext.shared_utils.health_check import (
     AttributionService,
@@ -617,21 +617,6 @@ class TestNodeHealthCheck(unittest.TestCase):
 
 class TestAttributionService(unittest.TestCase):
 
-    def test_default_decision_timeout_is_owned_by_service(self):
-        service = AttributionService(endpoint="http://attr.example:8000/")
-        none_service = AttributionService(
-            endpoint="http://attr.example:8000/",
-            decision_timeout=None,
-        )
-
-        self.assertEqual(
-            service.decision_timeout, AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS
-        )
-        self.assertEqual(
-            none_service.decision_timeout, AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS
-        )
-        self.assertEqual(AttributionService.DEFAULT_DECISION_TIMEOUT_SECONDS, 60.0)
-
     @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
     def test_http_endpoint_posts_progressive_intent_to_logs_route(self, mock_client):
         client = mock_client.return_value.__enter__.return_value
@@ -688,38 +673,102 @@ class TestAttributionService(unittest.TestCase):
 
     def test_submit_log_posts_progressive_work_synchronously(self):
         service = AttributionService(endpoint="http://attr.example:8000/")
-        service._next_result_poll_time = 42.0
 
         with patch.object(service, "_do_submit_log") as mock_submit:
             service._submit_log("/tmp/train.log")
 
         self.assertEqual(service._last_submitted, "/tmp/train.log")
-        self.assertEqual(service._next_result_poll_time, 0.0)
         mock_submit.assert_called_once_with(
             "/tmp/train.log",
             analysis_intent="progressive",
         )
 
-    def test_request_terminal_analysis_posts_terminal_work_synchronously(self):
-        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
-        service._last_submitted = "/tmp/train.log"
-        service._next_result_poll_time = 42.0
+    def test_submit_log_does_not_clobber_pending_terminal_analysis(self):
+        """Cycle N+1 starting must not abandon cycle N's in-flight verdict."""
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._terminal_pending = "/tmp/train_cycle0.log"
 
-        with (
-            patch.object(service, "_do_submit_log") as mock_submit,
-            patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                return_value=10.0,
-            ),
-        ):
+        with patch.object(service, "_do_submit_log"):
+            service._submit_log("/tmp/train_cycle1.log")
+
+        self.assertEqual(service._last_submitted, "/tmp/train_cycle1.log")
+        self.assertEqual(service._terminal_pending, "/tmp/train_cycle0.log")
+
+    def test_request_terminal_analysis_posts_terminal_work_synchronously(self):
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._last_submitted = "/tmp/train.log"
+
+        with patch.object(service, "_do_submit_log") as mock_submit:
             service.request_terminal_analysis()
 
         mock_submit.assert_called_once_with(
             "/tmp/train.log",
             analysis_intent="terminal",
         )
-        self.assertEqual(service._terminal_deadline, 17.0)
-        self.assertEqual(service._next_result_poll_time, 0.0)
+        self.assertEqual(service._terminal_pending, "/tmp/train.log")
+
+    def test_terminal_post_precedes_publishing_the_pollable_slot(self):
+        """The poller must never see a path attrsvc has not been asked to analyze.
+
+        Otherwise whatever a GET returns for that path becomes the terminal verdict.
+        """
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._last_submitted = "/tmp/train.log"
+        observed = []
+
+        def record_slot_at_post(*args, **kwargs):
+            observed.append(service._terminal_pending)
+            return True
+
+        with patch.object(service, "_do_submit_log", side_effect=record_slot_at_post):
+            service.request_terminal_analysis()
+
+        self.assertEqual(observed, [None])  # slot still unpublished during the POST
+        self.assertEqual(service._terminal_pending, "/tmp/train.log")  # published after
+
+    def test_failed_terminal_post_leaves_the_slot_free(self):
+        """Regression: a rejected submission must not pin the FCFS slot.
+
+        attrsvc never received the request, so the GET for that path can never complete.
+        Installing it would defer every later failed cycle behind it and disable
+        attribution for the rest of the job.
+        """
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._last_submitted = "/tmp/train_cycle0.log"
+
+        with patch.object(service, "_do_submit_log", return_value=False):
+            service.request_terminal_analysis()
+        self.assertIsNone(service._terminal_pending)
+
+        # A later failed cycle still installs normally.
+        service._last_submitted = "/tmp/train_cycle1.log"
+        with patch.object(service, "_do_submit_log", return_value=True):
+            service.request_terminal_analysis()
+        self.assertEqual(service._terminal_pending, "/tmp/train_cycle1.log")
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_submit_reports_failure_on_transport_error(self, mock_client):
+        mock_client.return_value.__enter__.return_value.post.side_effect = OSError("refused")
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        self.assertFalse(service._do_submit_log("/tmp/train.log"))
+
+    @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
+    def test_submit_reports_failure_on_error_status(self, mock_client):
+        """httpx does not raise for error statuses, so a rejection must be checked."""
+        client = mock_client.return_value.__enter__.return_value
+        client.post.return_value = SimpleNamespace(status_code=500)
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        self.assertFalse(service._do_submit_log("/tmp/train.log"))
+
+        client.post.return_value = SimpleNamespace(status_code=202)
+        self.assertTrue(service._do_submit_log("/tmp/train.log"))
+
+    def test_submit_reports_failure_for_unsupported_transport(self):
+        service = AttributionService(endpoint="unix:///tmp/attr.sock")
+
+        self.assertFalse(service._do_submit_log("/tmp/train.log"))
 
     def test_request_terminal_analysis_skips_without_submitted_log(self):
         service = AttributionService(endpoint="http://attr.example:8000/")
@@ -729,162 +778,270 @@ class TestAttributionService(unittest.TestCase):
 
         mock_submit.assert_not_called()
 
-    def test_get_last_result_allows_close_without_submitted_log(self):
+    def test_poll_once_is_noop_without_pending_terminal_analysis(self):
         service = AttributionService(endpoint="http://attr.example:8000/")
 
-        should_stop = service.get_last_result()
+        with patch.object(service, "_get_results") as mock_get:
+            service._poll_once()
 
-        self.assertFalse(should_stop)
+        mock_get.assert_not_called()
+        self.assertFalse(service.stop_requested())
 
-    def test_get_last_result_uses_remaining_decision_budget(self):
-        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
-        service._last_submitted = "/tmp/train.log"
-        service._terminal_deadline = 20.0
+    def test_poll_once_latches_stop_verdict(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", enforce_stop=True)
+        service._terminal_pending = "/tmp/train.log"
 
-        with (
-            patch.object(service, "_get_results", return_value=False) as mock_get,
-            patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                return_value=16.5,
-            ),
-        ):
-            should_stop = service.get_last_result()
+        with patch.object(service, "_get_results", return_value=True) as mock_get:
+            service._poll_once()
 
-        self.assertFalse(should_stop)
         mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
+        self.assertTrue(service.stop_requested())
+        # The latch is global: the pending path is kept for diagnostics, and the loop exits.
+        self.assertEqual(service._terminal_pending, "/tmp/train.log")
 
-    def test_get_last_result_throttles_http_polling(self):
-        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=20.0)
-        service._last_submitted = "/tmp/train.log"
-        service._terminal_deadline = 30.0
+    def test_log_only_mode_observes_a_stop_without_acting_on_it(self):
+        """Enforcement is opt-in: acting on a false-positive STOP is the expensive error."""
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._terminal_pending = "/tmp/train.log"
 
-        with (
-            patch.object(service, "_get_results", side_effect=[None, False]) as mock_get,
-            patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                side_effect=[10.0, 10.0, 11.9, 11.9, 12.0, 12.0],
-            ),
-        ):
-            self.assertIsNone(service.get_last_result())
-            self.assertIsNone(service.get_last_result())
-            self.assertFalse(service.get_last_result())
+        with patch.object(service, "_get_results", return_value=True):
+            service._poll_once()
 
-        self.assertEqual(mock_get.call_count, 2)
+        self.assertTrue(service.stop_verdict_observed())  # recorded for diagnosis
+        self.assertFalse(service.stop_requested())  # but never acted on
+
+    def test_log_only_mode_keeps_analyzing_later_cycles_after_a_stop(self):
+        """Regression: the first STOP must not silently end attribution for the job.
+
+        Log-only mode exists to accumulate a verdict per failed cycle so a deployment can
+        measure precision before enforcing. Latching on the first STOP left the pending
+        slot pinned and killed the poller, so every later cycle went unanalyzed.
+        """
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        with patch.object(service, "_do_submit_log") as mock_submit:
+            service._submit_log("/tmp/train_cycle0.log")
+            service.request_terminal_analysis()
+
+            with patch.object(service, "_get_results", return_value=True):
+                service._poll_once()
+            # Slot freed, so the next failed cycle can install its own analysis.
+            self.assertIsNone(service._terminal_pending)
+
+            service._submit_log("/tmp/train_cycle1.log")
+            service.request_terminal_analysis()
+            self.assertEqual(service._terminal_pending, "/tmp/train_cycle1.log")
+
+            with patch.object(service, "_get_results", return_value=True):
+                service._poll_once()
+
+        self.assertEqual(service.stop_verdict_count(), 2)
+        self.assertFalse(service.stop_requested())
+        terminal_posts = [
+            c for c in mock_submit.call_args_list if c.kwargs.get("analysis_intent") == "terminal"
+        ]
         self.assertEqual(
-            mock_get.call_args_list,
-            [
-                call("/tmp/train.log", timeout=2.0),
-                call("/tmp/train.log", timeout=2.0),
-            ],
+            [c.args[0] for c in terminal_posts],
+            ["/tmp/train_cycle0.log", "/tmp/train_cycle1.log"],
         )
 
-    def test_terminal_analysis_does_not_extend_existing_decision_budget(self):
-        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
-        service._last_submitted = "/tmp/train.log"
-        service._terminal_deadline = 20.0
+    def test_log_only_poller_survives_a_stop_verdict(self):
+        """The poller thread must keep running so later cycles still get polled."""
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._terminal_pending = "/tmp/train.log"
+
+        with patch.object(service, "_get_results", return_value=True):
+            service.start_poller()
+            # A latched verdict must not terminate the loop in log-only mode.
+            service._poll_stop_event.wait(0.05)
+            still_running = service._poll_thread is not None and service._poll_thread.is_alive()
+            service.stop_poller(timeout=5.0)
+
+        self.assertTrue(still_running)
+        self.assertTrue(service.stop_verdict_observed())
+
+    def test_enforcing_mode_keeps_the_pending_path_for_the_record(self):
+        """The job is ending, so the log that produced the verdict stays recorded."""
+        service = AttributionService(endpoint="http://attr.example:8000/", enforce_stop=True)
+        service._terminal_pending = "/tmp/train.log"
+
+        with patch.object(service, "_get_results", return_value=True):
+            service._poll_once()
+
+        self.assertEqual(service._terminal_pending, "/tmp/train.log")
+        self.assertEqual(service.stop_verdict_count(), 1)
+
+    def test_log_only_is_the_default(self):
+        self.assertFalse(AttributionService(endpoint="http://attr.example:8000/")._enforce_stop)
+
+    def test_enforcing_mode_acts_on_a_stop(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", enforce_stop=True)
+        service._terminal_pending = "/tmp/train.log"
+
+        with patch.object(service, "_get_results", return_value=True):
+            service._poll_once()
+
+        self.assertTrue(service.stop_verdict_observed())
+        self.assertTrue(service.stop_requested())
+
+    def test_poller_exits_after_a_verdict_even_when_not_enforcing(self):
+        """The analysis is finished; there is nothing further to learn by polling on."""
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._terminal_pending = "/tmp/train.log"
+
+        with patch.object(service, "_get_results", return_value=True) as mock_get:
+            service.start_poller()
+            service.stop_poller(timeout=5.0)
+
+        self.assertFalse(service.stop_requested())
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_poll_once_clears_pending_on_continue_verdict(self):
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._terminal_pending = "/tmp/train.log"
+
+        with patch.object(service, "_get_results", return_value=False):
+            service._poll_once()
+
+        self.assertFalse(service.stop_requested())
+        self.assertIsNone(service._terminal_pending)
+
+    def test_poll_once_keeps_polling_while_undecided(self):
+        """None means analysis is still running or attrsvc is unreachable: keep polling."""
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._terminal_pending = "/tmp/train.log"
+
+        with patch.object(service, "_get_results", return_value=None):
+            service._poll_once()
+            service._poll_once()
+
+        self.assertFalse(service.stop_requested())
+        self.assertEqual(service._terminal_pending, "/tmp/train.log")
+
+    def test_late_verdict_for_older_cycle_still_stops_the_job(self):
+        """A cycle-0 STOP arriving while cycle 2 runs is honored: the verdict is global."""
+        service = AttributionService(endpoint="http://attr.example:8000/", enforce_stop=True)
+
+        with patch.object(service, "_do_submit_log"):
+            service._submit_log("/tmp/train_cycle0.log")
+            service.request_terminal_analysis()
+            service._submit_log("/tmp/train_cycle1.log")
+            service._submit_log("/tmp/train_cycle2.log")
+
+        with patch.object(service, "_get_results", return_value=True) as mock_get:
+            service._poll_once()
+
+        mock_get.assert_called_once_with("/tmp/train_cycle0.log", timeout=2.0)
+        self.assertTrue(service.stop_requested())
+
+    def test_crash_loop_does_not_starve_the_verdict(self):
+        """Regression: cycles failing faster than analysis completes must still yield a STOP.
+
+        Replacing the pending path on every terminal request discarded each in-flight
+        analysis before it finished, so no verdict ever arrived -- in exactly the scenario
+        attribution exists to catch. The pending slot is first-come-first-served, so the
+        first analysis always runs to completion.
+        """
+        service = AttributionService(endpoint="http://attr.example:8000/", enforce_stop=True)
+        analysis_pending = True
+
+        def fake_get(log_path, timeout=None):
+            # attrsvc is still working on whatever it was first asked about.
+            return None if analysis_pending else True
 
         with (
             patch.object(service, "_do_submit_log") as mock_submit,
-            patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                return_value=19.0,
-            ),
+            patch.object(service, "_get_results", side_effect=fake_get) as mock_get,
         ):
+            service._submit_log("/tmp/train_cycle0.log")
             service.request_terminal_analysis()
 
-        self.assertEqual(service._terminal_deadline, 20.0)
-        mock_submit.assert_called_once_with(
-            "/tmp/train.log",
-            analysis_intent="terminal",
+            # 20 rapid crash-loop cycles, each failing before analysis can finish.
+            for cycle in range(1, 21):
+                service._poll_once()
+                service._submit_log(f"/tmp/train_cycle{cycle}.log")
+                service.request_terminal_analysis()
+
+            # Every GET stayed on the first log rather than chasing each new cycle.
+            self.assertEqual(
+                {c.args[0] for c in mock_get.call_args_list}, {"/tmp/train_cycle0.log"}
+            )
+            # Later terminal requests are skipped entirely, so no analysis budget is spent
+            # on results that would never be polled.
+            terminal_posts = [
+                c
+                for c in mock_submit.call_args_list
+                if c.kwargs.get("analysis_intent") == "terminal"
+            ]
+            self.assertEqual(len(terminal_posts), 1)
+            self.assertEqual(terminal_posts[0].args[0], "/tmp/train_cycle0.log")
+            self.assertFalse(service.stop_requested())
+
+            # The first analysis finally completes and the job stops.
+            analysis_pending = False
+            service._poll_once()
+
+        self.assertTrue(service.stop_requested())
+
+    def test_terminal_request_installs_again_once_the_slot_is_free(self):
+        """After a CONTINUE verdict the next failing cycle gets its own analysis."""
+        service = AttributionService(endpoint="http://attr.example:8000/")
+
+        with patch.object(service, "_do_submit_log") as mock_submit:
+            service._submit_log("/tmp/train_cycle0.log")
+            service.request_terminal_analysis()
+
+            with patch.object(service, "_get_results", return_value=False):
+                service._poll_once()
+            self.assertIsNone(service._terminal_pending)
+
+            service._submit_log("/tmp/train_cycle1.log")
+            service.request_terminal_analysis()
+
+        self.assertEqual(service._terminal_pending, "/tmp/train_cycle1.log")
+        terminal_posts = [
+            c for c in mock_submit.call_args_list if c.kwargs.get("analysis_intent") == "terminal"
+        ]
+        self.assertEqual(
+            [c.args[0] for c in terminal_posts], ["/tmp/train_cycle0.log", "/tmp/train_cycle1.log"]
         )
 
-    def test_get_last_result_uses_final_get_after_decision_budget_expires(self):
-        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
-        service._last_submitted = "/tmp/train.log"
-        service._terminal_deadline = 20.0
-        service._next_result_poll_time = 30.0
-
-        with (
-            patch.object(service, "_get_results", return_value=True) as mock_get,
-            patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                return_value=21.0,
-            ),
-        ):
-            should_stop = service.get_last_result()
-
-        self.assertTrue(should_stop)
-        mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
-
-    def test_get_last_result_uses_default_get_timeout_with_remaining_budget(self):
-        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
-        service._last_submitted = "/tmp/train.log"
-        service._terminal_deadline = 20.0
-
-        with (
-            patch.object(service, "_get_results", return_value=None) as mock_get,
-            patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                return_value=19.8,
-            ),
-        ):
-            should_stop = service.get_last_result()
-
-        self.assertIsNone(should_stop)
-        mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
-
-    def test_get_last_result_profiles_wait_until_decision(self):
-        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
-        service._last_submitted = "/tmp/train.log"
-        service._terminal_deadline = 20.0
+    def test_poll_once_profiles_get_started_once_per_terminal_request(self):
+        service = AttributionService(endpoint="http://attr.example:8000/")
+        service._terminal_pending = "/tmp/train.log"
+        service._poll_node_id = "node-a"
 
         with (
             patch.object(service, "_get_results", side_effect=[None, True]),
             patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                side_effect=[10.0, 10.0, 12.0, 12.0],
-            ),
-            patch(
                 "nvidia_resiliency_ext.shared_utils.health_check.record_profiling_event"
             ) as record_event,
         ):
-            self.assertIsNone(service.get_last_result(node_id="node-a"))
-            self.assertTrue(service.get_last_result(node_id="node-a"))
+            service._poll_once()
+            service._poll_once()
 
         self.assertEqual(record_event.call_args_list[0].args[0].value, "attribution_get_started")
         self.assertEqual(record_event.call_args_list[0].kwargs, {"node_id": "node-a"})
         self.assertEqual(record_event.call_args_list[1].args[0].value, "attribution_get_completed")
-        self.assertEqual(
-            record_event.call_args_list[1].kwargs,
-            {"node_id": "node-a"},
-        )
+        self.assertEqual(record_event.call_args_list[1].kwargs, {"node_id": "node-a"})
 
-    def test_get_last_result_profiles_budget_expiry_as_fail_open(self):
-        service = AttributionService(endpoint="http://attr.example:8000/", decision_timeout=7.0)
-        service._last_submitted = "/tmp/train.log"
-        service._terminal_deadline = 20.0
-        service._get_started_recorded = True
+    def test_poller_not_started_for_non_http_transport(self):
+        """Every GET would fail, so the poller would spin without ever reaching a verdict."""
+        service = AttributionService(endpoint="unix:///tmp/attr.sock")
 
-        with (
-            patch.object(service, "_get_results", return_value=None) as mock_get,
-            patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.time.monotonic",
-                return_value=21.25,
-            ),
-            patch(
-                "nvidia_resiliency_ext.shared_utils.health_check.record_profiling_event"
-            ) as record_event,
-        ):
-            should_stop = service.get_last_result(node_id="node-a")
+        service.start_poller()
 
-        self.assertFalse(should_stop)
-        mock_get.assert_called_once_with("/tmp/train.log", timeout=2.0)
-        record_event.assert_called_once()
-        self.assertEqual(record_event.call_args.args[0].value, "attribution_get_completed")
-        self.assertEqual(
-            record_event.call_args.kwargs,
-            {"node_id": "node-a"},
-        )
+        self.assertIsNone(service._poll_thread)
+
+    def test_poller_thread_latches_stop_and_exits(self):
+        service = AttributionService(endpoint="http://attr.example:8000/", enforce_stop=True)
+        service._terminal_pending = "/tmp/train.log"
+
+        with patch.object(service, "_get_results", return_value=True):
+            service.start_poller(node_id="node-a")
+            service.stop_poller(timeout=5.0)
+
+        self.assertTrue(service.stop_requested())
 
     @patch("nvidia_resiliency_ext.shared_utils.health_check.httpx.Client")
     def test_http_endpoint_omits_job_metadata_when_env_unset(self, mock_client):


### PR DESCRIPTION
Second forward-merge of `main` into `stable`, following #381. Picks up the 2 commits landed on `main` since that merge:

- `c35e691` Merge pull request #378 from hexinw-nvidia/early_terminate
- `bf2f464` Make attribution stop asynchronous and opt-in

## Clean merge

No conflicts. Main's changes are confined to `fault_tolerance/` (attribution manager, CLI args, control plane, barrier rendezvous, launcher, progress tracker) and `shared_utils/health_check.py`, none of which overlap `stable`'s async-checkpointing / nemo-lens telemetry work. `git merge-tree` confirmed a clean result before the merge was taken.

18 files changed, +1652 / −478 — mostly tests (`test_health_check.py`, `test_launcher.py`, `test_control_plane.py`) plus docs.

## Not verified

Tests were not run — the package is not installed in the environment used for the merge. CI needs to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)