### PR TITLE
Make live log convergence conservative

### DIFF
--- a/docs/design/attribution/restart_agent/PROGRESSIVE.md
+++ b/docs/design/attribution/restart_agent/PROGRESSIVE.md
@@ -123,8 +123,11 @@ initial unread-source ingestion. Each observed growth event resets the quiet
 interval and wakes a separate reader that ingests the newly available byte
 range without blocking metadata observation. When the source first becomes
 quiet, L0A may speculatively reduce the current captured boundary while the
-drain observer continues. Later growth makes that checkpoint stale and the next
-quiet interval may replace it. Once convergence is established, the observer
+drain observer continues. Live NVRx/attrsvc finalization cannot establish
+convergence before the internal minimum observation period has elapsed; its
+quiet interval begins no earlier than that boundary. Later growth makes a
+checkpoint stale, resets quiet observation, and the next quiet interval may
+replace it. Once convergence is established, the observer
 sends an explicit completion notification; finalization does not wait for
 another polling interval. It performs one exact catch-up read and reuses the
 checkpoint only when its source boundary is the final boundary, otherwise it
@@ -254,6 +257,10 @@ response.
   trace records the bound and discarded-tail byte count.
 - Shutdown cancels poll work without inventing a decision. A later terminal
   request may run a complete terminal analysis.
+
+The conservative drain belongs only to live sources ended through attrsvc.
+Direct CLI/library and evaluation calls over already-created files capture EOF
+as a known-complete boundary and finalize immediately.
 
 ## Latency And Candidate Publication
 

--- a/docs/design/attribution/restart_agent/SCHEMA.md
+++ b/docs/design/attribution/restart_agent/SCHEMA.md
@@ -1337,8 +1337,11 @@ retention.
 The existing terminal-drain settings remain
 `NVRX_ATTRSVC_RESTART_AGENT_LOG_POLL_SECONDS`,
 `NVRX_ATTRSVC_RESTART_AGENT_LOG_QUIET_SECONDS`, and
-`NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS`, with defaults of `0.25`, `2`,
-and `20` seconds respectively.
+`NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS`, with defaults of `0.25`, `5`,
+and `40` seconds respectively. Live attrsvc analysis also requires an internal
+10-second minimum observation period before quiet can establish convergence.
+Direct CLI/library analysis treats an existing input as a known-complete
+snapshot and does not wait for source convergence.
 
 The progressive implementation introduces two internal typed contracts:
 

--- a/services/attrsvc/README.md
+++ b/services/attrsvc/README.md
@@ -68,8 +68,8 @@ the legacy `AttributionControllerConfig` for `mcp`.
 | `NVRX_ATTRSVC_COMPUTE_TIMEOUT`  | Timeout for analysis in seconds                                                                                                                                                                               |
 | `NVRX_ATTRSVC_ANALYSIS_BACKEND` | `lib` (direct Restart Agent, default) or `mcp` (legacy LogSage/Flight Recorder path). |
 | `NVRX_ATTRSVC_RESTART_AGENT_CONFIG` | Optional authoritative `restart_agent_config.v1` JSON file for `lib`; the first attrsvc integration requires exactly one route. |
-| `NVRX_ATTRSVC_RESTART_AGENT_LOG_QUIET_SECONDS` | Unchanged-log interval before terminal analysis; default `2`. |
-| `NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS` | Maximum terminal log-drain wait; default `20`. |
+| `NVRX_ATTRSVC_RESTART_AGENT_LOG_QUIET_SECONDS` | Required unchanged-log interval after the internal 10-second minimum live observation period; default `5`. |
+| `NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS` | Maximum live terminal observation period before the source freezes; default `40`. |
 | `NVRX_ATTRSVC_RESTART_AGENT_LOG_POLL_SECONDS` | Log-drain polling interval; default `0.25`. |
 
 **LLM API Key**: the default `lib` route requires `LLM_API_KEY_FILE`. A supplied

--- a/src/nvidia_resiliency_ext/services/attrsvc/config.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/config.py
@@ -185,12 +185,12 @@ class Settings(BaseSettings):
         ),
     )
     RESTART_AGENT_LOG_QUIET_SECONDS: float = Field(
-        default=2.0,
-        description="Required unchanged-log interval before terminal Restart Agent analysis.",
+        default=5.0,
+        description=("Required unchanged-log interval before live terminal source convergence."),
     )
     RESTART_AGENT_LOG_MAX_WAIT_SECONDS: float = Field(
-        default=20.0,
-        description="Maximum terminal log-drain wait before Restart Agent analysis starts.",
+        default=40.0,
+        description="Maximum live terminal observation period before the source freezes.",
     )
     RESTART_AGENT_LOG_POLL_SECONDS: float = Field(
         default=0.25,

--- a/src/nvidia_resiliency_ext/services/attrsvc/restart_agent_backend.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/restart_agent_backend.py
@@ -65,8 +65,9 @@ _ELIGIBLE_NVRX_USES = frozenset({"eligible", "eligible_degraded"})
 class LogConvergencePolicy:
     """Bounded wait for log-funnel writes visible after terminal notification."""
 
-    quiet_seconds: float = 2.0
-    max_wait_seconds: float = 20.0
+    minimum_wait_seconds: float = 10.0
+    quiet_seconds: float = 5.0
+    max_wait_seconds: float = 40.0
     poll_seconds: float = 0.25
 
 
@@ -77,6 +78,10 @@ class _DrainOutcome:
     wall_clock_s: float = 0.0
     poll_count: int = 0
     growth_count: int = 0
+    completion_reason: str = "unknown"
+    minimum_wait_seconds: float = 0.0
+    quiet_seconds: float = 0.0
+    max_wait_seconds: float = 0.0
 
     @property
     def include_incomplete_tail(self) -> bool:
@@ -89,6 +94,10 @@ class _DrainOutcome:
             "wall_clock_s": round(self.wall_clock_s, 6),
             "poll_count": self.poll_count,
             "growth_count": self.growth_count,
+            "completion_reason": self.completion_reason,
+            "minimum_wait_seconds": self.minimum_wait_seconds,
+            "quiet_seconds": self.quiet_seconds,
+            "max_wait_seconds": self.max_wait_seconds,
         }
 
 
@@ -774,7 +783,14 @@ class RestartAgentServiceBackend:
     ) -> _DrainOutcome:
         policy = self._convergence
         if policy.max_wait_seconds <= 0:
-            return _DrainOutcome(converged=True, max_wait_expired=False)
+            return _DrainOutcome(
+                converged=True,
+                max_wait_expired=False,
+                completion_reason="disabled",
+                minimum_wait_seconds=policy.minimum_wait_seconds,
+                quiet_seconds=policy.quiet_seconds,
+                max_wait_seconds=policy.max_wait_seconds,
+            )
         reader_ready = Event()
         stop_observer = Event()
         notifications: SimpleQueue[str] = SimpleQueue()
@@ -843,6 +859,7 @@ class RestartAgentServiceBackend:
     ) -> _DrainOutcome | None:
         policy = self._convergence
         started = time.monotonic()
+        quiet_eligible_at = started + policy.minimum_wait_seconds
         unchanged_since: float | None = None
         previous: tuple[int, int] | None = None
         precompute_notified_for: tuple[int, int] | None = None
@@ -872,7 +889,8 @@ class RestartAgentServiceBackend:
             if (
                 current is not None
                 and unchanged_since is not None
-                and now - unchanged_since >= policy.quiet_seconds
+                and now >= quiet_eligible_at
+                and now - max(unchanged_since, quiet_eligible_at) >= policy.quiet_seconds
                 and reader_ready.is_set()
             ):
                 return _DrainOutcome(
@@ -881,6 +899,10 @@ class RestartAgentServiceBackend:
                     wall_clock_s=now - started,
                     poll_count=poll_count,
                     growth_count=growth_count,
+                    completion_reason="quiet_after_minimum_wait",
+                    minimum_wait_seconds=policy.minimum_wait_seconds,
+                    quiet_seconds=policy.quiet_seconds,
+                    max_wait_seconds=policy.max_wait_seconds,
                 )
             if now - started >= policy.max_wait_seconds:
                 return _DrainOutcome(
@@ -889,6 +911,10 @@ class RestartAgentServiceBackend:
                     wall_clock_s=now - started,
                     poll_count=poll_count,
                     growth_count=growth_count,
+                    completion_reason="max_wait_expired",
+                    minimum_wait_seconds=policy.minimum_wait_seconds,
+                    quiet_seconds=policy.quiet_seconds,
+                    max_wait_seconds=policy.max_wait_seconds,
                 )
             remaining = policy.max_wait_seconds - (time.monotonic() - started)
             if remaining <= 0:
@@ -898,6 +924,10 @@ class RestartAgentServiceBackend:
                     wall_clock_s=time.monotonic() - started,
                     poll_count=poll_count,
                     growth_count=growth_count,
+                    completion_reason="max_wait_expired",
+                    minimum_wait_seconds=policy.minimum_wait_seconds,
+                    quiet_seconds=policy.quiet_seconds,
+                    max_wait_seconds=policy.max_wait_seconds,
                 )
             if stop_observer.wait(min(max(policy.poll_seconds, 0.01), remaining)):
                 return None

--- a/tests/attribution/unit/test_attrsvc_restart_agent_backend.py
+++ b/tests/attribution/unit/test_attrsvc_restart_agent_backend.py
@@ -137,7 +137,12 @@ def _backend(tmp_path, runtime, *, max_total_records: int = 8):
         allowed_root=str(tmp_path),
         runtime=runtime,
         config=_config(max_total_records=max_total_records),
-        convergence=LogConvergencePolicy(quiet_seconds=0, max_wait_seconds=0, poll_seconds=0),
+        convergence=LogConvergencePolicy(
+            minimum_wait_seconds=0,
+            quiet_seconds=0,
+            max_wait_seconds=0,
+            poll_seconds=0,
+        ),
         progressive=ProgressiveAnalysisPolicy(
             enabled=True,
             pre_end_poll_seconds=180,
@@ -146,6 +151,15 @@ def _backend(tmp_path, runtime, *, max_total_records: int = 8):
             max_completed_results=max_total_records,
         ),
     )
+
+
+def test_live_log_convergence_policy_defaults():
+    policy = LogConvergencePolicy()
+
+    assert policy.minimum_wait_seconds == 10.0
+    assert policy.quiet_seconds == 5.0
+    assert policy.max_wait_seconds == 40.0
+    assert policy.poll_seconds == 0.25
 
 
 def test_progressive_start_accepts_expected_file_before_creation_and_preserves_cycle_zero(
@@ -185,6 +199,7 @@ def test_default_terminal_first_policy_registers_then_analyzes_at_terminal(tmp_p
         runtime=runtime,
         config=_config(),
         convergence=LogConvergencePolicy(
+            minimum_wait_seconds=0,
             quiet_seconds=0,
             max_wait_seconds=0,
             poll_seconds=0,
@@ -227,6 +242,7 @@ def test_progressive_start_precomputes_and_terminal_reuses_finalized_l0a(tmp_pat
         runtime=runtime,
         config=_config(),
         convergence=LogConvergencePolicy(
+            minimum_wait_seconds=0,
             quiet_seconds=0,
             max_wait_seconds=0,
             poll_seconds=0,
@@ -299,6 +315,7 @@ def test_terminal_drain_ingests_late_rank_output_and_precomputes_final_boundary(
         runtime=runtime,
         config=_config(),
         convergence=LogConvergencePolicy(
+            minimum_wait_seconds=0,
             quiet_seconds=0.04,
             max_wait_seconds=0.3,
             poll_seconds=0.01,
@@ -373,6 +390,36 @@ def test_terminal_drain_ingests_late_rank_output_and_precomputes_final_boundary(
         backend.shutdown()
 
 
+def test_terminal_drain_requires_minimum_observation_before_quiet_convergence(tmp_path):
+    runtime = _FakeRuntime()
+    backend = RestartAgentServiceBackend(
+        allowed_root=str(tmp_path),
+        runtime=runtime,
+        config=_config(),
+        convergence=LogConvergencePolicy(
+            minimum_wait_seconds=0.04,
+            quiet_seconds=0.02,
+            max_wait_seconds=0.2,
+            poll_seconds=0.005,
+        ),
+    )
+    log_path = tmp_path / "train_cycle1.log"
+    log_path.write_text("RuntimeError: CUDA out of memory\n", encoding="utf-8")
+
+    try:
+        outcome = backend._wait_for_log_convergence(str(log_path), accumulator=None)
+
+        assert outcome.converged is True
+        assert outcome.max_wait_expired is False
+        assert outcome.wall_clock_s >= 0.05
+        assert outcome.completion_reason == "quiet_after_minimum_wait"
+        assert outcome.minimum_wait_seconds == 0.04
+        assert outcome.quiet_seconds == 0.02
+        assert outcome.max_wait_seconds == 0.2
+    finally:
+        backend.shutdown()
+
+
 def test_terminal_drain_observes_source_while_initial_ingest_is_running(tmp_path, monkeypatch):
     # Arrange
     runtime = _FakeRuntime()
@@ -381,6 +428,7 @@ def test_terminal_drain_observes_source_while_initial_ingest_is_running(tmp_path
         runtime=runtime,
         config=_config(),
         convergence=LogConvergencePolicy(
+            minimum_wait_seconds=0,
             quiet_seconds=0.02,
             max_wait_seconds=0.5,
             poll_seconds=0.01,
@@ -432,6 +480,7 @@ def test_terminal_drain_completion_wakes_reader_without_poll_delay(tmp_path, mon
         runtime=runtime,
         config=_config(),
         convergence=LogConvergencePolicy(
+            minimum_wait_seconds=0,
             quiet_seconds=0.01,
             max_wait_seconds=2,
             poll_seconds=1,
@@ -587,7 +636,12 @@ def test_terminal_missing_log_returns_explicit_restart_agent_unavailable_result(
         allowed_root=str(tmp_path),
         runtime=build_restart_agent_runtime(config),
         config=config,
-        convergence=LogConvergencePolicy(quiet_seconds=0, max_wait_seconds=0, poll_seconds=0),
+        convergence=LogConvergencePolicy(
+            minimum_wait_seconds=0,
+            quiet_seconds=0,
+            max_wait_seconds=0,
+            poll_seconds=0,
+        ),
     )
     log_path = tmp_path / "never_created_cycle1.log"
 

--- a/tests/attribution/unit/test_attrsvc_settings.py
+++ b/tests/attribution/unit/test_attrsvc_settings.py
@@ -76,6 +76,14 @@ def test_attrsvc_progressive_analysis_defaults_to_all_explicit(tmp_path, monkeyp
     assert cfg.RESTART_AGENT_MAX_COMPLETED_RESULTS == 3000
 
 
+def test_attrsvc_live_terminal_drain_uses_conservative_defaults(tmp_path):
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.RESTART_AGENT_LOG_QUIET_SECONDS == 5.0
+    assert cfg.RESTART_AGENT_LOG_MAX_WAIT_SECONDS == 40.0
+    assert cfg.RESTART_AGENT_LOG_POLL_SECONDS == 0.25
+
+
 def test_attrsvc_progressive_analysis_accepts_off(tmp_path, monkeypatch):
     monkeypatch.setenv("NVRX_ATTRSVC_PROGRESSIVE_ANALYSIS", "OFF")
 

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -215,6 +215,17 @@ def test_attribution_config_accepts_lib_analysis_backend(tmp_path):
     assert cfg.analysis_backend == "lib"
 
 
+def test_managed_attrsvc_inherits_log_convergence_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("NVRX_ATTRSVC_RESTART_AGENT_LOG_QUIET_SECONDS", "15")
+    monkeypatch.setenv("NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS", "60")
+    cfg = _managed_cfg(tmp_path)
+
+    env = AttributionManager(cfg, is_store_host=True)._child_env(str(tmp_path / "key"))
+
+    assert env["NVRX_ATTRSVC_RESTART_AGENT_LOG_QUIET_SECONDS"] == "15"
+    assert env["NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS"] == "60"
+
+
 def test_attribution_stop_action_defaults_to_log_only(tmp_path):
     """Enabling attribution must not implicitly enable acting on its verdicts."""
     cfg = AttributionConfig.from_args(


### PR DESCRIPTION
## Summary

- require a minimum live-log observation period before terminal quiet detection
- use conservative NVRx/attrsvc defaults: 10 seconds minimum observation, 5 seconds quiet, and a 40-second hard maximum
- preserve immediate EOF finalization for known-complete CLI/library inputs
- expose convergence reason and timing policy in the drain trace

## Why

At large scale, rank output can continue reaching the shared application log well after the first workload failure is detected. The previous 2-second quiet interval and 20-second maximum could freeze the source before late rank output arrived. The new policy protects the live NVRx path without imposing delay on analysis of already-created files.

## Validation

- 82 focused attribution and fault-tolerance unit tests passed
- Black passed for all changed Python files
- isort passed for all changed Python files
- `git diff --check` passed
