### PR TITLE
Merge origin/main into stable

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -30,7 +30,6 @@ jobs:
             echo "Error: Documentation build failed. 'public/' directory not found."
             exit 1
           fi
-
       - name: Deploy to GitHub Pages
         run: |
           git config --global user.name "GitHub Actions"

--- a/docs/design/attribution/restart_agent/ATTRSVC_INTEGRATION.md
+++ b/docs/design/attribution/restart_agent/ATTRSVC_INTEGRATION.md
@@ -1,0 +1,292 @@
+# Attrsvc Integration
+
+This document specifies the first production integration from NVRx through
+`nvrx-attrsvc` to the Restart Agent. It is the source of truth for service
+composition, request identity, configuration resolution, state ownership, and
+result timing. The L0-L4 analysis contracts remain defined by the other Restart
+Agent design documents.
+
+## Scope
+
+The first cut runs the Restart Agent directly in the attrsvc process. It does
+not use MCP, LogSage, Flight Recorder analysis, or the legacy
+`RequestCoalescer` cache. The existing legacy path remains available behind the
+`mcp` backend value during migration.
+
+A progressive start registers the attempt before the log file must exist.
+Terminal-first execution is the default and performs no pre-end polling.
+Explicit progressive enablement additionally schedules L0A-only
+precomputation. Terminal submission performs bounded log drain, finalizes the
+same L0A accumulator and publishes deterministic policy. Model enrichment starts
+by default and may be explicitly disabled in the Restart Agent configuration.
+`PROGRESSIVE.md` owns that lifecycle.
+
+## Process Shape
+
+```text
+NVRx AttributionService
+  -> attrsvc POST /logs and GET /logs
+  -> AttributionHttpAdapter
+  -> RestartAgentServiceBackend
+  -> RestartAgentRuntime
+  -> L0-L4 and AttemptRecord history
+```
+
+`AttributionHttpAdapter` selects the implementation before constructing any
+legacy controller:
+
+| `ANALYSIS_BACKEND` | Implementation |
+| --- | --- |
+| `lib` | Direct in-process Restart Agent; default |
+| `mcp` | Existing LogSage/Flight Recorder MCP path |
+
+For `lib`, attrsvc MUST NOT construct `AttributionController`, `Analyzer`,
+`RequestCoalescer`, or an MCP client. The meaning of `lib` is intentionally
+repurposed because the prior in-process LogSage path was not productized.
+
+## Existing NVRx Lifecycle
+
+NVRx can supply the required identity explicitly or through the existing path
+convention:
+
+1. Before workers start cycle `N`, NVRx creates the expected path
+   `<prefix>_cycle<N>.log` and sends `POST /logs` with `analysis_intent=progressive`.
+   The Restart Agent always registers the attempt; it performs pre-end L0A work
+   only when its progressive optimization is explicitly enabled.
+2. The POST includes `user` and `job_id` from the job environment.
+3. When that cycle fails, NVRx sends the same path with
+   `analysis_intent=terminal`.
+4. During the next rendezvous, NVRx polls `GET /logs?wait=false` until attrsvc
+   reports a completed result or the NVRx-owned decision deadline expires.
+
+The progressive POST MAY arrive before the file exists. Terminal analysis also
+MUST tolerate a missing or empty file and return the Restart Agent's explicit
+log-unavailable result rather than failing the service request.
+
+## Attempt Identity
+
+The service constructs a normalized attempt identity as follows:
+
+- `log_path`: normalized absolute path under attrsvc `ALLOWED_ROOT`;
+- `job_id`: non-empty POST `job_id`, otherwise the existing path heuristic;
+- `cycle_id`: explicit integer POST field when present, otherwise the
+  `_cycle<N>.log` suffix parsed by the shared cycle-path helper;
+- `user`: POST user, retained for service observability but not consumed by the
+  stateless L0-L4 core.
+
+The explicit cycle ID takes precedence when it differs from the path-derived
+value. A path without either form has `cycle_id=None`; it MUST NOT be collapsed
+to cycle zero. Such a request remains analyzable but is history-ineligible. A
+literal explicit `0` or `_cycle0.log` has integer cycle ID zero and is
+history-eligible when a job ID is also available.
+
+The execution-registry key is `(job_id, cycle_id)` when both values exist.
+Otherwise the normalized path is the service correlation key. Repeated
+progressive and terminal POSTs for the same attempt are idempotent.
+
+## Configuration Sources
+
+All sources resolve to the same typed `RestartAgentConfig` and use the same
+`build_restart_agent_runtime()` composition root.
+
+```text
+CLI --config file ---------------------+
+library mapping or RestartAgentConfig -+-> RestartAgentConfig -> runtime
+attrsvc settings/environment ----------+
+```
+
+### Attrsvc Resolution
+
+For `ANALYSIS_BACKEND=lib`:
+
+1. When `NVRX_ATTRSVC_RESTART_AGENT_CONFIG` is set, attrsvc loads that file.
+2. Otherwise attrsvc constructs one route from its existing LLM settings and
+   `LLM_API_KEY_FILE`, then passes the generated mapping through
+   `parse_restart_agent_config()`.
+
+The environment-derived route uses:
+
+- `NVRX_ATTRSVC_LLM_MODEL`;
+- `NVRX_ATTRSVC_LLM_BASE_URL`;
+- optional temperature, top-p, and maximum-output-token overrides; and
+- `LLM_API_KEY_FILE` through the route's `credential_ref`.
+
+Restart Agent defaults supply history bounds, retry policy, tool advertisement,
+provider retries, and other fields not represented by attrsvc settings.
+Progressive polling, idle, active-state, completed-result, and terminal-drain
+settings remain attrsvc service configuration; they are traced but are not
+merged into `RestartAgentConfig`.
+
+`NVRX_ATTRSVC_RESTART_AGENT_PROGRESSIVE_ENABLED` defaults to `false`. Setting it
+to `true` enables pre-end Restart Agent polling only when the existing
+`NVRX_ATTRSVC_PROGRESSIVE_ANALYSIS` policy also permits explicit progressive
+requests. This restart-agent-specific switch does not alter the legacy
+attribution backend.
+
+A supplied file is authoritative. Attrsvc MUST NOT overlay model or behavioral
+settings onto it. Credential references in the file still resolve through the
+process environment. Attrsvc MUST reject a restart-agent config path when the
+selected backend is `mcp`.
+
+The first attrsvc integration supports exactly one model route so that the
+client-facing recommendation is unambiguous. CLI and library callers retain
+multi-route `collect_all` support. Attrsvc route priority/arbitration is a later
+extension.
+
+## State Ownership
+
+`RestartAgentRuntime` owns the bounded current-process `AttemptRecord` history
+used by L3. Attrsvc does not transform or persist those records.
+
+`RestartAgentServiceBackend` owns a separate bounded attempt execution registry
+needed by the HTTP lifecycle:
+
+```text
+registered -> precomputing <-> idle -> finalizing -> analyzing -> completed
+                                                           +-> failed
+```
+
+The registry contains active futures, the best currently available candidate,
+the final result, request identity, and timing/error metadata. This is
+operational workflow state, not the legacy attrsvc result cache. It MUST NOT use
+`RequestCoalescer`, cache-file persistence, mtime cache validation, or legacy
+LogSage result envelopes internally.
+
+Completed service results and retained active L0A states have separate attrsvc
+bounds. Old completed entries are evicted before accepting replacement
+retention; progressive-state eviction never removes attempt registration.
+Attrsvc process restart clears both execution state and current-lifetime
+history in the MVP.
+
+Each progressive entry uses the state machine and `ProgressiveL0State` defined
+by `PROGRESSIVE.md`. One coordinator scheduler
+tracks next-poll times and wakes on terminal submission; it MUST NOT dedicate a
+sleeping thread to every attempt. Due reads use a bounded executor and are
+serialized per attempt. Progressive-state eviction drops only the precomputed
+accumulator, never registration or the ability to run terminal analysis.
+
+## Request Semantics
+
+### Progressive POST
+
+The backend validates the path boundary, resolves explicit-or-inferred
+identity, and registers the attempt. The parent directory must exist under
+`ALLOWED_ROOT`; the file itself need not exist. It schedules an immediate
+metadata check and L0A-only precomputation when bytes are available. L0B-L4 do
+not run before terminal submission.
+
+### Terminal POST
+
+The backend resolves the same attempt and starts at most one background
+analysis. The POST returns after scheduling. Duplicate terminal requests return
+the existing state without starting another model call.
+
+Before L0 finalizes the captured source boundary, the backend performs a bounded
+convergence drain so log-funnel writes can finish. Growth notifications ingest
+and classify only newly visible complete lines. A quiet interval may start a
+speculative L0A reduction while metadata observation continues. Later growth
+invalidates that checkpoint; only an exact final source-boundary match permits
+reuse. Quiet convergence flushes a final unterminated line. If maximum wait
+expires before convergence, an incomplete actively written tail is excluded
+and its byte count is traced rather than treated as authoritative evidence.
+
+The existing progressive accumulator reads only its unread final tail;
+terminal-only execution feeds the same accumulator from byte zero. Quiet and
+maximum-wait values belong to attrsvc integration settings. The drain bound is
+independent of the external NVRx action deadline and does not consume the
+Restart Agent model-route timeout.
+
+### GET
+
+`GET /logs?wait=false` never starts analysis. It returns the current state:
+
+- `pending`: registered but terminal analysis has not started;
+- `in_flight`: analysis is running, optionally with a deterministic candidate;
+- `completed`: the configured route has completed, or no better result can be
+  produced within the Restart Agent analysis deadline;
+- `failed`: service execution failed without a valid candidate.
+
+The top-level response retains `status`, `result`, `recommendation`, and
+`candidate_recommendation`. The full Restart Agent response is stored under
+`result`.
+
+`recommendation` exposes attrsvc's currently selected result;
+`candidate_recommendation` explicitly exposes its best provisional candidate.
+Attrsvc publishes both fields, but the current NVRx client consumes
+`recommendation` only when `status=completed` and intentionally ignores
+`candidate_recommendation`. Consuming the latter requires a separate, explicit
+NVRx behavior change.
+
+## Candidate Timing
+
+The deterministic recommendation callback publishes the first usable candidate
+after L0, L3, and L4. When enrichment is enabled, L1 continues in the
+background and a completed usable route publishes its own enriched candidate.
+
+NVRx waits for `completed` and consumes only `recommendation`. If its action
+deadline expires first, it preserves the existing fail-open restart behavior.
+The independently published `candidate_recommendation` remains observable but
+is not an NVRx decision input in this integration.
+
+A candidate whose `result_provenance.nvrx_use` is
+`fallback_to_nvrx_default` is exposed with an `UNKNOWN` action.
+
+The NVRx action deadline is external to Restart Agent analysis. NVRx moving on
+does not close the attempt inside the analyzer. An L1 result that completes
+within the configured Restart Agent analysis timeout, 240 seconds by default,
+still updates the current attempt, runtime history, and service-visible result,
+and remains observable from attrsvc until bounded registry eviction. It does
+not retroactively alter the action NVRx already took.
+
+## NVRx Changes
+
+NVRx keeps its current endpoint, POST body, GET query, model, base URL, key-file,
+user, job-ID, and cycle-log behavior. The managed attrsvc launcher changes only
+to:
+
+- allow `lib` and `mcp` backend values;
+- let an unspecified backend use attrsvc's `lib` default.
+
+The current client parses and consumes only a completed top-level
+`recommendation`. Adding `candidate_recommendation` to the client contract and
+using it at the action deadline is intentionally deferred to a separate PR.
+
+No Restart Agent configuration file is required for the managed NVRx path.
+
+## Observability
+
+Attrsvc health and stats for `lib` report:
+
+- backend name and effective config fingerprint;
+- registered, in-flight, completed, and failed attempt counts;
+- deterministic-ready and route-complete counts;
+- background execution errors;
+- Restart Agent history-record count; and
+- active attempt paths without model credentials or raw prompt content.
+
+Legacy `/cache` persistence is unavailable for `lib`. `/inflight` and `/jobs`
+project the execution registry. Detailed traces remain owned by Restart Agent
+callbacks and optional artifact publishers rather than attrsvc reconstructing
+stage behavior. After L0A finalization attrsvc drops the progressive
+accumulator. Each route publishes and releases its route-local transcript/tool
+state independently. A completed execution-registry entry retains only the
+compact selected result and operational counters.
+
+## Verification
+
+The integration requires tests for:
+
+- file and environment configuration resolution;
+- `lib` default and `mcp` legacy selection;
+- cycle zero, positive cycle, and missing-cycle identity;
+- progressive submission before file creation;
+- duplicate progressive and terminal requests;
+- nonblocking pending, deterministic, completed, and failed GET responses;
+- attrsvc publishing completed and candidate recommendations independently;
+- NVRx ignoring in-flight candidates and consuming only a completed
+  recommendation;
+- missing/empty logs and log-convergence bounds;
+- late route completion updating history;
+- execution-registry eviction and clean shutdown; and
+- proof that the `lib` path does not instantiate legacy Analyzer, MCP, LogSage,
+  Flight Recorder, or RequestCoalescer objects.

--- a/docs/design/attribution/restart_agent/CONFIGURATION.md
+++ b/docs/design/attribution/restart_agent/CONFIGURATION.md
@@ -1,0 +1,270 @@
+# Restart Agent Configuration
+
+`restart_agent_config.v1` is the complete deployment configuration for one
+Restart Agent runtime. There is no separate executable profile object.
+
+This document is the human-readable field reference. `config.py` is the
+executable authority for parsing, defaults, validation, resolution, and
+fingerprint construction. `SCHEMA.md` owns request, response, and internal
+stage serialization rather than duplicating this configuration contract.
+
+The maintained example is
+`examples/attribution/restart_agent.json`.
+
+## Top-Level Fields
+
+| Field | Type | Required / default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `schema_version` | string | required | Must be exactly `restart_agent_config.v1`. |
+| `config_id` | string | required | Non-empty human-managed name. It is reported but excluded from the behavior fingerprint. |
+| `config_version` | integer | required | Human-managed revision, at least `1`. It is reported but excluded from the behavior fingerprint. |
+| `enrichment` | object | `{}` | Enables or disables L1/L2 model enrichment. |
+| `routing` | object | `{}` | Controls route fanout and the whole-analysis timeout. |
+| `runtime` | object | `{}` | Controls in-process history and L0 source reading. |
+| `retry_policy` | object | documented defaults | Configures L4 retry budgets. |
+| `declared_recovery_capabilities` | array | `[]` | Trusted workload-managed recovery declarations consumed by L4. |
+| `model_defaults` | object | `{}` | Shared defaults inherited by every model route. |
+| `model_routes` | array | `[]` | Independent L1 routes. Must be non-empty when enrichment is enabled and empty when it is disabled. |
+
+The configuration does not contain request data, attempt history, prompts,
+evidence, model responses, evaluation labels, API keys, or resolved
+credentials. Prompt, response-schema, detector, and stage-algorithm versions
+belong to the product build.
+
+## Enrichment
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `enrichment.enabled` | boolean | `true` | Runs configured L1/L2 model routes when true. |
+
+Deterministic-only execution is an explicit configuration:
+
+```json
+{
+  "enrichment": {"enabled": false},
+  "routing": {"mode": "collect_all", "max_parallel_models": 0},
+  "model_routes": []
+}
+```
+
+The deterministic L0 -> L3 -> L4 recommendation remains available when
+enrichment is enabled; model routes produce additional independent candidates.
+
+## Routing
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `routing.mode` | string | `collect_all` | Only `collect_all` is implemented. It returns every route independently and does not vote, merge, prioritize, or select a winner. |
+| `routing.max_parallel_models` | integer | number of resolved routes | Maximum concurrent model routes. Minimum is `1` with enrichment and `0` without it. The resolved value cannot exceed the number of routes. |
+| `routing.timeout_seconds` | number | `240` | Positive whole-analysis deadline shared by all routes. Provider calls, retries, and tool turns are bounded by its remaining time. This is not the external NVRx action deadline. |
+
+L0 is constructed once before `collect_all` fans out. Every route receives the
+same immutable L0A, Decision Evidence, L0B, request, prior-attempt view, and
+analysis deadline.
+
+## Runtime
+
+### History
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `runtime.history.enabled` | boolean | `true` | Enables the runtime-owned, current-process attempt-record store. |
+| `runtime.history.max_attempts_per_job` | integer | `10` | Positive per-job retained-attempt bound. |
+| `runtime.history.max_total_records` | integer | `3000` | Positive total retained-record bound across jobs. |
+
+The per-job limit evicts the smallest cycle id for that job. The total limit
+evicts the oldest insertion. Disabling history supplies a null store; it does
+not move history ownership into L0-L4.
+
+### L0 Source
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `runtime.l0_source.read_mode` | string | `chunked` | `chunked` is the production path. `single_snapshot` is the parity/regression path. |
+| `runtime.l0_source.chunk_size_bytes` | integer | `1048576` | Positive byte-delivery chunk size. It applies to chunked source reading. |
+
+Both modes must produce equivalent canonical L0A evidence for the same captured
+source bytes. These fields affect source delivery and operational performance,
+not policy semantics.
+
+## Retry Policy
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `retry_policy.confirmation_retry_allowed_retries` | integer | `1` | Non-negative budget for exact root-and-entity confirmation. Must not exceed the general budget. |
+| `retry_policy.bounded_retry_allowed_retries` | integer | `1` | Non-negative bounded retry budget. Must not exceed the general budget. |
+| `retry_policy.general_retry_allowed_retries` | integer | `3` | Non-negative same-root safety ceiling. |
+
+L4 owns the interpretation and ordered selection of these budgets. See
+`L4.md`; configuring a number does not cause an earlier stage to select that
+rule.
+
+## Declared Recovery Capabilities
+
+The MVP supports one closed declaration:
+
+```json
+{
+  "capability_id": "bad_token_retry_then_skip",
+  "behavior": "retry_then_skip",
+  "applies_to": ["bad_token_or_window"],
+  "required_entity_kind": "data_position",
+  "history_match_scope": "root_and_entity",
+  "allowed_retries": 2
+}
+```
+
+| Field | Type | Required value / constraint |
+| --- | --- | --- |
+| `capability_id` | string | `bad_token_retry_then_skip`; identifiers must be unique. |
+| `behavior` | string | `retry_then_skip`. |
+| `applies_to` | string array | Exactly `["bad_token_or_window"]`. |
+| `required_entity_kind` | string | `data_position`. |
+| `history_match_scope` | string | `root_and_entity`. |
+| `allowed_retries` | integer | Positive and no greater than `retry_policy.general_retry_allowed_retries`. |
+
+This is trusted deployment context, not a model conclusion. L4 may select it
+only when the grounded failure and affected entity satisfy the declaration.
+
+## Model Defaults And Routes
+
+`model_defaults` and each `model_routes[]` item support the same route settings.
+A route additionally requires a unique, non-empty `route_id`.
+
+Resolution is shallow by field group:
+
+1. start with built-in provider defaults;
+2. apply top-level fields and nested groups from `model_defaults`;
+3. apply that route's top-level fields and nested group members; and
+4. validate and record the credential-free effective route.
+
+A route may therefore override one request setting without repeating the rest
+of `model_defaults`.
+
+### Route Identity
+
+| Field | Type | Required / default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `route_id` | string | required per route | Unique, non-empty result and trace identity. Not used in `model_defaults`. |
+| `model` | string | `nvidia/qwen/qwen3.5-35b-a3b` | Non-empty provider model identifier. |
+| `base_url` | string | `https://inference-api.nvidia.com/v1` | Non-empty OpenAI-compatible endpoint base URL. |
+| `credential_ref` | string | `LLM_API_KEY_FILE` | Name of an environment variable containing a readable API-key file path. |
+
+The credential reference name may appear in effective configuration and trace.
+The environment value, file path, and key contents may not.
+
+### Request
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `request.timeout_seconds` | number | `120` | Positive per-provider-request timeout, clamped to the remaining whole-analysis deadline. |
+| `request.max_output_tokens` | integer | `64000` | Positive provider output-token cap. |
+| `request.context_window_tokens` | integer or omitted | model-specific when known | Positive total context-window cap. Known Qwen routes have built-in limits; otherwise omission means no configured cap. |
+| `request.context_safety_tokens` | integer | `4096` | Non-negative reserve removed from the usable context budget. |
+| `request.temperature` | number or omitted | `0.2` | Sampling temperature in `[0, 2]`. Some provider/model profiles omit sampling parameters. |
+| `request.top_p` | number or omitted | `0.7` | Nucleus-sampling value in `[0, 1]`. Some provider/model profiles omit sampling parameters. |
+
+Context budgeting accounts for the complete stateless conversation sent on
+each model turn, including prior messages and tool results.
+
+### Tools
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `tools.enabled` | boolean | `true` | Whether tool definitions are advertised and tool requests may execute. |
+| `tools.advertisement.overview` | boolean | `true` | Advertises compact source/evidence orientation. |
+| `tools.advertisement.grep_log` | boolean | `true` | Advertises source-log search. |
+| `tools.advertisement.read_window` | boolean | `true` | Advertises bounded raw source reading. |
+| `tools.advertisement.get_evidence_objects` | boolean | `false` | Advertises structured evidence-object retrieval. Implemented but opt-in. |
+| `tools.max_rounds` | integer | `8` | Non-negative maximum tool-request rounds for the route. |
+
+Tool implementation and response limits are defined in `TOOLS.md`. A tool is
+model-visible only when both `tools.enabled` and its advertisement value are
+true.
+
+### Reasoning
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `reasoning.thinking_mode` | string | `auto` | One of `auto`, `disable`, or `allow`. `auto` applies provider/model-specific behavior. |
+| `reasoning.reasoning_effort` | string or omitted | omitted | Optional provider reasoning-effort value. Unsupported providers may ignore or reject it. |
+
+Thinking mode controls provider reasoning features; it does not change the L1
+response contract or transfer L4 policy ownership to the model.
+
+### Reliability
+
+| Field | Type | Default | Meaning and constraints |
+| --- | --- | --- | --- |
+| `reliability.max_retries` | integer | `1` | Non-negative retry count for retryable provider failures. |
+| `reliability.retry_backoff_seconds` | number | `0.5` | Non-negative delay between provider retries, bounded by the remaining deadline. |
+
+Retries, provider failures, and timeout exhaustion remain visible in the route
+trace and metrics.
+
+## Credentials And Compliance
+
+Configuration contains credential-reference names only. The composition layer
+resolves each referenced environment variable to a readable key file while
+constructing provider clients.
+
+The operator owns workload classification and route authorization. For
+export-controlled context, every route and network fallback must be approved
+for the regulated inference environment. Model names and URLs do not prove
+compliance, and the configuration fingerprint is not a compliance certificate.
+
+## Validation And Effective Configuration
+
+The loader:
+
+1. validates required identity and supported top-level/runtime/policy fields;
+2. validates enrichment and route-count consistency;
+3. merges model defaults and route overrides;
+4. validates numeric ranges, route-id uniqueness, tool names, and routing mode;
+5. resolves credential references without retaining secret values; and
+6. returns an immutable `RestartAgentConfig` with route specifications and
+   credential-free `effective_config`.
+
+Only fields documented here participate in resolution. Unknown fields in
+closed configuration objects are errors; route/default keys outside the
+documented groups are unsupported and must not be used.
+
+Configuration parsing and dependency construction occur outside the stateful
+runtime. Loading a JSON file and parsing an already-loaded mapping produce the
+same resolved contract.
+
+## Configuration Identity
+
+Every resolved configuration records:
+
+- `config_id`;
+- `config_version`;
+- `config_fingerprint`; and
+- credential-free `effective_config`.
+
+`config_fingerprint` is `sha256:` plus SHA-256 over canonical JSON for
+`effective_config`, with sorted object keys, compact separators, and array
+order preserved. It includes resolved routing, history, L0 source settings,
+retry policy, declared capabilities, and route settings. It excludes secrets,
+the source file path, `config_id`, and `config_version`.
+
+Different names or file locations with identical resolved behavior therefore
+produce the same fingerprint. A route, timeout, tool, reasoning, reliability,
+history, L0 source, capability, or retry-policy change produces a different
+fingerprint.
+
+The fingerprint does not identify product code, prompt text, response-schema
+implementation, detector logic, or workload input.
+
+## Production And Evaluation Parity
+
+A reproducible comparison requires:
+
+- the same product revision and emitted contract versions;
+- the same `config_fingerprint`; and
+- explicit reporting of intentional code or configuration differences.
+
+The eval harness may recommend configuration changes, but production does not
+tune routes, tools, reasoning controls, retry budgets, or provider mappings at
+runtime. Model-panel experiments and qualification results belong to the eval
+harness rather than this product contract.

--- a/docs/design/attribution/restart_agent/DECISIONS.md
+++ b/docs/design/attribution/restart_agent/DECISIONS.md
@@ -1,0 +1,178 @@
+# Active Design Decisions
+
+This file explains why consequential architectural choices were made. It is not
+a normative contract; the focused specifications own current behavior.
+Superseded decisions remain in git history.
+
+## D1: Use A Layered Decision Pipeline
+
+- **Context:** A single model answer hides whether errors came from evidence
+  selection, semantic reasoning, grounding, history, or action policy.
+- **Decision:** Separate deterministic evidence, model interpretation,
+  grounding, history comparison, and policy into L0A/L0B, L1, L2, L3, and L4.
+- **Rejected alternative:** One end-to-end model prompt with a deterministic
+  postprocessor that exposes only the final action.
+- **Consequence:** Each stage has a typed boundary, trace, and independent KPI.
+- **Revisit when:** Corpus results show a stage adds material latency or
+  complexity without improving safety, accuracy, or diagnosis.
+
+## D2: Keep L2 Grounding Non-Overriding
+
+- **Context:** Strict semantic validation rejected credible model assessments
+  when citations were nearby, incomplete, or semantically expressed.
+- **Decision:** L2 mechanically grounds evidence and derives client identity,
+  while broader credibility findings remain advisory and preserve raw L1 output.
+- **Rejected alternative:** Rewrite or reject the model's semantic assessment
+  whenever an audit heuristic disagrees.
+- **Consequence:** Policy can require grounded facts without hiding what the
+  model actually concluded.
+- **Revisit when:** A corpus-validated transformation has explicit semantics,
+  measurable safety benefit, and its own observable contract.
+
+## D3: Derive History Identity In The Client
+
+- **Context:** Model-authored class names and fingerprints vary in wording and
+  granularity across models and repeated runs.
+- **Decision:** L0 derives deterministic identity and L2 derives the grounded
+  enriched equivalent. Identity consists of a normalized root and optional
+  exact affected entity.
+- **Rejected alternative:** Compare free-form L1 classes, summaries, or
+  model-generated fingerprints directly.
+- **Consequence:** L3 can perform deterministic recurrence comparison while L1
+  semantic identity remains visible for analysis.
+- **Revisit when:** A stronger structured runtime identity becomes available or
+  corpus evidence justifies extending the client identity contract.
+
+## D4: Introduce Prior Attempts Only At L3
+
+- **Context:** Showing history to L1 would mix current-log interpretation with
+  recurrence and could make model behavior depend on record ordering.
+- **Decision:** L1 assesses only the current attempt. L3 receives the selected
+  current failure facts and an immutable exact-job `PriorAttemptView`.
+- **Rejected alternative:** Include prior logs or attempt summaries in the L1
+  prompt and ask the model whether the issue recurred.
+- **Consequence:** Current-attempt semantics and history policy can be evaluated
+  independently.
+- **Revisit when:** Deterministic history proves insufficient and an explicit,
+  separately evaluated history-reasoning stage is proposed.
+
+## D5: Keep Stateful Runtime Outside The Analysis Core
+
+- **Context:** History, deadlines, route fanout, and record generations are
+  invocation concerns; L0-L4 should remain replayable from explicit inputs.
+- **Decision:** `RestartAgentRuntime` owns current-process state and orchestration.
+  The pipeline consumes injected immutable inputs and produces invocation-owned
+  outputs.
+- **Rejected alternative:** Store history or caller-visible last-run state
+  inside stage implementations or a module-global singleton.
+- **Consequence:** Library, CLI, tests, and future service adapters exercise the
+  same core with replaceable state and infrastructure.
+- **Revisit when:** A distributed runtime requires a different store
+  implementation, while preserving the same injected interfaces.
+
+## D6: Use Deterministic Prior Facts For MVP History
+
+- **Context:** Each route may produce a different enriched identity, while MVP
+  has no canonical route-selection policy.
+- **Decision:** Store route-keyed enriched facts for observation, but compare
+  prior attempts using their deterministic L0 facts.
+- **Rejected alternative:** Let completion order or an arbitrary preferred
+  route determine the history identity.
+- **Consequence:** Model timing and route availability cannot change recurrence
+  policy.
+- **Revisit when:** A production route-arbitration contract defines which
+  enriched result becomes canonical.
+
+## D7: Integrate Attrsvc Through The Library Boundary
+
+- **Context:** The first integration needs the existing NVRx HTTP lifecycle but
+  does not need another transport or the legacy analysis controller.
+- **Decision:** Attrsvc constructs and invokes the runtime in process behind
+  `ANALYSIS_BACKEND=lib`.
+- **Rejected alternative:** Require a Restart Agent MCP service for the first
+  product integration.
+- **Consequence:** Attrsvc remains the transport boundary while the Restart
+  Agent library owns analysis and current-process history.
+- **Revisit when:** Independent scaling, isolation, deployment ownership, or
+  cross-language access justifies a thin MCP adapter.
+
+## D8: Use Score-Free Deterministic Retry Policy
+
+- **Context:** User/not-user scores conflated attribution confidence with action
+  and produced contradictory explanations and thresholds.
+- **Decision:** L1 emits typed domain and recovery claims; L3 emits recurrence
+  and progress; L4 applies ordered retry rules and budgets.
+- **Rejected alternative:** Convert one model probability or score threshold
+  directly into `STOP` or `RESTART`.
+- **Consequence:** Every action is traceable to explicit semantic facts, history,
+  and configured policy.
+- **Revisit when:** Calibration evidence demonstrates a specific probabilistic
+  policy improves outcomes and can remain independently observable.
+
+## D9: Declare Workload-Managed Recovery
+
+- **Context:** Behavior such as retry-then-skip is a workload capability that
+  cannot be reliably inferred from generic failure text.
+- **Decision:** Trusted configuration declares recovery capabilities; L4 applies
+  one only when grounded classifier, behavior, and affected entity match.
+- **Rejected alternative:** Ask L1 to invent or infer retry/skip support.
+- **Consequence:** Special retry budgets are explicit, testable, and cannot
+  silently spread to unrelated failures.
+- **Revisit when:** A structured workload/runtime signal can declare the same
+  capability more directly.
+
+## D10: Publish The Deterministic Recommendation Before L1
+
+- **Context:** Model and endpoint latency may delay semantic enrichment, while
+  callers may need an earlier recommendation.
+- **Decision:** Run L3/L4 from deterministic facts and publish that candidate
+  before starting model routes.
+- **Rejected alternative:** Wait for the preferred model and construct a deterministic result
+  only after timeout or failure.
+- **Consequence:** A recommendation exists independently of L1. A caller may
+  act on it without closing the continuing Restart Agent analysis.
+- **Revisit when:** A different precomputed candidate demonstrably provides
+  better safety or pre-end semantic work proves necessary.
+
+## D11: Keep Parallel Model Results Independent
+
+- **Context:** Multiple routes help compare speed, reliability, and semantic
+  quality, but no validated production arbitration policy exists.
+- **Decision:** Build L0 once, execute routes concurrently, and return every
+  route result independently.
+- **Rejected alternative:** Vote, merge semantic fields, or select a winner
+  implicitly in MVP.
+- **Consequence:** Route behavior remains measurable without manufacturing
+  consensus or allowing one failure to fail the batch.
+- **Revisit when:** A reviewed priority or arbitration policy defines validity,
+  cutoff, winner selection, and canonical history behavior.
+
+## D12: Keep Root And Entity Retry Ledgers Independent
+
+- **Context:** Exact affected entities improve recurrence precision, but entities
+  may be absent or alternate across attempts with the same root. Selecting only
+  one history scope could let those changes reset the effective retry budget.
+- **Decision:** L3 always reports independent same-root and
+  same-root-plus-entity no-advance streaks. L4 always evaluates the general
+  same-root ceiling and concurrently evaluates any narrower selected-rule
+  budget. A narrower budget may stop earlier but cannot extend the ceiling.
+- **Rejected alternative:** Let the selected rule choose one exclusive history
+  scope and ignore the other count.
+- **Consequence:** Exact entities support workload-managed recovery without
+  allowing entity or rule changes to create unbounded retries.
+- **Revisit when:** A validated policy requires a specialized rule to exceed
+  the general ceiling and provides an explicit independent safety bound.
+
+## D13: Keep Scheduler Time Policy Outside Restart Policy
+
+- **Context:** An application log may record a Slurm wall-time termination, but
+  the scheduler enforces allocation lifetime regardless of the Restart Agent
+  recommendation.
+- **Decision:** L0 may preserve an explicit time-limit event as observed
+  evidence. L4 gives it no special rule or retry-budget exemption.
+- **Rejected alternative:** Infer that any `time limit` or `wall-time` text is
+  an expected restartable termination.
+- **Consequence:** Restart Agent does not duplicate scheduler policy, and
+  incidental time-related text cannot bypass normal recurrence accounting.
+- **Revisit when:** A caller provides a structured scheduler outcome with a
+  product requirement for a distinct recommendation.

--- a/docs/design/attribution/restart_agent/DESIGN.md
+++ b/docs/design/attribution/restart_agent/DESIGN.md
@@ -1,0 +1,855 @@
+# Restart Agent Design Spec
+
+This document is the canonical index and global system contract for the
+restart agent. The detailed normative rules live in the focused specs
+listed below. If two docs appear to conflict, treat this file as the routing
+source and the named focused spec as authoritative for that topic.
+
+## Canonical Docs
+
+- `README.md`: human-readable system narrative and learning path.
+- `REQUIREMENTS.md`: product use cases, latency requirements, model-selection
+  requirements, non-goals, and acceptance criteria.
+- `L0A.md`: complete deterministic evidence assembly, Decision Evidence,
+  progress, deterministic identity, and L0A KPIs.
+- `L0B.md`: bounded attention-efficient model projection, selection accounting,
+  and L0B KPIs.
+- `L1.md`: semantic model task, prompts, route execution, usability, and L1
+  measurements.
+- `L2.md`: source grounding, enriched identity, non-overriding audit, and L2
+  measurements.
+- `L3.md`: exact-job history comparison, affected-entity relation, progress,
+  and recurrence.
+- `L4.md`: ordered STOP/RESTART rule selection, retry budgets, declared
+  recovery capabilities, and action.
+- `RUNTIME.md`: configuration/bootstrap boundaries, stateful runtime ownership,
+  artifact lifetimes, history injection, and CLI/library execution.
+- `SCHEMA.md`: public request/response, internal execution context, model evidence
+  output, attempt records, trace records, and shared eval-boundary data shapes.
+- `PROGRESSIVE.md`: the optional progressive L0 precompute lifecycle, retained
+  state, finalization, latency, and parity validation. Terminal execution is the
+  production default.
+- `CONFIGURATION.md`: complete product configuration, credentials, resolution, validation, and
+  configuration identity.
+- `TOOLS.md`: L1 read-only tool interfaces, limits, advertisement, rejection
+  behavior, and call observability.
+- `TAXONOMY.md`: canonical distinctions among structural, semantic, history,
+  and policy vocabulary.
+- `PATTERN_REGISTRY.md`: active deterministic detector catalog, emitted L0
+  observations, and safety constraints.
+- `STATUS.md`: implementation coverage, maturity, and tracked follow-ups.
+- `DECISIONS.md`: rationale, rejected alternatives, consequences, and revisit
+  conditions for active architectural choices.
+- `EVALUATION.md`: product/harness ownership, packaging, secrets, and parity
+  boundary.
+
+The eval harness is a companion developer product under
+`tools/restart_agent_eval/` in a separate NVRx change chain. Its requirements,
+corpus, review-panel process, and model-comparison tooling are not canonical
+runtime specifications.
+
+## Goal
+
+The system decides whether a failed distributed training job should be restarted
+immediately or held for user/human intervention.
+
+The public action is binary:
+
+- `STOP`: do not restart immediately; hold for user/human intervention.
+- `RESTART`: restart immediately.
+
+Default bias is `RESTART`. L1 reports semantic recovery facts; L3 reports
+observational history; L4 selects a versioned retry rule and emits `STOP` only
+for grounded unrecoverable workload evidence or an exhausted retry budget.
+The public response contract has no user/not-user policy scores.
+
+## Scope And Boundary
+
+### Public Request
+
+The caller supplies a `restart_agent_request.v1` object containing:
+
+- `log_path`: path to one single interleaved multi-rank training log.
+- `job_id`: optional job identifier.
+- `cycle_id`: optional integer NVRx restart/cycle identifier. When present, it orders
+  restart attempts within the same `job_id`; it is not application progress.
+- `analysis_mode`: optional mode. Default is `terminal`; progressive cycle
+  integrations use `progressive_start` and `progressive_end`.
+
+Configuration, history, and evaluation metadata are deliberately absent from
+the public request. `SCHEMA.md` is canonical for the exact shape.
+
+### Internal Execution Context
+
+After request validation, the agent combines the request with:
+
+- an immutable `PriorAttemptView` selected by the restart-agent runtime;
+- configured restart-environment assumptions; and
+- configured L4 retry budgets.
+
+The resulting immutable `AnalysisExecutionContext` is the internal input to
+L0-L4. The stateful `RestartAgentRuntime` supplies history through the same
+boundary for library, CLI, and future MCP entrypoints. Configuration is loaded
+from `restart_agent_config.v1`; history data and evaluation labels are never
+configuration fields.
+
+The initial implementation targets one log file. Multi-file one-rank-per-file
+inputs are out of scope unless they are pre-concatenated into one interleaved
+file.
+
+Missing or invalid `log_path` is a request validation error, not an analyzer
+decision. `REQUIREMENTS.md` owns request-validation and unavailable-log
+behavior; `PROGRESSIVE.md` owns the cycle-start exception where the parent path
+exists but the target file may not yet exist.
+
+### Runtime Boundary
+
+`RestartAgentRuntime` is stateful orchestration around the stateless analysis
+pipeline. It owns current-process history, request orchestration, model-route
+concurrency, analysis timeouts, and candidate lifecycle. Configuration parsing,
+credential resolution, and concrete dependency construction happen outside it
+in a configuration loader and composition root.
+
+The composition root injects model routes, provider clients, an
+`AttemptRecordStore`, and an `AttemptRecordAssembler`. The runtime receives
+ready-to-use dependencies, not a configuration filename, raw JSON,
+environment-variable names, or secret paths. `RUNTIME.md` is canonical for
+these boundaries.
+
+History is enabled by default and retains up to 10 attempts per exact `job_id`
+and 3000 records across all jobs; product configuration may disable it or
+override either bound. The MVP store is local in-memory state for one runtime
+lifetime. It orders attempts by integer `cycle_id`, excludes current/future
+cycles, and upserts idempotently by `(job_id, cycle_id)`.
+
+The runtime exposes an `AttemptRecordControl` seam for library/unit tests to
+seed, inspect, and clear state. The CLI may explicitly import and export a
+deterministic JSON-array fixture for manual testing and scenario construction.
+This is not automatic persistence, a production transfer format, or an MCP
+operation. Attempt records are runtime state rather than a per-analysis public
+request field.
+
+The CLI, library, and direct attrsvc integration use this same runtime. History
+state is exercised through library/unit tests, and the CLI may explicitly
+import and export manual-test fixtures. A future Restart Agent MCP layer, if
+needed, is a thin adapter over the runtime and need not expose history
+operations in the product API. Persistent/distributed history and
+restart-surviving hydration remain outside MVP scope.
+
+The restart agent does not own job restart execution, node drain, or scheduler
+mutation.
+
+### Out Of Scope
+
+This design only emits binary `STOP` or `RESTART`. Non-binary operational
+actions such as node drain, GPU quarantine, retry-after-infra, or scheduler
+annotation are out of scope.
+
+Provider/model failure handling is in scope because the analyzer must always
+return the external output schema. `L1.md`, `L4.md`, and `RUNTIME.md` define
+provider failure handling and deterministic recommendation publication. Broader
+production safe-degradation behavior outside the analyzer, such as retry
+scheduling, alerting, or provider failover, is out of scope.
+
+### Experimental Future: Isolation
+
+Isolation is out of MVP scope and should be treated as experimental future work.
+The MVP MUST NOT emit, execute, or require non-binary actions such as node drain,
+GPU quarantine, temporal isolation, or scheduler mutation.
+
+The MVP SHOULD still preserve rank, node, and GPU evidence as structured fields
+when available. That keeps the current `STOP`/`RESTART` analyzer useful for a
+future isolation layer without making isolation part of the decision contract.
+
+A future isolation extension MAY combine log-derived locality evidence with
+external health signals. It MUST define its own schema, confidence threshold,
+action ownership, propagation path, and eval criteria before any isolation
+recommendation is acted on.
+
+## Global Invariants
+
+- L0 deterministic analysis builds the first evidence bundle before any LLM
+  call. `L0A.md` and `L0B.md` own the detailed assembly and projection
+  contracts.
+- L0 groups repeated log shapes by normalized template, summarizes routine log
+  output as structured facts, then preserves bounded original-log excerpts around
+  top candidate lines. Structurally classified cascades use their stable L0
+  identity for grouping so volatile temporary paths do not create hundreds of
+  model-facing patterns; exact counts and bounded representatives remain visible.
+- L0 parses complete traceback episodes and exposes both traceback starts and
+  terminal exception lines. Cleanup/finalizer stack frames may produce a
+  deterministic `teardown` cascade classification; a temporary path or
+  exception type without the cleanup stack is insufficient. All other causal
+  roles remain unasserted until L1 evaluates the episode.
+- L0 uses generic exception/assertion structure for observed failure anchors.
+  CUDA/PyTorch debugging advice is retained as `diagnostic_context` but MUST
+  NOT become a failure anchor, root fingerprint, or semantic taxonomy match.
+- L0 keeps terminal episodes open for later explicit scheduler, kernel, or
+  runtime cause confirmation. Bare process-kill records remain cause-unknown;
+  bounded confirmation representatives and excerpts are linked only when the
+  log directly names the cause and no compatible progress intervenes.
+- L0 represents an inherently distributed terminal mechanism, such as a
+  collective timeout, as a `distributed_mechanism` incident even when only one
+  reporter is observed. Additional same-epoch reports across ranks, operations,
+  and process groups are grouped into that incident. A separate
+  `distributed_fanout` incident requires observations from at least two
+  distinct ranks. The earliest terminal report is the observed mechanism;
+  later reports are fanout. L0 records progress-to-detection timing but leaves
+  the initiating cause unknown unless separate direct evidence establishes it.
+- L0 extracts bounded path-access facts from configured read/write/cache paths
+  and failed accesses. It may report distinct `/users/<name>` namespaces and a
+  failed-vs-configured-write namespace mismatch, but it records effective user
+  and ownership as unverified unless explicit evidence is present. Repeated
+  rank copies of one normalized terminal exception form a same-attempt
+  distributed exception-fanout incident only when at least two distinct ranks
+  are observed; a single-rank ordinary exception remains a failure episode
+  without a distributed incident. Incident membership
+  also consolidates those rank copies and subsequent structural teardown
+  exceptions into one failure episode before excerpt selection.
+- Model-facing registry evidence is deduplicated and explicitly provisional.
+  Internal registry policy/role fields remain available for deterministic analysis and trace
+  diagnostics, but MUST NOT be presented to L1 as an authoritative primary or
+  policy classification.
+- L0 separates observed accelerator-access mechanisms from root-cause priors.
+  In particular, invalid peer-GPU memory access over NVLink is an ambiguous
+  observed mechanism: fabric or remote-GPU failure is common, but invalid client
+  peer access remains possible. Only corroborating hardware diagnostics promote
+  it to a direct `gpu_hardware_fault` observation.
+- L0 candidate-anchor selection is progress-aware. High-signal-looking warning
+  patterns that are followed by compatible training/checkpoint progress are
+  summarized as background normalized occurrence groups or `progressed_after` context; they
+  should not be promoted to primary L1 evidence just because they appeared
+  early or repeated often.
+- L0 exposes deterministic job/run metadata such as explicit `world_size`,
+  observed-rank lower bounds, iteration deltas, consumed-sample deltas, and
+  checkpoint counts. An iteration explicitly attached to a terminal failure is
+  recorded as observed position, not completed progress; it may derive phase
+  and distance from a checkpoint load. L0 also records successful-runtime
+  duration, replay distance from the latest checkpoint, and later-progress
+  observations after fault-like events in the current log. These summarize scale, progress
+  depth, and execution ordering; they do not directly decide policy or prove
+  component recovery.
+- L0 also builds operation/artifact comparisons from explicit start/completion
+  markers. It records prior completed observations and the latest attempt
+  outcome at a declared identity strength: exact physical unit, same logical
+  artifact with another or unknown unit/shard, different artifact under the
+  same operation, or unknown comparability. This is current-log execution
+  context, distinct from L3 cross-cycle recurrence, and does not infer that an
+  inner write or append succeeded merely because the parent operation once
+  completed.
+- L0 does not make semantic `STOP` decisions in MVP. The analyzer may return
+  restart-biased results for nonsemantic availability cases such as a missing,
+  unreadable, or
+  empty log, but semantic `STOP` requires source-grounded L1 recovery evidence
+  or an exhausted L3/L4 retry budget.
+- Evidence extraction, candidate terminality, and final policy/action are
+  separate stages. Extraction may nominate candidates, but it does not decide
+  terminality or `STOP` / `RESTART`.
+- L1 may use read-only tools for ambiguous current-log evidence, but it does not
+  see attempt history in MVP.
+- The L1 tool interface is declared by each model-route configuration. The
+  model can call only tools advertised by the analyzer client; production MUST
+  NOT dynamically create arbitrary executable tools from model requests.
+- The model returns structured current-log evidence only. It must not emit
+  `decision_basis`, `decision`, or `evidence_coverage`. Its response separates
+  the observed primary mechanism, root-cause assessment, and model recovery
+  assessment; the client computes the action.
+- A non-null model primary MUST include a causal role and canonical evidence
+  citations. Missing required structural fields may trigger one
+  bounded L1 contract-repair response; repeated structural failure is invalid L1
+  output. A primary labeled `cascade` or `teardown`, or imperfect citation
+  grounding, is an L2 credibility finding rather than an L1 contract failure.
+- L1 evidence uses a compact closed contract: one observed primary failure,
+  one root-cause assessment, one model recovery assessment, optional minimal
+  related-failure role annotations, and cited evidence. L0/L2 derive
+  fine class, fault outcome, locality, data-position identity, and the stable
+  history fingerprint. L1 MUST NOT emit those client-owned fields or the final
+  action.
+- The model-visible L1 response schema and the client validator are generated
+  from one executable response contract. It owns fields, enums, limits,
+  confidence bounds, exact evidence support tags, and canonical
+  `no_failure_observed` / `insufficient_evidence` values, including their fixed
+  summary and rationale strings.
+- L0B selected object ids are provenance-only unless the route advertises
+  `get_evidence_objects`. Related failures are grounded diagnostic source
+  references, not additional policy citations; the canonical evidence array is
+  the only source of claim-support tags.
+- L1 recovery assessment reports exactly two independently qualified claims:
+  `failure_domain` and `retry_outlook_without_workload_change`. Each claim has
+  a value, evidence status, and confidence. Root-cause
+  assessment separately reports
+  whether the proposed cause is established, supported but unconfirmed,
+  hypothesis-only, or unknown, plus missing evidence. `workload`
+  includes application, model/data/configuration, and workload-selected
+  framework/library behavior. Uncertain ownership within the
+  workload stack MUST NOT by itself produce an ambiguous assessment.
+- External mutable resource state is different from ownership inside the
+  workload stack. A workload callsite does not prove who owns a port, lock,
+  path lease, or similar shared resource, nor that the state persists across a
+  restart. L1 requires evidence for both domain and retry-outlook claims;
+  absent that, it preserves supported, hypothetical, or unknown semantics for
+  L4 while L3 independently evaluates prior-attempt recurrence.
+- The static L1 system prompt declares immutable product guarantees: the
+  workload is unchanged, process state is recreated, normal restart delay
+  applies, and hardware allocation and mutable external-service state may
+  change. L1 must reason about the next attempt under those transition
+  semantics rather than assuming the failed process, allocation, port
+  ownership, or service state is preserved. L0B does not repeat them.
+- `retry_outlook_without_workload_change` asks whether the same workload may
+  recover after the product restart transition. Cross-attempt persistence is
+  not an L1 claim; L3 derives it from exact job and root-fingerprint matches.
+  Long-term remediation and
+  preventive advice are outside this contract. A deterministic resource
+  request proves repeated selection, not persistence of conflicting state.
+- Generic
+  CUDA asynchronous-reporting, `CUDA_LAUNCH_BLOCKING`, and
+  `TORCH_USE_CUDA_DSA` advice is not evidence of a transient fault or of the
+  condition named by the advice.
+- L1-selected fields used by policy receive a grounding audit and
+  stable client-derived identity. L0 observations may supply deterministic
+  fingerprint inputs. L2 preserves the raw L1 root-cause and recovery
+  assessment; it may emit audit findings, but has no separate policy-active
+  semantic view.
+  History identity is client-derived from observed log evidence rather than
+  model vocabulary.
+- L2 grounds the evidence tagged for each recovery claim. It does not infer
+  cross-attempt persistence from same-attempt fanout, deterministic exception
+  handling, or execution position.
+- L2 derives model visibility from the exact complete initial
+  `model_visible_payload` retained in the conversation trace and from returned
+  tool payloads. It does not reconstruct visibility from the compact evidence
+  subsection. Invalid related-failure references are findings and are omitted
+  from the audited projection without altering raw L1 output.
+- Canonical L1 citations are grounded only when their line/quote text was
+  model-visible. A quote that merely matches an unseen source-log line is an
+  audit finding and cannot support policy. Nearby line correction remains
+  available when the quoted text was visible at one unique nearby source line.
+- When L1 claims established infrastructure ownership or unrecoverability while
+  the product restart guarantees may replace the allocation or mutable
+  service state, L2 records a policy-material audit finding and an unapplied
+  suggestion. The raw L1 claim remains unchanged.
+- L2 records same-attempt rank fanout used as cross-attempt support as an
+  advisory because fanout is not recurrence by itself. The advisory does not
+  rewrite either L1 claim. Current-attempt deterministic checker behavior and
+  execution position/replay distance establish the current event, not survival
+  of its triggering state in the next attempt.
+- When L1 changes the primary anchor, the client MUST rebuild secondary and
+  cascade relationships relative to that grounded primary. It MUST NOT combine
+  an L1 primary with stale L0 relationship text or contradictory secondary
+  policy/causal labels.
+- L4 selects a versioned retry rule and budget, then computes
+  `decision_basis` and final `STOP` / `RESTART` from grounded recovery facts and
+  L3 observations.
+- A deterministic exact artifact or data-position identity selects
+  `confirmation_retry`. Its default one-retry ledger consumes only exact
+  root-and-entity recurrence without observed advance; a changed entity does
+  not reset the concurrent general same-root ceiling.
+- Trusted product configuration may declare workload-managed recovery
+  capabilities consumed only by L4. The closed MVP supports
+  `bad_token_retry_then_skip`: L4 applies its two-retry budget only when the
+  grounded primary has classifier `bad_token_or_window` and deterministic
+  `recovery_behavior=retry_then_skip`, and the selected facts contain a
+  `data_position` affected entity. Its retry accounting uses exact root and
+  entity matching while the general same-root ceiling remains active. Model
+  prose cannot activate it, and absence of the declaration leaves generic
+  policy unchanged.
+- Progressive execution follows `ATTRSVC_INTEGRATION.md` for the implemented
+  registration/terminal first cut and `PROGRESSIVE.md` for later L0
+  precompute: start is non-authoritative and end may produce the final action
+  after combining retained state with the final log tail.
+- Ordering, progress-before-fault, coverage, and history inputs used by L3/L4
+  come from L0, tool-call accounting, deterministic context assembly, the validated
+  request, effective configuration, and runtime-selected history. They do not
+  come from model-authored fields.
+- Observability is a design requirement for each layer. L0A reports assembly,
+  coverage, selection, progress, and fingerprint facts; Decision Evidence and
+  L0B report selection/projection integrity and size; L1 reports semantic
+  output, model/tool latency, retries/timeouts, tokens, contract status, and
+  tool-use efficiency; L2 reports grounding, identity, citation, and advisory
+  audit outcomes; L3 reports availability, per-dimension progress relations,
+  and recurrence counts; L4 reports the selected rule/budget, action, basis,
+  and latency.
+- Error-only candidate extraction can never prove terminality by itself; terminal
+  decisions require original-log context, explicit terminal evidence, or
+  qualifying recurrence.
+- Any filtering, deduplication, sampling, truncation, or summarization that
+  affects candidate evidence must be recorded as selection/lossiness metadata in
+  the trace.
+- Prompt-only policy rules are not authoritative. Any rule that can change the
+  final action belongs in `L4.md`, `TAXONOMY.md`, or deterministic client
+  code, and must be covered by eval.
+- L1 behavioral and policy semantics are single-sourced in the versioned system
+  prompt. The user message is a machine-readable invocation envelope containing
+  the static generated response schema and typed, request-specific L0B
+  evidence/context. It does not repeat the task, system policy text, advertised
+  tool schemas, or client tool-loop limits. Provider tool definitions travel in
+  the request's `tools` field. The eval harness compares prompt revisions using
+  contract compliance, semantic accuracy, tool use, latency, and token cost.
+- The static L1 prompt is generic-first: it defines causal reasoning,
+  restart-transition semantics, the two recovery concepts, and
+  grounding requirements. Failure-family examples belong in typed L0 evidence,
+  taxonomy/registries, or separately versioned prompt experiments. A rule
+  observed in one log MUST NOT be promoted into the core prompt without corpus
+  evidence and an A/B evaluation showing improvement without regressions.
+- The versioned `restart_agent_config.v1` contract binds runtime history, retry
+  policy, declared recovery capabilities, routing, and per-route request,
+  reasoning, tool, and reliability settings. Prompt, schema, detector, and
+  stage-algorithm versions belong to the product build rather than this config.
+- `CONFIGURATION.md` owns configuration resolution, credential handling, effective
+  identity, fingerprinting, and production/eval comparison semantics.
+- The configured whole-analysis timeout bounds Restart Agent execution. An
+  external NVRx action deadline may determine when NVRx consumes an available
+  candidate, but it does not close Restart Agent analysis or history updates.
+- Multi-model execution has one implemented, non-arbitrating `collect_all`
+  mode. It is enabled by default and may be explicitly disabled. When enabled, it reuses one
+  immutable L0 evidence state, publishes the deterministic recommendation, and
+  returns every independently computed route result without
+  preference, voting, or merging. Future arbitration is outside the current
+  configuration contract.
+- The `restart_agent_config.v1` JSON contract makes a
+  route the complete `(model, endpoint, request sampling/budgets, reasoning,
+  tools, reliability)` configuration rather than a model name. Shared defaults
+  are resolved before per-route overrides. Credentials remain external
+  environment references, while the resolved non-secret config and fingerprint
+  are traced. `restart_agent.json` is the conventional filename.
+- Production and eval results are comparable only when they use the same
+  product revision and resolved configuration fingerprint, or explicitly
+  report the differences.
+- Terminal analysis and progressive analysis are execution schedules for filling
+  the same evidence state; they MUST feed the same schema, fingerprinting,
+  history comparison, retry-budget mapping, and `STOP` / `RESTART` policy.
+- The production service shape is
+  `attrsvc/service adapter -> RestartAgentRuntime`. The runtime owns
+  current-lifetime history and orchestration. CLI and library entrypoints
+  exercise the same runtime. `ATTRSVC_INTEGRATION.md` owns this service
+  contract; any future Restart Agent MCP adapter remains optional and thin.
+- Only the selected `AttemptFailureFacts` identity participates in recurrence
+  policy. It contains a mechanism-level `root_fingerprint` and may contain one
+  exact-object `affected_entity`; secondary and cascade identities are not
+  recurrence keys.
+- Identity ownership is path-specific and deterministic. L0 creates the
+  deterministic root fingerprint and affected entity. L2 creates the enriched
+  equivalents after auditing the L1-selected primary against L0 evidence. L1
+  proposals are trace-only, L3 performs exact history comparison, and L4 does
+  not construct identity.
+- L3 computes root-only and root-plus-entity no-advance recurrence as
+  independent observations. L4 always evaluates the general same-root safety
+  ceiling and concurrently evaluates any narrower budget selected by grounded
+  policy or a declared recovery capability. A narrower budget may stop earlier
+  but cannot extend the general ceiling. Root identity answers whether the
+  mechanism recurred; entity identity distinguishes exact
+  token/sample/window positions and checkpoint/artifact paths. Entity identity
+  alone never selects a stricter rule.
+- If L1 selects a wrapper summary or traceback line belonging to an L0 failure
+  episode, L2 derives `root_fingerprint` from the episode's canonical causal
+  terminal exception. L0 consolidates duplicate serialization, inner-cause,
+  and outer-wrapper lines into that episode. This keeps history identity
+  independent of which equivalent line a model selected while preserving that
+  selected line as provenance.
+- If the stable anchor belongs to a distributed timeout incident, L2 uses the
+  incident history key. That key is invariant to rank, sequence number,
+  operation type, tensor size, and which member report appeared first; those
+  details remain diagnostic incident fields.
+- Rank, node, and GPU locality are structured evidence fields, not recurrence
+  keys. Same rank does not imply same GPU unless a rank-to-GPU mapping is
+  present; cross-node recurrence is recorded for calibration but does not
+  independently change the MVP retry budget.
+- Previously accepted paths that become unreadable/empty, malformed model
+  outputs, and provider-failed analysis paths must still return the external
+  analyzer schema with a restart-biased result. Invalid requests are rejected
+  before analysis.
+
+## Pipeline
+
+```text
+restart_agent_request.v1 + restart_agent_config.v1 + PriorAttemptView
+  -> terminal or progressive context assembly into the same evidence state
+  -> L0A complete evidence assembly -> immutable L0A bundle
+  -> shared DecisionEvidence
+  -> AttemptRecord(progress + deterministic failure facts)
+       +-> L3(current deterministic, prior deterministic) -> L4
+       |     -> publish deterministic recommendation
+       +-> L0B initial model evidence view -> L1 semantic analysis
+             -> L2 grounding, identity, and advisory audit
+             -> add/replace AttemptRecord.enriched[route_id]
+             -> L3(current enriched, prior deterministic) -> L4
+  -> publish deterministic and enriched candidates as they become ready
+  -> complete or stop at the configured Restart Agent analysis timeout
+  -> external analyzer output: retry-policy state + decision_basis + STOP/RESTART
+```
+
+### Layer Model
+
+The stages are explicit trust and observability boundaries:
+
+| Stage | Typed transformation | Authority |
+| --- | --- | --- |
+| L0A | `LogSnapshot -> L0Bundle + DecisionEvidence + deterministic attempt facts` | Complete deterministic evidence, progress, primary, and deterministic identity. See `L0A.md`. |
+| L0B | `L0Bundle + DecisionEvidence -> L0ModelFacingView` | Bounded attention projection and selection/lossiness accounting. See `L0B.md`. |
+| L1 | `L1EvidenceContext -> L1EvidenceResult` | Model semantic assessment and provider/tool execution record. See `L1.md`. |
+| L2 | `L2GroundingInput -> L2Result` | Source grounding, enriched identity, and non-overriding audit. See `L2.md`. |
+| L3 | `HistoryEvaluationInput -> HistorySummary` | Exact-job recurrence, affected-entity relation, and progress comparison. See `L3.md`. |
+| L4 | `L4PolicyInput -> L4PolicyOutcome` | Ordered retry-rule selection, budget accounting, and final action. See `L4.md`. |
+
+No layer silently rewrites an earlier layer. L1 semantics remain visible after
+L2 grounding, L3 reports observations without selecting thresholds, and L4
+records the exact semantic and history inputs used for policy. L1 confidence is
+calibration data, not an L4 threshold.
+
+`AttemptRecord` is the neutral runtime-owned aggregate for the current attempt
+and later immutable prior views. It contains shared L0 progress, one required
+deterministic `AttemptFailureFacts` block, and route-keyed L2 enriched blocks.
+It contains no L3 judgment or L4 outcome. `SCHEMA.md` owns exact contracts.
+
+Module ownership follows the stage boundary. `l0/` owns deterministic assembly,
+DecisionEvidence, bounded projection, replay codec, and the registry. `l1/`
+owns provider-neutral contracts, schema validation, prompt, read-only tools,
+invocation health, and the OpenAI-compatible adapter. `l2/` owns minimal source
+grounding, enriched failure-fact construction, identity, and advisory audit. `l3/`
+and `l4/` own history and action policy respectively. `infrastructure/` owns log
+and artifact I/O; `observability/` owns trace construction and envelope schema
+identifiers. Shared immutable contracts live in `models.py`, cross-stage
+identity in `identity.py`, public downstream-role assembly in `causality.py`,
+and invocation envelopes in `execution.py`. `pipeline.py` is the public facade;
+`preparation.py`, `single_run.py`, and `multi_route.py` own preparation,
+deadline-aware orchestration, and candidate publication. `decision_pipeline.py`
+composes L2/L3/L4 without reimplementing their policy.
+The runtime layer owns `AttemptRecordAssembler`, store generations,
+record closure, and immutable update commits; those responsibilities do not
+belong to any L0-L4 stage.
+
+#### Runtime Dependency Boundaries
+
+Preparation feeds one captured source boundary through the shared byte-chunk
+reader, incremental line decoder, and L0 observation accumulator, then freezes
+one immutable `LogSnapshot`. Terminal execution supplies every available chunk
+without waiting; progressive execution supplies available chunks, waits for
+growth, and drains the final tail at end. L0A, L1 evidence tools, and L2
+grounding reuse the finalized snapshot. Stages do not reopen
+`L0Bundle.log_path`. `LocalLogSource` is the default adapter; another source
+adapter may implement the same captured-boundary contract.
+
+Configuration loading produces immutable `ModelRouteSpec` values and does not
+create provider clients. The CLI composition root converts route specs into
+runtime `ModelRoute` values through an `EvidenceExtractorFactory`.
+The file loader delegates to the pure `parse_restart_agent_config` validator,
+which receives an explicit environment mapping. `LlmEvidenceExtractor` accepts
+a `CredentialProvider`, `ChatTransport`, clock, sleeper, and optional retry
+transport factory. `OpenAICompatibleTransport` receives an `HttpClient`; its
+default adapter owns one persistent synchronous `httpx.Client` connection pool
+per route. Restart Agent retains responsibility for provider retries,
+deadline clamping, error classification, and trace records rather than
+delegating those policies to the HTTP library. The read-only evidence-tool
+factory, executor factory, and multi-route prepared-runner factory are also
+injectable. Direct construction in the CLI and public facade is composition,
+not a stage dependency.
+
+The composition root also constructs `RestartAgentRuntime`, its
+`AttemptRecordStore`, and its `AttemptRecordAssembler`. History is enabled by
+default with `max_attempts_per_job=10` and `max_total_records=3000`. The
+runtime owns the live state but does not parse configuration or construct the
+store. Library/unit tests may
+inject or seed the store directly through `AttemptRecordControl`; that
+in-memory test seam is not a serialized artifact or transport contract.
+
+Orchestration receives a `Clock` and `ExecutorFactory`. Deadline checks,
+candidate timings, and route scheduling therefore have deterministic unit-test
+seams without changing the production thread-based implementation. The
+asynchronous L0 artifact publisher receives the same executor-factory contract,
+and the live artifact writer receives a clock for deterministic lifecycle
+timestamps and elapsed time. L0A itself
+is decomposed into typed detection, contextualization, and bundle-assembly
+steps. DecisionEvidence selection, L2 citation grounding, attempt-record
+assembly, history/policy execution, and final result assembly are separately
+testable transformations.
+
+The library contract is `RestartAgent.run()` / `run_many()`. Each returns an
+immutable run envelope containing the public result and the exact bundle,
+model view, trace, and deterministic artifacts for that invocation. The core
+orchestrator stores no caller-visible last-run state. There is no mutable
+compatibility adapter or alternate legacy execution path.
+
+L1 owns provider health, timeout, truncation, parsing, required output-contract
+checks, and its bounded contract-repair turn. L2 runs only when L1 produced a
+structurally usable semantic response; otherwise L2 reports `not_run`, L3 uses
+the available deterministic identity/history path, and L4 emits the deterministic policy.
+
+#### Concurrent Candidate Publication
+
+Every product run computes a `deterministic` candidate from immutable
+Decision Evidence and
+immutable `PriorAttemptView`. L0 supplies shared progress and deterministic
+failure facts; the runtime assembles the initial `AttemptRecord` and upserts it
+when eligible before running deterministic L3 and L4. This path does not build
+L0B or run L1/L2. Its provenance records `model_contribution=not_enabled` and
+`l1_execution_status=not_run`.
+
+With the default enriched execution, the analyzer publishes that same
+deterministic candidate before model routes start. While enrichment is pending,
+its provenance records `model_contribution=pending_not_used` and
+`l1_execution_status=in_flight`.
+
+If structurally usable L1 output becomes available before the configured
+Restart Agent analysis timeout, the analyzer runs L2, adds or replaces that
+route's enriched fact block in the same-key record, and recomputes L3/L4 as an
+`l1_enriched` candidate. Both branches use the same immutable runtime-selected
+`PriorAttemptView`; prior-record comparisons remain deterministic in MVP.
+Candidates are published as they become ready. An external caller may stop
+waiting and act on an earlier candidate without closing analysis. Route priority
+and canonical enriched-history selection remain deferred.
+
+Enriched execution is a second execution of existing L3/L4 over different
+current-cycle evidence, not an additional semantic layer. After deterministic
+publication, the analyzer starts L1. The synchronous library/CLI waits only
+until the configured analysis
+timeout and returns the selected final result; `on_deterministic_ready`
+exposes the earlier typed `DecisionCandidate` for a progressive service. The
+library callback executes synchronously, is failure-isolated, and has its
+latency traced separately from L1. It MUST perform only bounded work or hand
+off immediately; otherwise it delays L1 and consumes the analysis budget.
+
+`run()` and `run_many()` also expose `on_l0_ready`. For model-backed execution,
+it fires once after L0A, Decision Evidence, and L0B are complete and before
+model-route fanout. For deterministic-only execution it fires after L0A and
+Decision Evidence, with `model_view=null`. The
+callback receives one immutable `L0Artifacts` object; unavailable or empty logs
+do not produce it. The CLI binds this boundary to one background artifact
+writer, so serialization does not delay route start. When requested, the
+writer atomically publishes canonical `l0_bundle.json`,
+`decision_evidence.json`, and `l0_model_view.json` files while L1 is still
+running. Callback/persistence timing is observability data, not L0 build time.
+
+`collect_all` additionally exposes `on_route_complete`. The callback runs once
+for each route as that route reaches a terminal execution status; it does not
+wait for slower routes and callback failure cannot change route semantics. The
+caller may provide exact canonical result/trace paths for every configured route
+through a route-artifact manifest. The CLI writes each route trace and then its
+result directly to those final paths; result existence is the completion marker
+that guarantees the companion trace is already complete. The deterministic
+recommendation and shared L0 products likewise go directly to
+caller-declared paths.
+
+`--incremental-artifact-dir` contains lifecycle control data only: an atomically
+replaced status snapshot and an append-only event stream. Events reference the
+canonical artifacts rather than duplicating payloads below `live/`. The
+canonical batch trace is written before its result after all routes finish or
+the analysis timeout expires. This is incremental publication by completed
+logical artifact, not fragment streaming into one invalid partial JSON object.
+
+The implemented Restart Agent analysis timeout is configured by
+`routing.timeout_seconds` and defaults to 240 seconds from analysis start.
+Internally it is represented as an absolute monotonic deadline. Route-level
+provider timeouts are subordinate: each HTTP request is clamped to the remaining
+analysis budget, and retries, model turns, tool calls, and forced final
+responses cannot start after that boundary. Worker cancellation is cooperative;
+orchestration returns without waiting for an unfinished worker, while the
+built-in provider client unwinds at its clamped request timeout. This boundary
+is independent of any external NVRx action deadline.
+
+#### Audit And Policy Ownership
+
+L2 may make narrow mechanical reference repairs and derive client-owned
+identity, but its semantic suggestions are advisory and marked unapplied. Raw
+L1 remains visible. L4 alone maps eligible L1 semantics and L3 observations to
+retry policy and action. See `L2.md` and `L4.md` for the normative boundaries.
+
+Public downstream evidence assembly may annotate L0 cascade/teardown groups
+with grounded L1 relationships, but that observational rendering is not an L4
+input.
+
+#### Grounded History Identity
+
+History uses `root_fingerprint` for failure mechanism and optional
+`affected_entity` for the exact artifact or data position. L0A derives the
+deterministic identity; L2 derives route-enriched identity after grounding. L3
+consumes those typed values without reopening source logs or model prose.
+`L0A.md`, `L2.md`, and `L3.md` own the detailed rules.
+
+### End-to-End Example
+
+For a log whose first terminal episode contains a checkpoint metadata decode
+failure:
+
+1. L0A records the normalized occurrence group, bounded source window, failure
+   episode, progress/checkpoint facts, deterministic root fingerprint, and
+   affected checkpoint identity. The identity uses checkpoint path plus
+   iteration and an explicit shard/file/object when available; decoder-local
+   buffer positions remain diagnostic only.
+2. Decision Evidence selects that episode as the deterministic primary and
+   references the supporting L0A objects. L0B renders the bounded model-visible
+   view without changing those facts.
+3. The deterministic branch immediately compares the deterministic root/entity and
+   progress facts with prior exact-job attempts. In parallel, L1 may describe
+   the mechanism and recovery outlook; L2 grounds its cited line and derives
+   the enriched root/entity without rewriting the model assessment.
+4. L3 compares the selected current branch directly with each earlier
+   same-root attempt. A first occurrence has no consumed history. Repeated
+   terminal/unresolved occurrences with no observed advance consume the
+   selected rule's retry budget; an unknown progress relation does not. One
+   prior exact root-and-checkpoint recurrence exhausts the default
+   confirmation budget.
+5. L4 alone maps the selected rule and consumed budget to `RESTART` or `STOP`.
+   The result and trace keep deterministic recommendation, raw L1 assessment, L2
+   grounding, L3 comparisons, and L4 policy provenance distinct.
+
+### Layer Runtime Metrics
+
+The product emits measurements; the companion eval harness owns gold comparison,
+quality scoring, aggregation, and promotion gates. Required runtime measurement
+families are:
+
+| Boundary | Product-emitted measurements |
+| --- | --- |
+| L0A | Assembly time, source bytes/lines, object counts, caps/lossiness, deterministic root/entity availability/source/readiness. |
+| Decision Evidence | Selection time, schema, primary and identity availability, referenced source lines, exact branch reuse. |
+| L0B | Projection time, characters/estimated tokens, selected context, compaction/truncation, payload integrity. |
+| L1 | Semantic output, first-turn usability, model/tool/repair turns, tool yield, tokens, parsing/truncation, and contract status. |
+| Endpoint | Provider attempts, successes/failures, retries, timeouts, HTTP/provider errors, and failed-call time. |
+| L2 | Grounding/audit time and status, citation outcomes, findings/materiality, repairs, and enriched root/entity readiness/source. |
+| L3 | Comparable attempt counts, progress markers/relations, entity relations, root-only and root-plus-entity no-advance streaks, and unknowns. |
+| L4 | Policy version, selected rule and history scope, retry budget/count/exhaustion, observed-advance handling, action/basis, and latency. |
+| Candidate readiness | Deterministic/enriched readiness, result provenance/usability, selection reason, analysis-timeout outcome, and terminal request-to-result latency. |
+
+The eval harness specifications define how these measurements combine with human
+gold into per-stage quality KPIs. Product documentation does not duplicate those
+scoring formulas.
+
+End-to-end latency is measured once from the relevant analysis event to each
+usable candidate; stage wall times are diagnostics and need not sum to it.
+Progressive qualification measures `progressive_end` to deterministic recommendation
+and enriched L4 results separately. Total precompute work remains a
+capacity/cost metric. The current manual one-log bench does not exercise this
+progressive lifecycle and reports terminal request-to-result latency instead.
+Whether NVRx consumes a candidate within its own action window is an integration
+measurement, not a Restart Agent correctness requirement.
+
+## Observability Contract
+
+Observability is part of the analyzer contract, not an optional feature. Every
+verdict-producing path MUST emit the external analyzer output and a decision
+trace, including deterministic paths such as log unavailable, provider failure,
+malformed model output, and analysis timeout.
+
+The trace must be sufficient to explain which evidence view produced the final
+action and why production/eval runs may diverge. At architecture level that
+means preserving:
+
+- resolved configuration fingerprint, product contract versions, effective
+  analysis timeout, model-routing outcome, and deterministic path;
+- result provenance and usability: whether the final result used L0
+  deterministic evidence, source-grounded L1 model evidence with a separate
+  credibility audit, history recurrence, or deterministic behavior, and whether
+  NVRx should treat the result as normal, degraded, or unusable;
+- L1 raw semantic output and interaction transcript, preserved without client
+  rewriting;
+- L2 functional grounding/identity status and enriched `AttemptFailureFacts`,
+  plus separate per-field audit findings, citation resolutions,
+  unresolved-grounding reasons, and L1 usability;
+- L0A bundle reference or content, selected candidates, candidate anchors/event
+  timeline, evidence coverage, progress/checkpoint facts, and assembly
+  selection/lossiness metadata;
+- exact versioned Decision Evidence, including the deterministic primary and
+  references back to L0A;
+- exact typed L0B model-facing view, its schema version, projection metrics,
+  and projection selection/truncation metadata;
+- per-model and per-tool-call latency, configured budget/cap events,
+  truncation, unsupported requests, errors, and whether each result affected the
+  final evidence;
+- optional provider-reported L1 downstream-API and proxy processing spans when
+  response headers supply them. These remain distinct from client wall time,
+  are not labeled model compute, and are omitted when unavailable;
+- attempt-record lifecycle: deterministic creation, route-keyed enriched
+  updates, same-key generation, close/timeout state, and rejected stale or
+  late updates;
+- L3 history inputs and outputs: current `AttemptRecord`, selected deterministic
+  or enriched fact block, immutable ordered `PriorAttemptView`, typed progress
+  comparisons and deltas, stronger exact-position observations, and
+  streak/count facts;
+- L4 policy inputs and outputs: grounded L1 recovery assessment, L3 history
+  facts, selected retry rule, allowed retries, matching prior failures,
+  exhaustion and observed-advance state, `decision_basis`, and final
+  `STOP` / `RESTART`;
+- progressive state hit/fallback behavior, retained candidate summaries,
+  terminal-equivalence outcome, and deterministic/enriched publication latency.
+
+The trace preserves primary selection by stage: L0 deterministic candidate,
+raw L1 semantic primary, L2 grounded primary, and final L4 result. These fields
+MUST remain distinct even when their lines or classes agree.
+- references to bulky artifacts, especially the L0 evidence bundle and the
+  LLM/tool interaction transcript.
+
+`SCHEMA.md` owns the trace schema and required metrics. `L0A.md` and `L0B.md`
+own bundle traceability and selection/lossiness accounting. `TOOLS.md` owns
+tool-call observability. `CONFIGURATION.md` owns resolved configuration identity and
+route-setting traceability.
+
+External trace sink failures MUST NOT change the restart decision, but the
+analyzer MUST still return the external output schema and SHOULD record the
+sink failure wherever a local trace or response anomaly can preserve it.
+
+Service mode exposes trace inspection as non-critical observability views:
+`summary` for quick operator inspection and `detail` for the full trace record.
+CLI mode cannot rely on service endpoints, so CLI verdict-producing runs should
+support writing a local trace artifact, include a local `trace_uri`/path in the
+output when one is written, and support local rendering of the same
+summary/detail projections from that artifact.
+
+The optional CLI `--summary` is a human-readable projection of result and
+metric fields for interactive use; it is not a diagnostic artifact and review
+harnesses SHOULD NOT persist it. Decisions and primary evidence belong to the
+result, while timing, tokens, calls, retries, and handled model/provider errors
+belong to structured trace telemetry. Process stderr is reserved for unexpected
+warnings and failures and MAY be retained as a failure-only diagnostic log.
+
+Model/tool interaction debugging requires a separate artifact from the compact
+trace. The analyzer SHOULD write an interaction transcript file containing the
+evidence bundle snapshot or reference, rendered prompts/messages, advertised
+tools, raw visible model responses, parsed tool requests, tool results,
+provider retries, provider errors, token exhaustion, malformed output, JSON
+repair attempts, and any selection/arbitration outcomes when that future mode is
+enabled. The compact trace records summary
+counts, hashes, and artifact URIs; the transcript file carries the bulky
+payloads after required secret redaction.
+
+## Progressive Cycle Mode
+
+Attrsvc implements progressive registration, periodic L0A precomputation,
+terminal background scheduling, log-drain convergence, finalized-L0A handoff,
+and nonblocking result probes. Pre-end polling is opt-in; terminal-first
+execution is the default. The switch changes when L0A runs, not the evidence,
+history, or policy semantics. `PROGRESSIVE.md` owns retained state,
+finalization, latency, and validation.
+
+## Offline Calibration Boundary
+
+Production feedback such as shadow-mode STOP outcomes is calibration data, not
+runtime evidence for the decision that generated it. The companion eval harness
+owns shadow-outcome labels, ingestion, measurement, and translation into
+configuration or policy recommendations. Product `SCHEMA.md` owns only the decision
+and trace artifacts consumed by that evaluation.
+
+## Configuration Ownership
+
+This architecture document does not own concrete defaults. Focused specs own
+defaults close to the behavior they configure:
+
+- `L3.md` owns history comparison and recurrence counting.
+- `L4.md` owns retry-rule selection, retry budgets, capabilities, and action
+  mapping.
+- `CONFIGURATION.md` owns restart-agent configuration resolution, credential
+  references, effective identity, fingerprinting, and comparison semantics.
+- `RUNTIME.md` owns configuration/bootstrap boundaries and runtime-history
+  defaults, lifecycle, injection, and replay.
+- `TOOLS.md` owns fixed tool interfaces and response limits. `CONFIGURATION.md` owns
+  tool advertisement, model-call settings, and route overrides.
+- `REQUIREMENTS.md` and `SCHEMA.md` own Restart Agent execution semantics and
+  runtime schema fields. `ATTRSVC_INTEGRATION.md` owns how NVRx consumes
+  available candidates.
+- The companion eval harness owns generated configuration recommendations and
+  measured latency gates.
+- Provider deployment defaults are explicit route configurations. Credential values and
+  credential-file locations come from route configuration or environment; the
+  library does not assume a per-user key path.
+
+`STATUS.md` tracks work needed before promotion, including route
+qualification and progressive replay.

--- a/docs/design/attribution/restart_agent/EVALUATION.md
+++ b/docs/design/attribution/restart_agent/EVALUATION.md
@@ -1,0 +1,92 @@
+# Product And Evaluation Boundary
+
+This document is canonical for the boundary between the installable Restart
+Agent and its non-installable evaluation harness. It defines ownership,
+packaging, secrets, and parity requirements. Harness workflow, scoring, and
+artifact schemas remain under `tools/restart_agent_eval/docs/`.
+
+## Ownership
+
+| Concern | Owner |
+| --- | --- |
+| L0A, Decision Evidence, L0B, L1-L4, route execution, runtime results, traces, and metrics | Product |
+| Log corpus, human gold, review artifacts, panel summaries, corpus aggregation, stability analysis, configuration comparison, and promotion recommendations | Harness |
+| Production route-configuration choice, data classification, and NVRx candidate-consumption timing | NVRx deployment/operator |
+
+The harness MUST invoke the product under test. It MUST NOT reimplement evidence
+construction, prompts, tools, grounding, identity, history, or policy. Product
+`collect_all` owns shared-L0 parallel route execution; the harness selects its
+review routes and evaluates the independent product results afterward.
+
+The dependency is one-way. The harness may invoke or import an explicitly
+selected product checkout, but installable product code MUST NOT import the
+harness or depend on harness artifacts to produce a valid result.
+
+## Repository And Packaging
+
+The harness may be versioned in the product repository so product contracts,
+harness expectations, tests, and documentation can change together. It lives
+outside `src/nvidia_resiliency_ext`, has no product package entry point, and is
+excluded from product distributions.
+
+Installing `nvidia-resiliency-ext` MUST NOT install the harness, corpus, gold,
+generated runs, provider credentials, or harness-only dependencies. Harness
+implementation documents remain beside the tool rather than being copied into
+the product specifications.
+
+## Production And Eval Parity
+
+By default, the harness evaluates the NVRx checkout that contains it. An
+explicit `NVRX_RESTART_AGENT_PRODUCT_REPO` override may select another checkout
+for version-comparison experiments; the run manifest MUST record that product's
+commit and dirty state.
+
+A production-comparable run MUST use the same product version and resolved
+restart-agent configuration, or explicitly record their differences. Product
+version covers prompt, schema, evidence-selection, and stage algorithms. The
+configuration fingerprint covers model routes, provider requests, reasoning,
+tools, retries, deadlines, history bounds, recovery capabilities, and retry
+policy.
+
+Gold labels, expected actions, case names, source-directory labels, and review
+notes MUST NOT enter product or model-visible inputs. The product trace is
+authoritative for what L1 received and returned. The harness scores only after
+canonical product artifacts are complete.
+
+## Environment And Secrets
+
+Model-backed harness runs use the product's credential-resolution contract
+defined in `CONFIGURATION.md`. Each route's `credential_ref` names an environment
+variable whose value is a readable API-key file path. A harness may resolve
+multiple credential references for its panel, but panel-specific reference
+names and process mappings are harness configuration rather than product
+contracts.
+
+Provider, model, reasoning, timeout, sampling, and tool controls retain their
+normal product configuration semantics. The harness MUST NOT pass credential
+paths as command arguments.
+
+The repository MUST NOT contain API keys, bearer tokens, copied key material,
+credential-bearing configuration, or user-specific fallback key paths. Route
+configurations may contain public model identifiers, endpoint identifiers,
+credential-reference names, and non-secret controls, but never credential paths
+or values. Commands, traces, manifests, and reports MUST exclude credentials,
+authorization headers, key-file paths, and key-file contents.
+
+## Compliance
+
+The operator is responsible for selecting an endpoint authorized for the log
+content. Export-controlled workloads are expected to use an approved Regulated
+Inference Hub route and credentials. Neither product nor harness infers data
+classification or compliance from log text or model names.
+
+## Artifacts And Metrics
+
+The product emits stage artifacts, per-route results and traces, invocation
+health, timing, token, tool, and endpoint measurements. The harness consumes
+those artifacts and adds gold comparisons, model/prompt/configuration comparisons,
+stability measurements, and promotion reports.
+
+Product schemas are defined in `SCHEMA.md`. Harness artifact roots, gold schema,
+KPI definitions, and panel layout are defined under
+`tools/restart_agent_eval/docs/`; they are intentionally not duplicated here.

--- a/docs/design/attribution/restart_agent/L0A.md
+++ b/docs/design/attribution/restart_agent/L0A.md
@@ -1,0 +1,323 @@
+# L0A Complete Evidence Assembly
+
+L0A is the deterministic log-understanding stage. It converts one immutable log
+snapshot into complete typed evidence, selects deterministic decision evidence,
+and constructs the route-independent current-attempt facts used by the
+deterministic path. It runs before any model call.
+
+`SCHEMA.md` owns exact serialized shapes. `PATTERN_REGISTRY.md` owns executable
+pattern intent. `L0B.md` owns the bounded model-facing projection.
+
+L0A ends at deterministic evidence and current-attempt facts; model
+interpretation, grounding, history comparison, and action policy belong to
+L1-L4.
+
+## Purpose And Authority
+
+L0A exists to turn large, noisy, interleaved training logs into auditable
+structure without asking a model to discover basic chronology or repeatedly
+rendered events.
+
+```text
+immutable log snapshot + product-defined L0 settings
+  -> detection
+  -> contextualization
+  -> L0Bundle
+  -> deterministic selection
+  -> DecisionEvidence
+  -> AttemptProgressSummary + deterministic AttemptFailureFacts
+```
+
+L0A is authoritative for:
+
+- source line numbering and log metadata;
+- deterministic registry matches and normalized occurrence grouping;
+- progress, checkpoint, setup, recovery, and termination observations;
+- candidate anchors, bounded context windows, failure episodes, and distributed
+  incidents;
+- deterministic primary selection and observed failure identity;
+- selection, cap, truncation, and lossiness accounting.
+
+L0A observations are provisional evidence. L0A does not infer semantic
+ownership, compare prior attempts, consume retry budgets, or choose an action.
+
+## Inputs And Outputs
+
+| Direction | Contract | Meaning |
+| --- | --- | --- |
+| Input | `LogSnapshot` | Immutable source byte boundary, UTF-8 logical-line access with localized malformed-byte replacement, and stable original line numbers. |
+| Input | L0 settings and registries | Product-defined patterns, context limits, grouping rules, and evidence caps. |
+| Output | `L0Bundle` | Complete typed evidence over the inspected snapshot. |
+| Output | `DecisionEvidence` | Canonical policy-relevant facts and references selected from the bundle. |
+| Output | `AttemptProgressSummary` | Route-independent current-attempt progress facts. |
+| Output | deterministic `AttemptFailureFacts` | Root fingerprint, outcome, position, locality, and affected entity when deterministically available. |
+
+Complete does not mean a raw copy of every line. L0A may retain bounded windows
+and representative occurrences when it records the source counts, samples,
+omissions, caps, and lossiness needed to explain that reduction.
+
+The local-file implementation feeds fixed-size byte chunks through one
+incremental line decoder. It retains an incomplete byte tail until a line is
+complete, then adds that line exactly once to an append-only observation index.
+Each completed line is classified once into compact channels such as progress,
+registry matches, high-signal candidates, checkpoint operations, and teardown.
+Cheap exact cues route a line only to relevant regex families; the cue gates are
+an execution optimization and do not change the evidence definitions.
+Registry hits first become lightweight observations containing source identity,
+normalized shape, outcome, and locality. L0A aggregates repeated observations
+and selects representative head/tail samples before constructing full
+`FailureEvidence`, source context, and fingerprints. Counts, rank/node/GPU
+spread, first occurrence, and sample lines still describe the complete group.
+Canonical reducers consume these compact channels to build the bundle.
+Selected source text is read through one temporary, reduction-scoped source
+view shared by contextual reducers. Bounded selection projections preserve the
+existing evidence caps, while repeated reads reuse the temporary source text.
+The reuse cache may evict old entries, but eviction MUST NOT remove lines from
+an in-progress batch lookup or from the current reduction's evidence.
+The view is released as soon as the bundle is assembled; complete decoded log
+content is not retained between reductions.
+
+Production `chunked` mode does not retain a second decoded copy of the log.
+Completed lines are classified once and discarded after their compact
+observation channels are updated. A compact byte-offset index plus an open,
+boundary-limited source handle supplies later random or streaming line access
+to reducers, L1 tools, and L2 grounding. Byte chunks are released after decoder
+feed; only the incomplete byte tail remains between reads.
+
+`single_snapshot` changes byte delivery to one chunk for parity tests; it does
+not define another reducer path. Both modes must produce the same canonical
+L0A payload for the same source boundary.
+
+## Evidence Objects
+
+L0A uses a small set of related objects:
+
+| Object | Meaning |
+| --- | --- |
+| Normalized occurrence group | Repeated observations with the same volatile-token-stripped shape. Preserves count, first occurrence, samples, locality spread, and registry role. |
+| Candidate anchor | A high-signal source line selected for chronology or context assembly. It is a retrieval anchor, not a root-cause conclusion. |
+| Bounded context window | Original source lines around one or more anchors, with line range, selection reason, and truncation metadata. |
+| Failure episode | One local causal story: prior progress, initiating/terminal exception chain, downstream teardown, later progress or recovery, and final episode status. |
+| Distributed mechanism incident | An inherently distributed failure such as a collective timeout. One observer is sufficient. |
+| Distributed fanout incident | The same ordinary mechanism observed from at least two distinct ranks in one progress segment. |
+
+A single-rank ordinary exception produces an episode but not a distributed
+incident. A single-observer collective timeout may produce both an episode and
+a distributed-mechanism incident.
+
+## Assembly Algorithm
+
+The implementation follows three deterministic transformations:
+
+1. **Detect.** Decode completed source lines incrementally and classify each
+   line once. Parse rank and node fields, progress markers, checkpoint/setup
+   markers, registry matches, diagnostic context, generic
+   traceback/fatal/process-termination anchors, path-access facts, and
+   high-signal structural lines.
+2. **Contextualize.** Aggregate repeated lightweight observations before full
+   evidence enrichment, build context windows, attach progress before and after
+   candidate faults, group exception chains into episodes, group distributed
+   events into incidents, distinguish causes from cascades/teardown, and attach
+   explicit cause confirmations.
+3. **Assemble and select.** Collect eligible registry roots, terminal episode
+   identities, distributed-incident identities, and explicit cause
+   confirmations. Reject recovered, teardown, cascade, diagnostic, and generic
+   announcement candidates unless stronger causal structure reclassifies them.
+   Select the earliest supported initiating observation in the terminal
+   episode, attach alternatives and related evidence, freeze `L0Bundle`, and
+   then freeze `DecisionEvidence`.
+
+The source log is not rescanned while selecting `DecisionEvidence`.
+
+## Progress And Outcome
+
+L0A separates:
+
+- `application_progress`: a comparable monotonic training marker advanced;
+- `checkpoint_progress`: a checkpoint save completed successfully;
+- `setup_progress`: initialization advanced, without proving forward training;
+- `recovery_evidence`: the same operation later succeeded, retried
+  successfully, or explicitly skipped/quarantined a bad input;
+- `failure_iteration`: a position attached to failure, not proof that the
+  iteration completed.
+
+Repeated output, liveness, teardown, retry counters, rank ids, timestamps,
+checkpoint starts, and failed checkpoints are not progress by themselves.
+
+Progress is conservative when a workload dialect is not recognized:
+
+- `not_observed` is valid only when L0A recognized a compatible progress or
+  checkpoint dialect and found no completed marker;
+- otherwise the corresponding status is `unknown`;
+- `progress_after_failure=not_observed` also requires source content after the
+  selected failure;
+- a later interleaved marker proves job continuation, not recovery of a
+  particular rank, node, GPU, or component.
+
+Candidate outcome is one of:
+
+- `terminal`: tied to termination with no later recovery/progress;
+- `recovered`: the same operation later succeeded;
+- `progressed_after`: compatible application or checkpoint progress followed;
+- `unresolved`: neither terminality nor recovery was established.
+
+Only `terminal` or terminal-linked `unresolved` observations are eligible for
+the deterministic primary. Eligibility does not imply `STOP`.
+
+## Noise And Attention
+
+Noisy faults followed by compatible progress remain compressed context rather
+than consuming top-anchor and context-window budget repeatedly. Examples include
+filesystem warnings, network disturbances, port warnings, repeated path-access
+warnings, and downstream rank fanout.
+
+Such evidence is promoted only when it is:
+
+- temporally tied to the terminal episode;
+- the earliest unrecovered high-signal candidate;
+- an explicit cause confirmation; or
+- the strongest available terminal observation.
+
+Stable CUDA/PyTorch diagnostic boilerplate, cleanup messages, stack-trace
+warnings, and scheduler cancellation are retained with diagnostic, teardown,
+or cascade roles. They cannot become a primary merely because their text is
+high severity.
+
+## Deterministic Primary And Identity
+
+Primary selection uses chronology, causal role, episode status, explicit cause
+confirmation, and available progress context. Registry class alone is not
+decisive.
+
+The deterministic ordering is:
+
+1. preserve an eligible registry root when terminal episode context confirms
+   it;
+2. prefer a more specific initiating precursor linked to that episode;
+3. use the terminal episode identity when no registry root covers the episode;
+4. use an explicit cause confirmation linked to an otherwise cause-unknown
+   termination;
+5. retain no primary when only teardown, cascade, diagnostic, or unexplained
+   process termination remains.
+
+Generic error announcements and outer wrappers do not replace a concrete
+exception merely because they occur earlier. `selection_summary` records the
+selected line and basis so corpus review can distinguish registry,
+episode-derived, and cause-confirmation choices.
+
+The deterministic branch produces two independent history values when source
+evidence supports them:
+
+- `root_fingerprint`: stable observed failure mechanism;
+- `affected_entity`: exact `artifact` or `data_position`.
+
+Rank, node, GPU, timestamp, cycle id, and source line remain occurrence
+metadata. They do not enter the root fingerprint. Exact artifact paths and data
+positions are retained in the affected-entity identity because they distinguish
+otherwise similar failures.
+
+For an operation-associated artifact, L0A uses the strongest unambiguous
+identity observed for the failing operation. A checkpoint load normally uses
+the normalized checkpoint path plus checkpoint iteration; an explicit
+shard/file/object identity refines it when available. Buffer-local details such
+as a Unicode decoder position, offending byte, rank, or traceback line remain
+diagnostic observations. They do not enter the affected-entity identity because
+the same artifact may be buffered or sharded differently on replay.
+
+## Decision Evidence
+
+`DecisionEvidence` is a standalone immutable type built from `L0Bundle`. It
+contains:
+
+- `deterministic_primary_candidate`;
+- `canonical_observed_identity`;
+- references to selected anchors, windows, occurrence groups, episodes, and
+  incidents;
+- failure position and outcome;
+- progress and checkpoint state;
+- operation and artifact facts;
+- later-progress and recovery observations;
+- locality;
+- coverage, lossiness, and provenance.
+
+It selects canonical policy-relevant facts and references. It does not copy all
+L0A objects, create model prose, compare history, or emit an action. The exact
+same object feeds the deterministic recommendation and is embedded in L0B.
+
+## Degraded Behavior
+
+- Missing, unreadable, or empty logs produce the public log-unavailable result
+  outside normal L0A evidence assembly.
+- Malformed UTF-8 bytes are replaced only in the affected physical line and
+  counted; they do not fail analysis or trigger a whole-file replay.
+- Unknown progress remains `unknown`; absence is not converted into evidence.
+- A cap or unavailable after-context leaves the affected fact unresolved and
+  records lossiness.
+- No deterministic primary is a valid outcome. L4 returns the degraded
+  `no_primary_failure` result without recurrence accounting; L0A does not
+  invent a root.
+
+## Tracing
+
+The trace or its lossless artifact references must preserve:
+
+- exact source identity and line-numbering convention;
+- the complete `L0Bundle`;
+- exact `DecisionEvidence`;
+- deterministic progress and failure facts;
+- registry and L0 contract versions;
+- counts, caps, omissions, truncation, and anomalies;
+- deterministic payload hashes.
+
+## KPIs
+
+Quality KPIs require reviewer-owned gold. Missing labels produce
+`not_available`, not failure.
+
+| Quality KPI | Example |
+| --- | --- |
+| Primary evidence coverage | Gold accepts lines 100-110; at least one L0A candidate/window covers that range. |
+| Selected primary accuracy | L0A selects line 104, which is inside the accepted gold range. |
+| Progress/checkpoint precision and recall | All labeled completed-iteration markers are found and failed checkpoint starts are not counted as saves. |
+| Typed-event accuracy | A teardown line is typed `teardown`, not `primary_failure`. |
+| Episode/incident construction accuracy | Repeated rank renderings form one episode/fanout incident rather than independent roots. |
+| Outcome accuracy | A fault followed by compatible progress is `progressed_after`. |
+| Identity accuracy and stability | The expected root/entity are present and identical under rank/timestamp reordering. |
+| Lossiness correctness | Every omitted or truncated collection is represented in metadata. |
+
+Operational metrics include:
+
+- L0A wall time and scan throughput;
+- source bytes, decoded lines, chunks, read/storage modes, and encoding;
+- pending-tail, source-reset, and encoding-replay counts;
+- occurrence-group, window, anchor, episode, and incident counts;
+- serialized bundle size;
+- cap, truncation, omission, and anomaly counts;
+- bundle reuse status;
+- deterministic replay/hash consistency;
+- Decision Evidence selection time and referenced-object counts.
+
+## Example
+
+```text
+1000 [rank 7] iteration 418 completed
+1012 [rank 7] RuntimeError: CUDA out of memory
+1013 [rank 9] RuntimeError: CUDA out of memory
+1030 [rank 7] destroy_process_group() called during shutdown
+```
+
+L0A creates:
+
+- one progress marker at line 1000;
+- one normalized occurrence group for the repeated OOM observation;
+- a bounded window around lines 1012-1030;
+- one terminal failure episode;
+- one distributed-fanout incident because two ranks reported the same ordinary
+  mechanism;
+- a teardown role at line 1030;
+- a deterministic primary and root identity anchored at line 1012;
+- `progress_after_failure=not_observed` only if after-context is available and
+  the iteration dialect is recognized.
+
+`DecisionEvidence` selects that episode and its supporting references. L0A
+still does not decide whether a restart can recover.

--- a/docs/design/attribution/restart_agent/L0B.md
+++ b/docs/design/attribution/restart_agent/L0B.md
@@ -1,0 +1,200 @@
+# L0B Initial Model Evidence View
+
+L0B is the deterministic attention-projection stage. It converts the complete
+L0A evidence into the bounded structured payload supplied in the first L1 model
+request.
+
+L0B is intentionally lossy but explicitly accountable. It prioritizes what the
+model should inspect first while preserving references to the complete evidence
+and allowing route-advertised read-only tools to retrieve additional context.
+
+`L0A.md` owns source interpretation. `TOOLS.md` owns optional retrieval APIs.
+`SCHEMA.md` owns the exact `L0ModelFacingView` shape.
+
+L0B ends at deterministic evidence selection and rendering; model execution,
+grounding, history comparison, and action policy belong to L1-L4.
+
+## Purpose And Authority
+
+```text
+L0Bundle + DecisionEvidence + L0B selection limits
+  -> prioritize
+  -> deduplicate
+  -> compact
+  -> render
+  -> L0ModelFacingView
+  -> L1 initial request
+```
+
+L0B is authoritative for:
+
+- which L0A objects and source excerpts appear in the initial model payload;
+- deduplication and merging of overlapping windows;
+- per-section and total projection limits;
+- truncation and omission metadata;
+- projection integrity and deterministic payload hash.
+
+L0B does not reinterpret the log, choose another deterministic primary, or
+change Decision Evidence.
+
+## Inputs And Output
+
+| Direction | Contract | Meaning |
+| --- | --- | --- |
+| Input | `L0Bundle` | Complete typed evidence retained by the analyzer. |
+| Input | `DecisionEvidence` | Canonical deterministic facts shared with the deterministic path. |
+| Input | L0B evidence-selection rules and size limits | Deterministic limits for sections, excerpts, text, and references. |
+| Output | `L0ModelFacingView` | Exact model-visible current-attempt evidence, excluding provider tool schemas. |
+
+The output contains:
+
+```json
+{
+  "schema_version": "restart_agent_l0_model_view.v1",
+  "decision_evidence": {},
+  "attempt_execution_context": {},
+  "evidence_bundle": {},
+  "projection_metrics": {}
+}
+```
+
+Only the first three data sections are sent in the model user message.
+`projection_metrics` remains trace/eval metadata.
+
+## Selection Algorithm
+
+L0B starts with mandatory material:
+
+1. include exact `DecisionEvidence`;
+2. include current-attempt execution context that is not already authoritative
+   in Decision Evidence;
+3. include the deterministic primary's episode/incident and covering windows;
+4. include the nearest prior and next compatible progress/checkpoint facts;
+5. include explicit cause confirmations and first downstream cascade/teardown;
+6. include bounded supporting occurrence groups and candidate anchors;
+7. use remaining budget for earlier high-signal unrecovered candidates and
+   compact job/run orientation.
+
+Within a collection, selection prefers:
+
+- primary and identity-anchor support;
+- terminal or unresolved evidence over recovered/noisy observations;
+- explicit cause confirmation over diagnostic suggestion;
+- earlier initiating evidence over later cascade;
+- progress boundaries and complete traceback summaries;
+- representative evidence with wider causal/locality coverage.
+
+Overlapping windows are merged. Repeated occurrence groups contribute counts and
+bounded samples, not one copy per rank.
+
+If the configured budget cannot include every candidate, L0B omits the lowest
+priority objects and records available, selected, omitted, and truncated counts.
+It never silently drops required Decision Evidence.
+
+## References And Retrieval
+
+L1 may expand beyond the initial view through route-advertised read-only tools.
+Retrieved content is recorded separately and does not modify L0B.
+
+## Attention Efficiency
+
+The goal is not the smallest payload. The goal is enough relevant evidence for
+a correct first-turn semantic assessment without burying the primary causal
+story in noise.
+
+Bundle size alone is neither success nor failure:
+
+- a larger view is justified when it carries distinct decision-relevant
+  evidence;
+- a smaller view is harmful if every model retrieves the same omitted context;
+- rereading lines already present in L0B is model/route inefficiency;
+- tool retrieval of new decision-relevant lines is evidence of an L0B coverage
+  gap;
+- disagreement across models must be separated from a shared projection defect.
+
+## Invariants
+
+- `DecisionEvidence` is byte-equivalent to the object used by the deterministic
+  branch.
+- The model-visible payload contains no absolute log path, basename, parent
+  directory, eval label, case id, or path-derived hint.
+- Every source line has its original line number.
+- A cited line is considered initially visible only when the paired source text
+  or quote is present, not merely its reference number.
+- L0B does not include `AttemptRecord`, `PriorAttemptView`, retry budgets,
+  history conclusions, or final policy.
+- Advertised tool schemas are provider request metadata; they are not duplicated
+  in `L0ModelFacingView`.
+- Projection is deterministic for the same L0A bundle and effective limits.
+
+## Degraded Behavior
+
+- If serialization fails, references do not resolve, line ranges are invalid,
+  or accounting does not reconcile, L0B is unusable and the deterministic
+  recommendation remains available.
+- Deterministic-only execution need not build L0B.
+- Truncation is allowed only when represented in projection metrics and the
+  rendered section.
+- Missing optional context remains an explicit omission, never fabricated text.
+
+## Tracing
+
+The trace must preserve the exact versioned L0B snapshot supplied to L1, or a
+lossless artifact reference and payload hash. It also records:
+
+- selection rules and resolved limits;
+- available, selected, omitted, and truncated counts by collection;
+- merged windows and source/model-facing line counts;
+- characters and estimated tokens;
+- budget utilization;
+- integrity checks and anomalies.
+
+## KPIs
+
+Quality KPIs require gold evidence or controlled ablation:
+
+| Quality KPI | Example |
+| --- | --- |
+| Required-evidence coverage | Gold requires the primary line, prior progress, and teardown; all three appear in the initial view. |
+| Primary retention | The L0A deterministic primary is represented with a covering excerpt. |
+| Supporting-context coverage | The checkpoint-load start and terminal decode error are visible together. |
+| Compaction safety | Ten duplicate rank errors become one group with exact count and samples; no distinct cause is lost. |
+| First-turn usability | L1 returns valid structured evidence without a retrieval tool. |
+| Missing-context tool rate | `read_window` discovers a necessary line absent from L0B. |
+| Bundled-evidence reread rate | A model retrieves lines already visible in L0B. This is an L1 efficiency issue, not an L0A miss. |
+
+Operational metrics include:
+
+- L0B projection wall time;
+- JSON characters and estimated input tokens;
+- section budget used and limit;
+- available/selected/omitted counts;
+- merged window and truncation counts;
+- payload serialization and reference-resolution status;
+- deterministic hash consistency.
+
+Downstream first-turn and tool metrics are attribution signals. They do not make
+an individual projection automatically good or bad.
+
+## Example
+
+Assume L0A found:
+
+- 400 repeated warnings followed by progress;
+- one terminal failure episode around lines 1000-1030;
+- 14 candidate anchors;
+- 9 partially overlapping windows;
+- a deterministic primary at line 1012.
+
+L0B may render:
+
+- exact Decision Evidence;
+- one merged primary episode window;
+- nearest progress before the fault;
+- one representative recovered-warning group with count 400;
+- bounded supporting anchors and the first cascade;
+- metadata stating that 5 lower-priority anchors and 7 redundant windows were
+  omitted or merged.
+
+The model begins with the terminal story, while the complete L0A objects and raw
+snapshot remain available through optional tools.

--- a/docs/design/attribution/restart_agent/L1.md
+++ b/docs/design/attribution/restart_agent/L1.md
@@ -1,0 +1,297 @@
+# L1 Semantic Analysis
+
+L1 asks a configured model to interpret the current attempt. It receives the
+bounded L0B view, may use declared read-only evidence tools, and returns a
+structured observed failure, root-cause assessment, and recovery assessment.
+
+L1 does not compare attempt history or choose `STOP` / `RESTART`.
+`SCHEMA.md` owns the exact response shape, `TOOLS.md` owns tool APIs, and
+`CONFIGURATION.md` owns route/provider settings.
+
+L1 ends at the model's current-attempt semantic assessment and execution
+record; source grounding, history comparison, and action policy belong to
+L2-L4.
+
+## Purpose And Authority
+
+```text
+L0ModelFacingView
+  + static semantic contract
+  + optional advertised tools
+  + model route and deadline
+  -> model interaction
+  -> L1EvidenceResult
+```
+
+L1 is authoritative for preserving:
+
+- the model's selected primary and causal role;
+- semantic failure identity and root-cause assessment;
+- current-attempt failure domain and retry outlook;
+- related failure roles and cited evidence;
+- the raw provider response, model/tool turns, parsing state, and execution
+  health.
+
+L1 output is a model opinion under a closed contract. L2 grounds it; L4 decides
+whether grounded fields qualify for a retry rule.
+
+## Inputs And Outputs
+
+| Direction | Contract | Meaning |
+| --- | --- | --- |
+| Input | `L1EvidenceContext` | Immutable L0B view plus route-advertised read-only tools bound to L0A/source snapshot. |
+| Input | `ModelRoute` and deadline | Endpoint, model, credentials, generation controls, tool policy, request timeout, and remaining analysis time. |
+| Output | `L1EvidenceResult` | Provider-neutral execution status, transcript, calls, errors, usage, and parsed semantic payload. |
+| Semantic payload | `restart_agent_evidence.v1` | Closed structured model response validated by `L1ResponseContract`. |
+
+The semantic payload contains:
+
+- `analysis_status`;
+- `primary_failure`;
+- `root_cause_assessment`;
+- `model_recovery_assessment`;
+- `related_failures`;
+- canonical `evidence` citations.
+
+The executable `L1ResponseContract` generates both the model-visible response
+schema and the client validator. The advertised and enforced contract therefore
+has one source of truth.
+
+## Semantic Task
+
+L1 identifies:
+
+1. the initiating observed failure, after considering complete traceback and
+   chronological context;
+2. a concise semantic failure identity: operation, mechanism, component, and
+   artifact path when visible;
+3. root-cause status:
+   `established_by_current_log`, `supported_but_unconfirmed`,
+   `hypothesis_only`, or `unknown`;
+4. exactly two recovery claims:
+   - `failure_domain`: `workload`, `infrastructure`, or `unknown`;
+   - `retry_outlook_without_workload_change`: `cannot_recover`, `may_recover`,
+     or `unknown`;
+5. per-claim evidence status and confidence;
+6. downstream cascade, teardown, and unknown related failures;
+7. visible line-and-quote citations tagged to the claims they support.
+
+Failure domain and retry outlook are independent. A workload fault may recover
+after process recreation; an infrastructure fault may recur. Confidence is
+semantic self-confidence for calibration, not an action score or L4 threshold.
+
+## Declared Restart Context
+
+The static semantic contract defines the product restart transition assumed by
+the model:
+
+- failed processes are recreated;
+- a normal restart delay occurs;
+- hardware allocation may change;
+- mutable external-service state may change;
+- workload code, data, and configuration remain unchanged.
+
+The model assesses recovery in the next NVRx cycle under those guarantees.
+Durable remediation and long-term preventive advice are outside the current
+recovery assessment.
+
+These are immutable product guarantees and belong in the static prompt, not in
+per-request evidence. Retry budgets and history are not shown to L1.
+
+## Prompt Contract
+
+The static system prompt owns stable task semantics:
+
+- analyze one distributed-training attempt;
+- separate observed mechanism, root cause, and recovery assessment;
+- identify the initiating failure rather than tail noise;
+- treat application/model/data/configuration and workload-selected framework
+  behavior as workload-domain only when supported;
+- avoid inferring ownership or persistence of mutable resources from call stack
+  or missing cleanup text;
+- preserve uncertainty when one log cannot distinguish persistent failure from
+  retry recovery;
+- separate cascade and teardown from the primary;
+- cite only visible evidence;
+- return JSON only, without long chain-of-thought.
+
+The user message is one machine-readable per-invocation envelope. It contains:
+
+- the static generated `response_schema`;
+- request-specific `decision_evidence`;
+- request-specific `attempt_execution_context`;
+- request-specific `evidence_bundle`.
+
+The schema is generated from the executable L1 contract and transported in the
+invocation envelope; it is not dynamic evidence.
+
+It does not repeat static behavioral rules, route configuration, tool schemas,
+history, retry budgets, absolute paths, basenames, or eval labels.
+
+Failure-family examples do not accumulate in the static prompt. They belong in
+deterministic registries/taxonomy, eval gold, or versioned prompt experiments
+whose corpus-level benefit is measured.
+
+## Optional Tool Loop
+
+L1 always starts from L0B. If the selected route advertises tools, the model may
+request the generic read-only interfaces in `TOOLS.md`.
+
+Tools are a context escape hatch, not another policy path:
+
+- tool availability and turn limits are route-configured;
+- production-fidelity eval uses the same advertised tool shape;
+- unknown or unadvertised calls are rejected and traced;
+- each turn replays the conversation because the OpenAI-compatible API is
+  stateless at this contract boundary;
+- every request is clamped to the smaller of route timeout and remaining
+  whole-analysis deadline;
+- reaching the turn cap without valid evidence leaves the deterministic
+  recommendation authoritative.
+
+## Usability And Degradation
+
+An L1 semantic payload is usable when:
+
+- the route finishes before the whole-analysis deadline;
+- no provider timeout or output truncation invalidated the response;
+- extraction succeeded with one parsed evidence object;
+- the object passes `L1ResponseContract`.
+
+Earlier retryable HTTP failures, provider retries, or unsupported tool requests
+may mark a usable route `degraded`; they do not erase valid semantics. L2
+advisory findings do not make L1 unusable.
+
+Provider timeout, output truncation, missing/unparseable JSON, or
+contract-invalid output makes L1 unusable. One bounded no-tool contract-repair
+turn may be attempted for malformed structure. L1 failure never invalidates the
+already available deterministic recommendation.
+
+Non-primary statuses are intentionally uninformative:
+
+- `no_failure_observed` has no primary and unknown recovery claims;
+- `insufficient_evidence` has no primary, explicit missing evidence, and unknown
+  recovery claims.
+
+They cannot smuggle an unauditable policy conclusion through optional fields.
+
+## Provider And Context Safety
+
+The client:
+
+- uses an OpenAI-compatible `/chat/completions` route;
+- reuses one persistent synchronous `httpx` connection pool per model route;
+- applies effective model context-window limits before every turn;
+- reserves a safety margin and reduces only that turn's output cap when needed;
+- traces requested and effective output caps;
+- retries only configured transient provider failures;
+- classifies HTTP, connect, read, write, protocol, and timeout failures into
+  stable trace categories;
+- distinguishes provider retry from model contract repair;
+- does not log credentials or expose long chain-of-thought;
+- returns at the whole-analysis deadline without waiting for abandoned workers.
+
+The HTTP client performs transport and connection-pool work only. Restart Agent
+owns retry count and backoff, whole-analysis deadline enforcement, provider
+response parsing, tool-loop state, and observability. Runtime shutdown closes
+route-owned pools; caller-injected HTTP clients retain caller ownership.
+
+Multiple routes may execute concurrently after shared L0. Each route produces
+an independent L1-L4 candidate; the current `collect_all` mode does not
+arbitrate among them.
+
+## Tracing
+
+L1 tracing preserves:
+
+- exact static and dynamic prompt payloads;
+- advertised tool schemas;
+- resolved model-route options;
+- every model request and visible response;
+- every tool request and result;
+- provider attempts, HTTP/provider errors, retries, and timeouts;
+- token usage and finish reasons;
+- context-budget calculations;
+- contract parsing and repair;
+- final structural/usability status.
+
+Credentials, auth headers, and bearer tokens are never recorded.
+
+## KPIs
+
+L1 has three distinct measurement families.
+
+### Semantic Quality
+
+| KPI | Example |
+| --- | --- |
+| Primary/mechanism accuracy | Gold primary is checkpoint metadata decode; L1 selects the corresponding line and mechanism rather than the later Python wrapper. |
+| Root-cause status accuracy | One failed read with plausible corruption and transient alternatives is `supported_but_unconfirmed`, not established. |
+| Recovery-field accuracy | Domain and retry outlook independently match reviewer gold. |
+| Citation quality | Every claim has visible, correctly tagged source support. |
+| Calibration | Cases reported near 80 confidence are correct at approximately that rate over the corpus. |
+
+### Behavioral Efficiency
+
+| KPI | Example |
+| --- | --- |
+| First-turn usable-result rate | Valid evidence is returned from L0B without tools. |
+| Extra model turns | Two tool rounds and one final answer add two extra turns beyond the initial call. |
+| Useful tool yield | A tool returns new decision-relevant context absent from L0B. |
+| Duplicate/no-new tool rate | A model rereads an already visible window or retrieves no new lines. |
+| Token and latency efficiency | Semantic correctness is achieved with fewer turns, tokens, and wall time. |
+
+### Endpoint Reliability
+
+| KPI | Example |
+| --- | --- |
+| Request success rate | Completed provider responses divided by attempted requests. |
+| Retry/timeout/error rate | Transient 502, timeout, and retry counts remain separate from semantic failures. |
+| Total downstream API time | Wall time spent awaiting all provider calls, including queueing and model service work visible to the client. |
+| Deadline hit rate | A usable route result arrives before the configured analysis deadline. |
+
+Model quality, behavioral efficiency, and endpoint reliability are reported
+separately before a combined route recommendation is made.
+
+## Example
+
+Given L0B evidence showing a checkpoint metadata decode error followed by
+wrapper exceptions, L1 may return:
+
+```json
+{
+  "analysis_status": "primary_identified",
+  "primary_failure": {
+    "line": 12083,
+    "causal_role": "initiating",
+    "failure_identity": {
+      "operation": "checkpoint_load",
+      "mechanism": "metadata_deserialization",
+      "component": "torch_distributed_checkpoint",
+      "artifact_path": "/checkpoint/step_100"
+    }
+  },
+  "root_cause_assessment": {
+    "summary": "Checkpoint metadata could not be decoded.",
+    "status": "supported_but_unconfirmed",
+    "plausible_causes": ["persistent metadata corruption", "transient read corruption"],
+    "missing_evidence": ["same-offset recurrence across attempts"]
+  },
+  "model_recovery_assessment": {
+    "failure_domain": {
+      "value": "workload",
+      "status": "supported_but_unconfirmed",
+      "confidence": 74
+    },
+    "retry_outlook_without_workload_change": {
+      "value": "unknown",
+      "status": "unknown",
+      "confidence": 68
+    },
+    "rationale": "One failed read does not distinguish persistent corruption from a transient read."
+  }
+}
+```
+
+L1 has described the current attempt. It has not consumed history or selected
+an action.

--- a/docs/design/attribution/restart_agent/L2.md
+++ b/docs/design/attribution/restart_agent/L2.md
@@ -1,0 +1,226 @@
+# L2 Evidence Grounding And Identity
+
+L2 checks whether a usable L1 assessment is credibly tied to evidence the model
+could see. It derives client-owned enriched history identity and emits advisory
+audit findings without replacing the model's semantic opinion.
+
+`SCHEMA.md` owns exact field shapes. `L3.md` owns history comparison. L2 does
+not select policy.
+
+L2 ends at grounded current-attempt facts, enriched identity, and advisory
+findings; history comparison and action policy belong to L3-L4.
+
+## Purpose And Authority
+
+```text
+L0Bundle
+  + exact L0ModelFacingView
+  + L1EvidenceResult and tool transcript
+  + immutable source snapshot
+  -> source grounding
+  -> enriched AttemptFailureFacts
+  -> advisory audit
+  -> L2Result
+```
+
+L2 has two responsibilities with different authority:
+
+1. **Functional grounding and identity.** Resolve the model-selected primary and
+   claim-tagged citations, derive a stable root fingerprint and optional
+   affected entity, and determine whether recovery claims are mechanically
+   eligible for narrow L4 rules.
+2. **Advisory audit.** Report citation, causal-role, and semantic credibility
+   concerns. Suggestions are marked `applied=false`; they do not overwrite L1.
+
+This split keeps the model's answer visible while preventing invented or
+unseen evidence from silently entering history or policy.
+
+## Inputs And Output
+
+| Direction | Contract | Meaning |
+| --- | --- | --- |
+| Input | `L0Bundle` | Complete deterministic evidence and object relationships. |
+| Input | `L0ModelFacingView` | Exact initial evidence visible to the model. |
+| Input | `L1EvidenceResult` | Parsed semantic output, raw transcript, and tool results. |
+| Input | `LogSnapshot` | Immutable source used for line and quote resolution. |
+| Output | `L2Result` | Grounding status, enriched facts, policy-eligibility bit, and non-overriding audit diagnostics. |
+
+L2 runs only for structurally usable L1 output. Otherwise it reports `not_run`
+and the deterministic branch continues.
+
+## Grounding Rules
+
+Model-visible evidence is the union of:
+
+- the exact full initial `model_visible_payload`, including Decision Evidence,
+  attempt execution context, and evidence bundle;
+- all returned advertised-tool payloads in the conversation.
+
+A provenance line number alone does not make arbitrary source text visible.
+Canonical support requires the line and paired rendered text or quote.
+
+Citation resolution statuses are:
+
+- `exact`: line and quote match the source;
+- `rendered_exact`: quote exactly matches the visible client rendering,
+  including a truncation marker;
+- `nearby_resolved`: the visible quote maps uniquely to one nearby source line;
+- unresolved/ungrounded: no unique credible mapping exists.
+
+Mechanical repair is deliberately narrow. L2 may correct a small line-number
+error when the quote was visible and uniquely identifies a nearby source line.
+It cannot invent support, rewrite the quote, or substitute a semantically
+preferred source line.
+
+## Enriched Failure Facts
+
+For a grounded primary, L2 creates one route-keyed `AttemptFailureFacts` block:
+
+- source `l2_grounded`;
+- client-derived `root_fingerprint` and source;
+- client-observed `fault_outcome`;
+- selected primary and stable identity-anchor lines;
+- failure iteration when observed;
+- optional grounded `affected_entity`;
+- explicit locality and rank-to-GPU mapping.
+
+The runtime inserts or replaces this block under the route id in the current
+`AttemptRecord`. Shared progress remains the L0-derived record field.
+
+### Root Fingerprint
+
+The fingerprint identifies a stable observed failure family/mechanism. It is
+derived from the grounded source observation, not from free-form model class
+text. It excludes rank, node, GPU, timestamp, cycle id, and source line.
+
+### Affected Entity
+
+The optional affected entity identifies the exact object:
+
+- `artifact`: an exact checkpoint or file path grounded in source;
+- `data_position`: an exact token, sample, or window position.
+
+Entity identity is separate from failure mechanism. The exact path or position
+is hashed without removing its distinguishing components.
+
+If the model-selected line is not grounded, L2 may preserve usable L1 semantics
+for observability but leaves enriched history identity unavailable. An invented
+line cannot match a prior attempt.
+
+## Recovery-Assessment Eligibility
+
+`recovery_assessment_policy_grounded` is a mechanical eligibility bit, not a
+semantic endorsement. It is true only when:
+
+- the selected primary resolves to visible/source evidence;
+- support tagged for both failure domain and retry outlook resolves;
+- root-cause status is `established_by_current_log` or
+  `supported_but_unconfirmed`.
+
+L4 still evaluates the distinct claim values and statuses required by each
+rule. For example, eligibility alone does not make `cannot_recover` established
+and cannot select immediate `STOP`.
+
+`hypothesis_only` or `unknown` assessments remain visible but cannot select a
+rule narrower than `general_retry`.
+
+## Advisory Audit
+
+L2 may report:
+
+- missing, duplicate, unseen, or unresolved citations;
+- primary/related-failure causal-role inconsistencies;
+- prohibited fields outside the closed L1 contract;
+- unsupported path ownership or persistence claims;
+- same-attempt rank fanout incorrectly treated as cross-attempt recurrence;
+- failure position described as completed progress without a completed marker;
+- same-artifact or same-physical-unit observations that weaken a claim;
+- alternative interpretations with `applied=false`.
+
+Findings carry severity and `policy_material`. Advisory or observational
+findings remain visible without degrading result quality. Material credibility
+findings may mark a route degraded, but they do not replace L1 values.
+
+L2 audit status is:
+
+- `clean`;
+- `resolved` for permitted mechanical reference repair;
+- `findings`;
+- `not_run`.
+
+Grounding status is independently `grounded`, `unavailable`, or `not_run`.
+
+## Invariants
+
+- Raw L1 semantic output is immutable and remains traceable.
+- L2 never changes model confidence.
+- Audit suggestions never become hidden policy inputs.
+- Enriched identity is client-derived from grounded source evidence.
+- Related cascade/teardown events remain observational and are excluded from
+  `secondary_failures` when that would make them look like competing roots.
+- L2 does not read or mutate attempt history.
+- L2 does not emit `STOP`, `RESTART`, retry budgets, or `decision_basis`.
+
+## Degraded Behavior
+
+- Unusable L1 output produces `not_run`; no repair is attempted in L2.
+- An ungrounded primary leaves enriched history identity unavailable.
+- Partially grounded citations preserve the raw L1 answer and explicit
+  findings; no missing support is synthesized.
+- Audit failure cannot erase the deterministic recommendation.
+- Tightening audit into a blocking semantic validator requires an explicit
+  contract or configuration change and corpus evidence.
+
+## Tracing
+
+The L2 trace records:
+
+- exact visibility inputs used for grounding;
+- raw model-selected primary and citations;
+- citation resolutions and mechanical adjustments;
+- grounding and audit statuses;
+- functional enriched failure facts;
+- root fingerprint and affected-entity source;
+- recovery-support resolution and policy-eligibility calculation;
+- findings, severity, materiality, and unapplied suggestions;
+- L2 wall time.
+
+## KPIs
+
+| Quality KPI | Example |
+| --- | --- |
+| Primary grounding accuracy | Model line 12084 is uniquely repaired to visible quote at 12083. |
+| Citation resolution accuracy | A quote absent from all model-visible inputs remains ungrounded. |
+| Fingerprint availability | A grounded terminal failure produces a root identity; an invented line does not. |
+| Fingerprint stability | Different models selecting credible lines in the same episode derive the same root fingerprint. |
+| Affected-entity accuracy | Checkpoint step 100 and step 200 remain distinct artifact entities. |
+| Policy-eligibility accuracy | Claims with grounded primary but missing retry-outlook support do not qualify. |
+| Audit precision | Findings identify real credibility issues without rejecting semantically valid uncertainty. |
+
+Operational metrics include:
+
+- L2 wall time and status;
+- citation counts by resolution;
+- mechanical adjustment count;
+- findings by severity/materiality;
+- enriched root/entity readiness and source;
+- recovery-support grounding completeness;
+- route degradation caused by material findings.
+
+## Example
+
+L1 selects line 12084 and quotes a decode exception visible at line 12083.
+L2 finds one unique nearby match and records:
+
+```text
+grounding_status: grounded
+grounding_method: nearby_resolved
+primary line: 12083
+root fingerprint: observed:unicodedecodeerror:checkpoint_metadata
+affected entity: artifact:/checkpoint/step_100
+audit_status: resolved
+```
+
+The L1 semantic assessment remains unchanged. L3 receives the enriched
+fingerprint/entity through the current `AttemptRecord`; L4 later decides how
+that evidence affects policy.

--- a/docs/design/attribution/restart_agent/L3.md
+++ b/docs/design/attribution/restart_agent/L3.md
@@ -1,0 +1,254 @@
+# L3 History Comparison
+
+L3 compares one selected current-attempt failure fact block with an immutable
+view of earlier attempts from the same job. It reports recurrence, affected
+entity relation, progress relation, and two independent consecutive
+no-observed-advance counts: same root, and same root plus exact entity. It does
+not choose retry thresholds or an action.
+
+`RUNTIME.md` owns the in-memory attempt store and record lifecycle.
+`SCHEMA.md` owns exact `HistorySummary` fields. `L4.md` owns policy use.
+
+L3 ends at deterministic recurrence and progress observations; retry
+thresholds, budgets, and final action belong to L4.
+
+## Purpose And Authority
+
+```text
+current AttemptRecord + selected fact block
+  + immutable PriorAttemptView
+  -> exact-job and exact-root filtering
+  -> affected-entity comparison
+  -> marker-compatible progress comparison
+  -> HistorySummary
+```
+
+L3 answers:
+
+- has the same observed root occurred in earlier cycles of this job?
+- did those occurrences involve the same exact artifact/data position?
+- did the current cycle advance beyond each comparable prior cycle?
+- how many newest matching failures form a consecutive no-observed-advance
+  streak?
+
+L3 reports observations. L4 determines how many repetitions a selected policy
+rule permits.
+
+## Inputs And Output
+
+| Direction | Contract | Meaning |
+| --- | --- | --- |
+| Input | current `AttemptRecord` | Shared L0 progress, deterministic failure facts, and any route-keyed L2 enriched facts. |
+| Input | fact selector | Deterministic block or one route's enriched block. |
+| Input | `PriorAttemptView` | Immutable bounded records selected before analysis. |
+| Output | `HistorySummary` | Availability, comparisons, recurrence counts, progress relations, and locality observations. |
+
+MVP compares the selected current block against the deterministic block of each
+prior record. Stored enriched prior blocks remain observable but do not yet
+change recurrence counting.
+
+## Eligibility
+
+History is unavailable when:
+
+- history is disabled;
+- `job_id` is empty;
+- `cycle_id` is missing or not an integer;
+- the selected current fact block has no root fingerprint.
+
+When identity is valid but no prior records exist, history is available with an
+empty view and zero recurrence. This differs from unavailable history.
+
+A comparable prior record must have:
+
+- exact `job_id`;
+- a distinct earlier integer `cycle_id`;
+- exact selected `root_fingerprint`.
+
+L3 does not create synthetic unknown job/cycle ids.
+
+## Root And Entity
+
+The root fingerprint asks whether two attempts exhibit the same observed
+failure mechanism.
+
+The optional affected entity asks whether they involve the same exact object:
+
+- `data_position`;
+- `artifact`.
+
+Entity relation is `same`, `different`, or `unknown`. L3 always computes the
+root-only count when root identity is available. It also computes the
+root-plus-entity count when both current and prior facts have an exact
+comparable entity. Entity availability improves comparison precision; it does
+not select a stricter policy or suppress root-only recurrence.
+
+Rank, node, GPU, exact source line, and failure position remain comparison
+observations. They are not part of root identity. Same rank does not imply same
+GPU without a validated mapping.
+
+## Progress Comparison
+
+L3 compares current progress directly with each earlier same-root attempt; it
+does not infer an adjacent chain such as cycle 2 to cycle 3 to cycle 4.
+
+Comparison order is:
+
+1. compare `last_completed_step` when both attempts have comparable completed
+   training progress;
+2. compare `last_checkpoint_step` when both have comparable completed
+   checkpoint saves;
+3. when neither positive-progress dimension is comparable, compare
+   `failure_iteration` as a weaker position;
+4. report each dimension and combine positive-progress dimensions.
+
+Dimension relation is:
+
+- positive delta: `advanced`;
+- zero delta: `same`;
+- negative delta: `regressed`;
+- missing/incompatible evidence: `unknown`.
+
+Combination:
+
+- any `advanced` and no `regressed` -> `advanced`;
+- any `regressed` and no `advanced` -> `regressed`;
+- all comparable dimensions `same` -> `same`;
+- conflicting advanced/regressed or insufficient evidence -> `unknown`.
+
+If current progress is observed and a reliably observable prior attempt has
+`not_observed`, the relation is `advanced`; the inverse is `regressed`.
+Comparisons involving `unknown` remain unknown unless a stronger dimension
+establishes the relation.
+
+Marker counts and within-attempt deltas describe absolute attempt progress. They
+do not independently select the cross-attempt relation. For example, three
+checkpoint saves at 100, 200, and 400 produce a delta of 300, but advancement
+against another attempt depends on comparing final checkpoint positions.
+
+## Counting
+
+All same-root records remain in the summary. Retry-budget recurrence counts only
+prior outcomes `terminal` and `unresolved`.
+
+L3 emits:
+
+- matching same-root attempt count;
+- relation counts for advanced, same, regressed, and unknown;
+- root-only consecutive no-advance count;
+- root-plus-entity consecutive no-advance count;
+- observed-advance summaries;
+- exact failure-position and locality observations.
+
+`same` and `regressed` count as no observed advance. `unknown` does not.
+
+The two consecutive counts are independent:
+
+- `consecutive_same_root_no_advance_attempts` requires exact job and root,
+  a qualifying prior outcome, and no observed progress advance. Entity changes
+  do not break this count.
+- `consecutive_same_root_and_entity_no_advance_attempts` adds exact entity kind
+  and fingerprint equality. A different, missing, or untrusted entity breaks
+  only this count.
+
+Each count scans prior attempts newest to oldest and stops at the first:
+
+- root mismatch;
+- required entity mismatch for the root-plus-entity count;
+- nonqualifying prior outcome;
+- `advanced` relation;
+- `unknown` relation.
+
+The counts describe prior qualifying failures relative to the current attempt;
+the current failure is not included. L3 computes both counts in the same
+evaluation. It does not select one as the policy count.
+
+If the current attempt advanced beyond all comparable attempts, L3 reports that
+explicitly. L4 uses the observation to protect another restart.
+
+## Invariants
+
+- The current attempt is compared to each prior attempt independently.
+- L3 consumes typed fingerprints/entities; it does not reopen model prose or
+  source logs.
+- History never changes semantic failure domain.
+- Unknown progress is not treated as stalled progress.
+- Same-attempt multi-rank fanout is not cross-attempt recurrence.
+- A changed entity cannot reset or hide an otherwise consecutive same-root
+  streak.
+- Exact entity identity alone never selects a retry rule or budget.
+- The current and prior records are immutable.
+- L3 selects no retry rule, threshold, budget, or action.
+
+## Degraded Behavior
+
+- Missing identity produces an unavailable summary, not a synthetic match.
+- Incomparable progress produces `unknown`, not no-advance.
+- A different affected entity remains a same-root observation but does not
+  consume a root-plus-entity streak.
+- Store truncation is bounded runtime behavior; the selected prior view and its
+  availability reason remain traceable.
+
+## Tracing
+
+The L3 trace records:
+
+- selected current fact source and identity;
+- prior-view availability and record ids;
+- eligible/excluded prior records and reasons;
+- per-attempt dimension values, deltas, relations, outcomes, and entity
+  relation;
+- absolute progress summaries;
+- all aggregate and consecutive counts;
+- locality observations and mapping availability;
+- L3 wall time.
+
+## KPIs
+
+| Quality KPI | Example |
+| --- | --- |
+| Root-match accuracy | Rank/timestamp changes do not split the same mechanism; a different mechanism does. |
+| Entity-relation accuracy | The same checkpoint path is `same`; another checkpoint path is `different`. |
+| Progress-relation accuracy | Current checkpoint 500 versus prior 400 is `advanced`. |
+| Unknown-safety accuracy | Sparse logs without a recognized progress dialect remain `unknown`, not stalled. |
+| Root recurrence-count accuracy | Entity changes do not split a newest-first same-root no-advance streak. |
+| Entity recurrence-count accuracy | The exact-entity streak stops at a different or unknown artifact/data position. |
+| History-order accuracy | Cycle ids are evaluated in deterministic newest-to-oldest order. |
+
+Operational metrics include:
+
+- selected and eligible prior-record counts;
+- same-root and same-entity counts;
+- progress-relation counts and unknown rate;
+- consecutive root-only and root-plus-entity no-advance streaks;
+- history availability reasons;
+- L3 wall time.
+
+## Example
+
+Assume current cycle 4 has root `checkpoint_decode`, artifact
+`/checkpoint/step_100`, and last completed checkpoint 100.
+
+| Prior cycle | Root | Entity | Last checkpoint | Outcome | Relation |
+| ---: | --- | --- | ---: | --- | --- |
+| 3 | `checkpoint_decode` | same | 100 | terminal | same |
+| 2 | `checkpoint_decode` | same | 80 | terminal | advanced |
+| 1 | `port_bind` | unknown | 60 | terminal | excluded root |
+
+L3 reports two matching-root attempts, one same and one advanced comparison.
+The consecutive no-advance streak is one because scanning newest-to-oldest
+stops at cycle 2's `advanced` relation. L3 does not decide whether one consumed
+retry is enough to stop.
+
+For a second example, current cycle 4 has root `R` and entity `A`; cycles 3 and
+2 both have root `R` and no observed advance, but their entities are `B` and
+`A`. L3 reports:
+
+```text
+consecutive_same_root_no_advance_attempts = 2
+consecutive_same_root_and_entity_no_advance_attempts = 0
+```
+
+The newest entity mismatch stops the exact-entity streak, while the same-root
+streak continues. L4 may therefore exhaust the general root ceiling even when
+entity identities alternate.

--- a/docs/design/attribution/restart_agent/L4.md
+++ b/docs/design/attribution/restart_agent/L4.md
@@ -1,0 +1,350 @@
+# L4 Restart Policy
+
+L4 is the only stage that emits a `STOP` or `RESTART` recommendation. It selects
+one ordered current-attempt retry rule, applies any trusted declared recovery
+capability, and evaluates every applicable retry ledger. A general same-root
+ceiling remains active alongside any narrower selected-rule budget.
+
+`SCHEMA.md` owns exact fields. `L1.md` owns semantic claims. `L3.md` owns
+history observations.
+
+L4 owns policy selection and recommendation only; it consumes typed evidence
+and history without reparsing logs, rewriting semantics, or persisting state.
+
+## Purpose And Authority
+
+```text
+selected current failure facts
+  + usable grounded L1 recovery assessment, when available
+  + L3 HistorySummary
+  + retry-budget config
+  + declared recovery capabilities
+  -> ordered current-attempt rule selection
+  -> concurrent retry-ledger evaluation
+  -> L4PolicyOutcome
+  -> STOP or RESTART
+```
+
+Default bias is `RESTART`. `STOP` requires:
+
+- grounded current-attempt evidence that the unchanged workload cannot recover
+  through the declared restart transition; or
+- exhaustion of the general same-root ceiling or an applicable narrower
+  selected-rule budget under qualifying history without observed advance.
+
+## Inputs And Output
+
+| Direction | Contract | Meaning |
+| --- | --- | --- |
+| Input | selected `AttemptFailureFacts` | Deterministic recommendation or route-keyed L2 grounded current failure. |
+| Input | grounded L1 recovery assessment | Independent failure-domain and retry-outlook claims, when policy-eligible. |
+| Input | `HistorySummary` | L3 recurrence, entity, and progress observations. |
+| Input | retry-policy config | Allowed retries for confirmation, bounded, and general rules. |
+| Input | declared recovery capabilities | Trusted product behavior unavailable from logs alone. |
+| Output | `L4PolicyOutcome` | Selected rule, all applicable ledger evaluations, `decision_basis`, and action. |
+
+Confidence is retained for L1 calibration. It is not an L4 threshold.
+
+## Retry Configuration
+
+MVP defaults:
+
+```json
+{
+  "confirmation_retry_allowed_retries": 1,
+  "bounded_retry_allowed_retries": 1,
+  "general_retry_allowed_retries": 3
+}
+```
+
+`allowed_retries` counts retries after the first observed failure. An allowed
+budget of one means the first failure restarts and the second qualifying
+same-root failure stops.
+
+`general_retry_allowed_retries` is a global same-root safety ceiling. A
+selected rule may apply a smaller budget and a more specific history scope, but
+MVP configuration cannot use a selected-rule budget to extend the general
+ceiling.
+
+L4 emits `policy_version=retry_budget.v1` as behavior provenance. The version is
+not part of caller retry-budget configuration.
+
+## Ordered Rule Selection
+
+When no usable primary exists, L4 returns
+`RESTART / no_primary_failure` before rule selection. With no root fingerprint,
+L3 recurrence and retry-ledger accounting are unavailable.
+
+For a usable primary, L4 selects exactly one rule:
+
+1. **`workload_managed_recovery`**: trusted product configuration declares a
+   matching recovery capability, and the grounded primary has the required
+   classifier, recovery behavior, and affected entity.
+2. **`workload_unrecoverable`**: all of these current-attempt conditions hold:
+   - L2 grounded primary and claim-tagged recovery support;
+   - root-cause status is `established_by_current_log` or
+     `supported_but_unconfirmed`;
+   - failure domain is `workload` and its status is
+     `established_by_current_log`;
+   - retry outlook is `cannot_recover` and its status is
+     `established_by_current_log`.
+3. **`confirmation_retry`**: selected current failure facts contain an exact,
+   replay-stable affected artifact or data position. This rule confirms
+   persistence using exact root-and-entity recurrence without depending on L1.
+4. **`bounded_retry`**: recovery assessment is grounded, retry outlook is
+   `may_recover`, and its status is `established_by_current_log` or
+   `supported_but_unconfirmed`.
+5. **`general_retry`**: every other combination, including unknown semantics,
+   infrastructure attribution, unusable L1, and ungrounded model claims.
+
+| Rule | Immediate behavior | Selected-rule budget |
+| --- | --- | --- |
+| `workload_managed_recovery` | `RESTART` until a ledger exhausts | capability budget and declared scope |
+| `workload_unrecoverable` | immediate `STOP` | none |
+| `confirmation_retry` | `RESTART` until exact recurrence exhausts the ledger | confirmation config, root and entity |
+| `bounded_retry` | `RESTART` until a ledger exhausts | bounded config, root only |
+| `general_retry` | `RESTART` until the general ceiling exhausts | none beyond general ceiling |
+
+No individual field selects `STOP`. Workload ownership does not imply
+unrecoverability. A supported-but-unconfirmed `cannot_recover` claim does not
+justify immediate STOP. Infrastructure attribution does not grant unlimited
+retries. An exact replay-stable entity selects `confirmation_retry`, but it
+does not itself produce `STOP`: exact root-and-entity recurrence without
+observed advance must exhaust that rule's ledger. An entity does not activate
+`workload_managed_recovery` without its declared capability.
+
+An explicit scheduler wall-time event remains observable L0 evidence but has no
+special L4 rule. Scheduler time policy and allocation termination are outside
+Restart Agent authority. If such an event is the usable primary, it follows the
+ordinary rule and history path.
+
+## Concurrent Retry Ledgers
+
+For every history-eligible primary, L4 evaluates:
+
+1. **General root ceiling**: the L3
+   `consecutive_same_root_no_advance_attempts` count against
+   `general_retry_allowed_retries`.
+2. **Selected-rule budget**: only when the selected rule declares a narrower
+   budget. It consumes the L3 count for that rule's declared scope. The
+   confirmation retry and the workload-managed bad-token capability use
+   `consecutive_same_root_and_entity_no_advance_attempts`.
+
+These ledgers are concurrent, not alternatives. A changed or missing entity may
+reset the selected-rule ledger, but cannot reset the general same-root ceiling.
+This prevents alternating entity identities or policy classifications from
+creating an unbounded retry sequence.
+
+`workload_unrecoverable` immediately stops without a ledger. Unknown progress
+consumes neither ledger.
+
+## Decision Algorithm
+
+```text
+if no primary:
+    return RESTART / no_primary_failure
+
+rule = select ordered rule
+
+if rule == workload_unrecoverable:
+    return STOP / workload_unrecoverable
+
+general_ceiling = evaluate(
+    scope=root_only,
+    count=L3.consecutive_same_root_no_advance_attempts,
+    budget=general_retry_allowed_retries
+)
+selected_rule_budget = evaluate_if_applicable(
+    scope=selected rule scope,
+    count=L3 count for that scope,
+    budget=selected rule budget
+)
+
+if general_ceiling.exhausted or selected_rule_budget.exhausted:
+    STOP / retry_budget_exhausted
+else if L3 reports advancement for an applicable ledger:
+    RESTART / observed_advance
+else if rule == confirmation_retry:
+    RESTART / confirmation_retry_available
+else if rule == bounded_retry:
+    RESTART / retry_recovery_available
+else if rule == workload_managed_recovery:
+    RESTART / workload_managed_recovery_available
+else:
+    RESTART / general_retry_available
+```
+
+The output records `general_root_ceiling`, nullable `selected_rule_budget`, and
+`exhausted_by`. The aggregate `retry_budget_exhausted` is true when either
+ledger is exhausted.
+
+Valid decision bases are:
+
+- `log_unavailable`;
+- `workload_unrecoverable`;
+- `retry_budget_exhausted`;
+- `confirmation_retry_available`;
+- `retry_recovery_available`;
+- `workload_managed_recovery_available`;
+- `general_retry_available`;
+- `observed_advance`;
+- `no_primary_failure`;
+- `malformed_model_output`.
+
+## Declared Recovery Capabilities
+
+A declared recovery capability is trusted product configuration, not public
+request data and not model output. L0-L3 do not consume it. L4 matches it
+against grounded current failure facts.
+
+MVP supports:
+
+```json
+{
+  "capability_id": "bad_token_retry_then_skip",
+  "behavior": "retry_then_skip",
+  "applies_to": ["bad_token_or_window"],
+  "required_entity_kind": "data_position",
+  "history_match_scope": "root_and_entity",
+  "allowed_retries": 2
+}
+```
+
+The first bad-token failure and one matching recurrence may restart so the
+workload can execute its configured retry-then-skip behavior. The third
+consecutive same-root, same-position failure without observed advance stops. A
+different position does not consume this capability budget, but same-root
+failures at changed positions continue consuming the general root ceiling.
+
+The declaration does not classify arbitrary numerical failure as a bad token.
+The current facts must contain the matching deterministic classifier,
+`recovery_behavior=retry_then_skip`, and grounded data-position entity. If the
+required entity is missing, L4 falls back to a finite generic rule.
+
+## Invariants
+
+- L4 is deterministic for the same inputs and effective configuration.
+- L4 does not infer semantic facts from raw logs or model prose.
+- Ungrounded L1 fields remain observable but cannot tighten the retry budget.
+- L3 `unknown` progress does not count as no advance.
+- Observed advance protects another restart.
+- The general same-root ceiling is evaluated independently of any
+  selected-rule scope.
+- A selected-rule budget may stop earlier but cannot extend the general
+  same-root ceiling.
+- Only a typed replay-stable entity may select `confirmation_retry`; an
+  arbitrary path mention or ungrounded model entity cannot tighten policy.
+- Declared recovery capability matching precedes the generic unrecoverable rule
+  because trusted runtime behavior is not discoverable from the log alone.
+- L4 does not mutate the attempt record or history view.
+
+## Failure And Degraded Paths
+
+- A previously accepted log unavailable or empty at verdict time yields
+  `RESTART / log_unavailable`.
+- Provider timeout, truncation, malformed output, or unusable L1 semantics use
+  the deterministic recommendation. It selects `confirmation_retry` when L0
+  has an exact affected entity and otherwise selects `general_retry`.
+- A grounded primary alone is insufficient for immediate STOP; recovery claim
+  support and statuses must qualify.
+- No primary after malformed L1 yields
+  `RESTART / malformed_model_output`.
+- L2 audit suggestions never silently replace model values used by L4.
+
+## Tracing
+
+L4 records:
+
+- policy version and selected rule;
+- semantic inputs and their grounding eligibility;
+- declared capabilities considered and matched;
+- general-ceiling and selected-rule ledger inputs;
+- each ledger's scope, configured budget, recurrence count, advancement state,
+  and exhaustion result;
+- aggregate exhaustion and `exhausted_by`;
+- final action and basis;
+- L4 wall time.
+
+## KPIs
+
+| Quality KPI | Example |
+| --- | --- |
+| Rule-selection accuracy | Grounded workload/cannot-recover claims select `workload_unrecoverable`; a replay-stable artifact selects `confirmation_retry`; unknown semantics without an entity select `general_retry`. |
+| General-ceiling accuracy | Three prior same-root no-advance failures exhaust the default general ceiling even when entities alternate. |
+| Selected-rule budget accuracy | One prior exact root-and-entity failure exhausts the default confirmation budget of one. |
+| Capability-match accuracy | Bad-token recovery applies only to the same grounded data position. |
+| Budget-composition accuracy | A narrower rule may stop earlier but cannot extend the root ceiling. |
+| Advancement protection accuracy | Same root with a later completed checkpoint remains `RESTART / observed_advance`. |
+| Decision/basis accuracy | Action and reason agree with the selected rule and budget state. |
+| False-STOP rate | Retryable gold cases are not stopped prematurely. |
+| Deterministic replay | Identical inputs produce identical L4 output. |
+
+Operational metrics include L4 wall time, selected-rule counts, budget
+utilization/exhaustion, capability matches, deterministic/enriched candidate kind,
+and action/basis counts.
+
+## Examples
+
+### Grounded Workload Failure
+
+```text
+domain: workload / established_by_current_log
+retry outlook: cannot_recover / established_by_current_log
+history: unavailable
+```
+
+L4 selects `workload_unrecoverable` and immediately returns `STOP`. Its
+effective allowance is zero, but no retry ledger is activated or exhausted.
+
+### Ambiguous Permission Failure
+
+```text
+domain: workload / supported_but_unconfirmed
+retry outlook: cannot_recover / supported_but_unconfirmed
+history: no prior match
+```
+
+The exact access failure is observed, but ownership/ACL persistence is not
+established. When L0 or L2 can ground the exact path, L4 selects
+`confirmation_retry`; otherwise it selects `general_retry`.
+
+### Checkpoint Decode Failure
+
+```text
+root: checkpoint-load metadata UnicodeDecodeError
+entity: checkpoint path + iteration
+history: one prior exact root/entity match, no observed advance
+```
+
+The first occurrence restarts under `confirmation_retry`. The second exact
+occurrence exhausts its one-retry ledger and stops. A changed checkpoint
+iteration does not consume the confirmation ledger, although the concurrent
+same-root ceiling continues to protect against indefinite retries. A decoder's
+buffer-local byte position is diagnostic only and is not required to match.
+Ledger field `matching_prior_failures` excludes the current occurrence; four
+matching no-progress comparisons therefore represent five total occurrences.
+
+### Port Conflict
+
+```text
+domain: workload / supported_but_unconfirmed
+retry outlook: may_recover / supported_but_unconfirmed
+history: no prior match
+```
+
+L4 selects `bounded_retry`. The first occurrence restarts; a matching recurrence
+without observed advance exhausts the one-retry selected-rule budget. The
+general root ceiling is evaluated concurrently.
+
+### Infrastructure Or Unknown
+
+L4 selects `general_retry`. The first occurrence restarts. Repeated
+same-fingerprint failures without observed advance eventually exhaust the
+general budget, regardless of whether the external cause was proven.
+
+### Alternating Entity Identities
+
+Three consecutive cycles have the same root and no observed progress advance,
+but alternate entities `A`, `B`, and `A`. The exact-entity streak may remain
+zero or one. The root streak still reaches the general ceiling, so entity
+changes cannot indefinitely defer `STOP`.

--- a/docs/design/attribution/restart_agent/PATTERN_REGISTRY.md
+++ b/docs/design/attribution/restart_agent/PATTERN_REGISTRY.md
@@ -1,0 +1,147 @@
+# L0 Pattern Registry
+
+This document catalogs active deterministic detectors that turn raw log text
+into typed L0 observations. It answers three questions:
+
+1. What does L0 recognize?
+2. What fact or candidate does a match emit?
+3. What safety constraint prevents the match from being overinterpreted?
+
+`L0A.md` owns how observations become occurrence groups, episodes, incidents,
+Decision Evidence, and deterministic primary selection. `TAXONOMY.md` defines
+shared role meanings. L1-L4 own semantics, history, and action.
+
+## Executable Shape
+
+The implementation has two detector forms:
+
+| Form | Code owner | Output |
+| --- | --- | --- |
+| Signature registry | `l0/registry.py` | Failure candidate, cascade candidate, cause confirmation, fingerprint input, and optional recovery behavior |
+| Structural parsers | `l0/assembly.py` | Progress, checkpoint, setup, lifecycle, metadata, operation/artifact, diagnostic, and failure-episode facts |
+
+The executable code is canonical for exact matching syntax. This document
+records behavior and safety constraints rather than duplicating regexes.
+
+`SignatureRegistryRow` contains only `registry_id`, `pattern`, `role`, and
+`recovery_behavior`. Every row listed below is active. The implementation does
+not currently have runtime `candidate`, `profile`, `built_in`, or
+`l1_proposed` authority states.
+
+## Failure Signatures
+
+| Registry id | Observed signal | L0 role or annotation | Safety constraint |
+| --- | --- | --- | --- |
+| `gpu_hardware_fault` | Explicit Xid, uncorrectable ECC, GPU off-bus, link-health, PCIe fatal, or thermal fault | root candidate | A bare hardware-component mention is insufficient. |
+| `peer_gpu_memory_access_failure` | Explicit invalid peer-GPU memory access | root candidate | Hardware is plausible, but invalid workload/library access remains possible. |
+| `infra_policy_event` | Explicit preemption or node-failure event | root candidate | Records the observed event; L0 does not choose policy. |
+| `time_limit` | Explicit scheduler or wall-time termination event | root candidate | Records the observation only. Scheduler time policy is outside Restart Agent authority and receives no special L4 exemption. |
+| `user_cancelled` | Explicit user cancellation | root candidate | Requires cancellation language, not generic teardown. |
+| `observed_exception` | Generic exception-summary or assertion syntax | root candidate | Traceback frames and diagnostic advice are excluded; semantic ownership remains unresolved. |
+| `configuration_validation_failure` | Explicit invalid option/configuration or missing configuration/key | root candidate | Records validation failure without assigning user ownership or recoverability. |
+| `argument_validation_failure` | Explicit invalid argument | root candidate | The failing caller or component remains unresolved. |
+| `artifact_or_path_not_found` | Explicit missing file or path | root candidate | Does not distinguish bad configuration from transient storage visibility. |
+| `checkpoint_compatibility_mismatch` | Explicit checkpoint mismatch | root candidate | Does not establish whether the checkpoint, reader, or configuration is incompatible. |
+| `shape_mismatch` | Explicit shape mismatch | root candidate | Does not establish which input, component, or configuration is responsible. |
+| `filesystem_permission_denied` | `PermissionError`, EACCES, or permission denied | root candidate | Establishes failed access, not ownership or persistence. |
+| `cuda_oom` | CUDA allocation failure | root candidate | Does not establish whether restart can recover. |
+| `nan_or_inf` | Non-finite loss, gradient, activation, or signal | root candidate | Workload recovery and recurrence remain separate questions. |
+| `bad_token_or_window` | Explicit bad token/sample/window handling | root candidate plus `retry_then_skip` annotation | L4 uses the annotation only with a matching declared capability and affected entity. |
+| `framework_crash` | Segfault, illegal instruction, or core dump | root candidate | Does not determine workload versus infrastructure domain. |
+| `linux_oom_kill_confirmation` | Explicit scheduler/kernel OOM-kill record | cause confirmation | A bare `Killed` line does not match. |
+| `observed_distributed_operation_timeout` | Direct watchdog or collective-operation timeout | root candidate | Chronology may later associate it as a cascade behind an earlier root. |
+| `nccl_cascade` | NCCL watchdog, abort, timeout, or system-error fallout | cascade candidate | Search for an earlier initiating failure. |
+| `cuda_previous_error_cascade` | Failure explicitly attributed to an earlier CUDA/capture error | cascade candidate | Generic CUDA error text is insufficient. |
+
+Registry matches emit an observed failure class and source provenance. They do
+not emit failure domain, retry outlook, or `STOP`/`RESTART`.
+
+## Progress And Setup Detectors
+
+| Detector id | Typed observation | Required interpretation |
+| --- | --- | --- |
+| `megatron_iteration_summary.v1` | Completed iteration, total iterations, consumed samples, timestamp, and locality | Only an increasing completed marker is application progress. |
+| `checkpoint_complete.v1` | Completed checkpoint step | Requires explicit completion/success plus a parseable step; start, timer, config, deletion, and failed write text are not progress. |
+| `recovery_marker.v1` | Recovery/continuation wording | Context only; it does not replace a later completed progress marker. |
+| `checkpoint_load_complete.v1` | Completed checkpoint load and optional iteration | Setup progress, not training/checkpoint-save progress. |
+| `checkpoint_load_start.v1` | Started checkpoint load and iteration | Started work does not prove completion. |
+| `checkpoint_reshard.v1` | Checkpoint sharding change observed | Setup context only. |
+| `checkpoint_metadata_load_complete.v1` | Completed checkpoint metadata load | Setup context for the observed operation. |
+| `optimizer_setup_start.v1` | Optimizer setup started | Started work does not prove completion. |
+| `cuda_graph_build_complete.v1` | CUDA graph build completed | Setup progress, not application iteration progress. |
+
+## Lifecycle, Metadata, And Diagnostic Detectors
+
+| Detector id | Observation | Constraint |
+| --- | --- | --- |
+| `megatron_training_iterations_total.v1` | Configured training-iteration total | Metadata, not progress. |
+| `megatron_training_start_datetime.v1` | Training-start lifecycle boundary | Boundary, not progress. |
+| `megatron_rerun_iteration_reset.v1` | Rerun iteration baseline reset | Must not be compared as completed application progress. |
+| `world_size_config.v1` | Explicit world size | Job metadata; inferred rank count remains only a lower bound. |
+| `rank_gpu_mapping_warning.v1` | Warning that rank-to-GPU mapping may be heterogeneous | Diagnostic; rank is not treated as GPU identity. |
+| `nccl_version.v1` | NCCL version | Environment metadata, not a failure. |
+| `cuda_async_reporting_advice.v1` | CUDA asynchronous-reporting advice | Diagnostic context, never a failure anchor. |
+| `cuda_launch_blocking_advice.v1` | `CUDA_LAUNCH_BLOCKING` advice | Diagnostic context, not evidence the suggested condition occurred. |
+| `cuda_dsa_compile_advice.v1` | `TORCH_USE_CUDA_DSA` advice | Diagnostic context, not proof of a device-side assertion. |
+| `conditional_cause_language.v1` | “may/might/could be caused by” language | Diagnostic hypothesis, not an observed cause. |
+
+## Operation And Artifact Detectors
+
+These parser families produce comparisons rather than registry failure classes:
+
+| Family | Facts retained | Constraint |
+| --- | --- | --- |
+| Checkpoint save/load | Operation, iteration, artifact path, start/completion/failure lines, and observer locality | Success applies only at the observed artifact identity strength. |
+| Dataloader read | Physical unit, data region, integrity marker, outcome, and observer locality | Success on another file, shard, or region does not establish current-unit health. |
+| Path access | Configured read/write/cache paths and failed-access paths | Paths are string evidence, not proof of effective UID, owner, mode, or ACL. |
+
+## Failure-Structure Detectors
+
+L0 also recognizes traceback starts, exception chains, terminal operation
+timeouts, bare process kills, explicit process termination, scheduler
+cancellation, cleanup frames, and teardown calls. These establish chronology
+and causal-role hints:
+
+- a bare process kill has unknown cause until confirmation appears;
+- process termination and scheduler cancellation are downstream lifecycle facts;
+- cleanup exceptions remain teardown rather than competing roots; and
+- a later confirmation may be associated with the preceding compatible episode
+  only when no incompatible progress intervenes.
+
+## Global Safety Rules
+
+- Matching text records an observation; it does not establish semantic domain,
+  restart persistence, or policy.
+- Diagnostic and lifecycle rows cannot seed a primary or root fingerprint.
+- Completed progress requires an explicit completed marker with a comparable
+  value; configuration and starts are not progress.
+- Same-attempt copies are grouped rather than treated as recurrence.
+- Cascade and teardown variants retain bounded representatives and aggregate
+  counts instead of becoming independent roots.
+- Rank, node, and GPU remain separate unless the log supplies an explicit
+  mapping.
+- Generic exception structure is preferred over accumulating message-specific
+  error patterns.
+- Fast trigger gates and volatile-token normalization are execution
+  optimizations only. Boundary-aware gates must admit every line that can match
+  a registry row, and optimized normalization must preserve canonical
+  occurrence shapes.
+- L0A preserves source references and coverage/lossiness information for every
+  detector family used in decision evidence.
+
+## Change Qualification
+
+A new detector should be added only when:
+
+1. it represents a reusable structural or operational concept rather than one
+   incident's wording;
+2. its emitted typed fact and safety constraint are explicit;
+3. reviewed corpus examples demonstrate both matches and important non-matches;
+4. regression tests cover primary, cascade, diagnostic, and progress effects as
+   applicable; and
+5. the eval harness shows that it improves evidence quality without introducing
+   material false anchors or fingerprint collisions.
+
+Pattern discovery, corpus hit counts, candidate promotion discussions, and
+per-run evidence belong to the eval harness or issue history, not this product
+reference.

--- a/docs/design/attribution/restart_agent/PROGRESSIVE.md
+++ b/docs/design/attribution/restart_agent/PROGRESSIVE.md
@@ -1,0 +1,321 @@
+# Progressive Analysis
+
+This document is canonical for the Restart Agent progressive lifecycle.
+Progressive execution changes when L0A work runs. It does not introduce a
+second evidence schema, semantic analysis, history comparison, or retry policy.
+Terminal execution is the production default. Progressive pre-end polling is
+disabled unless attrsvc explicitly enables it after measurement shows that
+terminal post-end L0A latency warrants the additional state and polling.
+
+Terminal and progressive execution use one byte-range reader, one incremental
+line decoder, one append-only L0 observation index, and one canonical L0A
+finalizer. Direct terminal execution supplies the captured boundary
+immediately; attrsvc terminal execution may ingest additional chunks during its
+bounded rank-drain wait. Progressive execution supplies available chunks, waits
+when no new bytes exist, resumes from its saved byte offset, and finalizes after
+cycle end.
+
+## Lifecycle
+
+The intended NVRx service sequence is:
+
+```text
+cycle start
+  POST /logs analysis_intent=progressive
+    -> validate/register the cycle-unique log path
+    -> terminal default: retain registration only
+    -> progressive opt-in: start bounded, non-authoritative L0A precomputation
+
+cycle end or failure
+  POST /logs analysis_intent=terminal
+    -> combine retained state with the unread final log tail
+    -> finalize canonical L0A evidence
+    -> publish the deterministic L0A/L3/L4 recommendation
+    -> by default, schedule L0B/L1/L2/L3/L4 enrichment
+
+result probes
+  GET /logs?wait=false
+    -> return completed, in_flight, or pending immediately
+```
+
+`GET /logs` with omitted `wait` or `wait=true` may join analysis and block until
+a result or service timeout. `track_only` is service-local registration; it does
+not invoke verdict-producing Restart Agent work.
+
+The normalized, cycle-unique `log_path` is the service correlation key. The
+service records `job_id` and integer `cycle_id` when available, but terminal
+signals need not repeat them.
+
+## State Machine
+
+```text
+registered -> precomputing <-> idle
+     |              |           |
+     +--------------+-----------+-> finalizing -> completed
+                                                 +-> failed
+```
+
+`finalizing` is monotonic. A terminal request atomically enters it, wakes the
+poller, waits for any in-flight read for that attempt, and starts final drain.
+Duplicate progressive and terminal requests return the existing state or future.
+Each same-attempt replacement has a generation; stale poll or route callbacks
+cannot mutate a newer generation.
+`failed` means service execution ended without a usable result; a normal
+log-unavailable result is `completed`.
+
+## Start And End Authority
+
+Progressive start may inspect newly appended bytes, update deterministic
+occurrence groups, collect progress/checkpoint facts, build candidate summaries,
+and retain bounded context windows. It must not emit `STOP`, `RESTART`,
+`decision_basis`, or another final policy result. The first implementation of
+progressive evidence work runs only L0A before cycle end. It does not run L0B,
+L1, L2, L3, or L4 speculatively against a provisional failure.
+
+Progressive end is authoritative. It must:
+
+- merge retained state with the unread final log tail;
+- allow for bounded post-end log drain and rank interleaving;
+- finalize canonical `L0Bundle`, `DecisionEvidence`, progress facts, and
+  deterministic failure facts over the combined evidence;
+- select one immutable `PriorAttemptView` after L0A finalization and use it for
+  the deterministic and enriched branches;
+- publish the deterministic recommendation before starting L1 routes;
+- return the same external result schema as terminal execution; and
+- trace missing, stale, evicted, or unusable progressive state before falling
+  back to terminal analysis.
+
+Canonical equivalence is structural equality after removing fields explicitly
+designated as timing or operational metadata. Ingestion chunk boundaries,
+progressive read count, idle/resume events, and pre-end timestamps must not
+change canonical object identity, ordering, selected evidence, progress facts,
+or deterministic failure facts.
+
+Excluded comparison fields are limited to stage/request timestamps and
+durations, read/poll/idle counters, source-reset reread byte counts, and
+progressive cache hit/eviction/fallback diagnostics. Final source identity and
+size, line numbers, object IDs, evidence content and ordering, selection and
+lossiness metadata, and all policy-relevant facts remain part of the canonical
+comparison.
+
+## Bounded Reconciliation
+
+Progressive state is one L0A accumulator, not a sequence of independently
+combined bundles. It retains source identity and boundary, the next unread byte
+offset, the decoder's incomplete byte tail, a compact logical-line byte index,
+one-time-classified observation channels, the latest canonical L0A checkpoint,
+and operational poll/build metadata.
+
+The MVP checks file metadata first. An unchanged source is not reread. Growth
+reads only `[saved_offset, captured_boundary)`. Completed lines are appended
+exactly once and classified into reusable observation channels; an incomplete
+line remains only in the decoder until a later read completes it. Canonical L0A
+reducers build checkpoints from those channels rather than rescanning or
+redecoding the complete log boundary.
+
+If the file did not exist at progressive start, the accumulator adopts its
+source identity when the file first appears. An idle accumulator may resume when
+growth is observed or when progressive end requests finalization; idle is a
+resource-management state, not an attempt outcome.
+
+At progressive end, a stat-only drain observer runs concurrently with the
+initial unread-source ingestion. Each observed growth event resets the quiet
+interval and wakes a separate reader that ingests the newly available byte
+range without blocking metadata observation. When the source first becomes
+quiet, L0A may speculatively reduce the current captured boundary while the
+drain observer continues. Later growth makes that checkpoint stale and the next
+quiet interval may replace it. Once convergence is established, the observer
+sends an explicit completion notification; finalization does not wait for
+another polling interval. It performs one exact catch-up read and reuses the
+checkpoint only when its source boundary is the final boundary, otherwise it
+performs the canonical reduction then. This overlaps unavoidable drain time
+with L0A work without freezing an early boundary. If maximum wait expires
+before convergence, the active incomplete tail is excluded and counted.
+Replacement, truncation, or same-size modification resets the byte cursor,
+decoder, observations, and checkpoint, then replays the captured boundary from
+byte zero.
+
+A precomputed checkpoint records the exact source boundary from which it was
+built. Finalization reuses it only when that boundary still matches; unseen
+terminal growth forces a new reduction after catch-up. Object IDs derive from
+canonical type and source position, not poll or chunk sequence.
+
+Decoding uses UTF-8. Malformed byte sequences are replaced only in the affected
+physical line and are reported by replacement-character and affected-line
+counters; they do not trigger a second whole-file decoding pass. LF is the only
+physical-line boundary. CRLF strips its CR, while bare CR remains content.
+Split CRLF, bare CR, multibyte characters, and unterminated final lines are
+invariant to chunk boundaries.
+
+The supported source modes are:
+
+- `chunked`: production default; read fixed-size byte ranges and resume from
+  the saved offset;
+- `single_snapshot`: parity/regression mode; supply the captured boundary as one
+  chunk through the same decoder, observation index, reducers, and finalizer.
+
+For the same captured bytes, mode and chunk size are operational metadata and
+must not change canonical evidence.
+
+## Ownership And Handoff
+
+The service owns scheduling and lifecycle; the product owns evidence semantics:
+
+```text
+ProgressiveCoordinator
+  -> ChunkedLogReader
+  -> ProgressiveL0Accumulator
+  -> FinalizedL0A
+  -> RestartAgentRuntime
+```
+
+`ProgressiveL0Accumulator` exposes typed `refresh`, `state`, and `finalize`
+operations that are independently testable without attrsvc. `FinalizedL0A`
+contains canonical `L0Bundle`, `DecisionEvidence`, an indexed file-backed
+`LogSnapshot`, and a fixed source identity/byte/line boundary. The runtime
+derives route-independent deterministic facts from that evidence, accepts this
+object directly, builds L0B, and does not rebuild L0A. Model tools inspect only
+the finalized boundary through that source view.
+
+The product also exposes one deterministic test projection that removes only
+the operational fields listed above. Terminal and progressive fixtures compare
+that projection byte-for-byte rather than maintaining separate equivalence
+logic in the service or harness.
+
+## Pre-End Polling
+
+The first progressive implementation uses service-owned periodic polling rather
+than filesystem notifications. `pre_end_poll_seconds` is configurable and
+defaults to `180` seconds.
+
+- Progressive start schedules an immediate metadata check.
+- Thereafter, the service checks file existence, identity, size, and mtime once
+  per interval.
+- An absent or unchanged file is not scanned or reprocessed.
+- A new file starts at byte zero. A grown file reads only the new byte range and
+  refreshes the canonical L0A checkpoint from the updated observation index.
+- Replacement, truncation, or same-size modification resets and replays the
+  captured source.
+- Progressive end interrupts the polling wait and immediately starts final
+  log-drain convergence and L0A finalization.
+
+The polling interval bounds how stale precomputed L0A state may be during a
+running attempt. It does not affect correctness because progressive end always
+reads the final tail before producing authoritative evidence.
+
+## Retained State
+
+Progressive state is analyzer state, not an independent bundle cache. The
+current implementation retains:
+
+- source identity, byte boundary, read offset, incomplete byte tail, and compact
+  logical-line byte offsets;
+- one-time-classified observation channels and the latest canonical checkpoint;
+- normalized occurrence groups and deterministic candidate summaries;
+- progress, checkpoint, failure-episode, and incident facts;
+- bounded raw windows around recent tail, progress, checkpoint, first-fault, and
+  top-candidate anchors;
+- selection, truncation, eviction, and lossiness metadata; and
+- request identity and anomalies required for finalization.
+
+Decoded completed lines are classified once and released. `LogSnapshot`
+preserves original line numbers and quotes through a boundary-limited source
+handle and compact offset index. The handle remains available only through the
+last active L1/L2 route or the Restart Agent analysis timeout.
+
+MVP service retention may be local in memory and is bounded by:
+
+- `active_idle_seconds`: release active parsing resources after no observed
+  growth; idle records remain subject to the low-cost pre-end metadata poll, and
+  becoming idle does not emit a final action;
+- `max_active_states`: cap active progressive records; and
+- `max_completed_results`: cap retained completed decisions.
+
+The defaults are `active_idle_seconds=900`, `max_active_states=64`, and
+`max_completed_results=3000`. The active bound counts retained non-finalized
+accumulators, not registrations. At the bound, the service evicts the
+least-recently-used idle accumulator, then the oldest non-finalizing
+accumulator. If none is safe to evict, it registers the attempt without
+precomputation. Registration remains valid, and an evicted attempt uses terminal
+L0A at end. A finalizing state is never evicted. Completed-result eviction
+removes the oldest service entry; a later GET returns the existing not-found
+response.
+
+## Read And State Failures
+
+- A transient pre-end stat/read failure preserves prior state, records the
+  error, and retries on the next poll.
+- Missing files before end are normal. Missing, empty, or unreadable files at
+  finalization use the existing terminal log-unavailable result.
+- Replacement, truncation, same-size modification, encoding reset, corrupt
+  state, or eviction triggers replay from byte zero when possible.
+- If final drain reaches its maximum wait, the last observed size becomes the
+  immutable source boundary, an incomplete active tail is excluded, and the
+  trace records the bound and discarded-tail byte count.
+- Shutdown cancels poll work without inventing a decision. A later terminal
+  request may run a complete terminal analysis.
+
+## Latency And Candidate Publication
+
+The Restart Agent does not own or enforce the NVRx action window. NVRx may
+consume the best candidate available under its own policy and move on. That
+external action does not close the analysis.
+
+The Restart Agent publishes the deterministic recommendation as soon as authoritative
+L0A, L3, and L4 complete. L1 routes continue under the configured Restart Agent
+analysis timeout, 240 seconds by default. A later usable L1/L2/L3/L4 result
+updates the current
+`AttemptRecord`, internal history, and service-visible completed analysis. It
+does not retroactively change an action NVRx already took.
+
+The deterministic recommendation and every configured model route use the same L0A
+state, Decision Evidence, immutable `PriorAttemptView`, schemas, and policy.
+Output arriving after the Restart Agent's own analysis timeout or a superseding
+same-attempt generation is rejected and traced. Future priority selection and
+enriched prior-record selection are outside the implemented `collect_all` mode.
+
+Qualification measures separately:
+
+- work completed before progressive end;
+- progressive-end-to-deterministic-recommendation latency;
+- progressive-end-to-enriched-result p50, p90, and p99 latency;
+- analyzer timeout and route completion rates.
+
+Terminal timing uses the terminal signal as a common monotonic origin and
+reports drain completion, canonical L0A readiness, deterministic recommendation
+readiness, first route readiness, and full analysis completion separately.
+L0A additionally reports source decode, source index/classification, and
+canonical reduction time. These subphase durations explain cost; they are not
+summed with overlapping drain time.
+
+## Validation
+
+Progressive qualification must verify:
+
+- terminal and progressive executions produce structurally equal canonical
+  `L0Bundle`, `DecisionEvidence`, progress facts, and deterministic failure
+  facts for the same finalized source bytes after designated timing and
+  operational fields are removed;
+- terminal and progressive scans using different byte chunk sizes preserve
+  physical lines and produce identical canonical evidence;
+- `single_snapshot` and `chunked` modes produce identical canonical evidence;
+- incomplete lines, split CRLF, bare CR content, split multibyte UTF-8, and an
+  unterminated final line are neither duplicated nor omitted;
+- progressive start performs an immediate metadata check, scheduled polls do not
+  reread unchanged files, and progressive end interrupts the polling wait;
+- duplicate requests and poll/end races produce one finalization;
+- UTF-8 boundaries, malformed-byte replacement, truncation, and state-eviction
+  cases preserve safe terminal fallback;
+- post-end drain does not omit the initiating failure;
+- replacement, truncation, state loss, or unusable state degrades to terminal
+  L0A without changing policy semantics;
+- terminal-versus-progressive divergence is reported;
+- canonical comparison fixtures exercise multiple chunk schedules for the same
+  source bytes;
+- post-`progressive_end` deterministic and, when enabled, enriched-result latency
+  measurements use
+  the production lifecycle rather than terminal request-to-result timing;
+- NVRx moving on does not prevent a later usable L1 result from updating
+  internal history; and
+- output rejected after the Restart Agent analysis timeout or superseding
+  generation cannot mutate the current record.

--- a/docs/design/attribution/restart_agent/README.md
+++ b/docs/design/attribution/restart_agent/README.md
@@ -1,0 +1,104 @@
+# Restart Agent
+
+The NVRx Restart Agent analyzes one failed distributed-training attempt and
+returns an auditable `RESTART` or `STOP` recommendation. Training logs are
+large, interleaved, and full of downstream failures, so the design separates
+deterministic evidence construction, model interpretation, grounding, history,
+and action policy.
+
+```text
+current log
+  -> L0A complete typed evidence
+  -> DecisionEvidence
+       -> AttemptRecord(progress + deterministic facts)
+            +-> L3(PriorAttemptView) -> L4         deterministic recommendation
+            +-> L0B bounded model view -> L1 -> L2
+                 -> add route-keyed enriched facts
+                 -> L3(same PriorAttemptView) -> L4 enriched candidate
+```
+
+L0 records observed facts, preserves source references, and supplies the shared
+progress and deterministic failure blocks of the current `AttemptRecord`. L1 describes the
+failure and its recovery outlook but does not choose the action. L2 minimally
+grounds model-selected evidence and supplies one route-keyed enriched failure
+block; its broader credibility findings are advisory. L3 reads the selected
+current block and compares it against exact-job,
+same-root history and reports progress relations. L4 alone selects a versioned
+retry rule and action. The deterministic recommendation is ready independently of
+model or endpoint latency. Model enrichment is the product default, while the
+deterministic recommendation remains available first and independently.
+Configuration may explicitly select deterministic-only execution.
+
+`RestartAgentRuntime` owns a bounded in-memory `AttemptRecordStore`
+for its current process lifetime. The same record type represents an attempt
+while it is current and later when it appears in an immutable
+`PriorAttemptView`; no history-record conversion occurs. History is enabled by
+default with 10 attempts per exact `job_id` and 3000 records total;
+configuration may disable it or change either bound. Library/unit tests can
+seed, inspect, and clear this state in memory. The
+CLI may read a test-only JSON-array fixture and explicitly export the resulting
+records for scenario construction. It does not maintain history automatically.
+MVP recurrence compares only deterministic blocks from prior records. Enriched
+blocks remain observable for later policy work. MCP remains a later thin
+transport adapter rather than the owner of history semantics.
+
+The terminal-first implementation establishes feasibility and observability.
+Progressive pre-end polling is available as a disabled-by-default optimization.
+Neither path yet establishes corpus-level accuracy, a preferred model-route
+configuration, target-scale latency, or production readiness. See
+[STATUS.md](STATUS.md) for the current proof boundary.
+
+## Read In This Order
+
+1. [REQUIREMENTS.md](REQUIREMENTS.md) - problem, production constraints, and acceptance criteria.
+2. [DESIGN.md](DESIGN.md) - canonical architecture, stage boundaries, and global invariants.
+3. [L0A.md](L0A.md) - complete deterministic evidence, Decision Evidence, progress, and deterministic identity.
+4. [L0B.md](L0B.md) - bounded, attention-efficient initial model evidence.
+5. [L1.md](L1.md) - semantic model task, prompts, route execution, and usability.
+6. [L2.md](L2.md) - source grounding, enriched identity, and non-overriding audit.
+7. [L3.md](L3.md) - same-job recurrence and progress comparison.
+8. [L4.md](L4.md) - ordered retry rules, budgets, capabilities, and action.
+9. [RUNTIME.md](RUNTIME.md) - runtime composition, attempt-record ownership, injection, and replay.
+10. [CONFIGURATION.md](CONFIGURATION.md) - complete product configuration field reference and resolution.
+11. [SCHEMA.md](SCHEMA.md) - exact public and internal serialization reference.
+12. [ATTRSVC_INTEGRATION.md](ATTRSVC_INTEGRATION.md) - NVRx/attrsvc composition and lifecycle.
+
+## Focused Reference
+
+| Question | Document |
+| --- | --- |
+| Which deterministic patterns are active, and what may they establish? | [PATTERN_REGISTRY.md](PATTERN_REGISTRY.md) |
+| How do structural, semantic, history, and policy labels differ? | [TAXONOMY.md](TAXONOMY.md) |
+| What can L1 inspect beyond its initial evidence? | [TOOLS.md](TOOLS.md) |
+| Who owns configuration, runtime state, and history? | [RUNTIME.md](RUNTIME.md) |
+| What is implemented now and what remains for progressive execution? | [PROGRESSIVE.md](PROGRESSIVE.md) |
+| How does NVRx reach the Restart Agent through attrsvc? | [ATTRSVC_INTEGRATION.md](ATTRSVC_INTEGRATION.md) |
+| Where is the product/eval ownership boundary? | [EVALUATION.md](EVALUATION.md) |
+| What is implemented and what remains open? | [STATUS.md](STATUS.md) |
+| Why were consequential alternatives accepted or rejected? | [DECISIONS.md](DECISIONS.md) |
+
+## Code Map
+
+```text
+src/nvidia_resiliency_ext/attribution/restart_agent/
+  pipeline.py             small public RestartAgent facade
+  agent_runtime.py        stateful invocation and attempt-record owner
+  preparation.py          shared L0 preparation and callback boundary
+  single_run.py           one-route orchestration and deadline handling
+  multi_route.py          parallel route fanout and collection
+  decision_pipeline.py    L2/L3/L4 decision composition
+  models.py               shared immutable stage/result contracts
+  config.py               versioned routing and runtime configuration
+  runtime.py              current injectable clock, sleeper, and executor boundaries
+  l0/                     log assembly, DecisionEvidence, projection, registry
+  l1/                     semantic contract, prompt, tools, provider adapter
+  l2/                     source grounding, typed history identity, audit
+  l3/                     cross-attempt history comparison
+  l4/                     deterministic retry policy
+  infrastructure/         log and artifact I/O
+  observability/          per-stage trace rendering and envelope schemas
+```
+
+The companion eval harness source lives under `tools/restart_agent_eval/` in a
+separate development change and does not ship in the NVRx package. It invokes
+the product rather than implementing another analyzer.

--- a/docs/design/attribution/restart_agent/REQUIREMENTS.md
+++ b/docs/design/attribution/restart_agent/REQUIREMENTS.md
@@ -1,0 +1,173 @@
+# Restart Agent Requirements
+
+This document defines externally meaningful product obligations and production
+qualification gates. `DESIGN.md` routes detailed behavior to the L0A-L4,
+runtime, schema, configuration, tool, progressive, and integration
+specifications.
+
+## Goal
+
+Given the application log for one failed distributed-training attempt, produce
+an auditable recommendation to:
+
+- `RESTART`: start another NVRx cycle; or
+- `STOP`: hold the workload for user or operator intervention.
+
+The default bias is `RESTART`. Unavailable, late, or ambiguous model analysis
+must not create an unsafe `STOP`.
+
+## Core Behavior
+
+- **RA-01: Input and invocation.** The analyzer MUST accept one attempt log and
+  MAY accept `job_id` and integer `cycle_id`. It MUST support library, CLI, and
+  NVRx/attrsvc invocation. Missing attempt identity disables history without
+  preventing analysis.
+  **Verify:** request-validation, missing-identity, CLI/library, and attrsvc
+  contract tests.
+
+- **RA-02: Decision contract.** A completed analysis MUST return one `STOP` or
+  `RESTART`, its decision basis, retry rule and budget state, primary evidence,
+  provenance, and degradation status.
+  **Verify:** public-schema and decision-composition tests.
+
+- **RA-03: Terminal-first production path.** Production MUST default to
+  terminal analysis. Attrsvc MUST overlap incremental L0A ingestion and
+  boundary-safe precomputation with its bounded post-terminal log-drain wait.
+  Progressive pre-end L0A polling remains an explicit optimization that MAY be
+  enabled when measured terminal latency at target scale justifies its retained
+  state and polling cost. For identical finalized source bytes, enabled
+  progressive and terminal execution MUST produce structurally equal canonical
+  `L0Bundle`, `DecisionEvidence`, progress facts, and deterministic failure
+  facts after designated timing and operational metadata are removed. Both
+  schedules MUST use the same byte decoder, observation accumulator, reducers,
+  and finalizer. Chunk boundaries and incomplete-line tails MUST neither
+  duplicate nor omit evidence. A `single_snapshot` parity/regression mode MUST
+  exercise the same path as production `chunked` ingestion.
+  **Verify:** terminal-default and progressive-opt-in configuration,
+  polling/state-race, canonical terminal/progressive equivalence, byte-chunk
+  boundary, source-reset, log-drain, state-loss, and post-end
+  deterministic/enriched latency tests.
+
+- **RA-04: Deterministic-first and bounded enrichment.** The analyzer MUST
+  produce a deterministic L0A/L3/L4 recommendation without requiring a model
+  route. Model enrichment MUST be enabled by default, and configuration MUST
+  allow it to be explicitly disabled. Whenever enrichment is enabled, the analyzer MUST
+  publish the deterministic recommendation before model routes start. Model
+  routes MUST honor the configured Restart Agent analysis timeout. An external
+  caller acting on the deterministic recommendation MUST NOT
+  close internal analysis; a later usable enriched result may update the current
+  attempt record, history, and service-visible completed result. Runtime
+  artifacts MUST be released after their last consumer: byte chunks after
+  decoding, terminal drain state after L0A finalization, route-local model/tool
+  state after route publication, and source access after all routes finish or
+  the analysis timeout expires. A completed service entry MUST retain only its
+  compact result, history, and operational metadata.
+  **Verify:** blocked-provider, analysis-timeout, cancellation, late-enrichment,
+  superseding-generation, deterministic-readiness, artifact-retention, and repeated
+  cycle memory tests.
+
+## Analysis And Policy
+
+- **RA-05: Deterministic evidence.** Before any model call, L0A MUST construct
+  source-traceable structured evidence for candidate failures, bounded source
+  context, progress, checkpoints, recovery, termination, cascades, teardown,
+  and stable client identity when available. L0B MUST create a bounded,
+  attention-efficient initial model view without changing those facts. Neither
+  stage may choose the action.
+  **Verify:** reviewed L0 gold facts, source-reference integrity, projection
+  coverage, and attention-efficiency measurements.
+
+- **RA-06: Model semantic assessment.** L1 MUST identify the primary failure,
+  semantic identity, and root-cause support, then independently assess failure
+  domain and whether the next normal cycle may recover without workload
+  changes. It MUST return structured citations and calibration confidence. It
+  MUST NOT compare history or choose the action.
+  **Verify:** response-contract, semantic-gold, calibration, stability, and
+  malformed-output tests.
+
+- **RA-07: Grounding and audit.** L2 MUST ground model-selected primary and
+  supporting evidence before deriving enriched history identity or enabling
+  narrow policy. Audit findings MUST remain visible and MUST NOT silently
+  rewrite model semantics.
+  **Verify:** exact, nearby, unresolved, invented-line, and non-overriding audit
+  tests.
+
+- **RA-08: Same-job history and progress.** Runtime history MUST be bounded,
+  exact-job, cycle ordered, and idempotent by `(job_id, cycle_id)`. L3 MUST
+  compare stable root identity and optional affected entity without an LLM and
+  report independent root-only and root-plus-entity no-advance recurrence
+  counts plus compatible training/checkpoint advancement. Entity changes MUST
+  NOT reset the root-only count. Missing or unknown progress MUST NOT count as
+  proven no progress.
+  **Verify:** ordering, replacement, eviction, identity-match, and
+  progress-comparison tests.
+
+- **RA-09: Deterministic retry policy.** L4 alone MUST select the retry rule,
+  evaluate the general same-root ceiling and any applicable narrower retry
+  budget concurrently, and emit the action. Immediate `STOP` requires
+  grounded current-log evidence satisfying the configured nonrecoverability
+  rule; otherwise `STOP` requires exhaustion of either applicable ledger
+  without compatible progress. A narrower rule MAY stop earlier but MUST NOT
+  extend or reset the general ceiling. Domain, confidence, rank fanout, exact
+  entity availability, or an ambiguous symptom alone MUST NOT produce `STOP`.
+  An exact replay-stable entity MUST select a confirmation ledger scoped to
+  exact root and entity; its default one retry stops only on the first
+  qualifying recurrence without observed advance.
+  **Verify:** ordered-rule, immediate-STOP, retry-exhaustion,
+  progress-protection, and ambiguity tests.
+
+- **RA-10: Declared recovery capabilities.** Workload-managed recovery MUST be
+  explicit configuration rather than model inference. The MVP MUST support
+  bad-token retry-then-skip using same-root-and-data-position history; without
+  a matching declaration and grounded entity, generic policy applies.
+  **Verify:** capability-present, capability-absent, changed-position, and
+  missing-entity tests.
+
+## Operations And Qualification
+
+- **RA-11: Configuration, tools, and parallel routes.** A versioned
+  configuration MUST bind runtime history, L0 source read mode/chunk size,
+  retry policy, declared recovery capabilities, routing, and per-route request,
+  reasoning, tool, and reliability settings. N routes MUST execute independently
+  and concurrently from identical L0 evidence and prior history. MVP collection
+  MUST NOT silently vote, merge, or select a winner. Tools MUST be optional,
+  read-only, advertised, bounded, and traced.
+  **Verify:** configuration-resolution, shared-L0, route-isolation, concurrency,
+  analysis-timeout, and tool-contract tests.
+
+- **RA-12: Observability.** Results and traces MUST explain evidence selection,
+  model/tool interactions, grounding, history comparison, policy, provenance,
+  latency, analysis-timeout behavior, endpoint errors, and degradation. Large
+  transcripts may be out of band but MUST remain discoverable. Secrets MUST
+  never be recorded.
+  **Verify:** trace-schema, redaction, artifact-publication, and summary/detail
+  tests.
+
+- **RA-13: Production/eval parity.** Production and evaluation MUST use the
+  same product revision and equivalent resolved configuration. Qualification
+  MUST measure decision and root-cause accuracy, false-STOP safety, shadow
+  STOP, repeated-run stability, fingerprint false merges/splits, model
+  efficiency, endpoint reliability, latency percentiles, and timeout rate.
+  **Verify:** reviewed corpus and representative load tests.
+
+- **RA-14: Export compliance and secrets.** Export-controlled model context MUST
+  use approved regulated routes and credentials, including network fallbacks.
+  The operator owns workload classification and authorization. The analyzer
+  MUST NOT infer compliance from route names or expose credentials in
+  configuration artifacts, prompts, traces, or reports.
+  **Verify:** approved route/fallback and secret-redaction tests.
+
+## Non-Goals
+
+- Selecting nodes or devices for drain, quarantine, or scheduler mutation.
+- Providing complete workload repair instructions.
+- Using a model to compare prior attempts or consume retry budgets.
+- Depending on unbounded or mandatory model-driven tool loops.
+- Persistent or distributed history in the MVP.
+- Model voting, semantic merging, or priority arbitration in the MVP.
+- Owning or enforcing the external NVRx action deadline.
+- Treating current-process feasibility as production qualification.
+
+Exact contracts and algorithms remain canonical in `SCHEMA.md`, `L0A.md`
+through `L4.md`, `RUNTIME.md`, `CONFIGURATION.md`, `TOOLS.md`,
+`ATTRSVC_INTEGRATION.md`, and `PROGRESSIVE.md`.

--- a/docs/design/attribution/restart_agent/RUNTIME.md
+++ b/docs/design/attribution/restart_agent/RUNTIME.md
@@ -1,0 +1,491 @@
+# Restart Agent Runtime And Attempt Record Spec
+
+This document is canonical for runtime composition, current-lifetime attempt
+record ownership, prior-attempt injection, and CLI/library execution.
+`SCHEMA.md` owns the data shapes, `L3.md` owns history comparison, and `L4.md`
+owns how policy interprets a `HistorySummary`.
+
+## Runtime Boundary
+
+The restart-agent runtime is stateful orchestration around the stateless
+analysis pipeline. Configuration parsing and concrete dependency construction
+remain outside the runtime.
+
+```text
+JSON file / CLI arguments / environment
+  -> configuration loader
+  -> immutable RestartAgentConfig
+  -> composition root
+       -> credential and provider-client resolution
+       -> model-route construction
+       -> attempt-record-store construction
+  -> RestartAgentRuntime
+       -> request orchestration
+       -> current-lifetime attempt records
+       -> model-route concurrency and analysis timeouts
+  -> CLI, library, or future thin MCP adapter
+```
+
+The same runtime implementation MUST be used by CLI, library, and future MCP
+entrypoints. A transport adapter MUST NOT implement a second attempt-record,
+history-comparison, or policy path.
+
+## Component Responsibilities
+
+| Component | Responsibility |
+| --- | --- |
+| Configuration loader | Read JSON, validate closed schemas, apply defaults, and return immutable typed configuration. |
+| Credential resolver | Resolve external credential references without placing secrets in effective configuration or traces. |
+| Composition root | Interpret typed configuration and construct routes, clients, attempt-record storage, the record assembler, and the runtime. |
+| `RestartAgentRuntime` | Coordinate requests, analysis timeouts, route execution, candidate publication, and current-lifetime attempt records. |
+| `AttemptRecordStore` | Store current and prior `AttemptRecord` objects without interpreting evidence or policy. |
+| `AttemptRecordControl` | Seed, inspect, and clear in-memory attempt records; the CLI may serialize inspected records as an explicit fixture. |
+| `AttemptRecordAssembler` | Create the initial immutable L0 record and produce immutable same-key replacements as enriched L2 facts become available. |
+| `ProgressiveCoordinator` | Attrsvc-owned polling, state transitions, concurrent stat-only terminal drain observation, and safe degradation to terminal preparation. |
+| `ChunkedLogReader` | Read exact byte ranges from one captured source boundary using `chunked` or `single_snapshot` mode. |
+| `IncrementalLineDecoder` | Preserve Linux-style LF-delimited physical-line numbering and an incomplete byte tail across reads; strip CR only as part of CRLF, retain bare CR as content, and localize malformed bytes as counted replacement characters. |
+| `ProgressiveL0Accumulator` | Product-owned byte cursor, decoder, append-only observation index, and deterministic `refresh`, `state`, and `finalize` operations. |
+| Route HTTP client | Maintain one persistent synchronous `httpx` connection pool for an OpenAI-compatible model route; it does not own retries or analysis policy. |
+| CLI adapter | Convert arguments and files into typed configuration and analysis requests; optionally import/export manual history fixtures. |
+| Future MCP adapter | Expose the required product operations as a thin view over the same runtime. |
+
+Ownership and construction are distinct: the runtime owns the live record
+lifecycle, but the composition root constructs and injects the concrete store.
+This preserves a clean test seam and permits another store implementation
+without changing runtime behavior.
+
+## Progressive Preparation Boundary
+
+Progressive orchestration remains outside the stateless L0-L4 pipeline:
+
+```text
+attrsvc ProgressiveCoordinator
+  -> ChunkedLogReader
+  -> ProgressiveL0Accumulator.finalize()
+  -> FinalizedL0A
+  -> RestartAgentRuntime.analyze_prepared()
+```
+
+`analyze_prepared()` consumes `FinalizedL0A` without rereading or rebuilding
+L0A. It selects `PriorAttemptView` at finalization and runs deterministic L3/L4.
+When enrichment is enabled, it also builds L0B, publishes the deterministic
+recommendation, and starts L1. The configured analysis timeout
+starts when finalized L0A is handed to the runtime; pre-end polling and final
+log-drain/L0A work do not consume the model-route timeout. Attrsvc observes
+terminal quiet convergence concurrently with source ingestion and
+boundary-specific L0A precomputation, then performs an exact final catch-up read
+before freezing L0A. NVRx owns any broader action deadline.
+
+The finalized source boundary and its logical-line view are passed to all
+raw-log tools. Production `chunked` mode backs that view with compact line
+offsets and a boundary-limited file descriptor rather than retained decoded
+lines. The descriptor keeps the captured inode readable if its path is later
+replaced or removed. Bytes appended after the final boundary are not visible to
+the invocation.
+
+## Runtime Artifact Lifetime
+
+Artifacts are released after their last consumer, not at the end of the next
+cycle. The canonical ownership table is:
+
+| Artifact | Owner | Last consumer | Release condition | Durable representation | Completed service state |
+| --- | --- | --- | --- | --- | --- |
+| Source byte chunk | reader/decoder | incremental decoder | decoder feed returns | byte/chunk counters | none |
+| Incomplete byte tail | decoder | terminal finalizer | quiet finalization, or discard when max-wait expires without convergence | pending/discarded byte counts | none |
+| Line-offset index and source handle | finalized `LogSnapshot` | last active L1 tool or L2 grounding route | all routes finish or 240-second analysis timeout; a still-unwinding worker retains its own reference only until exit | source boundary, encoding, read mode, line count | none |
+| Observation channels and progressive accumulator | L0A coordinator | canonical L0A finalizer | `L0Bundle`, `DecisionEvidence`, progress, and deterministic facts are frozen | L0A artifacts and metrics | none |
+| `L0Bundle` and `DecisionEvidence` | prepared invocation | last active route/L2 pass | all routes finish or analysis timeout | trace/artifact files when requested | none in attrsvc result registry |
+| L0B prompt view | route invocation | route L1/L2 | route terminal status | route trace when requested | none |
+| Route transcript, tool payloads, and raw response | route invocation | route parser, L2, and route callback | route callback publishes completion | route trace when requested | none |
+| Route HTTP connection pool | route-owned L1 extractor | model calls across invocations | runtime/service shutdown; caller-injected clients remain caller-owned | transport type and per-call outcome telemetry | none |
+| Attempt record | runtime history store | later L3 invocations | bounded history eviction | explicit history fixture only when requested | compact in-memory record |
+| Analysis result | caller/service registry | GET/result consumer | completed-result eviction | result artifact when requested | compact result and operational status |
+
+CLI and evaluation execution retain detailed return artifacts by default.
+Attrsvc selects compact retention: callbacks may persist detailed route traces,
+but the in-process completed entry does not retain them.
+
+Any new artifact, tool, stage output, or route state must declare its owner,
+last consumer, release condition, durable trace representation, and
+completed-state representation.
+
+## Configuration Flow
+
+The runtime MUST NOT receive a configuration path, raw JSON dictionary,
+credential environment-variable name, or API-key file path. The supported
+flow is:
+
+```python
+config = load_restart_agent_config("restart_agent.json")
+runtime = build_restart_agent_runtime(config)
+result = runtime.analyze(request)
+```
+
+The loader performs parsing, validation, defaulting, and normalization. The
+composition root resolves credentials and constructs dependencies. The runtime
+receives ready-to-use dependencies plus non-secret effective-configuration
+metadata for tracing.
+
+Actual attempt records are runtime state, not configuration. Product
+configuration controls route execution, retry budgets, declared recovery
+capabilities, and record retention. The restart transition is an immutable
+product guarantee encoded in the L1 system prompt. For example,
+runtime history and L0 source configuration are:
+
+```json
+{
+  "runtime": {
+    "history": {
+      "enabled": true,
+      "max_attempts_per_job": 10,
+      "max_total_records": 3000
+    },
+    "l0_source": {
+      "read_mode": "chunked",
+      "chunk_size_bytes": 1048576
+    }
+  }
+}
+```
+
+History is enabled by default. Omitting `runtime.history` is equivalent to the
+object above. `max_attempts_per_job` and `max_total_records` MUST be positive
+integers and default to `10` and `3000`, respectively. Operators may override
+either bound. When history is disabled, the composition root injects a null
+record store and explicit seeding fails with a clear `history_disabled` error
+rather than silently discarding records.
+
+The checked-in `restart_agent.json` includes these defaults explicitly so the
+runtime-owned state policy is visible to operators.
+
+`runtime.l0_source.read_mode` is `chunked` by default. It incrementally reads
+fixed-size ranges and is the production mode. `single_snapshot` captures the
+same immutable boundary as one byte chunk and exists for parity and regression
+testing. Both modes use the same decoder, observation accumulator, reducers,
+and finalizer. `chunk_size_bytes` must be a positive integer and affects read
+scheduling, not canonical evidence.
+
+## Attempt Record Store Contract
+
+The runtime depends on a store interface equivalent to:
+
+```python
+class AttemptRecordStore(Protocol):
+    def get_prior_attempts(
+        self,
+        job_id: str,
+        before_cycle_id: int,
+    ) -> PriorAttemptView: ...
+
+    def upsert_attempt(self, record: AttemptRecord) -> None: ...
+
+    def records(
+        self,
+        job_id: str | None = None,
+    ) -> tuple[AttemptRecord, ...]: ...
+
+    def replace(self, records: Sequence[AttemptRecord]) -> None: ...
+
+    def clear(self, job_id: str | None = None) -> None: ...
+```
+
+The MVP store is `InMemoryAttemptRecordStore`. It has these semantics:
+
+- exact `job_id` matching;
+- integer `cycle_id` ordering;
+- current and future cycles excluded from `PriorAttemptView` results;
+- immutable in-memory views supplied to an invocation;
+- idempotent upsert by `(job_id, cycle_id)`;
+- replacement rather than recurrence inflation when a cycle is reanalyzed;
+- retention of one shared L0 progress summary, one required deterministic
+  failure-facts block, and a compact enriched-facts list; each fact block owns
+  its mechanism root and optional exact affected entity;
+- at most one enriched entry per `route_id`; a repeated route update replaces
+  that entry rather than appending a duplicate;
+- deterministic facts remain the only history-comparison source in MVP;
+- independent state for different jobs;
+- thread-safe view and update operations;
+- oldest-cycle eviction after `max_attempts_per_job` records for one job; and
+- oldest-record eviction by internal insertion sequence when
+  `max_total_records` is exceeded across all jobs.
+
+The per-job bound is a cycle-ordered bounded queue. Replacing an existing
+`(job_id, cycle_id)` does not change record count or insertion sequence. New
+records are inserted under one store lock; per-job eviction runs first, followed
+by total-record eviction. The internal insertion sequence is store metadata and
+is not serialized in an `AttemptRecord` fixture.
+
+`records()` returns deterministic `(job_id, cycle_id)` order. Because fixtures
+do not serialize live insertion sequence, `seed()` first validates unique keys
+and normalizes records to that same order. `replace` assigns fresh insertion
+sequence in normalized order; `merge` applies normalized records through
+idempotent upsert in that order. This makes fixture replay deterministic while
+keeping live total-cap eviction based on actual insertion sequence.
+
+The MVP store survives only for the lifetime of one runtime process. A runtime
+restart starts with no records. Prior-view availability, record count, enriched
+entry count, and eviction MUST be traced. Persistent, distributed, or
+automatically serialized records are outside MVP scope.
+
+## Attempt Record Control And Injection
+
+The runtime exposes a transport-independent control surface:
+
+```python
+class AttemptRecordControl:
+    def seed(
+        self,
+        records: Sequence[AttemptRecord],
+        *,
+        mode: Literal["replace", "merge"] = "replace",
+    ) -> None: ...
+
+    def records(
+        self,
+        job_id: str | None = None,
+    ) -> tuple[AttemptRecord, ...]: ...
+
+    def clear(self, job_id: str | None = None) -> None: ...
+```
+
+This is primarily a library/unit-test seam for state-based testing. The CLI may
+adapt `--attempt-records-json-in` through `seed()` and write `records()` through
+`--attempt-records-json-out`. These explicit fixture
+operations are not a public analysis request, automatic persistence,
+production state-transfer format, or MCP operation. A later hydration design
+may reuse the typed store/control boundary, but that is not an MVP contract.
+
+Attempt records are seeded as established runtime state before analysis. They
+are not arbitrary fields on each public analysis request. This preserves one
+state lifecycle while allowing exact in-memory state-based tests.
+
+`replace` is the deterministic default for tests and delegates to the store's
+atomic `replace()` operation. `merge` performs the same idempotent
+`(job_id, cycle_id)` upsert used during live operation. Both modes validate
+record shape, unique keys, and ordering. The store then applies the same
+per-job and total eviction rules used during live operation.
+
+## Prior-View And Record Eligibility
+
+`job_id` remains a string and `cycle_id` remains an integer. Literal `0` is
+valid only when it is the caller's real identifier; the runtime MUST NOT invent
+`"unknown"`, `0`, a log-path hash, or another synthetic identity for missing
+metadata. Synthetic identities could join unrelated jobs or replace unrelated
+cycles.
+
+Selecting a `PriorAttemptView` requires all of:
+
+- history enabled;
+- non-empty `job_id` supplied by the caller;
+- integer `cycle_id` supplied by the caller.
+
+The runtime can select prior records before L0 knows the current fingerprint.
+L3 additionally requires a non-empty fingerprint in the deterministic or
+selected enriched facts before it can compare roots. An `AttemptRecord` upsert
+requires a non-empty deterministic L0 fingerprint because the deterministic
+block is mandatory in MVP.
+
+If store, request, or fingerprint eligibility is absent, analysis continues
+without recurrence evidence. Trace state reports one of `history_disabled`,
+`missing_job_id`, `missing_cycle_id`, or `missing_root_fingerprint`. Missing
+identity is not an error in the public analysis request. Missing job/cycle
+prevents prior selection and record upsert; missing deterministic fingerprint
+prevents record upsert and makes L3 unavailable for that branch.
+
+An eligible lookup that finds no prior records is available-but-empty, not
+unavailable. L3 receives an empty immutable view with
+`availability_reason=ready`; this distinguishes a first attempt from disabled
+history or missing identity.
+
+## Attempt Progress Construction
+
+L0 constructs one immutable `AttemptProgressSummary` from deterministic log
+facts. `AttemptRecordAssembler` places that summary at the top level of the
+record so deterministic and enriched routes share it. Rank-duplicated marker
+lines are deduplicated into logical observations before values or counts are
+computed.
+
+- Training progress uses completed application iteration/step markers. Setup,
+  started-but-not-completed operations, traceback copies, and raw rank fanout do
+  not count.
+- `training_progress=observed` requires at least one completed marker.
+  `not_observed` requires a fully scanned readable log and a recognized
+  progress-marker dialect. Otherwise it is `unknown`.
+- `first_completed_step` and `last_completed_step` are the minimum and maximum
+  comparable completed values. `completed_step_delta` is `last - first`.
+  `progress_marker_count` is the number of distinct logical completed-marker
+  observations, not raw log lines.
+- Checkpoint progress uses successfully completed checkpoint saves made by the
+  current attempt. Checkpoint-save starts and failed saves do not count.
+- `checkpoint_load_step` is the most recent successfully loaded resume point
+  before the primary failure. It is never counted as a save by this attempt.
+- `first_checkpoint_step`, `last_checkpoint_step`, `checkpoint_step_delta`, and
+  `checkpoint_marker_count` are computed from deduplicated completed saves.
+- `failure_position` is relative to the canonical L0 failure episode and is
+  `before_observed_training_progress`, `after_observed_training_progress`, or
+  `unknown`.
+- `progress_after_failure` is `observed` when a completed compatible progress
+  marker occurs after the canonical failure episode ends. In an interleaved log
+  it proves job-level continuation, not recovery of the same rank or component.
+  It is `not_observed` only with adequate readable tail coverage and a
+  recognized progress dialect; otherwise it is `unknown`.
+
+Checkpoint delta and marker count are intentionally distinct. For successful
+saves at steps `100`, `200`, and `400`, `checkpoint_step_delta=300` while
+`checkpoint_marker_count=3`. The former measures observed distance and the
+latter measures observation frequency; only comparable step values participate
+in L3 advancement.
+
+## Invocation Lifecycle
+
+For one request, the runtime performs:
+
+```text
+validate request
+  -> take immutable PriorAttemptView for exact job and earlier cycles
+  -> construct invocation context
+  -> L0 builds progress and deterministic failure facts
+  -> assemble current AttemptRecord(enriched=[]); upsert when eligible
+  -> run deterministic L3/L4
+  -> publish deterministic recommendation candidate
+  -> start configured model routes
+  -> each completed L2 route atomically adds/replaces enriched[route_id]
+  -> run that enriched route through L3/L4 using the same PriorAttemptView
+  -> close record updates at completion or analysis timeout
+  -> return invocation-owned results and artifacts
+```
+
+The record has one contract throughout its lifetime. Immutable replacements
+represent the current `AttemptRecord` during analysis; its final value appears
+unchanged in a later cycle's `PriorAttemptView`. There is no conversion to a
+differently named history record. L0 supplies shared progress and deterministic
+facts, including the root and optional affected entity, and L2 supplies each
+enriched fact block under the same contract.
+`AttemptRecordAssembler` creates the immutable replacements and the runtime
+commits them. L3 and L4 read the selected block and prior view but do not mutate
+the record.
+
+The deterministic block is the sole policy-active history-comparison source
+for MVP `collect_all`. Enriched entries are retained for observability and
+future design but ignored by later L3 comparisons. Model-route completion order
+therefore cannot affect MVP policy. Future route selection may choose enriched
+facts only after its authority and migration semantics are specified.
+
+Attempt progress is not route-selected semantic output. The runtime constructs
+`AttemptProgressSummary` from deterministic current-log L0 facts and stores it
+once alongside the deterministic failure block. This prevents two model routes
+from creating different claims about whether the same cycle reached training,
+checkpointed, or progressed after the fault.
+
+An enriched entry contains only compact L2-grounded current-attempt failure
+facts plus `route_id`. It does not contain model transcripts, citations, tool
+payloads, token metrics, `HistorySummary`, or `L4PolicyOutcome`. Copying L3 into
+the record would recursively embed prior history; copying L4 would make the
+record depend on policy version and retry state rather than only this attempt's
+observations.
+
+At the configured analysis timeout, represented internally as an absolute
+monotonic deadline, the runtime stops waiting and returns the best result
+already available. Pending futures are cancelled when possible. An
+already-running HTTP worker may unwind after the timeout because Python threads
+cannot be forcibly terminated, but its output is abandoned: it cannot publish a
+route result or mutate the invocation's closed attempt record.
+Provider-request timeouts remain clamped to the remaining analysis budget, and
+no new retry, model turn, or tool call starts after the timeout.
+
+An external caller moving on before this timeout does not close the invocation.
+Any usable route that completes within the Restart Agent analysis timeout may
+still publish its result and update the current attempt record and
+current-lifetime history.
+
+Re-running analysis for the same workload attempt uses the same
+`(job_id, cycle_id)` and atomically replaces its record, initially clearing the
+old enriched list. An actual NVRx workload restart uses a new `cycle_id` and
+appends a distinct record. Concurrent invocations for one `(job_id, cycle_id)`
+are serialized by the runtime. Each invocation has an internal generation, and
+an older-generation or post-timeout callback cannot update the replacement
+record.
+
+## Library And CLI Exercise Paths
+
+The library supports direct stateful execution:
+
+```python
+config = load_restart_agent_config("restart_agent.json")
+records = InMemoryAttemptRecordStore(
+    max_attempts_per_job=10,
+    max_total_records=3000,
+)
+runtime = build_restart_agent_runtime(config, attempt_record_store=records)
+
+runtime.attempt_record_control.seed(initial_records)
+for request in ordered_requests:
+    result = runtime.analyze(request)
+
+assert runtime.attempt_record_control.records("job-123") == expected_records
+```
+
+For manual testing, the CLI may seed one invocation from a plain JSON array of
+`AttemptRecord` objects and explicitly export the resulting store:
+
+```text
+restart-agent cycle-4.log --job-id job-123 --cycle-id 4 \
+  --attempt-records-json-in prior-attempts.json \
+  --attempt-records-json-out attempts-through-cycle-4.json
+```
+
+Both flags are explicit manual-test operations. The output is the complete
+post-upsert in-memory record set, deterministically ordered by `job_id` and
+integer `cycle_id`, written atomically as the same plain JSON-array fixture
+shape accepted by `--attempt-records-json-in`. The CLI chooses no default
+record path,
+does not write unless requested, and does not preserve state after the process
+exits. A user may edit or branch the exported fixture to construct alternate
+history scenarios. Ordered multi-cycle state behavior is also exercised
+through library/unit tests that preserve one in-memory store across requests.
+
+These APIs are implemented; `STATUS.md` records their current qualification
+level and remaining production work.
+
+## Attrsvc Runtime Integration
+
+Attrsvc's `lib` backend constructs and owns one `RestartAgentRuntime` directly;
+`ATTRSVC_INTEGRATION.md` defines its HTTP lifecycle and configuration mapping.
+The runtime's current-lifetime attempt store remains the only L3 history owner.
+The service's active-request registry is separate workflow state and does not
+replace or reinterpret attempt records.
+
+MCP remains a possible later transport adapter over `RestartAgentRuntime`; it
+does not own attempt-record or history-comparison semantics. If attrsvc
+hydration is designed later, it may build on the same typed store boundary.
+No MCP history endpoint, hydration protocol, or restart-surviving persistence
+is required for MVP.
+
+## Verification
+
+The runtime/attempt-record implementation is complete only when tests cover:
+
+- exact-job selection, integer ordering, and exclusion of current/future cycles;
+- available-but-empty history versus disabled or identity-ineligible history;
+- bounds, oldest-cycle eviction, and disabled history;
+- total-record eviction across multiple jobs;
+- duplicate-cycle idempotency and deterministic replacement;
+- initial L0 record creation with empty enriched entries;
+- route-keyed enriched add/replace without duplicate entries or lost updates;
+- deterministic-only prior comparison despite stored enriched entries;
+- missing job, cycle, and root identity without synthetic joins;
+- completed-step/checkpoint-step comparison, fallback iteration comparison,
+  and conflicting progress dimensions;
+- progress-marker deduplication, observed/not-observed/unknown classification,
+  checkpoint load-versus-save separation, and delta/count construction;
+- L3 completed-step/checkpoint/failure-position comparison, including
+  conflicting-marker fallback to `unknown`;
+- immutable invocation views and concurrent access;
+- same-key invocation generations, serialization, and rejection of stale or
+  post-timeout record updates;
+- in-memory seed, inspect, clear, and deterministic CLI fixture round trips;
+- multiple jobs and multiple ordered cycles in one runtime;
+- model timeout with the deterministic attempt record still available;
+- deterministic record behavior independent of enriched route completion order;
+- runtime restart with empty state; and
+- repeated library invocations sharing one runtime-owned attempt-record store.

--- a/docs/design/attribution/restart_agent/SCHEMA.md
+++ b/docs/design/attribution/restart_agent/SCHEMA.md
@@ -1,0 +1,1366 @@
+# Restart Agent Schema Spec
+
+This file is canonical for product configuration, public request/response,
+internal stage, and trace data shapes. `L3.md` and `L4.md` own interpretation and
+action rules.
+
+## Contract Classes
+
+### Public Product Contracts
+
+| Object | Version |
+| --- | --- |
+| Product configuration | `restart_agent_config.v1` |
+| Public analysis request | `restart_agent_request.v1` |
+| Public analysis response | `restart_agent_response.v1` |
+| Collect-all result | `restart_agent_collect_all.v1` |
+
+These are caller-visible wire contracts. Unknown fields and unsupported schema
+versions are rejected at the product boundary.
+
+### Serialized Internal Contracts
+
+| Object | Version |
+| --- | --- |
+| Persisted L0A evidence bundle | `restart_agent_l0_bundle.v1` |
+| Decision Evidence | `restart_agent_decision_evidence.v1` |
+| L0B model view | `restart_agent_l0_model_view.v1` |
+| L1 model evidence | `restart_agent_evidence.v1` |
+
+These objects are not general caller inputs. They are serialized because they
+cross a provider, trace, replay, or evaluation boundary. Schema versions are
+exact contracts; producers must not silently emit a new shape under an old
+version.
+
+### Operational Artifact Contracts
+
+| Object | Version |
+| --- | --- |
+| Single-route CLI trace | `restart_agent_cli_trace.v1` |
+| Collect-all CLI trace | `restart_agent_cli_collect_all_trace.v1` |
+| Route-artifact manifest | `restart_agent_route_artifacts.v1` |
+| Incremental status snapshot | `restart_agent_live_status.v1` |
+| Incremental lifecycle event | `restart_agent_live_event.v1` |
+| Deterministic recommendation artifact | `restart_agent_deterministic_recommendation.v1` |
+| Optional evidence-object tool response | `restart_agent_evidence_objects.v1` |
+
+These versions identify product-generated operational artifacts, not additional
+analysis stages. Their lifecycle and commit-marker semantics are defined under
+`Incremental Collect-All Artifacts`; tool response semantics remain in
+`TOOLS.md`.
+
+### Internal Stage Contracts
+
+Internal stage inputs and outputs are immutable Python types. They are explicit
+contracts even when they have no independent wire-schema version.
+
+| Stage | Input | Output |
+| --- | --- | --- |
+| Request assembly | `RestartAgentRequest`, effective config, runtime-selected `PriorAttemptView` | `AnalysisExecutionContext` |
+| Attempt-record assembly | L0 progress/deterministic facts or one L2 enriched fact update | immutable `AttemptRecord` replacement |
+| L0A log interpretation | validated log path, `LogSnapshot` or replayed `L0Bundle` | `L0Bundle` |
+| L0A decision selection | `L0Bundle` | `DecisionEvidence` |
+| L0B attention projection | `L0Bundle`, `DecisionEvidence` | `L0ModelFacingView` |
+| L1 semantic extraction | `L1EvidenceContext`, route settings, deadline | `L1EvidenceResult` containing `restart_agent_evidence.v1` when usable |
+| L2 grounding and audit | `L2GroundingInput` | `L2Result` |
+| L3 history comparison | `HistoryEvaluationInput` | `HistorySummary` |
+| L4 deterministic policy | `L4PolicyInput` | `L4PolicyOutcome` |
+| Response assembly | L0-L4 outputs and execution health | `AnalysisResult` / `restart_agent_response.v1` |
+
+An internal contract receives its own version only if it later becomes a
+persisted, replayed, provider-facing, or independently consumed wire object.
+
+`retry_budget.v1` is an L4 behavior identifier emitted in policy results and
+traces. It is not a nested request or configuration schema.
+
+Implementation status matters when reading the contracts below. The terminal
+L0-L4 pipeline and current per-invocation history input are implemented. The
+stateful `RestartAgentRuntime`, `AttemptProgressSummary`, `AttemptRecord`,
+runtime-selected `PriorAttemptView`, record control/export, and multi-dimension
+L3 comparison are implemented contracts. `STATUS.md` records qualification
+gaps rather than schema availability.
+
+## Public Analysis Request
+
+`RestartAgent.run()` accepts `RestartAgentRequest` or its exact JSON mapping and
+returns an `AnalysisRun` containing the public result plus the exact trace,
+L0A bundle, Decision Evidence, optional L0B view, and deterministic candidate owned
+by that invocation. L0B is present when an L1 route is scheduled and may be
+null for deterministic-only or log-unavailable execution. The same ownership
+applies to `run_many()`.
+
+```json
+{
+  "schema_version": "restart_agent_request.v1",
+  "log_path": "/logs/job-123/cycle-2.log",
+  "job_id": "job-123",
+  "cycle_id": 2,
+  "analysis_mode": "terminal"
+}
+```
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `schema_version` | exact string | yes | `restart_agent_request.v1`. |
+| `log_path` | absolute string | yes | One interleaved current-attempt log. |
+| `job_id` | string or null | no | Exact MVP history boundary. |
+| `cycle_id` | integer or null | no | NVRx restart-attempt order within the job. |
+| `analysis_mode` | enum | no | `terminal` by default. Attrsvc owns progressive start/end orchestration and hands finalized L0A to the same runtime path. |
+
+Validation:
+
+- `schema_version` must exactly match `restart_agent_request.v1`;
+- unknown request fields are rejected;
+- `log_path` must be present and absolute;
+- `cycle_id` must be an integer, not a numeric string or Boolean;
+- a path unavailable at analysis time produces the documented
+  `log_unavailable` result after request validation.
+
+Literal zero is accepted for `cycle_id` only when it is the real caller-supplied
+cycle number. The runtime does not substitute `0` or `"unknown"` for absent
+`job_id`/`cycle_id`. If either is absent, analysis remains valid but history
+lookup and current-attempt upsert are disabled and the reason is traced.
+
+Attempt records, prior-attempt views, `retry_policy`, eval labels, and case
+metadata are not public request fields.
+
+## Internal Analysis Execution Context
+
+**Boundary contract**
+
+| Direction | Type | Meaning |
+| --- | --- | --- |
+| Input | `RestartAgentRequest` | Validated caller-owned request. |
+| Input | selected `PriorAttemptView` | Immutable in-memory prior-attempt view from `RestartAgentRuntime`. |
+| Input | effective product configuration | Retry counts and declared recovery capabilities. |
+| Output | `AnalysisExecutionContext` | Immutable invocation context consumed by pipeline orchestration. |
+
+The agent validates the public request and then builds one immutable
+`AnalysisExecutionContext`:
+
+```text
+RestartAgentRequest
++ RestartAgentRuntime PriorAttemptView
++ effective restart-agent configuration
+-> AnalysisExecutionContext
+```
+
+The context contains:
+
+- the validated request;
+- compact `prior_attempts` selected by the runtime attempt-record store;
+- effective retry-budget counts from product configuration.
+- effective declared recovery capabilities from product configuration.
+
+This object is an internal stage boundary, not a caller-controlled wire shape.
+Duplicate `(job_id, cycle_id)` records are resolved by explicit idempotent
+seed/upsert semantics in library/unit tests; current and future cycle records
+are excluded from the immutable in-memory view supplied to L3.
+
+### Restart Environment Guarantees
+
+The workload is unchanged, process state is recreated, normal restart delay
+applies, hardware allocation may change, and external-service state may change.
+These are immutable product guarantees encoded in the static L1 system prompt.
+They are not configuration, request, execution-context, or L0B fields. They
+describe possible restart transitions, not evidence that recovery will happen.
+
+### Retry-Budget Configuration
+
+```json
+{
+  "confirmation_retry_allowed_retries": 1,
+  "bounded_retry_allowed_retries": 1,
+  "general_retry_allowed_retries": 3
+}
+```
+
+All retry counts are non-negative integers. The confirmation and bounded
+budgets must not exceed `general_retry_allowed_retries`, and unknown fields are
+rejected. L4 emits
+`policy_version: retry_budget.v1` to identify the behavior that interpreted
+these values.
+
+### Declared Recovery Capabilities
+
+`declared_recovery_capabilities` is a closed array in product configuration.
+It is empty when omitted. The MVP accepts only:
+
+```json
+[
+  {
+    "capability_id": "bad_token_retry_then_skip",
+    "behavior": "retry_then_skip",
+    "applies_to": ["bad_token_or_window"],
+    "required_entity_kind": "data_position",
+    "history_match_scope": "root_and_entity",
+    "allowed_retries": 2
+  }
+]
+```
+
+Every item requires exactly those fields. `allowed_retries` is a positive
+integer that must not exceed `general_retry_allowed_retries`, duplicate
+capability identifiers are rejected, and the MVP values for `behavior` and
+`applies_to` are exact. The array is copied into `AnalysisExecutionContext` and
+then into `L4PolicyInput`; L0-L3 do not consume it.
+
+### Attempt Progress Summary
+
+`AttemptProgressSummary` is the shared immutable L0 progress type stored once
+at the top of every `AttemptRecord`:
+
+```json
+{
+  "training_progress": "observed",
+  "first_completed_step": 1,
+  "last_completed_step": 418,
+  "completed_step_delta": 417,
+  "progress_marker_count": 42,
+  "checkpoint_progress": "observed",
+  "checkpoint_load_step": 0,
+  "first_checkpoint_step": 100,
+  "last_checkpoint_step": 400,
+  "checkpoint_step_delta": 300,
+  "checkpoint_marker_count": 4,
+  "failure_position": "after_observed_training_progress",
+  "progress_after_failure": "not_observed"
+}
+```
+
+All numeric fields are integer or null. Counts are non-negative integers.
+`training_progress`, `checkpoint_progress`, and `progress_after_failure` are
+`observed`, `not_observed`, or `unknown`. `failure_position` is
+`before_observed_training_progress`, `after_observed_training_progress`, or
+`unknown`. `L0A.md` is canonical for progress observation semantics,
+`RUNTIME.md` for attempt-record construction/deduplication, and `L3.md` for
+cross-attempt comparison.
+
+### Attempt Failure Facts
+
+`AttemptFailureFacts` is the compact branch-specific observation stored in the
+deterministic block or one enriched entry:
+
+```json
+{
+  "source": "l0_deterministic",
+  "root_fingerprint": "observed:runtimeerror:cuda_device_assert",
+  "root_fingerprint_source": "observed_exception",
+  "fault_outcome": "terminal",
+  "primary_line": 1012,
+  "identity_anchor_line": 1012,
+  "identity_anchor_reason": "canonical_episode_terminal",
+  "failure_iteration": 419,
+  "affected_entity": null,
+  "faulting_rank": "7",
+  "faulting_node": "node-2",
+  "faulting_gpu": "3",
+  "rank_to_gpu_map": {"7": "3"}
+}
+```
+
+The required fields are `source`, `root_fingerprint`,
+`root_fingerprint_source`, and `fault_outcome`; other fields may be null or
+empty. The deterministic block requires a non-empty `root_fingerprint` and
+source before the record is eligible for storage. An enriched block may retain
+null identity when L2 could not ground one; that branch is ineligible for L3
+comparison. `source` is `l0_deterministic` for the deterministic block and
+`l2_grounded` for enriched entries. Progress is deliberately absent because the
+enclosing `AttemptRecord.progress` is shared across every route.
+The semantic `failure_class` remains on `FailureEvidence` and analysis output; it
+is not duplicated in this L3-facing recurrence contract.
+
+`root_fingerprint` identifies the failure mechanism. Optional
+`affected_entity` identifies the exact observed object:
+
+```json
+{
+  "kind": "data_position",
+  "identity": "token:42",
+  "fingerprint": "affected_entity:data_position:3d97...",
+  "evidence_line": 1012
+}
+```
+
+Allowed kinds are `data_position` and `artifact`. The identity remains visible
+for review; the fingerprint is an exact stable hash over kind and identity.
+An artifact identity is replay-stable evidence from the failing operation: for
+checkpoint load this is normally normalized checkpoint path plus iteration,
+refined by an explicit shard/file/object when available. A decoder's
+buffer-local offset, offending byte, rank, timestamp, and traceback location
+remain observations and are excluded from exact entity matching.
+
+### Attempt Record
+
+`AttemptRecord` is temporally neutral: immutable replacements represent the
+current cycle while it is open, and the final value appears under the same
+contract as a prior attempt in a later cycle.
+
+```json
+{
+  "job_id": "job-123",
+  "cycle_id": 2,
+  "progress": {
+    "training_progress": "observed",
+    "first_completed_step": 1,
+    "last_completed_step": 418,
+    "completed_step_delta": 417,
+    "progress_marker_count": 42,
+    "checkpoint_progress": "observed",
+    "checkpoint_load_step": 0,
+    "first_checkpoint_step": 100,
+    "last_checkpoint_step": 400,
+    "checkpoint_step_delta": 300,
+    "checkpoint_marker_count": 4,
+    "failure_position": "after_observed_training_progress",
+    "progress_after_failure": "not_observed"
+  },
+  "deterministic": {
+    "source": "l0_deterministic",
+    "root_fingerprint": "observed:runtimeerror:cuda_device_assert",
+    "root_fingerprint_source": "observed_exception",
+    "fault_outcome": "terminal",
+    "primary_line": 1012,
+    "identity_anchor_line": 1012,
+    "identity_anchor_reason": "canonical_episode_terminal",
+    "failure_iteration": 419,
+    "affected_entity": null,
+    "faulting_rank": "7",
+    "faulting_node": "node-2",
+    "faulting_gpu": "3",
+    "rank_to_gpu_map": {"7": "3"}
+  },
+  "enriched": [
+    {
+      "route_id": "gpt",
+      "facts": {
+        "source": "l2_grounded",
+        "root_fingerprint": "observed:runtimeerror:cuda_device_assert",
+        "root_fingerprint_source": "observed_exception",
+        "fault_outcome": "terminal",
+        "primary_line": 1012,
+        "identity_anchor_line": 1012,
+        "identity_anchor_reason": "l2_grounded_primary",
+        "failure_iteration": 419,
+        "affected_entity": null,
+        "faulting_rank": "7",
+        "faulting_node": "node-2",
+        "faulting_gpu": "3",
+        "rank_to_gpu_map": {"7": "3"}
+      }
+    }
+  ]
+}
+```
+
+Required fields are non-empty `job_id`, integer `cycle_id`, `progress`,
+`deterministic`, and `enriched`. `enriched` is an array for serialization but
+has unique `route_id` keys. Adding the same route again replaces its entry. An
+initial L0 record has `enriched=[]`; completed L2 routes may add compact entries
+before the invocation closes.
+
+The record contains no raw logs, L1 transcript, citations, tool payloads,
+`HistorySummary`, `L4PolicyOutcome`, token/latency metrics, or final decision.
+Those remain in result and trace artifacts. MVP L3 compares only the
+deterministic block; enriched entries are retained but policy-inactive.
+
+`not_observed` means the relevant marker was absent from a fully scanned,
+readable current-attempt log for which L0 recognized a compatible marker
+dialect; it is not a claim that no unlogged work occurred. `unknown` is required
+when log coverage, marker-dialect applicability, or comparability is
+insufficient. L0A preserves this prerequisite as
+`ProgressFacts.training_progress_dialect_recognized` and
+`checkpoint_progress_dialect_recognized`. `progress_after_failure` additionally
+requires readable source lines after the primary before absence can become
+`not_observed`.
+
+### Prior Attempt View
+
+`PriorAttemptView` is an immutable ordered tuple of `AttemptRecord` objects
+selected from the runtime-owned store for one invocation. It contains exact-job
+records with `cycle_id` less than the current cycle and therefore excludes the
+current and future attempts. It is an internal typed object, not a versioned
+JSON artifact, disk format, or public request field.
+
+### Runtime Attempt Record Control
+
+The internal library control contract is:
+
+```text
+seed(AttemptRecord[], mode=replace|merge) -> status
+records(job_id=None) -> immutable AttemptRecord[]
+clear(job_id=None) -> status
+```
+
+This is an in-memory library/unit-test control surface, not part of
+`restart_agent_request.v1`.
+
+### Manual Attempt Record Fixture
+
+For manual testing, `--attempt-records-json-in` reads a plain JSON array of
+`AttemptRecord` objects and seeds the store before analysis.
+`--attempt-records-json-out` atomically writes the complete post-upsert store as
+the same array shape, ordered by `job_id` and integer `cycle_id`. The output can
+be edited or copied to construct alternate L3/L4 scenarios and then reused as a
+later input fixture.
+
+The fixture has no wrapper, schema-version field, implicit location, or
+automatic lifecycle. It is an explicit test artifact, not a public request
+field, production persistence format, automatic checkpoint, or MCP history
+operation.
+
+The runtime selects prior attempts as:
+
+```text
+get_prior_attempts(job_id, before_cycle_id)
+  -> select exact job_id
+  -> select cycle_id < before_cycle_id
+  -> order by integer cycle_id
+  -> return the configured last N records as PriorAttemptView
+```
+
+`AttemptRecordAssembler` creates the initial deterministic record from L0 and
+produces immutable same-key replacements when L2 adds or replaces one enriched
+entry. Reanalysis of the same `(job_id, cycle_id)` replaces the record and
+starts with an empty enriched list. L3 and L4 never mutate the record.
+
+## L0A Complete Evidence Bundle
+
+**Stage contract**
+
+| Direction | Type | Meaning |
+| --- | --- | --- |
+| Input | validated log path | Current-attempt path selected from `AnalysisExecutionContext`. |
+| Input | `LogSnapshot` | Immutable captured byte boundary, decoding choice, read mode, storage mode, stable line index, and logical-line access for the current log. |
+| Optional input | replayed `L0Bundle` | Reuses a previously built bundle after log-path validation. |
+| Output | `L0Bundle` | Complete immutable structured evidence for this log snapshot. |
+
+`L0Bundle` is immutable structured evidence derived from the complete log. Its
+top-level collections are:
+
+- source identity: `log_path`, `byte_size`, `line_count`;
+- path/access facts and namespace summary;
+- `occurrence_groups`;
+- `context_windows`;
+- `candidate_anchors`;
+- registry matches and cause confirmations;
+- `deterministic_primary_candidate`;
+- cascades, failure episodes, and distributed incidents;
+- post-fault summaries;
+- progress, checkpoint, setup, and run-progress summaries;
+- operation/artifact comparisons;
+- later-progress-after-fault observations;
+- job metadata;
+- evidence coverage, selection/lossiness summary, and anomalies.
+
+The detailed collection semantics are canonical in `L0A.md`. L0A
+does not emit an action.
+
+`LogSnapshot` is an internal source-view contract, not a wire payload.
+Production `storage_mode=indexed_file` retains compact line-start offsets and a
+boundary-limited source handle; `memory` is available for provided snapshots
+and tests. `line()`, `log_lines()`, and `context_before()` have identical
+logical behavior in either mode. Progressive metrics record pending and
+discarded incomplete-tail bytes.
+
+### Failure Evidence
+
+The primary and registry candidate payload shape is:
+
+```json
+{
+  "failure_class": "checkpoint_metadata_decode_error",
+  "signature": "UnicodeDecodeError while decoding metadata",
+  "root_fingerprint": "observed:unicodedecodeerror:checkpoint_metadata",
+  "root_fingerprint_source": "observed_exception",
+  "fault_outcome": "terminal",
+  "causal_role": "initiating",
+  "failure_iteration": null,
+  "data_position_fingerprint": null,
+  "line": 12083,
+  "rank": "4175",
+  "phase": "setup",
+  "node": null,
+  "gpu": null,
+  "affected_entity": {
+    "kind": "artifact",
+    "identity": "/checkpoints/job-1#checkpoint_iteration=622125",
+    "fingerprint": "affected_entity:artifact:...",
+    "evidence_line": 12050
+  }
+}
+```
+
+`failure_class` names the observed failure mechanism; it does not prescribe an
+action. `causal_role` records structural position such as initiating, cascade,
+or teardown. `affected_entity` is optional and identifies an exact grounded
+artifact or data position involved in the failure. L0 derives it from
+deterministic evidence; L2 may derive it from a model-proposed artifact only
+after the path is found in source evidence.
+
+## Decision Evidence
+
+**Stage contract:** `L0Bundle -> DecisionEvidence`.
+
+`DecisionEvidence` is the canonical deterministic subset selected once from
+L0A and shared by deterministic and model branches:
+
+```json
+{
+  "schema_version": "restart_agent_decision_evidence.v1",
+  "deterministic_primary_candidate": {},
+  "canonical_observed_identity": {},
+  "selected_evidence_references": {},
+  "failure_position": {},
+  "progress_checkpoint_state": {},
+  "operation_artifact_facts": [],
+  "later_progress_recovery": {},
+  "locality": {},
+  "coverage_lossiness": {},
+  "provenance": {}
+}
+```
+
+References retain L0A object/line identity. They are provenance-only: an object
+id is resolvable by L1 only when `get_evidence_objects` is advertised for the
+route. Decision Evidence does not inline every raw excerpt and does not choose
+an action.
+
+## L0B Initial Model Evidence View
+
+**Stage contract**
+
+| Direction | Type | Meaning |
+| --- | --- | --- |
+| Input | `L0Bundle` | Complete structured source evidence. |
+| Input | `DecisionEvidence` | Canonical policy-relevant facts and references. |
+| Output | `L0ModelFacingView` | Bounded initial L1 payload plus projection metrics. |
+
+```json
+{
+  "schema_version": "restart_agent_l0_model_view.v1",
+  "decision_evidence": {},
+  "attempt_execution_context": {},
+  "evidence_bundle": {},
+  "projection_metrics": {}
+}
+```
+
+The L1 user message is one machine-readable per-invocation envelope. It carries
+the static generated `response_schema` alongside request-specific
+`decision_evidence`, `attempt_execution_context`, and `evidence_bundle`.
+Transporting the schema in this envelope does not make it dynamic evidence.
+Immutable restart guarantees remain in the static system prompt and are not
+repeated here.
+`attempt_execution_context` contains only current-log scope and terminal timing;
+progress, checkpoint, operation, artifact, and later-progress facts remain
+single-sourced in Decision Evidence. `projection_metrics` remain client trace
+data. L0B is bounded and lossy by design; it must record selection, compaction,
+truncation, size, and estimated-token facts.
+
+The initial conversation trace stores `model_visible_payload`, the exact parsed
+JSON object serialized into the user message. L2 visibility grounding consumes
+that complete payload, plus subsequent tool results. It does not reconstruct a
+smaller approximation from `evidence_bundle` alone.
+
+## L1 Model Evidence Contract
+
+**Stage contract**
+
+| Direction | Type | Meaning |
+| --- | --- | --- |
+| Input | `L1EvidenceContext` | L0B model view plus the read-only tools advertised by the route. |
+| Input | route settings and deadline | Model, endpoint, generation controls, tool policy, and remaining time. |
+| Output | `L1EvidenceResult` | Provider-neutral execution result, transcript, calls, errors, and parsed evidence. |
+| Usable semantic payload | `restart_agent_evidence.v1` | Validated model assessment inside `L1EvidenceResult.evidence`. |
+
+L1 returns exactly one `restart_agent_evidence.v1` JSON object. Required
+top-level fields are:
+
+```json
+{
+  "schema_version": "restart_agent_evidence.v1",
+  "analysis_status": "primary_identified",
+  "primary_failure": {},
+  "root_cause_assessment": {},
+  "model_recovery_assessment": {},
+  "related_failures": [],
+  "evidence": []
+}
+```
+
+`analysis_status` is `primary_identified`, `no_failure_observed`, or
+`insufficient_evidence`. `primary_failure` is null unless a primary was
+identified.
+
+The model-visible `response_schema` and client validator are generated from the
+same `L1ResponseContract`. It owns closed field sets, required fields, enums,
+array limits, confidence bounds, evidence support tags, and non-primary
+semantics. A contract change must therefore update one executable source and
+its tests rather than separate prompt and parser descriptions.
+
+An L1 result is **usable** when the route completes before the whole-analysis
+deadline without provider timeout or output truncation, the extractor reports
+success with a parsed evidence object, and that object passes
+`L1ResponseContract`. Provider retries, earlier failed HTTP attempts, or
+unsupported tool requests may make an otherwise usable route `degraded`; they
+do not erase its valid semantic payload. L2 advisory findings likewise do not
+make L1 unusable. Provider timeout, truncation, missing/unparseable output, or a
+contract-invalid object is unusable and leaves the deterministic branch
+authoritative.
+
+Non-primary results use canonical, deliberately uninformative values:
+
+| Status | Primary | Root cause | Missing evidence | Recovery claims | Related/evidence |
+| --- | --- | --- | --- | --- | --- |
+| `no_failure_observed` | `null` | `No failure was observed in the supplied evidence.`; `unknown`; no plausible causes | empty | `unknown` value/status, confidence `1`; canonical no-failure rationale | empty |
+| `insufficient_evidence` | `null` | `Insufficient evidence to identify a primary failure.`; `unknown`; no plausible causes | one or more gaps | `unknown` value/status, confidence `1`; canonical insufficient-evidence rationale | empty |
+
+This prevents a non-primary response from smuggling an unauditable semantic or
+policy conclusion through fields that look authoritative.
+
+### L1 Primary Failure
+
+```json
+{
+  "line": 12083,
+  "causal_role": "initiating",
+  "failure_identity": {
+    "operation": "checkpoint_load",
+    "mechanism": "metadata_deserialization",
+    "component": "torch_distributed_checkpoint",
+    "artifact_path": "/path/from/log/or/null"
+  }
+}
+```
+
+Required `causal_role` values are `initiating`, `cascade`, `teardown`, or
+`unknown`. The nested L1 `failure_identity` contains semantic claims used during
+grounding; it is not a history identity and is not copied into the product
+result. L0/L2 derive `failure_class`, signature, fault outcome, locality,
+`root_fingerprint`, and optional `affected_entity` from grounded client
+evidence.
+
+### Root-Cause Assessment
+
+```json
+{
+  "summary": "Checkpoint metadata could not be decoded.",
+  "status": "supported_but_unconfirmed",
+  "plausible_causes": ["corrupt metadata", "transient read corruption"],
+  "missing_evidence": ["same offset failure on another attempt"]
+}
+```
+
+`status` is one of `established_by_current_log`,
+`supported_but_unconfirmed`, `hypothesis_only`, or `unknown`.
+
+### Model Recovery Assessment
+
+```json
+{
+  "failure_domain": {
+    "value": "workload",
+    "status": "supported_but_unconfirmed",
+    "confidence": 74
+  },
+  "retry_outlook_without_workload_change": {
+    "value": "unknown",
+    "status": "unknown",
+    "confidence": 68
+  },
+  "rationale": "One failed read cannot distinguish persistent corruption from a transient read failure."
+}
+```
+
+Allowed values:
+
+| Field | Values |
+| --- | --- |
+| `failure_domain.value` | `workload`, `infrastructure`, `unknown` |
+| `retry_outlook_without_workload_change.value` | `cannot_recover`, `may_recover`, `unknown` |
+| either claim's `status` | `established_by_current_log`, `supported_but_unconfirmed`, `hypothesis_only`, `unknown` |
+| either claim's `confidence` | integer `1..99` |
+
+This object contains no action, user/not-user score, retry count, or history
+assessment. Each claim has its own evidence status and confidence. Confidence
+is retained for corpus calibration and is not an L4 threshold.
+
+### Related Failure And Evidence Items
+
+Related failures contain exactly:
+
+```json
+{
+  "line": 12135,
+  "causal_role": "cascade",
+  "rationale": "Wrapper exception after the checkpoint decode failure."
+}
+```
+
+These are diagnostic source references describing cascade, teardown, or unknown
+relationships to the selected primary. Their line must be visible to the model.
+They are not additional policy-claim citations and do not substitute for the
+canonical `evidence` array.
+
+Evidence entries contain:
+
+```json
+{
+  "id": "e1",
+  "line": 12083,
+  "quote": "UnicodeDecodeError: ...",
+  "supports": [
+    "primary_failure",
+    "root_cause_assessment",
+    "failure_domain",
+    "retry_outlook_without_workload_change"
+  ]
+}
+```
+
+The model may cite only line/quote text visible in L0B or returned by advertised
+tools. A line number present only as provenance does not authorize a model-made
+quote, even when that quote happens to match the source log. L2 may correct a
+nearby line-number error only when the quoted text was visible at the resolved
+line. Evidence IDs are unique and `supports` uses only the four closed claim tags
+shown above. This array is the canonical citation source; the contract has no
+second supporting-line list. The tags identify which claim a citation supports;
+they do not encode claim strength or policy. L2 records unavailable or
+ungrounded citations.
+
+## L2 Result
+
+**Stage contract**
+
+`L2GroundingInput` is an immutable aggregate rather than a wire payload:
+
+| Direction | Field | Type | Meaning |
+| --- | --- | --- | --- |
+| Input | `bundle` | `L0Bundle` | Complete structured evidence used to resolve source facts. |
+| Input | `model_view` | `L0ModelFacingView` | Exact initial model-visible evidence and Decision Evidence. |
+| Input | `l1_result` | `L1EvidenceResult` | Raw and parsed L1 output, transcript, and tool results. |
+| Input | `source_log` | `LogSnapshot` | Immutable source used for citation and line grounding. |
+| Output | - | `L2Result` | Grounded L1 semantics, enriched `AttemptFailureFacts`, and non-overriding audit diagnostics. |
+
+L2 emits a typed result and a trace payload:
+
+```json
+{
+  "used": true,
+  "grounding_status": "grounded",
+  "grounding_method": "exact_source_line",
+  "audit_status": "clean",
+  "primary_used": true,
+  "enriched_failure_facts": {},
+  "recovery_assessment_used": true,
+  "recovery_assessment_policy_grounded": true,
+  "root_cause_assessment": {},
+  "model_recovery_assessment": {},
+  "field_findings": {},
+  "field_finding_codes": {},
+  "findings": [],
+  "citation_audits": [],
+  "grounding_adjustments": [],
+  "recovery_field_audits": []
+}
+```
+
+Grounding status is `grounded`, `unavailable`, or `not_run`. Audit status is
+`clean`, `resolved`, `findings`, or `not_run`. Recovery-field audits are
+non-overriding and include `applied=false` when suggesting another
+interpretation. `recovery_assessment_policy_grounded` is the mechanical
+eligibility bit that lets L4 use L1 claims for a rule narrower than
+`general_retry`: the primary plus domain and retry-outlook support must resolve
+to source evidence, and root-cause status must be
+`established_by_current_log` or `supported_but_unconfirmed`. `L4.md` then
+applies the distinct status/value predicates for `workload_unrecoverable` and
+`bounded_retry`.
+
+L2 visibility is evaluated against the exact full `model_visible_payload`
+recorded for the initial request and every returned tool payload. A source line
+present in Decision Evidence or another initial-payload
+section is therefore visible even when it is absent from the compact
+`evidence_bundle` subsection. Canonical evidence requires visible line/quote
+text; exact source-log content that the model never saw is not grounded support.
+A related-failure line outside the line-reference visibility set is retained in
+raw L1 trace but omitted from L2's audited related-failure view.
+
+## L2 Enriched Attempt Facts
+
+L0 supplies `AttemptRecord.deterministic`; each usable L2 route supplies one
+entry with the same `AttemptFailureFacts` shape for
+`AttemptRecord.enriched`. The runtime assembler applies both updates:
+
+```json
+{
+  "route_id": "gpt",
+  "facts": {
+    "source": "l2_grounded",
+    "root_fingerprint": "observed:unicodedecodeerror:checkpoint_metadata",
+    "root_fingerprint_source": "observed_exception",
+    "fault_outcome": "terminal",
+    "primary_line": 12083,
+    "identity_anchor_line": 12083,
+    "identity_anchor_reason": "canonical_episode_terminal",
+    "failure_iteration": null,
+    "affected_entity": {
+      "kind": "artifact",
+      "identity": "/path/to/checkpoint",
+      "fingerprint": "affected_entity:artifact:7f28...",
+      "evidence_line": 12083
+    },
+    "faulting_rank": "4175",
+    "faulting_node": null,
+    "faulting_gpu": null,
+    "rank_to_gpu_map": {}
+  }
+}
+```
+
+The route entry does not duplicate shared progress. It is inserted only while
+the invocation remains open. L2 audit output remains separate and is not copied
+into the compact attempt record.
+
+## L3 History Summary
+
+**Stage contract**
+
+| Direction | Field | Type | Meaning |
+| --- | --- | --- | --- |
+| Input | `current_record` | `AttemptRecord` | Current attempt with shared progress and deterministic/enriched fact blocks. |
+| Input | `fact_selector` | deterministic or enriched `route_id` | Chooses the current facts evaluated by this branch. |
+| Input | `prior_attempts` | `PriorAttemptView` | Runtime-selected bounded exact-job earlier records. |
+| Output | - | `HistorySummary` | Deterministic recurrence, locality, and observed-progress comparisons. |
+
+These input fields are carried together as immutable
+`HistoryEvaluationInput`. L3 receives no raw log, L1 transcript, model
+confidence, or retry policy. MVP prior comparison always reads each prior
+record's deterministic block even when enriched entries are present.
+
+```json
+{
+  "available": true,
+  "availability_reason": "ready",
+  "same_job_attempts": 2,
+  "matching_root_attempts": 1,
+  "comparisons": [
+    {
+      "prior_cycle_id": 1,
+      "selected_basis": "completed_step_and_checkpoint_step",
+      "dimension_comparisons": [
+        {
+          "dimension": "completed_step",
+          "prior_observation_status": "observed",
+          "current_observation_status": "observed",
+          "prior_value": 418,
+          "current_value": 418,
+          "delta": 0,
+          "relation": "same"
+        },
+        {
+          "dimension": "checkpoint_step",
+          "prior_observation_status": "observed",
+          "current_observation_status": "observed",
+          "prior_value": 400,
+          "current_value": 400,
+          "delta": 0,
+          "relation": "same"
+        }
+      ],
+      "positive_progress_conflict": false,
+      "relation": "same",
+      "prior_attempt_progress": {
+        "training_progress": "observed",
+        "progress_marker_count": 42,
+        "checkpoint_progress": "observed",
+        "failure_position": "after_observed_training_progress"
+      },
+      "prior_fault_outcome": "terminal",
+      "same_failure_iteration": true,
+      "same_rank": false,
+      "affected_entity_relation": "same"
+    }
+  ],
+  "observed_advance_attempts": 0,
+  "same_progress_attempts": 1,
+  "regressed_progress_attempts": 0,
+  "unknown_progress_attempts": 0,
+  "no_observed_advance_attempts": 1,
+  "matching_root_attempts_with_observed_training_progress": 1,
+  "matching_root_attempts_before_observed_training_progress": 0,
+  "matching_root_attempts_with_unknown_training_progress": 0,
+  "exact_failure_position_attempts": 1,
+  "same_rank_iteration_attempts": 0,
+  "same_entity_attempts": 1,
+  "different_entity_attempts": 0,
+  "unknown_entity_attempts": 0,
+  "consecutive_same_root_no_advance_attempts": 1,
+  "consecutive_same_root_and_entity_no_advance_attempts": 1,
+  "advanced_beyond_all_comparable_attempts": false,
+  "advanced_beyond_all_same_entity_comparable_attempts": false,
+  "cross_node_recurrence": false,
+  "same_node_recurrence": false,
+  "same_gpu_recurrence": false,
+  "same_rank_only_recurrence": false,
+  "rank_to_gpu_mapping_available": false
+}
+```
+
+`HistorySummary` preserves both relative progress (`advanced`, `same`,
+`regressed`, or `unknown`) and each comparable attempt's absolute progress
+summary. Relative progress answers whether the current attempt advanced beyond
+an earlier one. Absolute progress answers whether that earlier attempt failed
+before training progress or after doing observable work. L3 reports both and
+does not decide how much progress changes the retry policy. Entity relation is
+reported independently as `same`, `different`, or `unknown`, and L3 exposes
+both root-only and root-plus-entity aggregates.
+
+The two consecutive fields are independent observations, not alternate views
+selected by L3:
+
+- `consecutive_same_root_no_advance_attempts` continues across entity changes;
+- `consecutive_same_root_and_entity_no_advance_attempts` requires exact entity
+  kind and fingerprint equality at every newest-first step.
+
+A different or unknown entity stops only the second count. Root mismatch,
+nonqualifying prior outcome, observed advance, or unknown progress stops both
+as applicable. The current failure is not included in either prior-attempt
+count.
+
+`available=true` means history lookup was eligible and completed, including when
+the selected view contains zero prior records; its `availability_reason` is
+`ready`. `available=false` means lookup was disabled or identity was incomplete;
+its reason is one of `history_disabled`, `missing_job_id`, `missing_cycle_id`,
+or `missing_root_fingerprint`. Current/future-cycle filtering and its counts
+belong to the runtime-history trace because the view supplied to L3 already
+contains only prior records.
+
+Each dimension relation is `advanced`, `same`, `regressed`, or `unknown`.
+`selected_basis` records whether L3 used completed steps, checkpoint-save steps,
+both positive-progress dimensions, or fallback failure position. If completed
+step and checkpoint directions conflict, `positive_progress_conflict=true` and
+the overall relation is `unknown`; the dimension results remain visible. L3
+reports facts and does not report `STOP`, `RESTART`, or budget exhaustion.
+
+### Multi-Attempt Comparison Example
+
+For current cycle 4 with root `R` and completed step 100, L3 compares cycle 4
+directly with every earlier same-root record. It does not build an adjacent
+trajectory such as 4-to-3, then 3-to-2:
+
+| Prior cycle | Root | Outcome | Completed step | Current-to-prior relation | Policy-qualifying |
+| ---: | --- | --- | ---: | --- | --- |
+| 1 | `R` | `terminal` | 80 | `advanced` | yes |
+| 2 | `R` | `progressed_after` | 90 | `advanced` | no |
+| 3 | `R` | `terminal` | 100 | `same` | yes |
+
+This produces `matching_root_attempts=3`, but retry accounting considers only
+cycles 1 and 3 because `progressed_after` is not a terminal/unresolved prior
+failure. The contiguous newest-to-oldest count is
+`consecutive_same_root_no_advance_attempts=1`: cycle 3 is the same, then cycle
+2 stops the scan because its outcome is nonqualifying. Counts describing the
+shape of all matching history and counts consumed by policy are therefore
+deliberately different.
+
+## L4 Retry Policy Evaluation
+
+**Stage contract**
+
+| Direction | Field | Type | Meaning |
+| --- | --- | --- | --- |
+| Input | `primary` | `FailureEvidence` or null | Current primary selected from L0 deterministic or grounded L2 evidence. |
+| Input | `history` | `HistorySummary` | L3 facts; L4 does not recompute history. |
+| Input | `current_affected_entity` | `AffectedEntity` or null | Selected branch's exact-object identity; L4 does not derive it. |
+| Input | `model_recovery_assessment` | `ModelRecoveryAssessment` or null | Grounded L1 domain and unchanged-workload retry outlook. |
+| Input | `assessment_grounded` | Boolean | Whether L2 established policy-eligible support. |
+| Input | `retry_policy` | `RetryPolicyConfig` | Effective confirmation, bounded, and general retry counts. |
+| Input | `declared_recovery_capabilities` | tuple of `DeclaredRecoveryCapability` | Trusted configured recovery behaviors matched only in L4. |
+| Output | `primary` | `FailureEvidence` or null | Primary propagated into response assembly. |
+| Output | `retry_policy` | `RetryPolicyEvaluation` | Deterministic decision, basis, selected rule, and concurrent ledger accounting. |
+
+The inputs are carried as `L4PolicyInput`; the outputs are carried as
+`L4PolicyOutcome`.
+
+`matching_prior_failures` counts prior matching attempts only. The total
+matching occurrences observed at the current decision are
+`matching_prior_failures + 1`.
+
+```json
+{
+  "policy_version": "retry_budget.v1",
+  "rule": "workload_managed_recovery",
+  "decision": "RESTART",
+  "decision_basis": "workload_managed_recovery_available",
+  "retry_budget_exhausted": false,
+  "exhausted_by": [],
+  "general_root_ceiling": {
+    "ledger_id": "general_root_ceiling",
+    "applicable": true,
+    "rule": "general_retry",
+    "history_match_scope": "root_only",
+    "allowed_retries": 3,
+    "matching_prior_failures": 1,
+    "observed_advance": false,
+    "exhausted": false,
+    "inapplicable_reason": null
+  },
+  "selected_rule_budget": {
+    "ledger_id": "selected_rule_budget",
+    "applicable": true,
+    "rule": "workload_managed_recovery",
+    "history_match_scope": "root_and_entity",
+    "allowed_retries": 2,
+    "matching_prior_failures": 1,
+    "observed_advance": false,
+    "exhausted": false,
+    "inapplicable_reason": null
+  },
+  "failure_domain": "workload",
+  "failure_domain_status": "supported_but_unconfirmed",
+  "failure_domain_confidence": 74,
+  "retry_outlook_without_workload_change": "may_recover",
+  "retry_outlook_status": "supported_but_unconfirmed",
+  "retry_outlook_confidence": 68,
+  "recovery_assessment_policy_grounded": true,
+  "current_evidence_qualified": false,
+  "current_affected_entity": {
+    "kind": "data_position",
+    "identity": "token:42",
+    "fingerprint": "affected_entity:data_position:3d97...",
+    "evidence_line": 1012
+  },
+  "declared_recovery_capability_ids": [
+    "bad_token_retry_then_skip"
+  ],
+  "applied_recovery_capability": {
+    "capability_id": "bad_token_retry_then_skip",
+    "behavior": "retry_then_skip",
+    "applies_to": ["bad_token_or_window"],
+    "required_entity_kind": "data_position",
+    "history_match_scope": "root_and_entity",
+    "allowed_retries": 2
+  },
+  "match_requirements": {
+    "job_id": "exact",
+    "root_fingerprint": "exact",
+    "affected_entity": "exact",
+    "progress": "no_observed_advance"
+  }
+}
+```
+
+`general_root_ceiling` is present for every history-eligible primary and always
+uses `consecutive_same_root_no_advance_attempts`. It is inapplicable for
+missing-primary and immediate `workload_unrecoverable` outcomes. A
+missing-primary result has `rule=null`, `decision=RESTART`, and
+`decision_basis=no_primary_failure`; it is a degraded-analysis result rather
+than a retry rule.
+
+`selected_rule_budget` is nullable. It is present only when the selected rule
+declares a budget narrower than the general ceiling. Its
+`history_match_scope` selects the corresponding L3 count:
+
+- `root_only` uses `consecutive_same_root_no_advance_attempts`;
+- `root_and_entity` uses
+  `consecutive_same_root_and_entity_no_advance_attempts`.
+
+`retry_budget_exhausted` is the aggregate of both ledgers. `exhausted_by`
+contains zero or more of `general_root_ceiling` and `selected_rule_budget`; both
+may be present. An immediate `workload_unrecoverable` STOP has
+`retry_budget_exhausted=false` and is identified by `decision_basis`. For MVP,
+a selected-rule `allowed_retries` value must not exceed the configured general
+ceiling.
+
+Each ledger is a `RetryLedgerEvaluation` with the exact fields shown above.
+`inapplicable_reason` is null when active; otherwise it is one of
+`missing_primary`, `immediate_unrecoverable`,
+`rule_has_no_narrower_budget`, or `history_unavailable`.
+
+Allowed non-null rules are `workload_managed_recovery`,
+`workload_unrecoverable`, `confirmation_retry`, `bounded_retry`, and
+`general_retry`. See `L4.md` for selection and action semantics.
+
+## Public Analysis Response
+
+**Boundary contract**
+
+| Direction | Type | Meaning |
+| --- | --- | --- |
+| Input | L0-L4 outputs and execution health | Stage results selected by the deterministic or enriched branch. |
+| Output | `AnalysisResult` | Typed public result assembled by the client. |
+| Wire output | `restart_agent_response.v1` | Exact serialized caller-visible response. |
+
+`restart_agent_response.v1`:
+
+```json
+{
+  "schema_version": "restart_agent_response.v1",
+  "decision": "RESTART",
+  "decision_basis": "general_retry_available",
+  "retry_policy": {},
+  "failure_domain": "unknown",
+  "result_provenance": {},
+  "primary_failure": {},
+  "root_cause_assessment": {},
+  "model_recovery_assessment": {},
+  "secondary_failures": [],
+  "cascades": [],
+  "evidence_coverage": {},
+  "evidence": [],
+  "justification": "..."
+}
+```
+
+Required top-level fields are `schema_version`, `decision`, `decision_basis`,
+`retry_policy`, `failure_domain`, `result_provenance`, `primary_failure`,
+`root_cause_assessment`, `model_recovery_assessment`, `secondary_failures`,
+`cascades`, `evidence_coverage`, `evidence`, and `justification`. Nullable
+semantic fields remain present with `null` when unavailable.
+
+`cascades` is the public downstream-effect collection. Every entry preserves
+whether the effect is an ordinary cascade or teardown:
+
+```json
+{
+  "failure_class": "observed_exception",
+  "cascade_fingerprint": "teardown_cleanup:filenotfounderror",
+  "causal_role": "teardown",
+  "first_line": 12135,
+  "last_line": 12135,
+  "count": 1,
+  "sample_lines": [12135],
+  "rank_spread": ["4175"],
+  "node_spread": [],
+  "gpu_spread": [],
+  "reason": "appears after primary candidate at line 12083",
+  "relationship_rationales": [
+    "Finalizer cleanup occurred after the checkpoint-load failure."
+  ]
+}
+```
+
+L0 owns structural `cascade` and `teardown` roles. When L2 grounds an L1
+related-failure rationale for the same event, the rationale annotates the
+deterministic group. A grounded L1-only downstream event is retained as a
+single-entry group. Downstream events do not remain in `secondary_failures`.
+
+### Result Provenance
+
+The compact result provenance includes:
+
+- `candidate_kind`: `deterministic` or `l1_enriched`;
+- `evidence_source`;
+- `model_contribution`;
+- `history_contribution`;
+- `result_quality`: `normal`, `degraded`, or `unusable`;
+- `nvrx_use`: `eligible`, `eligible_degraded`, or
+  `fallback_to_nvrx_default`;
+- L1 execution status/issues;
+- concise notes.
+
+`result_quality` measures result usability, not failure ownership.
+
+### Deterministic And Degraded Results
+
+| Condition | Decision / basis | Primary | Quality |
+| --- | --- | --- | --- |
+| Accepted path unavailable or empty | `RESTART / log_unavailable` | null | `unusable` |
+| Provider timeout/truncation with L0 primary | Deterministic L4 result | L0 candidate | normally `degraded` |
+| Malformed L1 and no L0 primary | `RESTART / malformed_model_output` | null | `unusable` |
+| L1 pending | Published deterministic L0/L3/L4 candidate | L0 candidate or null | normally `degraded` |
+
+## Collect-All Result
+
+`RestartAgent.run_many().result`
+returns:
+
+```json
+{
+  "schema_version": "restart_agent_collect_all.v1",
+  "deterministic_result": {},
+  "model_results": [
+    {
+      "route_id": "qwen_fast",
+      "model": "nvidia/qwen/eccn-qwen-235b",
+      "endpoint": "https://inference-api.nvidia.com/v1",
+      "credential_ref": "LLM_API_KEY_FILE",
+      "execution_status": "completed",
+      "l1_usable": true,
+      "analysis_result": {},
+      "error": null
+    }
+  ],
+  "shared_analysis": {}
+}
+```
+
+All routes receive the same immutable L0A, Decision Evidence, L0B, public
+request, `PriorAttemptView`, and deadline. Results are independent; collect-all
+does not vote, merge, or select a winner.
+
+`analysis_result` is the route's final product response after L2, L3, and L4;
+it is not the raw L1 model answer. The exact raw/parsed model response and tool
+conversation remain in that route's trace/transcript.
+
+## Product Configuration
+
+Product configuration uses `restart_agent_config.v1`.
+`CONFIGURATION.md` owns its complete field catalog, defaults, constraints,
+inheritance, credential handling, and fingerprint semantics. The maintained
+example is `examples/attribution/restart_agent.json`.
+
+Configuration is supplied independently from `restart_agent_request.v1` and
+attempt history. Parsing emits immutable route/runtime settings plus a
+credential-free `effective_config` and stable `config_fingerprint`; those
+identity fields are recorded in results and traces.
+
+## Trace Contract
+
+The detailed trace is local/out-of-band from the compact public result. It must
+preserve raw stage behavior before downstream interpretation.
+
+| Layer | Required trace content |
+| --- | --- |
+| Runtime attempt records | Availability/reason, configured per-job and total bounds, records before/after, eviction, deterministic creation, route-keyed enriched updates, same-key generation/replacement, close/timeout state, rejected late updates, and operation timing. |
+| Progressive service | State transitions, generation, poll/growth counts, source identity and offsets, bytes ingested/reread, malformed-byte replacements, resets/eviction, drain outcome, terminal-to-L0A/deterministic/route/completion timing, finalized L0A hash, pre-end work, and terminal-degradation reason. |
+| L0A | Bundle schema, source size, source decode time, source index/classification time, canonical reduction time, coverage/lossiness, primary, and fingerprint provenance. |
+| Decision Evidence | Selection timing, deterministic primary, canonical identity, references, and shared-object provenance. |
+| L0B | View schema, projection timing, selected/compacted/truncated counts, characters, estimated tokens, and payload hash. |
+| L1 | Exact credential-free requests, prompts/messages, advertised tools, raw and parsed responses, model/tool calls, retries, provider errors, finish reasons, token usage, and timing. |
+| L2 | Grounding status/method, citation audits, adjustments, findings, recovery-field audits, enriched identity, and timing. |
+| L3 | Current facts source, history input summary, per-attempt comparisons, aggregates, and timing. |
+| L4 | Full `retry_policy` evaluation, result provenance, decision/basis, and timing. |
+
+The trace also records candidate readiness, analysis timeout, deterministic publication,
+the candidate used by each result, route-selection state when applicable, and
+anomalies. A debug/summary stream is optional and must not duplicate the
+reconstructable trace.
+
+## Incremental Collect-All Artifacts
+
+The CLI may publish the following canonical stage-complete L0 files before
+model routes finish:
+
+```text
+--l0-bundle-json-out          -> l0_bundle.json
+--decision-evidence-json-out -> decision_evidence.json
+--l0-model-view-json-out     -> l0_model_view.json
+```
+
+The first file is the replay envelope described by
+`restart_agent_l0_bundle.v1`; the other two are the exact
+`DecisionEvidence.to_payload()` and `L0ModelFacingView.to_payload()` objects.
+All use same-directory temporary files and atomic replacement. They are absent
+until complete, then immutable for the invocation.
+
+The caller may declare final per-route paths with
+`--route-artifact-manifest`:
+
+```json
+{
+  "schema_version": "restart_agent_route_artifacts.v1",
+  "routes": {
+    "qwen-fast": {
+      "result_json": "model.qwen-fast.result.json",
+      "trace_json": "model.qwen-fast.trace.json"
+    }
+  }
+}
+```
+
+Relative paths resolve from the manifest directory. Route IDs MUST exactly
+match the configured routes. On route completion the CLI writes the complete
+`restart_agent_cli_trace.v1` trace first and the `AnalysisResult` second. The
+result file is the route commit marker: if it exists, its trace is already
+durable. `--deterministic-json-out`, `--trace-json`, and `--result-json` similarly
+select canonical deterministic-recommendation and final batch paths. The final batch
+trace is written before its result.
+
+When the CLI receives `--incremental-artifact-dir`, it publishes only this
+local lifecycle projection while `collect_all` is running:
+
+```text
+<dir>/run_status.json
+<dir>/events.jsonl
+```
+
+`run_status.json` uses `restart_agent_live_status.v1` and is a complete atomic
+snapshot. `events.jsonl` is append-only; every line is a complete
+`restart_agent_live_event.v1` object with a sequence number, UTC timestamp, and
+elapsed time. Its `l0.status` is `pending`, `ready`, or `not_published`; a
+`l0_artifacts_ready` event includes stage timings and canonical artifact paths.
+The event stream reports canonical L0, deterministic recommendation, per-route, and
+final batch paths as they become ready. The deterministic recommendation uses
+`restart_agent_deterministic_recommendation.v1`. A route trace carries the normalized
+public request, its complete analyzer trace, and shared L0, so a downstream
+harness can review the route before the final batch trace exists.
+
+Lifecycle artifacts are observational. They do not replace the canonical batch
+result/trace, select a route, or modify an analysis result. Canonical JSON files
+and status snapshots use temporary files plus atomic replacement. Readers see
+each completed artifact as it becomes ready, never a partially serialized JSON
+object. `events.jsonl` is the intentionally append-as-you-go interface.
+
+## Progressive Service Shape
+
+Attrsvc's implemented first-cut `POST /logs` request is:
+
+```json
+{
+  "log_path": "/logs/job-123/train_cycle2.log",
+  "user": "alice",
+  "job_id": "job-123",
+  "cycle_id": 2,
+  "analysis_intent": "progressive"
+}
+```
+
+`cycle_id` is an optional strict integer. When absent, the direct Restart Agent
+backend infers it from `_cycle<N>.log`; an explicit value takes precedence.
+`analysis_intent` is `track_only`, `progressive`, or `terminal`. Repeating the
+same normalized path is idempotent when its resolved attempt identity is
+unchanged.
+
+The target progressive implementation adds service-local settings. They do not
+belong to `restart_agent_config.v1` because attrsvc owns polling and result
+retention.
+
+| Attrsvc setting | Default | Validation |
+| --- | ---: | --- |
+| `NVRX_ATTRSVC_RESTART_AGENT_PROGRESSIVE_ENABLED` | `false` | boolean |
+| `NVRX_ATTRSVC_RESTART_AGENT_PRE_END_POLL_SECONDS` | `180` | finite and greater than zero |
+| `NVRX_ATTRSVC_RESTART_AGENT_ACTIVE_IDLE_SECONDS` | `900` | finite and at least the poll interval |
+| `NVRX_ATTRSVC_RESTART_AGENT_MAX_ACTIVE_STATES` | `64` | positive integer |
+| `NVRX_ATTRSVC_RESTART_AGENT_MAX_COMPLETED_RESULTS` | `3000` | positive integer |
+
+The existing terminal-drain settings remain
+`NVRX_ATTRSVC_RESTART_AGENT_LOG_POLL_SECONDS`,
+`NVRX_ATTRSVC_RESTART_AGENT_LOG_QUIET_SECONDS`, and
+`NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS`, with defaults of `0.25`, `2`,
+and `20` seconds respectively.
+
+The progressive implementation introduces two internal typed contracts:
+
+| Contract | Required content |
+| --- | --- |
+| `ProgressiveL0State` | Phase, source identity/boundary, read mode/chunk size, decoding choice, decoded-line and pending-tail counts, read offset, poll/chunk/growth/reset/replay/build counters, precompute timing, last activity, and last error. |
+| `FinalizedL0A` | Canonical `L0Bundle`, `DecisionEvidence`, immutable indexed source `LogSnapshot`, source identity/byte/line boundary, canonical hash, and separate operational timings. |
+
+These objects are not public wire schemas. `RestartAgentRuntime` accepts
+`FinalizedL0A` directly; L0B and model tools must honor its immutable source
+boundary.
+
+`GET /logs?wait=false` returns `pending`, `in_flight`, `completed`, or `failed`
+without starting or awaiting analysis. The response retains top-level
+`status`, `result`, `wl_restart`, and `recommendation`; the full
+`restart_agent_response.v1` payload is under `result` once available.
+`ATTRSVC_INTEGRATION.md` owns this implemented HTTP lifecycle.
+`PROGRESSIVE.md` owns the service sequence, L0 precompute state, finalization,
+and late-result behavior.
+
+## Eval Boundary
+
+`EVALUATION.md` owns the product/harness boundary. This file defines only the
+product artifacts and measurements consumed by evaluation; harness gold,
+scores, panel reports, and aggregate schemas are not repeated here.

--- a/docs/design/attribution/restart_agent/STATUS.md
+++ b/docs/design/attribution/restart_agent/STATUS.md
@@ -1,0 +1,50 @@
+# Restart Agent Status
+
+This document is descriptive. Normative behavior remains in `DESIGN.md` and the
+canonical focused specifications that it indexes.
+
+## Current Maturity
+
+The terminal analyzer is a feasibility implementation with complete stage
+tracing and deterministic replay support. It is not production-qualified.
+Exploratory one-log runs show that structured evidence, semantic recovery
+assessment, minimal grounding, history comparison, and deterministic policy can
+produce useful decisions. The current gold corpus is intentionally small and
+cannot establish fleet-wide accuracy or false-STOP safety.
+
+## Current Scope
+
+- Terminal-first L0A-L4 analysis over one byte-chunk ingestion, incremental
+  decoding, and observation-index path, with typed evidence, deterministic
+  recommendation, bounded same-job history, and deterministic retry policy.
+  Parallel model enrichment is implemented and enabled by default. Progressive
+  pre-end L0A polling remains implemented and disabled by default.
+- Library and CLI execution with history seed, inspection, and export controls.
+- Direct attrsvc integration for progressive registration and L0A
+  precomputation, terminal drain/finalization, background enrichment, and
+  nonblocking result probes.
+- File-backed finalized source access with compact line offsets, incremental
+  terminal drain, one canonical final reduction, compact attrsvc retention, and
+  a 240-second default enrichment timeout.
+- Per-stage results, provenance, timing, model/tool activity, endpoint events,
+  and token usage in result and trace artifacts.
+
+## Production Qualification Gates
+
+1. Expand and review a representative gold corpus before adding narrow
+   signatures or action rules.
+2. Measure L0A/L0B quality, semantic accuracy, model behavior, endpoint
+   reliability, fingerprint false merges/splits, policy accuracy, and repeated
+   decision stability.
+3. Qualify model-route configurations and regulated inference routing.
+4. Measure terminal log-drain/L0A and end-to-candidate latency at target scale.
+   Qualify progressive precompute only if those measurements justify enabling
+   it.
+5. Run shadow-mode STOP validation before production action authority.
+
+## Deferred Scope
+
+- Restart-surviving or distributed history and attrsvc history hydration.
+- Route arbitration, verifier models, and a Restart Agent MCP transport.
+- Structured runtime signals, isolation recommendations, and provider-capacity
+  control.

--- a/docs/design/attribution/restart_agent/TAXONOMY.md
+++ b/docs/design/attribution/restart_agent/TAXONOMY.md
@@ -1,0 +1,112 @@
+# Failure Vocabulary
+
+Restart Agent labels describe different aspects of a failure. They are not
+interchangeable, and no single label directly determines `STOP` or `RESTART`.
+This document is the canonical glossary for those distinctions. Exact field
+shapes live in `SCHEMA.md`; stage behavior lives in `L0A.md` through `L4.md`.
+
+## Vocabulary Map
+
+| Stage | Vocabulary | Question answered | Example |
+| --- | --- | --- | --- |
+| L0A | Registry role | How may a deterministic match contribute to evidence? | `root_candidate`, `cascade_candidate`, `cause_confirmation` |
+| L0A/L1 | Causal role | Where does an event sit in the observed failure chain? | `initiating`, `cascade`, `teardown`, `unknown` |
+| L0A/L2 | Failure class | What stable mechanism was observed by the client? | `observed_exception`, `cuda_oom`, `nccl_cascade` |
+| L1 | Failure identity | What operation, mechanism, component, and artifact does the model infer? | checkpoint load, metadata deserialization, checkpoint component, exact path |
+| L1 | Root-cause status | How strongly does the current log support the explanation? | `supported_but_unconfirmed` |
+| L1 | Failure domain | Where does the failure originate? | `workload`, `infrastructure`, `unknown` |
+| L1 | Retry outlook | Can the next cycle recover without changing workload code, data, or configuration? | `cannot_recover`, `may_recover`, `unknown` |
+| L2 | History identity | Which stable root and optional affected entity may be compared across cycles? | exception fingerprint plus checkpoint path |
+| L3 | Recurrence and progress | Has the same root recurred, and did the job advance between occurrences? | same root and artifact, checkpoint step advanced |
+| L4 | Retry rule and action | Which rule applies, and are the general ceiling or a narrower selected-rule budget exhausted? | `general_retry` leading to `RESTART` |
+
+## Structural Roles
+
+### Registry Role
+
+Registry roles are deterministic candidate-selection hints:
+
+| Value | Meaning |
+| --- | --- |
+| `root_candidate` | May initiate a failure episode. |
+| `cascade_candidate` | Usually follows another failure and should be checked against earlier evidence. |
+| `cause_confirmation` | Corroborates a cause but need not be the first observed symptom. |
+| `either` | Requires surrounding chronology to determine its role. |
+
+A registry match is observed structure, not semantic root cause or policy.
+`PATTERN_REGISTRY.md` owns the executable detectors and emitted failure classes.
+
+### Causal Role
+
+| Value | Meaning |
+| --- | --- |
+| `initiating` | Best-supported start of the selected failure chain. |
+| `cascade` | Downstream consequence of an earlier failure. |
+| `teardown` | Shutdown or cleanup activity after failure. |
+| `unknown` | The available evidence cannot establish the relationship. |
+
+Diagnostic advice, such as CUDA asynchronous-reporting warnings or debugging
+suggestions, remains visible as context but is not a failure anchor.
+
+## Semantic Assessment
+
+L1 produces two independent recovery claims:
+
+| Claim | Values | Meaning |
+| --- | --- | --- |
+| `failure_domain` | `workload`, `infrastructure`, `unknown` | Where the failure is attributed. Workload includes application code, model, data, configuration, and workload-selected framework behavior. |
+| `retry_outlook_without_workload_change` | `cannot_recover`, `may_recover`, `unknown` | Whether the next normal NVRx cycle may recover while workload code, data, and configuration remain unchanged. |
+
+Each claim has an independent evidence status:
+
+| Status | Meaning |
+| --- | --- |
+| `established_by_current_log` | Direct current-log evidence establishes the claim. |
+| `supported_but_unconfirmed` | Evidence favors the claim but material alternatives remain. |
+| `hypothesis_only` | Plausible explanation without sufficient supporting evidence. |
+| `unknown` | The log does not support a useful conclusion. |
+
+Confidence from 1 to 99 records model self-confidence for calibration. It is
+not an action score or an L4 threshold.
+
+The retry outlook assumes failed processes are recreated, normal restart delay
+occurs, hardware allocation may change, and mutable external-service state may
+change. Same-attempt fanout cannot establish cross-cycle persistence; L3 owns
+observed recurrence.
+
+## Worked Example
+
+```text
+12083 [rank 4175] UnicodeDecodeError loading /checkpoints/step_600000/metadata
+12135 [rank 4175] worker exited with exception
+12150 scheduler: cancelling remaining tasks
+```
+
+The labels can coexist without collapsing into one conclusion:
+
+```text
+L0A registry role:       root_candidate
+L1 causal role:          initiating
+client failure class:    observed_exception
+L1 failure identity:     checkpoint_load / metadata_deserialization
+L1 root-cause status:    supported_but_unconfirmed
+L1 failure domain:       unknown
+L1 retry outlook:        may_recover
+L2 history identity:     UnicodeDecodeError mechanism + exact checkpoint path
+L3 observation:          no prior matching cycle yet
+L4 result:               select the applicable retry rule and budget
+```
+
+The worker exit and scheduler cancellation are teardown consequences, not
+competing root causes. A decode error may indicate a bad checkpoint or a
+transient read failure; the current log need not prove which one occurred.
+
+## Non-Substitution Rules
+
+- An exception does not by itself imply workload ownership.
+- A registry match does not establish semantic domain or recovery outlook.
+- Diagnostic text cannot become a primary failure or history fingerprint.
+- Cascade and teardown events cannot replace an earlier initiating failure.
+- Same-attempt repetition across ranks is not cross-cycle persistence.
+- L1 semantics do not directly choose an action; L3 supplies history and L4
+  applies retry policy.

--- a/docs/design/attribution/restart_agent/TOOLS.md
+++ b/docs/design/attribution/restart_agent/TOOLS.md
@@ -1,0 +1,257 @@
+# Restart Agent Read-Only Tools
+
+This document is canonical only for L1 evidence-tool availability, interfaces,
+limits, rejection behavior, and observability.
+
+`L0B.md` owns the initial model evidence view. `L1.md` owns the model loop and
+prompt contract. `CONFIGURATION.md` owns route-specific advertisement and turn limits.
+
+## Tool Boundary
+
+Tools are read-only views over one immutable attempt:
+
+- raw-log tools read the `LogSnapshot` created during preparation;
+- evidence-object lookup reads the immutable `L0Bundle`;
+- no tool rescans through a separate analyzer or mutates evidence;
+- no tool reads history, policy state, credentials, or another log.
+
+The model can call only tools advertised by the selected model route.
+Implementation availability does not make a tool callable.
+
+Unknown names, malformed arguments, unsupported requests, and calls outside the
+advertised set are rejected and traced. The product does not dynamically create
+executable tools from model requests.
+
+## Advertised Set
+
+The default route configuration advertises:
+
+- `overview`;
+- `grep_log`;
+- `read_window`.
+
+`get_evidence_objects` is implemented but not advertised by default. A route
+may enable it explicitly for controlled evaluation.
+
+Tools remain generic inspection primitives. Failure-specific helpers such as
+`find_device_side_assert` or `find_nccl_timeout` do not belong in this
+interface.
+
+## Fixed Response Limits
+
+These are implementation bounds. Model routes control whether a tool is
+advertised and how many model/tool rounds are allowed.
+
+| Setting | Default |
+| --- | ---: |
+| `overview.head_lines` | 40 |
+| `overview.tail_lines` | 80 |
+| `overview.max_chars` | 12000 |
+| `grep_log.max_matches` | 50 |
+| `grep_log.max_matches_hard_limit` | 200 |
+| `read_window.before` | 20 |
+| `read_window.after` | 80 |
+| `read_window.max_lines` | 240 |
+| `read_window.max_chars` | 50000 |
+| `get_evidence_objects.max_refs` | 8 |
+| `get_evidence_objects.max_chars` | 50000 |
+
+Every response reports truncation and relevant applied limits. A cap never
+silently changes source-line numbering.
+
+## `overview`
+
+Input: none.
+
+Purpose: orient the model to file scale, bounded head/tail content, and the
+existing deterministic evidence without recomputing L0.
+
+Example output:
+
+```json
+{
+  "line_count": 1234,
+  "byte_size": 456789,
+  "head": [{"line": 1, "text": "..."}],
+  "tail": [{"line": 1200, "text": "..."}],
+  "deterministic_summary": {
+    "progress_lines": [],
+    "registry_candidate_groups": [],
+    "registry_candidate": null,
+    "candidate_anchors": [],
+    "failure_episodes": [],
+    "cause_confirmations": [],
+    "cascade_groups": [],
+    "termination_candidates": []
+  },
+  "truncated": false
+}
+```
+
+The output excludes absolute paths, basenames, eval labels, and path-derived
+hints.
+
+## `grep_log`
+
+Input:
+
+```json
+{
+  "pattern": "Traceback|RuntimeError",
+  "ignore_case": true,
+  "max_matches": 50
+}
+```
+
+Purpose: search the immutable source snapshot while preserving original line
+numbers.
+
+Example output:
+
+```json
+{
+  "pattern": "Traceback|RuntimeError",
+  "matches": [{"line": 1174, "text": "..."}],
+  "total_matches": 1,
+  "truncated": false
+}
+```
+
+The client bounds requested match count by the hard limit and records any
+truncation.
+
+## `read_window`
+
+Input:
+
+```json
+{
+  "center_line": 1174,
+  "before": 20,
+  "after": 80
+}
+```
+
+Purpose: retrieve original raw lines around a selected source location.
+
+Example output:
+
+```json
+{
+  "start_line": 1154,
+  "end_line": 1254,
+  "lines": [{"line": 1174, "text": "..."}],
+  "truncated": false
+}
+```
+
+The client bounds before/after context, total lines, and serialized characters.
+The result should be large enough to show progress before a failure and
+cascade/recovery after it without becoming an unbounded log dump.
+
+If the range is unavailable because of source truncation, overwrite,
+progressive eviction, or a configured cap, the tool returns a deterministic
+non-crashing result:
+
+```json
+{
+  "start_line": 1154,
+  "end_line": 1254,
+  "lines": [],
+  "truncated": true,
+  "error": "window_unavailable",
+  "unavailable_reason": "progressive_window_evicted",
+  "candidate_summary_refs": ["cand-17"]
+}
+```
+
+Retained candidate references may orient the model but are never rendered as
+fabricated raw lines.
+
+## `get_evidence_objects`
+
+Status: implemented, disabled in the default advertisement.
+
+Input:
+
+```json
+{
+  "refs": ["fe-1", "w-3", "og-4"]
+}
+```
+
+Purpose: resolve attempt-scoped L0A object identifiers for occurrence groups,
+windows, anchors, episodes, distributed incidents, and progress/setup markers
+without rescanning the source log.
+
+Example output:
+
+```json
+{
+  "schema_version": "restart_agent_evidence_objects.v1",
+  "requested_refs": ["fe-1", "w-3", "og-4"],
+  "objects": [
+    {
+      "ref": "fe-1",
+      "object_type": "failure_episode",
+      "payload": {"episode_id": "fe-1", "start_line": 1000},
+      "truncated": false
+    }
+  ],
+  "missing_refs": [],
+  "invalid_refs": [],
+  "omitted_refs": [],
+  "limits": {"max_refs": 8, "max_chars": 50000},
+  "truncated": false
+}
+```
+
+Missing, invalid, omitted, and truncated objects are represented explicitly.
+
+## Error And Deadline Behavior
+
+- Tool execution checks the remaining whole-analysis deadline.
+- Tool calls do not begin after that deadline.
+- Invalid arguments and unadvertised tools produce structured failures rather
+  than exceptions escaping the route.
+- Tool errors do not become evidence.
+- Exhausting the route's tool-round limit makes L1 degraded if no valid final
+  evidence was produced; the deterministic recommendation remains available.
+- Tool result truncation is visible to the model and trace.
+
+## Observability
+
+Each accepted or rejected request records:
+
+- tool-call id;
+- route and model-turn ids;
+- phase;
+- tool name;
+- redacted argument summary and normalized argument hash;
+- start/end time and latency;
+- visible source offset or line range;
+- returned lines/characters and newly visible line ids;
+- match count and truncation;
+- effective caps and caps hit;
+- timeout, execution error, or rejection reason.
+
+Aggregates include:
+
+- call count and extra model turns;
+- tool latency;
+- error and unsupported-request rates;
+- truncation rate;
+- duplicate-call count;
+- no-new-line count;
+- new decision-relevant context yield;
+- incremental token cost.
+
+Interpretation belongs in evaluation:
+
+- new decision-relevant evidence absent from L0B suggests a projection gap;
+- rereading lines already visible in L0B suggests model/route inefficiency;
+- the same missing context requested by many models is a high-priority L0B
+  improvement signal;
+- one model overusing tools is not evidence that L0B is defective.
+
+Tool metrics never directly select a policy action.

--- a/docs/source/attribution/features/index.rst
+++ b/docs/source/attribution/features/index.rst
@@ -10,4 +10,5 @@ or alongside implementation. Keep implementation details in
    :maxdepth: 1
 
    progressive-ft-launcher-attribution
+   restart-agent
    requirements-template

--- a/docs/source/attribution/features/progressive-ft-launcher-attribution.rst
+++ b/docs/source/attribution/features/progressive-ft-launcher-attribution.rst
@@ -4,6 +4,13 @@ Progressive FT Launcher Attribution
 Summary
 -------
 
+.. note::
+
+   This page describes the ``ft_launcher`` and attrsvc integration behavior.
+   The Restart Agent's internal progressive lifecycle and terminal-equivalence
+   contract are specified in
+   ``docs/design/attribution/restart_agent/PROGRESSIVE.md``.
+
 Progressive FT launcher attribution reduces the time to an authoritative
 stop/restart verdict by starting log analysis when a fault-tolerance cycle
 starts, while the workload is still running. When the cycle ends and

--- a/docs/source/attribution/features/restart-agent.rst
+++ b/docs/source/attribution/features/restart-agent.rst
@@ -1,0 +1,150 @@
+Restart Agent
+====================
+
+The restart agent is an experimental NVRx attribution analyzer that
+turns one interleaved distributed-training log and optional compact restart
+history into ``STOP`` or ``RESTART`` guidance.
+
+The implementation lives in:
+
+.. code-block:: text
+
+   src/nvidia_resiliency_ext/attribution/restart_agent/
+
+Quick Start
+-----------
+
+Run deterministic L0/history/L4 analysis without an LLM:
+
+.. code-block:: bash
+
+   python3 -m nvidia_resiliency_ext.attribution.restart_agent.cli \
+     /absolute/path/to/cycle.log \
+     --job-id job-123 \
+     --cycle-id 1 \
+     --disable-l1 \
+     --result-json /absolute/path/to/result.json \
+     --trace-json /absolute/path/to/trace.json \
+     --summary
+
+The command prints the versioned result JSON to stdout. ``--result-json``
+stores the public result and ``--trace-json`` stores stage evidence, timing,
+provider events when applicable, and policy provenance. ``--disable-l1`` makes
+this invocation deterministic-only. A missing or empty log produces a degraded
+restart-biased result rather than invoking a model.
+
+The Python facade returns the result and invocation-owned artifacts together:
+
+.. code-block:: python
+
+   from nvidia_resiliency_ext.attribution.restart_agent import (
+       RestartAgent,
+       RestartAgentRequest,
+   )
+
+   run = RestartAgent().run(
+       RestartAgentRequest(
+           log_path="/absolute/path/to/cycle.log",
+           job_id="job-123",
+           cycle_id=1,
+       )
+   )
+   print(run.result.decision)
+
+Stateful Runtime
+----------------
+
+The implemented transport-independent ``RestartAgentRuntime`` wraps the
+stateless analysis pipeline. It owns
+an ``AttemptRecordStore`` containing bounded in-memory history for the current
+process, enabled by default with 10
+attempts per exact job and 3,000 records total. Product configuration may
+disable history or override either bound. The same neutral ``AttemptRecord``
+type represents an attempt while current and when later selected in a
+``PriorAttemptView``. Each record retains explicit progress facts, including first/last
+iteration and checkpoint-save markers, so later policy can distinguish early
+failure from an attempt that completed observable work. It also contains one
+required deterministic failure block and a route-keyed list of completed L2
+enriched blocks. MVP prior-attempt comparison uses deterministic blocks only.
+
+The initial record is assembled from L0 and, when its deterministic identity is
+eligible, committed before deterministic publication. L2 may add or replace a
+route-keyed enriched block while the record is open. Model output unfinished at the analysis deadline is abandoned and
+cannot mutate the closed record. Reanalysis of the same job and cycle replaces
+its record; an actual workload restart uses the next cycle id and appends a
+record.
+
+Library/unit tests use ``AttemptRecordControl`` to seed, inspect, and clear
+the same in-memory store used by runtime analysis. For manual testing, the CLI
+may read a JSON-array fixture through ``--attempt-records-json-in`` and
+explicitly export the resulting records through
+``--attempt-records-json-out``. These are editable test fixtures, not automatic
+persistence. MCP is a later thin adapter over this runtime and need not expose
+history operations in its product API. These interfaces are specified in
+``docs/design/attribution/restart_agent/RUNTIME.md``.
+
+Model Routes
+------------
+
+Use ``--config`` with ``restart_agent_config.v1`` for model routes. The minimal
+``examples/attribution/restart_agent.json`` contains one Nemotron route and
+uses ``LLM_API_KEY_FILE`` for its credential file. Deployment configurations
+may additionally define route endpoints, request limits, tool advertisement,
+reasoning controls, retries, declared recovery capabilities, and the
+whole-analysis deadline:
+
+.. code-block:: bash
+
+   export LLM_API_KEY_FILE=/secure/path/to/key
+   python3 -m nvidia_resiliency_ext.attribution.restart_agent.cli \
+     /absolute/path/to/cycle.log \
+     --config examples/attribution/restart_agent.json \
+     --result-json /absolute/path/to/restart_agent.result.json \
+     --trace-json /absolute/path/to/restart_agent.trace.json \
+     --deterministic-json-out /absolute/path/to/deterministic_recommendation.json \
+     --summary
+
+Export-controlled workloads must use an authorized ECCN-compliant route on
+the Regulated Inference Hub. Keys and resolved secret values are not emitted
+in results or traces.
+
+The canonical engineering specifications start at:
+
+.. code-block:: text
+
+   docs/design/attribution/restart_agent/README.md
+
+The complete configuration field reference is:
+
+.. code-block:: text
+
+   docs/design/attribution/restart_agent/CONFIGURATION.md
+
+Every run builds deterministic evidence, compares same-job history, applies
+retry policy, and publishes a deterministic recommendation before L1 begins.
+Model enrichment is enabled by default in ``restart_agent_config.v1`` and may
+be explicitly disabled. When enabled, an LLM/tool stage returns structured
+current-log evidence, while deterministic client policy owns history
+comparison, retry-rule and retry-budget evaluation, and the final action. A
+configurable whole-analysis deadline bounds enrichment; a service can use the
+already-published deterministic recommendation at the NVRx-owned deadline.
+
+Attrsvc implements progressive registration, terminal scheduling, log-drain
+convergence, and nonblocking result probes. Terminal analysis is the default
+Restart Agent schedule. Progressive pre-end L0 polling is an explicit opt-in
+for deployments where target-scale measurements justify shifting evidence work
+into the running cycle.
+
+For local multi-model runs, callers can declare canonical output paths for the
+deterministic recommendation and each route result/trace. Each completed artifact is
+published directly at its final path. A separate incremental directory contains
+only an atomic lifecycle status snapshot and append-only event stream; the
+canonical batch result remains the final artifact.
+The complete L0 bundle and Decision Evidence can be written to canonical JSON
+files as soon as L0 finishes. Model-backed execution can additionally publish
+the L0B model view before model routes complete.
+
+The separate eval corpus and N-model comparison harness live under
+``tools/restart_agent_eval/`` when the harness development change is checked
+out. They qualify product configurations and model routes but do not ship in
+the NVRx package or provide a second runtime implementation.

--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -225,7 +225,7 @@ a launcher-managed attribution service:
   - ``--ft-attribution-llm-api-key-file <PATH>`` (alias: ``--ft_attribution_llm_api_key_file``)
   - ``--ft-attribution-llm-base-url <URL>`` (alias: ``--ft_attribution_llm_base_url``)
   - ``--ft-attribution-llm-model <MODEL>`` (alias: ``--ft_attribution_llm_model``)
-  - ``--ft-attribution-analysis-backend mcp`` (alias: ``--ft_attribution_analysis_backend``)
+  - ``--ft-attribution-analysis-backend {lib,mcp}`` (alias: ``--ft_attribution_analysis_backend``)
   - ``--ft-attribution-stop-action {log,no-restart}`` (alias: ``--ft_attribution_stop_action``), default ``log``
   - ``--ft-attribution-startup-timeout <SECONDS>`` (alias: ``--ft_attribution_startup_timeout``), default ``20``
   - ``--ft-attribution-export-url <URL>`` (alias: ``--ft_attribution_export_url``)
@@ -242,9 +242,9 @@ a launcher-managed attribution service:
   To export managed attribution results, pass ``--ft-attribution-export-url`` or
   set ``attribution_export_url`` in the fault tolerance YAML config.
 
-  Launcher-managed attribution supports only the ``mcp`` analysis backend. The backend flag may be
-  left unset, which uses the service default, or set explicitly to ``mcp``. The in-process ``lib``
-  backend is available only when running ``nvrx-attrsvc`` as a standalone service.
+  Launcher-managed attribution defaults to the ``lib`` backend, which runs the Restart Agent
+  directly in the attrsvc process. The backend flag may be left unset to use that default or set
+  explicitly to ``lib``. Set it to ``mcp`` only for the legacy LogSage/Flight Recorder path.
 
   Attribution never delays a restart. When a cycle ends, the rendezvous host requests
   terminal analysis and immediately closes the next round, so the workload restarts while
@@ -266,13 +266,13 @@ a launcher-managed attribution service:
   polled, logged and recorded, but a STOP never terminates anything. Set
   ``--ft-attribution-stop-action no-restart`` to make a STOP end the job.
 
-  The default is deliberate. Attribution verdicts come from an LLM, and the two kinds of
-  mistake are not equally expensive. A missed STOP is bounded: the job crash-loops until
-  ``--max-restarts`` runs out, and the progress tracker independently catches the stuck
-  case. An enforced false STOP is not bounded: the job ends with the no-restart exit code
-  and stays down until a human resubmits it. Run in ``log`` mode first, review the recorded
-  verdicts against what actually happened on your workloads, and enable ``no-restart``
-  once you trust the precision.
+  The default is deliberate because the two kinds of attribution mistake are not equally
+  expensive. A missed STOP is bounded: the job crash-loops until ``--max-restarts`` runs
+  out, and the progress tracker independently catches the stuck case. An enforced false
+  STOP is not bounded: the job ends with the no-restart exit code and stays down until a
+  human resubmits it. Run in ``log`` mode first, review the recorded verdicts against what
+  actually happened on your workloads, and enable ``no-restart`` once you trust the
+  precision.
 
   In ``log`` mode every failed cycle is analyzed, not just the first one that produces a
   STOP, so the verdicts accumulate over the life of the job. Each unenforced STOP is logged

--- a/examples/attribution/README.md
+++ b/examples/attribution/README.md
@@ -1,8 +1,10 @@
-# NVRX Attribution Examples
+# NVRx Attribution Examples
 
-Minimal examples using the attribution library and MCP integration.
+These examples cover the existing attribution MCP integration and the Restart
+Agent CLI configuration.
 
-Install NVIDIA Resiliency Extension first:
+Install NVIDIA Resiliency Extension, then run the examples from the repository
+root:
 
 ```bash
 pip install nvidia-resiliency-ext
@@ -11,5 +13,23 @@ pip install nvidia-resiliency-ext
 | File | Description |
 |------|-------------|
 | `single_server_example.py` | Single MCP server with multiple attribution modules (run from repo root). |
+| `restart_agent.json` | Minimal `restart_agent_config.v1` configuration with one Nemotron model route. |
 
-For the runnable HTTP services (**nvrx-attrsvc**, **nvrx-smonsvc**), install and run from [services/](../../services/) — see [services/README.md](../../services/README.md).
+The Restart Agent configuration contains no credential path or key material. It
+omits `base_url` and therefore uses the product's default provider endpoint.
+Its `credential_ref` names `LLM_API_KEY_FILE`; set that environment variable to
+an authorized, readable API-key file, then run:
+
+```bash
+python3 -m nvidia_resiliency_ext.attribution.restart_agent.cli \
+  /absolute/path/to/cycle.log \
+  --config examples/attribution/restart_agent.json
+```
+
+See the complete
+[Restart Agent configuration reference](../../docs/design/attribution/restart_agent/CONFIGURATION.md)
+for every field, default, and constraint.
+
+For the runnable HTTP services (**nvrx-attrsvc**, **nvrx-smonsvc**), install and
+run from [services/](../../services/); see
+[services/README.md](../../services/README.md).

--- a/examples/attribution/restart_agent.json
+++ b/examples/attribution/restart_agent.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "restart_agent_config.v1",
+  "config_id": "single-nemotron-example",
+  "config_version": 1,
+  "enrichment": {
+    "enabled": true
+  },
+  "routing": {
+    "mode": "collect_all",
+    "max_parallel_models": 1,
+    "timeout_seconds": 240
+  },
+  "runtime": {
+    "history": {
+      "enabled": true,
+      "max_attempts_per_job": 10,
+      "max_total_records": 3000
+    },
+    "l0_source": {
+      "read_mode": "chunked",
+      "chunk_size_bytes": 1048576
+    }
+  },
+  "retry_policy": {
+    "confirmation_retry_allowed_retries": 1,
+    "bounded_retry_allowed_retries": 1,
+    "general_retry_allowed_retries": 3
+  },
+  "model_defaults": {
+    "request": {
+      "timeout_seconds": 120,
+      "max_output_tokens": 64000,
+      "temperature": 0,
+      "top_p": 1
+    },
+    "reliability": {
+      "max_retries": 1,
+      "retry_backoff_seconds": 0.5
+    },
+    "tools": {
+      "enabled": true,
+      "advertisement": {
+        "overview": true,
+        "grep_log": true,
+        "read_window": true,
+        "get_evidence_objects": false
+      },
+      "max_rounds": 8
+    },
+    "reasoning": {
+      "thinking_mode": "auto"
+    }
+  },
+  "model_routes": [
+    {
+      "route_id": "nemotron",
+      "model": "nvidia/nemotron-3-super-120b-a12b",
+      "credential_ref": "LLM_API_KEY_FILE"
+    }
+  ]
+}

--- a/services/attrsvc/ATTRSVC_SPEC.md
+++ b/services/attrsvc/ATTRSVC_SPEC.md
@@ -96,10 +96,12 @@ Two layers: **library** (`nvidia_resiliency_ext.attribution`) and **service**
 Summary:
 - Prefix **`NVRX_ATTRSVC_`** for service settings (see README for exceptions: LLM
   API key, Slack tokens, optional `LLM_API_KEY_FILE` / file paths in `api_keys.py`).
-- **`LLM_API_KEY`** / **`LLM_API_KEY_FILE`**: required for attribution (or default key files);
-  validated by `AttributionController` at startup — **empty/missing → log error and startup failure**.
-  Slack is optional.
-- LLM-related env vars are optional; unset → lower-layer LogSage/MCP defaults.
+- The default direct backend requires **`LLM_API_KEY_FILE`**, or the key-file
+  environment reference named by an explicit Restart Agent config. The legacy
+  backend retains the older `LLM_API_KEY` / file lookup behavior. Slack is
+  optional and legacy-only in the first direct integration.
+- LLM-related env vars are optional; unset values use the selected backend's
+  defaults.
 - Rate limits: slowapi, `RATE_LIMIT_SUBMIT` / `RATE_LIMIT_ANALYZE` / `RATE_LIMIT_PREVIEW`.
 
 **3.2 Constants** (library `orchestration/config.py` — single source)
@@ -131,7 +133,7 @@ Summary:
 Patterns tried in order (scheduler-agnostic where possible): `_(\d+)_date_`,
 `job_(\d+)`, `slurm-(\d+)\.(out|err|log)`, etc. User: often `"unknown"`.
 
-**3.7 Processed-files ledger (optional cache persistence)**
+**3.7 Processed-files ledger (legacy `mcp` backend only)**
 
 - Env: `NVRX_ATTRSVC_CACHE_FILE`, `NVRX_ATTRSVC_CACHE_GRACE_PERIOD_SECONDS` (see README).
 - Purpose: avoid duplicate LLM/analysis work after restarts when clients resubmit.
@@ -145,15 +147,16 @@ Patterns tried in order (scheduler-agnostic where possible): `_(\d+)_date_`,
 --------------------------------------------------------------------------------
 
 **Startup (conceptual)**  
-Load `Settings` → configure logging → construct `AttributionHttpAdapter` /
-**`AttributionController`** / **`Analyzer`**. Controller startup validates the LLM
-API key and wires postprocessing (direct dataflow HTTP poster, Slack) before analysis
-begins. Then background poll → Uvicorn. Optional cache import.
+Load `Settings` → configure logging → construct `AttributionHttpAdapter`. The
+default `lib` branch resolves `RestartAgentConfig` and constructs
+`RestartAgentRuntime`; the `mcp` branch constructs `AttributionController` and
+`Analyzer`. Then start Uvicorn. Legacy-only startup may also restore cache and
+start controller dependencies.
 
 **Shutdown**  
-Drain HTTP → stop poll → export cache (if configured) → exit. Job map is not
-persisted; ledger/cache persistence behavior is implementation-defined in the
-coalescer (see library).
+Drain HTTP and stop backend-owned workers. The direct backend drops its bounded
+execution registry and current-lifetime history. The legacy backend may export
+its configured cache; see the coalescer documentation.
 
 ================================================================================
 
@@ -209,7 +212,7 @@ mitigates abuse.
 | GET | /jobs | Paginated job dump (`mode`, `limit`, `offset`) |
 | GET | /print | First 4KB preview (`log_path`) |
 | GET | /inflight | In-flight analyses |
-| POST | /logs | Register job (`log_path`, `user`, optional `job_id`) |
+| POST | /logs | Register/signal an attempt (`log_path`, `user`, optional `job_id`, `cycle_id`, `analysis_intent`) |
 | GET | /logs | Analyze / return results (`log_path`, optional `file`, `wl_restart`) |
 
 **GET /healthz**  
@@ -225,10 +228,23 @@ deferred, permission errors, …) with **dataflow** counters and **Slack** stats
 **POST /logs** body
 
 ```json
-{ "log_path": "/abs/path/to/job.out", "user": "owner", "job_id": "optional" }
+{
+  "log_path": "/abs/path/to/job_cycle2.log",
+  "user": "owner",
+  "job_id": "optional",
+  "cycle_id": 2,
+  "analysis_intent": "progressive"
+}
 ```
 
-Response: `{ "mode": "pending" | "single" | "splitlog" }`.
+`cycle_id` is an optional strict integer. The `lib` Restart Agent backend
+infers it from `_cycle<N>.log` only when the field is absent.
+`analysis_intent` is `track_only`, `progressive`, or `terminal`.
+
+Response fields are `submitted`, `normalized_path`, `mode`, `logs_dir`,
+`sched_restarts`, and `files_analyzed`. `mode` remains the legacy
+pending/single/splitlog compatibility view; the direct Restart Agent lifecycle
+is read through `GET /logs` status.
 
 **GET /logs**  
 Returns single-file or splitlog-shaped JSON; optional `file` selects a file in
@@ -244,6 +260,16 @@ Flight-recorder findings are monitor-only; missing/hanging ranks are exposed in
 FR result fields and dataflow records, not as restart/stop policy.
 
 **6.1 GET /logs — processing flow (implementation)**
+
+The default `lib` flow is:
+
+```text
+POST progressive -> register attempt
+POST terminal -> bounded log drain -> RestartAgentRuntime in background
+GET wait=false -> pending | in_flight with optional fallback | completed
+```
+
+The following diagram describes only the legacy `mcp` backend:
 
 ```mermaid
 flowchart TD
@@ -278,8 +304,12 @@ flowchart TD
   end
 ```
 
-Notes: Coalescer key is the normalized log file path. `ANALYSIS_BACKEND` (`NVRX_ATTRSVC_ANALYSIS_BACKEND`) defaults to
-`mcp` (set `lib` for in-process LogSage and FR). See **ARCHITECTURE.md §7**. Splitlog: with `file=`, key is the per-file path.
+Notes: `ANALYSIS_BACKEND` (`NVRX_ATTRSVC_ANALYSIS_BACKEND`) defaults to `lib`,
+which runs the Restart Agent directly and does not use `RequestCoalescer`.
+The `mcp` backend preserves the diagrammed legacy flow, where the coalescer key
+is the normalized path and splitlog `file=` selects a per-file key. See
+`docs/design/attribution/restart_agent/ATTRSVC_INTEGRATION.md` for the direct
+contract and **ARCHITECTURE.md §7** for the legacy path.
 
 **curl / examples** — **README.md** (avoid duplicating here).
 
@@ -328,23 +358,26 @@ diagram.
 10. GET FLOW
 --------------------------------------------------------------------------------
 
-Validate → locate job → trigger analysis via coalescer (single-flight) → serialize
-result. Coalescing: concurrent GETs on same key share one compute — **ARCHITECTURE.md**
-(coalescing section).
+For `lib`, GET only projects a registered attempt's pending, in-flight, or
+completed result; terminal POST starts analysis. For `mcp`, validate → locate
+job → trigger analysis via the legacy coalescer → serialize result. Legacy
+coalescing details are in **ARCHITECTURE.md**.
 
 11. BACKGROUND POLL
 --------------------------------------------------------------------------------
 
-Periodic: pending promotion, splitlog file discovery, cleanup, stuck in-flight
-handling. Interval: `POLL_INTERVAL_SECONDS`. **Detail:** library splitlog tracker +
-coalescer.
+Legacy `mcp` only: pending promotion, splitlog discovery, cleanup, and stuck
+in-flight handling. The direct backend uses its bounded execution registry and
+background terminal futures instead of this poll loop.
 
 ================================================================================
                          LIBRARY TOPICS (POINTERS ONLY)
 ================================================================================
 
 12. LLM ANALYSIS  
-Availability, retries, timeouts, MCP vs lib — **ARCHITECTURE.md §7–9**, `LogAnalyzerConfig`,
+Direct Restart Agent behavior — `docs/design/attribution/restart_agent/`.
+Legacy availability, retries, timeouts, and MCP behavior —
+**ARCHITECTURE.md §7–9**, `LogAnalyzerConfig`, and
 `RequestCoalescer.compute_timeout`.
 
 13. LOG FILE MARKER PARSING  
@@ -366,16 +399,19 @@ workload chunk within that file.
 18. CLEANUP
 --------------------------------------------------------------------------------
 
-TTL-based removal of pending, terminated, abandoned jobs; coalescer eviction rules.
-Constants in **§3.2**.
+The direct backend evicts the oldest completed execution when its bounded
+registry is full. Legacy TTL-based job cleanup and coalescer eviction use the
+constants in **§3.2**.
 
 ================================================================================
 
 19. CONCURRENCY
 --------------------------------------------------------------------------------
 
-Thread/async model, locks, poll thread vs asyncio, `_in_flight` futures — **ARCHITECTURE.md**
-and inline comments in **`Analyzer`** / `RequestCoalescer`. Do not duplicate here.
+The direct backend schedules terminal runs on a bounded thread pool and guards
+its execution registry independently of `RestartAgentRuntime` history. Legacy
+poll-thread, asyncio, and coalescer behavior remains documented in
+**ARCHITECTURE.md** and the `Analyzer` / `RequestCoalescer` source.
 
 ================================================================================
 
@@ -384,10 +420,12 @@ and inline comments in **`Analyzer`** / `RequestCoalescer`. Do not duplicate her
 
 `GET /stats` aggregates:
 
-- **Library** (`Analyzer.get_stats`): coalescer stats (hits/misses, compute,
+- **Direct `lib`**: Restart Agent config fingerprint, execution-state counts,
+  fallback/route completion counts, errors, evictions, and history-record count.
+- **Legacy library** (`Analyzer.get_stats`): coalescer stats (hits/misses, compute,
   submissions, …), splitlog folder stats under the `splitlog` key, `detection`,
   `deferred`, `permission_errors`, poll gauges, etc. — **exact keys per implementation**.
-- **Controller/adapter** (`AttributionController.get_stats`, exposed by
+- **Legacy controller/adapter** (`AttributionController.get_stats`, exposed by
   `AttributionHttpAdapter.get_stats`): adds **`dataflow`** (direct HTTP post
   attempts) and **`slack`** (attempts, successes, failures, user lookup stats when enabled).
 
@@ -398,12 +436,13 @@ Refer to live **`GET /stats`** response or OpenAPI for the current JSON shape.
 21. DATAFLOW & SLACK (OPTIONAL)
 --------------------------------------------------------------------------------
 
-Postprocessing posts results when `EXPORT_URL` is configured with the
+Legacy `mcp` postprocessing posts results when `EXPORT_URL` is configured with the
 complete posting URI. No endpoint is built into the package. Slack posts when
 `SLACK_BOT_TOKEN` set or token fallback files are present. Wiring:
 `Settings` → `AttributionControllerConfig` → `AttributionController`. Record build:
 `build_dataflow_record`; backend: `postprocessing/post_backend.py`. Retry behavior in
-implementation.
+implementation. The first direct Restart Agent integration does not invoke
+legacy dataflow or Slack postprocessing.
 
 ================================================================================
                          OPERATIONS & DEVELOPMENT (POINTERS)

--- a/services/attrsvc/README.md
+++ b/services/attrsvc/README.md
@@ -1,6 +1,9 @@
 # NVRX Attribution Service (nvrx-attrsvc)
 
-FastAPI server that exposes log analysis over HTTP. It wraps the **`nvidia_resiliency_ext.attribution`** library (**`AttributionController`**, **`Analyzer`**, coalescing, postprocessing) with pydantic `Settings`, routes, and rate limits.
+FastAPI server that exposes log analysis over HTTP. The default `lib` backend
+runs `RestartAgentRuntime` directly. The legacy `mcp` backend retains
+`AttributionController`, `Analyzer`, LogSage, Flight Recorder, coalescing, and
+postprocessing. Both use the same HTTP routes and pydantic `Settings` boundary.
 
 ---
 
@@ -8,10 +11,12 @@ FastAPI server that exposes log analysis over HTTP. It wraps the **`nvidia_resil
 
 | | **Library** (`nvidia_resiliency_ext.attribution`) | **This package** (`nvidia_resiliency_ext.services.attrsvc`) |
 |---|--------------------------------------------------|-----------------------------------|
-| **Role** | **`AttributionController`** (config, cache persistence, health/status, dataflow/Slack stats) over **`Analyzer`** (→ `LogAnalyzer`, pipelines, MCP/lib LogSage, FR analysis, jobs/splitlog) | HTTP API, env-based `Settings`, rate limits, ledger file |
-| **Docs** | [`src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md`](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md), [`README.md`](../../src/nvidia_resiliency_ext/attribution/README.md) | This file, [`ATTRSVC_SPEC.md`](ATTRSVC_SPEC.md) |
+| **Role** | **`RestartAgentRuntime`** for direct analysis; **`AttributionController`** for the legacy MCP path | HTTP API, backend selection, env-based `Settings`, and rate limits |
+| **Docs** | [`restart_agent/README.md`](../../docs/design/attribution/restart_agent/README.md), [`ARCHITECTURE.md`](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md) for legacy analysis | This file, [`ATTRSVC_SPEC.md`](ATTRSVC_SPEC.md) |
 
-Do not duplicate library internals here—**ARCHITECTURE.md** is the source of truth for package layout, `LogAnalyzerConfig` / `AnalysisPipelineMode` (default `LOG_AND_TRACE` for this service), MCP vs in-process backends, and analysis flow.
+The Restart Agent design directory is the source of truth for the direct
+backend. **ARCHITECTURE.md** remains the source of truth for the legacy
+controller/LogSage/Flight Recorder path.
 
 ---
 
@@ -25,7 +30,7 @@ pip install -e .
 # Run
 export NVRX_ATTRSVC_ALLOWED_ROOT=/path/to/logs
 # API key: set env var OR create ~/.llm_api_key file
-export LLM_API_KEY=your-llm-api-key-here
+export LLM_API_KEY_FILE=/secure/llm_api_key
 nvrx-attrsvc
 ```
 
@@ -49,7 +54,9 @@ Environment variables (prefix: `NVRX_ATTRSVC_`):
 | `RATE_LIMIT_ANALYZE` | `60/minute` | Rate limit for GET /logs |
 | `RATE_LIMIT_PREVIEW` | `120/minute` | Rate limit for GET /print |
 
-**LLM / analysis** (optional — unset vars keep library defaults). Use the prefixed names below in the environment or ``.env``; ``AttributionHttpAdapter`` passes them into ``AttributionControllerConfig``, which wires ``LogSageExecutionConfig`` and the library ``Analyzer`` (LogSage / MCP / merge paths). See **ARCHITECTURE.md §7**.
+**LLM / analysis** (optional — unset vars keep library defaults).
+`AttributionHttpAdapter` resolves these into `RestartAgentConfig` for `lib`, or
+the legacy `AttributionControllerConfig` for `mcp`.
 
 | Variable (with prefix)          | Description                                                                                                                                                                                                   |
 |---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -59,9 +66,15 @@ Environment variables (prefix: `NVRX_ATTRSVC_`):
 | `NVRX_ATTRSVC_LLM_TOP_P`        | Top-p for nucleus sampling                                                                                                                                                                                    |
 | `NVRX_ATTRSVC_LLM_MAX_TOKENS`   | Max tokens for response                                                                                                                                                                                       |
 | `NVRX_ATTRSVC_COMPUTE_TIMEOUT`  | Timeout for analysis in seconds                                                                                                                                                                               |
-| `NVRX_ATTRSVC_ANALYSIS_BACKEND` | `mcp` (subprocess MCP, default) or `lib` (in-process LogSage and flight-recorder analysis). Same setting for both; library behavior: **ARCHITECTURE.md §7**. |
+| `NVRX_ATTRSVC_ANALYSIS_BACKEND` | `lib` (direct Restart Agent, default) or `mcp` (legacy LogSage/Flight Recorder path). |
+| `NVRX_ATTRSVC_RESTART_AGENT_CONFIG` | Optional authoritative `restart_agent_config.v1` JSON file for `lib`; the first attrsvc integration requires exactly one route. |
+| `NVRX_ATTRSVC_RESTART_AGENT_LOG_QUIET_SECONDS` | Unchanged-log interval before terminal analysis; default `2`. |
+| `NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS` | Maximum terminal log-drain wait; default `20`. |
+| `NVRX_ATTRSVC_RESTART_AGENT_LOG_POLL_SECONDS` | Log-drain polling interval; default `0.25`. |
 
-**LLM API Key** (required, checked in order — see `api_keys.load_llm_api_key`):
+**LLM API Key**: the default `lib` route requires `LLM_API_KEY_FILE`. A supplied
+Restart Agent config may name another key-file environment variable through its
+`credential_ref`. The legacy `mcp` path retains the older lookup order:
 1. `LLM_API_KEY` environment variable
 2. `LLM_API_KEY_FILE` environment variable (path to file)
 3. `~/.llm_api_key` file
@@ -125,9 +138,11 @@ Example: `NVRX_ATTRSVC_CACHE_FILE=/var/lib/nvrx/attrsvc_cache.json`
 **POST /logs** body:
 ```json
 {
-  "log_path": "/path/to/slurm-12345.out",
+  "log_path": "/path/to/train_cycle2.log",
   "user": "alice",
-  "job_id": "12345"
+  "job_id": "12345",
+  "cycle_id": 2,
+  "analysis_intent": "progressive"
 }
 ```
 
@@ -150,6 +165,8 @@ All success responses use HTTP 200. Interpret outcome from the response body onl
 | `log_path` | string | Yes | Absolute path to job output file under allowed root |
 | `user` | string | Yes | Job owner |
 | `job_id` | string | No | Job ID (used for splitlog detection) |
+| `cycle_id` | integer | No | Explicit restart-attempt order. The direct Restart Agent backend infers `_cycle<N>.log` only when absent. |
+| `analysis_intent` | string | No | `track_only` (default), `progressive`, or `terminal`. |
 
 | Response (200) | Type | Description |
 |----------------|------|-------------|
@@ -262,7 +279,11 @@ For combined deployment with monitor, see `../scripts/nvrx_services.sbatch`
 
 ## Python API
 
-**Embedding the library** (no HTTP): use **`AttributionController`** for the service-grade boundary, or **`Analyzer`** / `LogAnalyzer` / `LogAnalyzerConfig` for lower-level control, from `nvidia_resiliency_ext.attribution`. Overview and examples: **[attribution README](../../src/nvidia_resiliency_ext/attribution/README.md)** · **[ARCHITECTURE.md](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md)**.
+**Embedding the direct analyzer** (no HTTP): use `build_restart_agent_runtime()`
+and `RestartAgentRuntime.analyze()`, or the `restart-agent` CLI. See the
+**[Restart Agent design](../../docs/design/attribution/restart_agent/README.md)**.
+For the legacy analysis stack, use `AttributionController`, `Analyzer`, or
+`LogAnalyzer`; see the **[attribution README](../../src/nvidia_resiliency_ext/attribution/README.md)**.
 
 **In-process HTTP adapter** (same repo, after `pip install`):
 
@@ -285,8 +306,10 @@ asyncio.run(main())
 | File | Description |
 |------|-------------|
 | `app.py` | FastAPI routes and middleware |
-| `service.py` | `AttributionHttpAdapter` — wraps **`AttributionController`** |
+| `service.py` | `AttributionHttpAdapter` and the common backend protocol |
 | `config.py` | `Settings` (pydantic), `setup()` loads settings and configures logging |
+| `restart_agent_config.py` | Resolves attrsvc settings into `RestartAgentConfig` |
+| `restart_agent_backend.py` | Direct progressive/terminal HTTP lifecycle over `RestartAgentRuntime` |
 | `deploy/run_attrsvc.sh` | Run service with logging (background) |
 | `deploy/snapshot_attrsvc.sh` | Periodic endpoint snapshot for debugging |
 | `deploy/Dockerfile` | Docker build instructions |
@@ -298,11 +321,14 @@ asyncio.run(main())
 | Document | Audience |
 |----------|----------|
 | [ATTRSVC_SPEC.md](ATTRSVC_SPEC.md) | HTTP contract, service-level behavior; library internals in **ARCHITECTURE.md** |
+| [../../docs/design/attribution/restart_agent/ATTRSVC_INTEGRATION.md](../../docs/design/attribution/restart_agent/ATTRSVC_INTEGRATION.md) | Direct NVRx/attrsvc/Restart Agent composition |
 | [../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md) | Library architecture, pipelines, MCP, coalescing |
 
 ## Configuration and postprocessing (summary)
 
 - **Service config** is in `config.py` (`Settings` from env with prefix `NVRX_ATTRSVC_`).
 - **`setup()`** in `config.py` loads settings and configures logging only.
-- **`AttributionHttpAdapter`** translates `Settings` into `AttributionControllerConfig`; **`AttributionController`** validates the LLM API key and wires postprocessing (`cluster_name`, Slack, and the default poster).
-- The analyzer schedules library postprocessing after analysis; dataflow and Slack use the values owned by the controller and do not gate the response returned to clients.
+- **`AttributionHttpAdapter`** translates `Settings` into `RestartAgentConfig`
+  for `lib`, or `AttributionControllerConfig` for `mcp`.
+- Dataflow and Slack postprocessing remain on the legacy controller path in the
+  first direct integration and do not gate responses there.

--- a/services/attrsvc/deploy/Dockerfile
+++ b/services/attrsvc/deploy/Dockerfile
@@ -7,8 +7,9 @@
 #   docker run -d \
 #       -p 8000:8000 \
 #       -e NVRX_ATTRSVC_ALLOWED_ROOT=/data/logs \
-#       -e LLM_API_KEY=your-llm-api-key-here \
+#       -e LLM_API_KEY_FILE=/run/secrets/llm_api_key \
 #       -v /path/to/logs:/data/logs:ro \
+#       -v /secure/llm_api_key:/run/secrets/llm_api_key:ro \
 #       nvrx-attrsvc
 #
 # Build from repo root to include nvidia_resiliency_ext library

--- a/services/attrsvc/deploy/kubernetes.yaml
+++ b/services/attrsvc/deploy/kubernetes.yaml
@@ -4,7 +4,7 @@
 #   kubectl apply -f services/attrsvc/deploy/kubernetes.yaml
 #
 # Prerequisites:
-#   - Create secret: kubectl create secret generic llm-api-key --from-literal=api-key=your-llm-api-key-here
+#   - Create secret: kubectl create secret generic llm-api-key --from-file=llm_api_key=/secure/llm_api_key
 #   - Ensure log volume is accessible (update hostPath as needed)
 #
 # Deployment considerations:
@@ -54,14 +54,14 @@ spec:
             - configMapRef:
                 name: nvrx-attrsvc-config
           env:
-            - name: LLM_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: llm-api-key
-                  key: api-key
+            - name: LLM_API_KEY_FILE
+              value: /run/secrets/llm_api_key
           volumeMounts:
             - name: logs
               mountPath: /data/logs
+              readOnly: true
+            - name: llm-api-key
+              mountPath: /run/secrets
               readOnly: true
           resources:
             requests:
@@ -90,6 +90,9 @@ spec:
           hostPath:
             path: /path/to/logs
             type: Directory
+        - name: llm-api-key
+          secret:
+            secretName: llm-api-key
 
 ---
 apiVersion: v1

--- a/services/attrsvc/deploy/run_attrsvc.sh
+++ b/services/attrsvc/deploy/run_attrsvc.sh
@@ -6,7 +6,7 @@
 #
 # Required environment variables:
 #   NVRX_ATTRSVC_ALLOWED_ROOT - Root path for log files to analyze
-#   LLM_API_KEY               - API key for LLM (or LLM_API_KEY_FILE)
+#   LLM_API_KEY_FILE          - LLM key file for the default Restart Agent backend
 #
 # Optional environment variables:
 #   NVRX_ATTRSVC_PORT         - Listen port (default: 8000)
@@ -17,7 +17,7 @@
 #
 # Example:
 #   export NVRX_ATTRSVC_ALLOWED_ROOT=/lustre/logs
-#   export LLM_API_KEY=your-llm-api-key-here
+#   export LLM_API_KEY_FILE=/secure/llm_api_key
 #   ./run_attrsvc.sh ~/nvrx_logs
 
 set -e

--- a/services/attrsvc/deploy/slurm.sbatch
+++ b/services/attrsvc/deploy/slurm.sbatch
@@ -17,9 +17,9 @@
 # Required environment variables:
 #   NVRX_ATTRSVC_ALLOWED_ROOT - Root path for log files to analyze
 #
-# API Key Options (in priority order):
-#   1. LLM_API_KEY env var (direct key)
-#   2. LLM_API_KEY_FILE env var (path to file containing key)
+# API Key Options for the default Restart Agent backend:
+#   1. LLM_API_KEY_FILE env var (path to file containing key)
+#   2. NVRX_ATTRSVC_RESTART_AGENT_CONFIG with its declared credential reference
 #   3. Default: ~/.llm_api_key or ~/.config/nvrx/llm_api_key
 #
 # Example:

--- a/services/scripts/README.md
+++ b/services/scripts/README.md
@@ -20,8 +20,7 @@ Shared shell scripts for deployment and monitoring.
 ```bash
 # Set required environment
 export NVRX_ATTRSVC_ALLOWED_ROOT=/lustre/logs
-# API key: set env var OR create ~/.llm_api_key file
-export LLM_API_KEY=your-llm-api-key-here
+export LLM_API_KEY_FILE=/secure/llm_api_key
 
 # Install, start, and manage
 ./scripts/run_services.sh install   # Install packages
@@ -49,11 +48,10 @@ sudo ./scripts/setup_systemd.sh start
 
 ### API Key
 
-The API key can be provided in multiple ways (checked in order):
-1. `LLM_API_KEY` environment variable
-2. `LLM_API_KEY_FILE` environment variable (path to key file)
-3. `~/.llm_api_key` file
-4. `~/.config/nvrx/llm_api_key` file
+The default direct backend accepts `LLM_API_KEY_FILE`, an explicit Restart
+Agent config with its own credential reference, or the default key-file paths
+`~/.llm_api_key` and `~/.config/nvrx/llm_api_key`. A raw `LLM_API_KEY` is
+accepted only by the legacy `mcp` backend.
 
 **Output files** (in `~/nvrx_logs/` by default):
 - `<timestamp>_attrsvc.log` - Attribution service stdout/stderr

--- a/services/scripts/build_enroot_image.sh
+++ b/services/scripts/build_enroot_image.sh
@@ -14,8 +14,8 @@
 #   # Run attribution service
 #   srun --container-image=/path/to/nvrx-services.sqsh \
 #        --container-env=NVRX_ATTRSVC_ALLOWED_ROOT=/data \
-#        --container-env=LLM_API_KEY=${LLM_API_KEY} \
-#        --container-mounts=/path/to/logs:/data:ro \
+#        --container-env=LLM_API_KEY_FILE=/run/secrets/llm_api_key \
+#        --container-mounts=/path/to/logs:/data:ro,/secure/llm_api_key:/run/secrets/llm_api_key:ro \
 #        nvrx-attrsvc
 #
 #   # Run SLURM monitor (requires attrsvc running elsewhere)
@@ -146,8 +146,8 @@ echo ""
 echo "  # Attribution service"
 echo "  srun --container-image=${OUTPUT_PATH} \\"
 echo "       --container-env=NVRX_ATTRSVC_ALLOWED_ROOT=/data \\"
-echo "       --container-env=LLM_API_KEY=\${LLM_API_KEY} \\"
-echo "       --container-mounts=/path/to/logs:/data:ro \\"
+echo "       --container-env=LLM_API_KEY_FILE=/run/secrets/llm_api_key \\"
+echo "       --container-mounts=/path/to/logs:/data:ro,/secure/llm_api_key:/run/secrets/llm_api_key:ro \\"
 echo "       nvrx-attrsvc"
 echo ""
 echo "  # SLURM monitor"

--- a/services/scripts/common.sh
+++ b/services/scripts/common.sh
@@ -5,19 +5,25 @@
 # Get the directory where this script lives
 COMMON_SETUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Setup LLM API key for processes that read nvidia_resiliency_ext.attribution.api_keys.load_llm_api_key
-# Checks in order:
-#   1. LLM_API_KEY environment variable
-#   2. LLM_API_KEY_FILE (path to file; must exist)
-#   3. ~/.llm_api_key — sets export LLM_API_KEY_FILE to that path
-#   4. ~/.config/nvrx/llm_api_key
+# Setup the key contract for the selected attrsvc backend.
 setup_llm_api_key() {
-    if [[ -n "${LLM_API_KEY}" ]]; then
+    local backend="${NVRX_ATTRSVC_ANALYSIS_BACKEND:-lib}"
+
+    if [[ "${backend}" == "lib" && -n "${NVRX_ATTRSVC_RESTART_AGENT_CONFIG:-}" ]]; then
+        if [[ ! -f "${NVRX_ATTRSVC_RESTART_AGENT_CONFIG}" ]]; then
+            echo "ERROR: Restart Agent config not found: ${NVRX_ATTRSVC_RESTART_AGENT_CONFIG}"
+            return 1
+        fi
+        echo "Using Restart Agent config credentials: ${NVRX_ATTRSVC_RESTART_AGENT_CONFIG}"
+        return 0
+    fi
+
+    if [[ "${backend}" == "mcp" && -n "${LLM_API_KEY:-}" ]]; then
         echo "Using LLM_API_KEY from environment"
         return 0
     fi
 
-    if [[ -n "${LLM_API_KEY_FILE}" ]]; then
+    if [[ -n "${LLM_API_KEY_FILE:-}" ]]; then
         if [[ ! -f "${LLM_API_KEY_FILE}" ]]; then
             echo "ERROR: LLM_API_KEY_FILE specified but not found: ${LLM_API_KEY_FILE}"
             return 1
@@ -39,7 +45,11 @@ setup_llm_api_key() {
     done
 
     echo "WARNING: LLM API key not found - LLM analysis may fail"
-    echo "  Set LLM_API_KEY, LLM_API_KEY_FILE, or create ~/.llm_api_key"
+    if [[ "${backend}" == "lib" ]]; then
+        echo "  Set LLM_API_KEY_FILE, provide NVRX_ATTRSVC_RESTART_AGENT_CONFIG, or create ~/.llm_api_key"
+    else
+        echo "  Set LLM_API_KEY, LLM_API_KEY_FILE, or create ~/.llm_api_key"
+    fi
     return 1
 }
 

--- a/services/scripts/nvrx_services.sbatch
+++ b/services/scripts/nvrx_services.sbatch
@@ -25,9 +25,9 @@
 # Optional environment variables:
 #   NVRX_LOGS_DIR - Directory for service logs (default: current directory)
 #
-# API Key Options (in priority order):
-#   1. LLM_API_KEY env var (direct key)
-#   2. LLM_API_KEY_FILE env var (path to file containing key)
+# API Key Options for the default Restart Agent backend:
+#   1. LLM_API_KEY_FILE env var (path to file containing key)
+#   2. NVRX_ATTRSVC_RESTART_AGENT_CONFIG with its declared credential reference
 #   3. Default: ~/.llm_api_key or ~/.config/nvrx/llm_api_key
 #
 # Example with custom output directory:

--- a/services/scripts/run_services.sh
+++ b/services/scripts/run_services.sh
@@ -15,11 +15,11 @@
 #
 # Required environment variables:
 #   NVRX_ATTRSVC_ALLOWED_ROOT - Root path for log files to analyze
-#   LLM_API_KEY               - API key for LLM (or LLM_API_KEY_FILE)
+#   LLM_API_KEY_FILE          - LLM key file for the default Restart Agent backend
 #
 # Optional environment variables:
 #   NVRX_LOGS_DIR             - Output directory for logs (default: ~/nvrx_logs)
-#   NVRX_ATTRSVC_ANALYSIS_BACKEND - Log + FR: mcp (default) or lib
+#   NVRX_ATTRSVC_ANALYSIS_BACKEND - lib Restart Agent (default) or legacy mcp
 #   NVRX_SMONSVC_PARTITIONS   - SLURM partitions to monitor (default: "batch batch_long")
 #   NVRX_ATTRSVC_ENDPOINT     - Unified attrsvc endpoint: http://host:port or unix:///path.sock
 #   NVRX_ATTRSVC_PORT         - TCP port fallback when endpoint is unset (default: 8000)
@@ -29,7 +29,7 @@
 #
 # Example:
 #   export NVRX_ATTRSVC_ALLOWED_ROOT=/lustre/logs
-#   export LLM_API_KEY=your-llm-api-key-here
+#   export LLM_API_KEY_FILE=/secure/llm_api_key
 #   ./run_services.sh install
 #   ./run_services.sh start
 #   ./run_services.sh status

--- a/src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md
+++ b/src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md
@@ -216,6 +216,7 @@ implemented using MCP transport, it should expose service-grade methods such as
 | **`combined_log_fr/`** | MCP tool **`log_fr_analyzer`** for one-call LogSage + FR collection; optional **log + FR LLM fusion** (`CombinedLogFR`, `merge_log_fr_llm()`) for `LOG_AND_TRACE_WITH_LLM` |
 | **`postprocessing/`** | Build records, optional direct dataflow HTTP post, Slack; `post_analysis_items` / `post_results` run as best-effort observability after analysis |
 | **`mcp_integration/`** | Subprocess MCP client/server so LogSage can run isolated from the caller (see `mcp_integration/README.md`) |
+| **`restart_agent/`** | Experimental evidence-first restart agent: deterministic L0 bundle, optional structured L1 interpretation, history-aware policy, and `STOP`/`RESTART` output. Canonical specs live under `docs/design/attribution/restart_agent/`. |
 
 ---
 

--- a/src/nvidia_resiliency_ext/attribution/README.md
+++ b/src/nvidia_resiliency_ext/attribution/README.md
@@ -13,3 +13,15 @@ pip install nvidia-resiliency-ext
 **[ARCHITECTURE.md](./ARCHITECTURE.md)**
 
 The public API is re-exported from `nvidia_resiliency_ext.attribution` (see package `__init__.py`).
+
+## Restart agent
+
+The experimental restart agent lives in
+`restart_agent/`. It builds deterministic log evidence, optionally asks
+an LLM for structured current-log interpretation, and applies deterministic
+policy to emit `STOP` or `RESTART` guidance. Its canonical engineering specs
+start at:
+
+```text
+docs/design/attribution/restart_agent/DESIGN.md
+```

--- a/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
+++ b/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
@@ -302,6 +302,7 @@ class Analyzer:
         log_path: str,
         user: str = "unknown",
         job_id: Optional[str] = None,
+        cycle_id: int | None = None,
         analysis_intent: str | None = ANALYSIS_INTENT_TRACK_ONLY,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
         """
@@ -314,6 +315,8 @@ class Analyzer:
             log_path: Path to the log file (or slurm output for splitlog mode)
             user: Job owner (for dataflow records)
             job_id: Job ID (required for split logging mode)
+            cycle_id: Optional restart-attempt identity. The legacy analyzer
+                accepts but does not consume it.
             analysis_intent: Track-only by default; ``progressive`` starts early
                 analysis when the configured backend supports it; ``terminal`` starts
                 final analysis through the coalescer without waiting for the result.
@@ -326,6 +329,7 @@ class Analyzer:
         except ValueError as e:
             return LogAnalyzerError(error_code=ErrorCode.INVALID_PARAMETER, message=str(e))
 
+        del cycle_id
         result = await self._log.submit(log_path, user=user, job_id=job_id)
         if isinstance(result, LogAnalyzerError):
             return result

--- a/src/nvidia_resiliency_ext/attribution/controller.py
+++ b/src/nvidia_resiliency_ext/attribution/controller.py
@@ -316,6 +316,7 @@ class AttributionController:
         log_path: str,
         user: str = "unknown",
         job_id: str | None = None,
+        cycle_id: int | None = None,
         analysis_intent: str | None = ANALYSIS_INTENT_TRACK_ONLY,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
         """Submit a log file for attribution tracking."""
@@ -323,6 +324,7 @@ class AttributionController:
             log_path,
             user=user,
             job_id=job_id,
+            cycle_id=cycle_id,
             analysis_intent=analysis_intent,
         )
 

--- a/src/nvidia_resiliency_ext/attribution/orchestration/http_api.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/http_api.py
@@ -17,6 +17,7 @@ ROUTE_HEALTHZ = "/healthz"
 PARAM_LOG_PATH = "log_path"
 PARAM_USER = "user"
 PARAM_JOB_ID = "job_id"
+PARAM_CYCLE_ID = "cycle_id"
 PARAM_ANALYSIS_INTENT = "analysis_intent"
 
 # GET /logs optional query parameters (splitlog mode)
@@ -32,14 +33,17 @@ def log_submit_payload(
     *,
     user: str | None = None,
     job_id: str | None = None,
+    cycle_id: int | None = None,
     analysis_intent: str | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Build the JSON body for ``POST /logs``."""
     payload = {PARAM_LOG_PATH: log_path}
     if user is not None:
         payload[PARAM_USER] = user
     if job_id is not None:
         payload[PARAM_JOB_ID] = job_id
+    if cycle_id is not None:
+        payload[PARAM_CYCLE_ID] = cycle_id
     if analysis_intent is not None:
         payload[PARAM_ANALYSIS_INTENT] = normalize_analysis_intent(analysis_intent)
     return payload
@@ -69,6 +73,7 @@ def post_log(
     *,
     user: str | None = None,
     job_id: str | None = None,
+    cycle_id: int | None = None,
     analysis_intent: str | None = None,
 ) -> Any:
     """Submit a log to attrsvc with an existing HTTP client."""
@@ -78,6 +83,7 @@ def post_log(
             log_path,
             user=user,
             job_id=job_id,
+            cycle_id=cycle_id,
             analysis_intent=analysis_intent,
         ),
         headers=ACCEPT_JSON_HEADERS,

--- a/src/nvidia_resiliency_ext/attribution/orchestration/types.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/types.py
@@ -253,6 +253,9 @@ class LogAnalysisCycleResult:
     recommendation: Dict[str, str] = field(
         default_factory=lambda: {"action": RECOMMENDATION_UNKNOWN, "source": ""}
     )
+    candidate_recommendation: Dict[str, str] = field(
+        default_factory=lambda: {"action": RECOMMENDATION_UNKNOWN, "source": ""}
+    )
 
 
 @dataclass

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/__init__.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Restart agent for terminal distributed-training log decisions."""
+
+from __future__ import annotations
+
+from .agent_runtime import RestartAgentRuntime, build_restart_agent_runtime
+from .attempt_records import (
+    AttemptRecordAssembler,
+    AttemptRecordControl,
+    AttemptRecordStore,
+    InMemoryAttemptRecordStore,
+    NullAttemptRecordStore,
+)
+from .config import (
+    HistoryConfig,
+    L0SourceConfig,
+    ModelRouteSpec,
+    RestartAgentConfig,
+    build_log_source_factory,
+    build_model_routes,
+    load_restart_agent_config,
+    parse_restart_agent_config,
+)
+from .execution import AnalysisRun, CollectAllAnalysisRun, L0Artifacts
+from .l0 import (
+    FinalizedL0A,
+    ProgressiveL0Accumulator,
+    ProgressiveL0State,
+    ProgressiveSourceUnavailable,
+)
+from .l1 import ModelRoute
+from .models import (
+    AffectedEntity,
+    AffectedEntityKind,
+    AnalysisResult,
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    AttemptProgressSummary,
+    AttemptRecord,
+    CausalRole,
+    CollectAllAnalysisResult,
+    Decision,
+    DecisionBasis,
+    DecisionCandidate,
+    DecisionCandidateKind,
+    DecisionEvidence,
+    DeclaredRecoveryCapability,
+    DistributedIncidentKind,
+    HistoryMatchScope,
+    L0Bundle,
+    L0ModelFacingView,
+    ModelAnalysisResult,
+    PriorAttemptView,
+    RecoveryBehavior,
+    RecoveryCapabilityId,
+    RestartAgentRequest,
+)
+from .pipeline import RestartAgent
+
+__all__ = [
+    "AffectedEntity",
+    "AffectedEntityKind",
+    "AnalysisResult",
+    "AnalysisRun",
+    "AttemptFailureFacts",
+    "AttemptFailureFactsSource",
+    "AttemptProgressSummary",
+    "AttemptRecord",
+    "AttemptRecordAssembler",
+    "AttemptRecordControl",
+    "AttemptRecordStore",
+    "CollectAllAnalysisResult",
+    "CollectAllAnalysisRun",
+    "CausalRole",
+    "Decision",
+    "DecisionBasis",
+    "DecisionCandidate",
+    "DecisionCandidateKind",
+    "DecisionEvidence",
+    "DeclaredRecoveryCapability",
+    "DistributedIncidentKind",
+    "HistoryConfig",
+    "HistoryMatchScope",
+    "InMemoryAttemptRecordStore",
+    "L0SourceConfig",
+    "L0Bundle",
+    "L0Artifacts",
+    "L0ModelFacingView",
+    "FinalizedL0A",
+    "ModelAnalysisResult",
+    "ModelRoute",
+    "ModelRouteSpec",
+    "NullAttemptRecordStore",
+    "PriorAttemptView",
+    "ProgressiveL0Accumulator",
+    "ProgressiveL0State",
+    "ProgressiveSourceUnavailable",
+    "RecoveryBehavior",
+    "RecoveryCapabilityId",
+    "RestartAgentConfig",
+    "RestartAgent",
+    "RestartAgentRuntime",
+    "RestartAgentRequest",
+    "build_model_routes",
+    "build_log_source_factory",
+    "build_restart_agent_runtime",
+    "load_restart_agent_config",
+    "parse_restart_agent_config",
+]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/agent_runtime.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/agent_runtime.py
@@ -1,0 +1,573 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stateful restart-agent orchestration around the stateless L0-L4 core."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
+from threading import RLock
+from typing import Any, Callable, Iterator, Mapping, Sequence
+
+from .attempt_records import (
+    AttemptRecordAssembler,
+    AttemptRecordControl,
+    AttemptRecordStore,
+    InMemoryAttemptRecordStore,
+    NullAttemptRecordStore,
+)
+from .config import RestartAgentConfig, build_log_source_factory, build_model_routes
+from .execution import AnalysisRun, CollectAllAnalysisRun, L0Artifacts
+from .l0.streaming import FinalizedL0A
+from .l1 import DEFAULT_ANALYSIS_TIMEOUT_SECONDS, LlmEvidenceExtractor, ModelRoute
+from .models import (
+    AttemptRecord,
+    DecisionCandidate,
+    ModelAnalysisResult,
+    PriorAttemptView,
+    RestartAgentRequest,
+    normalize_restart_agent_request,
+)
+from .pipeline import RestartAgent
+from .runtime import SYSTEM_CLOCK, Clock
+
+
+@dataclass
+class _InvocationRecordState:
+    key: tuple[str, int] | None
+    generation: int | None
+    prior_attempts: PriorAttemptView
+    record: AttemptRecord | None = None
+    open: bool = True
+    initial_upserted: bool = False
+    enriched_updates: int = 0
+    ignored_updates: int = 0
+    upsert_reason: str = "l0_not_ready"
+    excluded_current_or_future_records: int = 0
+    store_metrics_before: Mapping[str, int | bool] | None = None
+    enriched_route_updates: list[str] = field(default_factory=list)
+    record_operation_wall_clock_s: float = 0.0
+
+
+@dataclass
+class _InvocationGate:
+    lock: RLock = field(default_factory=RLock)
+    users: int = 0
+
+
+class RestartAgentRuntime:
+    """Own current-process history, invocation generations, and core execution."""
+
+    def __init__(
+        self,
+        analyzer: RestartAgent,
+        *,
+        attempt_record_store: AttemptRecordStore | None = None,
+        attempt_record_assembler: AttemptRecordAssembler | None = None,
+        model_routes: Sequence[ModelRoute] = (),
+        max_parallel_models: int | None = None,
+        timeout_seconds: float = DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+        config_metadata: Mapping[str, Any] | None = None,
+        clock: Clock = SYSTEM_CLOCK,
+    ) -> None:
+        self._analyzer = analyzer
+        self._store = attempt_record_store or InMemoryAttemptRecordStore()
+        self._assembler = attempt_record_assembler or AttemptRecordAssembler()
+        self._model_routes = tuple(model_routes)
+        self._max_parallel_models = max_parallel_models
+        self._timeout_seconds = timeout_seconds
+        self._config_metadata = dict(config_metadata or {})
+        self._clock = clock
+        self._state_lock = RLock()
+        self._closed = False
+        self._key_gates: dict[tuple[str, int], _InvocationGate] = {}
+        self._generations: dict[tuple[str, int], int] = {}
+        self.attempt_record_control = AttemptRecordControl(self._store)
+
+    @property
+    def model_routes(self) -> tuple[ModelRoute, ...]:
+        return self._model_routes
+
+    def close(self) -> None:
+        """Release infrastructure owned by configured model routes."""
+
+        with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+        closed: set[int] = set()
+        for route in self._model_routes:
+            extractor = route.evidence_extractor
+            if id(extractor) in closed:
+                continue
+            closed.add(id(extractor))
+            close = getattr(extractor, "close", None)
+            if close is not None:
+                close()
+
+    def analyze(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        **kwargs: Any,
+    ) -> AnalysisRun | CollectAllAnalysisRun:
+        """Use configured routes when present, otherwise run the single core path."""
+
+        if self._model_routes:
+            return self.analyze_many(request, self._model_routes, **kwargs)
+        return self.analyze_one(request, **_deterministic_kwargs(kwargs))
+
+    def analyze_prepared(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        finalized_l0a: FinalizedL0A,
+        **kwargs: Any,
+    ) -> AnalysisRun | CollectAllAnalysisRun:
+        """Analyze caller-finalized L0A without rereading the source log."""
+
+        if self._model_routes:
+            return self.analyze_many_prepared(
+                request,
+                finalized_l0a,
+                self._model_routes,
+                **kwargs,
+            )
+        return self.analyze_one_prepared(
+            request,
+            finalized_l0a,
+            **_deterministic_kwargs(kwargs),
+        )
+
+    def analyze_one(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        *,
+        l0_bundle: Any = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        timeout_seconds: float | None = None,
+        retain_detailed_artifacts: bool = True,
+    ) -> AnalysisRun:
+        normalized = normalize_restart_agent_request(request)
+        return self._analyze_one(
+            normalized,
+            finalized_l0a=None,
+            l0_bundle=l0_bundle,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            timeout_seconds=timeout_seconds,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+
+    def analyze_one_prepared(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        finalized_l0a: FinalizedL0A,
+        *,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        timeout_seconds: float | None = None,
+        retain_detailed_artifacts: bool = True,
+    ) -> AnalysisRun:
+        normalized = normalize_restart_agent_request(request)
+        return self._analyze_one(
+            normalized,
+            finalized_l0a=finalized_l0a,
+            l0_bundle=None,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            timeout_seconds=timeout_seconds,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+
+    def analyze_many(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        model_routes: Sequence[ModelRoute] | None = None,
+        *,
+        l0_bundle: Any = None,
+        max_parallel_models: int | None = None,
+        config_metadata: Mapping[str, Any] | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None = None,
+        timeout_seconds: float | None = None,
+        retain_detailed_artifacts: bool = True,
+    ) -> CollectAllAnalysisRun:
+        normalized = normalize_restart_agent_request(request)
+        routes = tuple(model_routes or self._model_routes)
+        if not routes:
+            raise ValueError("analyze_many requires at least one model route")
+        return self._analyze_many(
+            normalized,
+            routes,
+            finalized_l0a=None,
+            l0_bundle=l0_bundle,
+            max_parallel_models=max_parallel_models,
+            config_metadata=config_metadata,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            on_route_complete=on_route_complete,
+            timeout_seconds=timeout_seconds,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+
+    def analyze_many_prepared(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        finalized_l0a: FinalizedL0A,
+        model_routes: Sequence[ModelRoute] | None = None,
+        *,
+        max_parallel_models: int | None = None,
+        config_metadata: Mapping[str, Any] | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None = None,
+        timeout_seconds: float | None = None,
+        retain_detailed_artifacts: bool = True,
+    ) -> CollectAllAnalysisRun:
+        normalized = normalize_restart_agent_request(request)
+        routes = tuple(model_routes or self._model_routes)
+        if not routes:
+            raise ValueError("analyze_many_prepared requires at least one model route")
+        return self._analyze_many(
+            normalized,
+            routes,
+            finalized_l0a=finalized_l0a,
+            l0_bundle=None,
+            max_parallel_models=max_parallel_models,
+            config_metadata=config_metadata,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            on_route_complete=on_route_complete,
+            timeout_seconds=timeout_seconds,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+
+    def _analyze_one(
+        self,
+        request: RestartAgentRequest,
+        *,
+        finalized_l0a: FinalizedL0A | None,
+        l0_bundle: Any,
+        on_l0_ready: Callable[[L0Artifacts], None] | None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None,
+        timeout_seconds: float | None,
+        retain_detailed_artifacts: bool,
+    ) -> AnalysisRun:
+        with self._key_guard(request):
+            state = self._begin(request)
+
+            def l0_callback(artifacts: L0Artifacts) -> None:
+                self._publish_initial(state, request, artifacts)
+                if on_l0_ready is not None:
+                    on_l0_ready(artifacts)
+
+            try:
+                common = {
+                    "prior_attempts": state.prior_attempts,
+                    "on_l0_ready": l0_callback,
+                    "on_deterministic_ready": on_deterministic_ready,
+                    "timeout_seconds": (
+                        self._timeout_seconds if timeout_seconds is None else timeout_seconds
+                    ),
+                    "retain_detailed_artifacts": retain_detailed_artifacts,
+                }
+                run = (
+                    self._analyzer.run(
+                        request,
+                        l0_bundle=l0_bundle,
+                        **common,
+                    )
+                    if finalized_l0a is None
+                    else self._analyzer.run_prepared(
+                        request,
+                        finalized_l0a,
+                        **common,
+                    )
+                )
+                self._publish_single_enriched(state, run.attempt_record)
+            finally:
+                self._close(state)
+            return replace(run, trace=self._runtime_trace(run.trace, state))
+
+    def _analyze_many(
+        self,
+        request: RestartAgentRequest,
+        routes: tuple[ModelRoute, ...],
+        *,
+        finalized_l0a: FinalizedL0A | None,
+        l0_bundle: Any,
+        max_parallel_models: int | None,
+        config_metadata: Mapping[str, Any] | None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None,
+        on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None,
+        timeout_seconds: float | None,
+        retain_detailed_artifacts: bool,
+    ) -> CollectAllAnalysisRun:
+        with self._key_guard(request):
+            state = self._begin(request)
+
+            def l0_callback(artifacts: L0Artifacts) -> None:
+                self._publish_initial(state, request, artifacts)
+                if on_l0_ready is not None:
+                    on_l0_ready(artifacts)
+
+            def record_callback(route_id: str, route_record: AttemptRecord) -> None:
+                self._publish_enriched(state, route_id, route_record)
+
+            try:
+                common = {
+                    "prior_attempts": state.prior_attempts,
+                    "max_parallel_models": (
+                        self._max_parallel_models
+                        if max_parallel_models is None
+                        else max_parallel_models
+                    ),
+                    "config_metadata": (
+                        self._config_metadata if config_metadata is None else config_metadata
+                    ),
+                    "on_l0_ready": l0_callback,
+                    "on_deterministic_ready": on_deterministic_ready,
+                    "on_route_complete": on_route_complete,
+                    "on_attempt_record_ready": record_callback,
+                    "timeout_seconds": (
+                        self._timeout_seconds if timeout_seconds is None else timeout_seconds
+                    ),
+                    "retain_detailed_artifacts": retain_detailed_artifacts,
+                }
+                run = (
+                    self._analyzer.run_many(
+                        request,
+                        routes,
+                        l0_bundle=l0_bundle,
+                        **common,
+                    )
+                    if finalized_l0a is None
+                    else self._analyzer.run_many_prepared(
+                        request,
+                        finalized_l0a,
+                        routes,
+                        **common,
+                    )
+                )
+            finally:
+                self._close(state)
+            return replace(run, trace=self._runtime_trace(run.trace, state))
+
+    def _begin(self, request: RestartAgentRequest) -> _InvocationRecordState:
+        prior_attempts = self._prior_attempts(request)
+        key = _request_key(request)
+        generation = None
+        if key is not None:
+            with self._state_lock:
+                generation = self._generations.get(key, 0) + 1
+                self._generations[key] = generation
+        return _InvocationRecordState(
+            key=key,
+            generation=generation,
+            prior_attempts=prior_attempts,
+            upsert_reason=(
+                prior_attempts.availability_reason
+                if key is None or not self._store.enabled
+                else "l0_not_ready"
+            ),
+            excluded_current_or_future_records=(
+                sum(record.cycle_id >= key[1] for record in self._store.records(key[0]))
+                if key is not None and self._store.enabled
+                else 0
+            ),
+            store_metrics_before=self._store.metrics(),
+        )
+
+    def _prior_attempts(self, request: RestartAgentRequest) -> PriorAttemptView:
+        if not self._store.enabled:
+            return PriorAttemptView(availability_reason="history_disabled")
+        if request.job_id is None:
+            return PriorAttemptView(availability_reason="missing_job_id")
+        if request.cycle_id is None:
+            return PriorAttemptView(availability_reason="missing_cycle_id")
+        return self._store.get_prior_attempts(request.job_id, request.cycle_id)
+
+    def _publish_initial(
+        self,
+        state: _InvocationRecordState,
+        request: RestartAgentRequest,
+        artifacts: L0Artifacts,
+    ) -> None:
+        started = self._clock.monotonic()
+        try:
+            if state.key is None or request.job_id is None or request.cycle_id is None:
+                return
+            record = self._assembler.initial_record(
+                job_id=request.job_id,
+                cycle_id=request.cycle_id,
+                bundle=artifacts.bundle,
+                decision_evidence=artifacts.decision_evidence,
+            )
+            state.record = record
+            if not self._store.enabled:
+                state.upsert_reason = "history_disabled"
+                return
+            if not record.deterministic.root_fingerprint:
+                state.upsert_reason = "missing_root_fingerprint"
+                return
+            if not self._accepts_update(state):
+                state.ignored_updates += 1
+                return
+            self._store.upsert_attempt(record)
+            state.record = record
+            state.initial_upserted = True
+            state.upsert_reason = "stored"
+        finally:
+            state.record_operation_wall_clock_s += self._clock.monotonic() - started
+
+    def _publish_single_enriched(
+        self,
+        state: _InvocationRecordState,
+        route_record: AttemptRecord | None,
+    ) -> None:
+        if route_record is None:
+            return
+        for entry in route_record.enriched:
+            self._publish_enriched(state, entry.route_id, route_record)
+
+    def _publish_enriched(
+        self,
+        state: _InvocationRecordState,
+        route_id: str,
+        route_record: AttemptRecord,
+    ) -> None:
+        started = self._clock.monotonic()
+        try:
+            entry = next(
+                (item for item in route_record.enriched if item.route_id == route_id),
+                None,
+            )
+            if entry is None or state.record is None or not state.initial_upserted:
+                return
+            if not self._accepts_update(state):
+                state.ignored_updates += 1
+                return
+            replacement = self._assembler.with_enriched(
+                state.record,
+                route_id=route_id,
+                facts=entry.facts,
+            )
+            self._store.upsert_attempt(replacement)
+            state.record = replacement
+            state.enriched_updates += 1
+            state.enriched_route_updates.append(route_id)
+        finally:
+            state.record_operation_wall_clock_s += self._clock.monotonic() - started
+
+    def _accepts_update(self, state: _InvocationRecordState) -> bool:
+        if not state.open or state.key is None or state.generation is None:
+            return False
+        with self._state_lock:
+            return self._generations.get(state.key) == state.generation
+
+    def _close(self, state: _InvocationRecordState) -> None:
+        state.open = False
+
+    @contextmanager
+    def _key_guard(self, request: RestartAgentRequest) -> Iterator[None]:
+        key = _request_key(request)
+        if key is None:
+            yield
+            return
+        with self._state_lock:
+            gate = self._key_gates.setdefault(key, _InvocationGate())
+            gate.users += 1
+        try:
+            with gate.lock:
+                yield
+        finally:
+            with self._state_lock:
+                gate.users -= 1
+                if gate.users == 0 and self._key_gates.get(key) is gate:
+                    self._key_gates.pop(key, None)
+                    self._generations.pop(key, None)
+
+    def _runtime_trace(
+        self,
+        trace: Mapping[str, Any],
+        state: _InvocationRecordState,
+    ) -> dict[str, Any]:
+        payload = dict(trace)
+        payload["runtime_history"] = {
+            "enabled": self._store.enabled,
+            "availability_reason": state.prior_attempts.availability_reason,
+            "prior_attempt_count": len(state.prior_attempts.records),
+            "excluded_current_or_future_record_count": (state.excluded_current_or_future_records),
+            "record_key": (
+                {"job_id": state.key[0], "cycle_id": state.key[1]}
+                if state.key is not None
+                else None
+            ),
+            "generation": state.generation,
+            "initial_upserted": state.initial_upserted,
+            "upsert_reason": state.upsert_reason,
+            "enriched_updates": state.enriched_updates,
+            "enriched_route_updates": tuple(state.enriched_route_updates),
+            "ignored_closed_or_stale_updates": state.ignored_updates,
+            "closed": not state.open,
+            "record_operation_wall_clock_s": round(
+                state.record_operation_wall_clock_s,
+                6,
+            ),
+            "current_attempt_record": (
+                state.record.to_payload() if state.record is not None else None
+            ),
+            "store_before": dict(state.store_metrics_before or {}),
+            "store_after": self._store.metrics(),
+        }
+        return payload
+
+
+def build_restart_agent_runtime(
+    config: RestartAgentConfig,
+    *,
+    attempt_record_store: AttemptRecordStore | None = None,
+) -> RestartAgentRuntime:
+    """Composition root for validated config, provider routes, and runtime state."""
+
+    store = attempt_record_store
+    if store is None:
+        store = (
+            InMemoryAttemptRecordStore(
+                max_attempts_per_job=config.history.max_attempts_per_job,
+                max_total_records=config.history.max_total_records,
+            )
+            if config.history.enabled
+            else NullAttemptRecordStore()
+        )
+    analyzer = RestartAgent(
+        log_source_factory=build_log_source_factory(config),
+        retry_policy=config.retry_policy,
+        declared_recovery_capabilities=config.declared_recovery_capabilities,
+    )
+    return RestartAgentRuntime(
+        analyzer,
+        attempt_record_store=store,
+        model_routes=build_model_routes(config, LlmEvidenceExtractor),
+        max_parallel_models=config.max_parallel_models,
+        timeout_seconds=config.timeout_seconds,
+        config_metadata=config.metadata(),
+    )
+
+
+def _request_key(request: RestartAgentRequest) -> tuple[str, int] | None:
+    if request.job_id is None or request.cycle_id is None:
+        return None
+    return request.job_id, request.cycle_id
+
+
+def _deterministic_kwargs(kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    """Remove controls that apply only to optional model-route execution."""
+
+    deterministic = dict(kwargs)
+    for option_name in ("max_parallel_models", "config_metadata", "on_route_complete"):
+        deterministic.pop(option_name, None)
+    return deterministic

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/attempt_records.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/attempt_records.py
@@ -1,0 +1,380 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attempt-record assembly, bounded storage, and test control surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from threading import RLock
+from typing import Literal, Protocol, Sequence
+
+from .l2.failure_facts import build_attempt_failure_facts
+from .models import (
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    AttemptProgressSummary,
+    AttemptRecord,
+    DecisionEvidence,
+    EnrichedAttemptFacts,
+    L0Bundle,
+    PriorAttemptView,
+    normalize_attempt_records,
+)
+
+DEFAULT_MAX_ATTEMPTS_PER_JOB = 10
+DEFAULT_MAX_TOTAL_RECORDS = 3000
+
+
+class AttemptRecordStore(Protocol):
+    """Runtime-owned storage contract for current-process attempt history."""
+
+    @property
+    def enabled(self) -> bool: ...
+
+    def get_prior_attempts(self, job_id: str, before_cycle_id: int) -> PriorAttemptView: ...
+
+    def upsert_attempt(self, record: AttemptRecord) -> None: ...
+
+    def records(self, job_id: str | None = None) -> tuple[AttemptRecord, ...]: ...
+
+    def replace(self, records: Sequence[AttemptRecord]) -> None: ...
+
+    def clear(self, job_id: str | None = None) -> None: ...
+
+    def metrics(self) -> dict[str, int | bool]: ...
+
+
+class InMemoryAttemptRecordStore:
+    """Thread-safe bounded attempt records with idempotent key replacement."""
+
+    def __init__(
+        self,
+        *,
+        max_attempts_per_job: int = DEFAULT_MAX_ATTEMPTS_PER_JOB,
+        max_total_records: int = DEFAULT_MAX_TOTAL_RECORDS,
+    ) -> None:
+        self._max_attempts_per_job = _positive_int(max_attempts_per_job, "max_attempts_per_job")
+        self._max_total_records = _positive_int(max_total_records, "max_total_records")
+        self._records: dict[tuple[str, int], AttemptRecord] = {}
+        self._insertion_sequence: dict[tuple[str, int], int] = {}
+        self._next_sequence = 0
+        self._eviction_count = 0
+        self._lock = RLock()
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    def get_prior_attempts(self, job_id: str, before_cycle_id: int) -> PriorAttemptView:
+        with self._lock:
+            records = tuple(
+                sorted(
+                    (
+                        record
+                        for (stored_job, cycle_id), record in self._records.items()
+                        if stored_job == job_id and cycle_id < before_cycle_id
+                    ),
+                    key=lambda item: item.cycle_id,
+                )
+            )
+        return PriorAttemptView(
+            records=records[-self._max_attempts_per_job :],
+            available=True,
+            availability_reason="ready",
+        )
+
+    def upsert_attempt(self, record: AttemptRecord) -> None:
+        _validate_storable_record(record)
+        key = (record.job_id, record.cycle_id)
+        with self._lock:
+            if key not in self._records:
+                self._insertion_sequence[key] = self._next_sequence
+                self._next_sequence += 1
+            self._records[key] = record
+            self._evict_per_job(record.job_id)
+            self._evict_total()
+
+    def records(self, job_id: str | None = None) -> tuple[AttemptRecord, ...]:
+        with self._lock:
+            selected = (
+                record
+                for (stored_job, _cycle_id), record in self._records.items()
+                if job_id is None or stored_job == job_id
+            )
+            return tuple(sorted(selected, key=lambda item: (item.job_id, item.cycle_id)))
+
+    def replace(self, records: Sequence[AttemptRecord]) -> None:
+        normalized = normalize_attempt_records(records)
+        for record in normalized:
+            _validate_storable_record(record)
+        with self._lock:
+            self._records.clear()
+            self._insertion_sequence.clear()
+            self._next_sequence = 0
+            for record in normalized:
+                self._upsert_locked(record)
+
+    def clear(self, job_id: str | None = None) -> None:
+        with self._lock:
+            if job_id is None:
+                self._records.clear()
+                self._insertion_sequence.clear()
+                return
+            keys = [key for key in self._records if key[0] == job_id]
+            for key in keys:
+                self._remove_locked(key)
+
+    def metrics(self) -> dict[str, int | bool]:
+        with self._lock:
+            return {
+                "enabled": True,
+                "record_count": len(self._records),
+                "job_count": len({job_id for job_id, _cycle_id in self._records}),
+                "enriched_entry_count": sum(
+                    len(record.enriched) for record in self._records.values()
+                ),
+                "eviction_count": self._eviction_count,
+                "max_attempts_per_job": self._max_attempts_per_job,
+                "max_total_records": self._max_total_records,
+            }
+
+    def _upsert_locked(self, record: AttemptRecord) -> None:
+        key = (record.job_id, record.cycle_id)
+        if key not in self._records:
+            self._insertion_sequence[key] = self._next_sequence
+            self._next_sequence += 1
+        self._records[key] = record
+        self._evict_per_job(record.job_id)
+        self._evict_total()
+
+    def _evict_per_job(self, job_id: str) -> None:
+        job_keys = sorted(
+            (key for key in self._records if key[0] == job_id),
+            key=lambda key: key[1],
+        )
+        while len(job_keys) > self._max_attempts_per_job:
+            self._remove_locked(job_keys.pop(0))
+
+    def _evict_total(self) -> None:
+        while len(self._records) > self._max_total_records:
+            oldest = min(self._insertion_sequence, key=self._insertion_sequence.__getitem__)
+            self._remove_locked(oldest)
+
+    def _remove_locked(self, key: tuple[str, int]) -> None:
+        if key in self._records:
+            self._records.pop(key)
+            self._insertion_sequence.pop(key, None)
+            self._eviction_count += 1
+
+
+class NullAttemptRecordStore:
+    """Explicit disabled-history store used by the composition root."""
+
+    @property
+    def enabled(self) -> bool:
+        return False
+
+    def get_prior_attempts(self, job_id: str, before_cycle_id: int) -> PriorAttemptView:
+        return PriorAttemptView(availability_reason="history_disabled")
+
+    def upsert_attempt(self, record: AttemptRecord) -> None:
+        return None
+
+    def records(self, job_id: str | None = None) -> tuple[AttemptRecord, ...]:
+        return ()
+
+    def replace(self, records: Sequence[AttemptRecord]) -> None:
+        raise ValueError("history_disabled")
+
+    def clear(self, job_id: str | None = None) -> None:
+        return None
+
+    def metrics(self) -> dict[str, int | bool]:
+        return {
+            "enabled": False,
+            "record_count": 0,
+            "job_count": 0,
+            "enriched_entry_count": 0,
+            "eviction_count": 0,
+        }
+
+
+class AttemptRecordControl:
+    """Transport-independent test seam for seeding and inspecting records."""
+
+    def __init__(self, store: AttemptRecordStore) -> None:
+        self._store = store
+
+    def seed(
+        self,
+        records: Sequence[AttemptRecord | dict[str, object]],
+        *,
+        mode: Literal["replace", "merge"] = "replace",
+    ) -> None:
+        if not self._store.enabled:
+            raise ValueError("history_disabled")
+        normalized = normalize_attempt_records(records)
+        if mode == "replace":
+            self._store.replace(normalized)
+        elif mode == "merge":
+            for record in normalized:
+                self._store.upsert_attempt(record)
+        else:
+            raise ValueError("attempt-record seed mode must be 'replace' or 'merge'")
+
+    def records(self, job_id: str | None = None) -> tuple[AttemptRecord, ...]:
+        return self._store.records(job_id)
+
+    def clear(self, job_id: str | None = None) -> None:
+        self._store.clear(job_id)
+
+
+class AttemptRecordAssembler:
+    """Build immutable initial records and route-keyed enriched replacements."""
+
+    def initial_record(
+        self,
+        *,
+        job_id: str,
+        cycle_id: int,
+        bundle: L0Bundle,
+        decision_evidence: DecisionEvidence,
+    ) -> AttemptRecord:
+        deterministic = build_attempt_failure_facts(
+            decision_evidence.deterministic_primary_candidate,
+            decision_evidence,
+            source=AttemptFailureFactsSource.L0_DETERMINISTIC,
+        )
+        return AttemptRecord(
+            job_id=job_id,
+            cycle_id=cycle_id,
+            progress=build_attempt_progress_summary(bundle, decision_evidence),
+            deterministic=deterministic,
+            enriched=(),
+        )
+
+    def with_enriched(
+        self,
+        record: AttemptRecord,
+        *,
+        route_id: str,
+        facts: AttemptFailureFacts,
+    ) -> AttemptRecord:
+        if not route_id:
+            raise ValueError("route_id is required for enriched attempt facts")
+        entries = {entry.route_id: entry for entry in record.enriched}
+        entries[route_id] = EnrichedAttemptFacts(route_id=route_id, facts=facts)
+        return replace(
+            record,
+            enriched=tuple(entries[key] for key in sorted(entries)),
+        )
+
+
+def build_attempt_progress_summary(
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+) -> AttemptProgressSummary:
+    """Derive route-independent attempt progress from fully scanned L0 facts."""
+
+    completed = _logical_marker_values(bundle.progress.progress_markers, marker_type="iteration")
+    checkpoints = _logical_marker_values(bundle.progress.checkpoint_markers)
+    primary = decision_evidence.deterministic_primary_candidate
+    primary_line = primary.line if primary is not None else None
+    training_status = _observation_status(
+        observed=bool(completed),
+        dialect_recognized=bundle.progress.training_progress_dialect_recognized,
+    )
+    checkpoint_status = _observation_status(
+        observed=bool(checkpoints),
+        dialect_recognized=bundle.progress.checkpoint_progress_dialect_recognized,
+    )
+    progress_lines = sorted(
+        {
+            marker.line
+            for marker in bundle.progress.progress_markers
+            if marker.marker_type == "iteration"
+        }
+    )
+    if primary_line is None:
+        failure_position = "unknown"
+        progress_after_failure = "unknown"
+    else:
+        prior_progress = any(line <= primary_line for line in progress_lines)
+        failure_position = (
+            "after_observed_training_progress"
+            if prior_progress
+            else (
+                "before_observed_training_progress"
+                if bundle.progress.training_progress_dialect_recognized
+                else "unknown"
+            )
+        )
+        progress_after_failure = (
+            "observed"
+            if bundle.run_progress_summary.progress_after_failure_episode is True
+            else (
+                "not_observed"
+                if (
+                    bundle.run_progress_summary.progress_after_failure_episode is False
+                    and bundle.progress.training_progress_dialect_recognized
+                    and bool(bundle.selection_summary.get("primary_after_context_available"))
+                )
+                else "unknown"
+            )
+        )
+    return AttemptProgressSummary(
+        training_progress=training_status,
+        first_completed_step=min(completed) if completed else None,
+        last_completed_step=max(completed) if completed else None,
+        completed_step_delta=(max(completed) - min(completed) if completed else None),
+        progress_marker_count=len(completed),
+        checkpoint_progress=checkpoint_status,
+        checkpoint_load_step=bundle.run_progress_summary.checkpoint_load_iteration,
+        first_checkpoint_step=min(checkpoints) if checkpoints else None,
+        last_checkpoint_step=max(checkpoints) if checkpoints else None,
+        checkpoint_step_delta=(max(checkpoints) - min(checkpoints) if checkpoints else None),
+        checkpoint_marker_count=len(checkpoints),
+        failure_position=failure_position,
+        progress_after_failure=progress_after_failure,
+    )
+
+
+def _observation_status(*, observed: bool, dialect_recognized: bool) -> str:
+    if observed:
+        return "observed"
+    return "not_observed" if dialect_recognized else "unknown"
+
+
+def _logical_marker_values(markers: Sequence[object], marker_type: str | None = None) -> list[int]:
+    values = {
+        int(marker.value)
+        for marker in markers
+        if isinstance(getattr(marker, "value", None), int)
+        and (marker_type is None or getattr(marker, "marker_type", None) == marker_type)
+    }
+    return sorted(values)
+
+
+def _validate_storable_record(record: AttemptRecord) -> None:
+    if not record.job_id:
+        raise ValueError("AttemptRecord job_id is required")
+    if isinstance(record.cycle_id, bool) or not isinstance(record.cycle_id, int):
+        raise TypeError("AttemptRecord cycle_id must be an integer")
+    if not record.deterministic.root_fingerprint:
+        raise ValueError("AttemptRecord deterministic root_fingerprint is required")
+    if not record.deterministic.root_fingerprint_source:
+        raise ValueError("AttemptRecord deterministic root_fingerprint_source is required")
+    if not record.deterministic.fault_outcome:
+        raise ValueError("AttemptRecord deterministic fault_outcome is required")
+    for entry in record.enriched:
+        if not entry.facts.fault_outcome:
+            raise ValueError(f"AttemptRecord enriched[{entry.route_id}] fault_outcome is required")
+
+
+def _positive_int(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 1:
+        raise ValueError(f"{field_name} must be greater than zero")
+    return value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/causality.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/causality.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Assemble causal downstream evidence for the public result."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Mapping
+
+from .l0 import build_cascades_for_primary
+from .models import CascadeEvidence, CausalRole, FailureEvidence, L0Bundle
+
+
+def build_result_cascades(
+    bundle: L0Bundle,
+    primary: FailureEvidence | None,
+    l2_audit: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    """Merge deterministic downstream groups with grounded L1 relationships."""
+
+    l0_primary = bundle.deterministic_primary_candidate
+    primary_matches_l0 = (
+        primary is not None
+        and l0_primary is not None
+        and primary.line is not None
+        and primary.line == l0_primary.line
+    )
+    deterministic = list(bundle.cascades) if primary_matches_l0 else []
+    if not deterministic:
+        deterministic = build_cascades_for_primary(
+            bundle.registry_matches,
+            primary,
+            bundle.distributed_failure_incidents,
+        )
+    audited_roles = tuple(
+        item
+        for item in l2_audit.get("audited_related_failure_roles") or ()
+        if isinstance(item, Mapping)
+        and item.get("causal_role") in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}
+    )
+    audited_failures_by_line = {
+        item.get("line"): item
+        for item in l2_audit.get("audited_related_failures") or ()
+        if isinstance(item, Mapping) and isinstance(item.get("line"), int)
+    }
+    covered_audited_lines: set[int] = set()
+    result: list[Mapping[str, Any]] = []
+
+    for cascade in deterministic:
+        member_lines = _cascade_member_lines(bundle, primary, cascade)
+        rationales = tuple(
+            str(item.get("rationale"))
+            for item in audited_roles
+            if item.get("line") in member_lines and item.get("rationale")
+        )
+        covered_audited_lines.update(
+            int(item["line"]) for item in audited_roles if item.get("line") in member_lines
+        )
+        result.append(_cascade_payload(replace(cascade, relationship_rationales=rationales)))
+
+    for item in audited_roles:
+        line = item.get("line")
+        if not isinstance(line, int) or line in covered_audited_lines:
+            continue
+        failure = audited_failures_by_line.get(line, {})
+        role = str(item.get("causal_role"))
+        result.append(
+            {
+                "failure_class": failure.get("failure_class") or "related_failure",
+                "cascade_fingerprint": failure.get("root_fingerprint"),
+                "causal_role": role,
+                "first_line": line,
+                "last_line": line,
+                "count": 1,
+                "sample_lines": [line],
+                "rank_spread": _optional_singleton(failure.get("rank")),
+                "node_spread": _optional_singleton(failure.get("node")),
+                "gpu_spread": _optional_singleton(failure.get("gpu")),
+                "reason": f"L2-grounded {role} related to primary failure",
+                "relationship_rationales": [str(item.get("rationale"))],
+            }
+        )
+
+    return tuple(sorted(result, key=lambda item: int(item.get("first_line") or 0)))
+
+
+def _cascade_member_lines(
+    bundle: L0Bundle,
+    primary: FailureEvidence | None,
+    cascade: CascadeEvidence,
+) -> set[int]:
+    primary_line = primary.line if primary is not None else None
+    if primary_line is None:
+        return set()
+    return {
+        int(match.line)
+        for match in bundle.registry_matches
+        if match.line is not None
+        and match.line > primary_line
+        and match.failure_class == cascade.failure_class
+        and match.root_fingerprint == cascade.cascade_fingerprint
+        and _downstream_role(match) == cascade.causal_role
+    }
+
+
+def _downstream_role(failure: FailureEvidence) -> str:
+    if failure.causal_role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}:
+        return failure.causal_role
+    return CausalRole.CASCADE.value
+
+
+def _cascade_payload(cascade: CascadeEvidence) -> dict[str, Any]:
+    return {
+        "failure_class": cascade.failure_class,
+        "cascade_fingerprint": cascade.cascade_fingerprint,
+        "causal_role": cascade.causal_role,
+        "first_line": cascade.first_line,
+        "last_line": cascade.last_line,
+        "count": cascade.count,
+        "sample_lines": list(cascade.sample_lines),
+        "rank_spread": list(cascade.rank_spread),
+        "node_spread": list(cascade.node_spread),
+        "gpu_spread": list(cascade.gpu_spread),
+        "reason": cascade.reason,
+        "relationship_rationales": list(cascade.relationship_rationales),
+    }
+
+
+def _optional_singleton(value: Any) -> list[str]:
+    return [] if value is None or value == "" else [str(value)]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/cli.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/cli.py
@@ -1,0 +1,603 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Command-line entrypoint for local restart-policy analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import Any
+
+from .agent_runtime import RestartAgentRuntime, build_restart_agent_runtime
+from .attempt_records import InMemoryAttemptRecordStore
+from .config import load_restart_agent_config
+from .infrastructure import (
+    DETERMINISTIC_RECOMMENDATION_SCHEMA_VERSION,
+    L0ArtifactPublisher,
+    LiveArtifactWriter,
+    RouteArtifactPublisher,
+    load_route_artifact_manifest,
+    write_json_atomic,
+)
+from .l0 import read_l0_bundle
+from .l1 import THINKING_MODES, LlmConfig, LlmEvidenceExtractor
+from .models import (
+    AnalysisResult,
+    AttemptRecord,
+    CollectAllAnalysisResult,
+    RestartAgentRequest,
+    normalize_attempt_records,
+)
+from .observability import CLI_COLLECT_ALL_TRACE_SCHEMA_VERSION, CLI_TRACE_SCHEMA_VERSION
+from .pipeline import RestartAgent
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    attempt_records = _load_attempt_records(args.attempt_records_json_in)
+    request = RestartAgentRequest(
+        log_path=args.log_path,
+        job_id=args.job_id,
+        cycle_id=args.cycle_id,
+    )
+    replayed_bundle = (
+        read_l0_bundle(args.l0_bundle_json_in, expected_log_path=args.log_path)
+        if args.l0_bundle_json_in
+        else None
+    )
+    if args.config:
+        return _run_configured(args, request, attempt_records, replayed_bundle)
+
+    runtime = RestartAgentRuntime(
+        RestartAgent(evidence_extractor=_evidence_extractor_from_args(args)),
+        attempt_record_store=InMemoryAttemptRecordStore(),
+    )
+    if attempt_records:
+        runtime.attempt_record_control.seed(attempt_records)
+    l0_publisher = L0ArtifactPublisher(
+        bundle_path=args.l0_bundle_json_out,
+        decision_evidence_path=args.decision_evidence_json_out,
+        model_view_path=args.l0_model_view_json_out,
+    )
+    try:
+
+        def deterministic_callback(candidate: Any) -> None:
+            if args.deterministic_json_out:
+                write_json_atomic(
+                    args.deterministic_json_out,
+                    {
+                        "schema_version": DETERMINISTIC_RECOMMENDATION_SCHEMA_VERSION,
+                        "candidate": candidate.to_payload(),
+                    },
+                )
+
+        run = runtime.analyze_one(
+            request,
+            l0_bundle=replayed_bundle,
+            on_l0_ready=l0_publisher.publish,
+            on_deterministic_ready=deterministic_callback,
+        )
+        l0_publisher.wait()
+    finally:
+        l0_publisher.close()
+    result = run.result
+    if args.trace_json:
+        _write_trace_json(
+            args.trace_json,
+            request,
+            result,
+            run.trace,
+            run.bundle,
+        )
+    if args.result_json:
+        write_json_atomic(args.result_json, result.to_payload())
+    _write_attempt_records(args.attempt_records_json_out, runtime)
+    if args.summary:
+        _print_summary(args.trace_json, result, run.trace)
+    print(json.dumps(result.to_payload(), sort_keys=True))
+    return 0
+
+
+def _run_configured(
+    args: argparse.Namespace,
+    request: RestartAgentRequest,
+    attempt_records: tuple[AttemptRecord, ...],
+    replayed_bundle: Any,
+) -> int:
+    config = load_restart_agent_config(args.config)
+    runtime = build_restart_agent_runtime(config)
+    if attempt_records:
+        runtime.attempt_record_control.seed(attempt_records)
+    model_routes = runtime.model_routes
+    if args.route_artifact_manifest and not model_routes:
+        raise ValueError("--route-artifact-manifest requires enrichment.enabled=true")
+    route_artifact_publisher = (
+        RouteArtifactPublisher(
+            load_route_artifact_manifest(
+                args.route_artifact_manifest,
+                expected_route_ids=[route.route_id for route in model_routes],
+            ),
+            request=request.to_payload(),
+            batch_trace_path=args.trace_json,
+        )
+        if args.route_artifact_manifest
+        else None
+    )
+    live_writer = (
+        LiveArtifactWriter(args.incremental_artifact_dir) if args.incremental_artifact_dir else None
+    )
+    if live_writer is not None:
+        live_writer.start(
+            routes=[
+                {
+                    "route_id": route.route_id,
+                    "model": route.model,
+                    "endpoint": route.endpoint,
+                    "credential_ref": route.credential_ref,
+                }
+                for route in model_routes
+            ],
+            config_metadata=config.metadata(),
+        )
+
+    def deterministic_callback(candidate: Any) -> None:
+        candidate_payload = candidate.to_payload()
+        if args.deterministic_json_out:
+            write_json_atomic(
+                args.deterministic_json_out,
+                {
+                    "schema_version": DETERMINISTIC_RECOMMENDATION_SCHEMA_VERSION,
+                    "candidate": candidate_payload,
+                },
+            )
+        if live_writer is not None:
+            live_writer.publish_deterministic(
+                candidate_payload,
+                artifact_path=args.deterministic_json_out,
+            )
+
+    def route_callback(route_result: Any, route_trace: Any) -> None:
+        artifact_paths = (
+            route_artifact_publisher.publish(route_result, route_trace)
+            if route_artifact_publisher is not None
+            else {}
+        )
+        if live_writer is not None:
+            live_writer.publish_route(
+                route_result.to_payload(),
+                artifact_paths=artifact_paths,
+            )
+
+    l0_publisher = L0ArtifactPublisher(
+        bundle_path=args.l0_bundle_json_out,
+        decision_evidence_path=args.decision_evidence_json_out,
+        model_view_path=args.l0_model_view_json_out,
+        on_published=(live_writer.publish_l0_artifacts if live_writer is not None else None),
+    )
+
+    def l0_callback(artifacts: Any) -> None:
+        if route_artifact_publisher is not None:
+            route_artifact_publisher.set_l0_artifacts(artifacts)
+        l0_publisher.publish(artifacts)
+
+    try:
+        run = runtime.analyze(
+            request,
+            l0_bundle=replayed_bundle,
+            max_parallel_models=config.max_parallel_models,
+            config_metadata=config.metadata(),
+            on_l0_ready=l0_callback,
+            on_deterministic_ready=deterministic_callback,
+            on_route_complete=route_callback,
+            timeout_seconds=config.timeout_seconds,
+        )
+        result = run.result
+        l0_publisher.wait()
+        if args.trace_json:
+            if isinstance(result, CollectAllAnalysisResult):
+                _write_collect_all_trace_json(
+                    args.trace_json,
+                    request,
+                    result,
+                    run.trace,
+                    run.bundle,
+                )
+            else:
+                _write_trace_json(
+                    args.trace_json,
+                    request,
+                    result,
+                    run.trace,
+                    run.bundle,
+                )
+        if args.result_json:
+            write_json_atomic(args.result_json, result.to_payload())
+        _write_attempt_records(args.attempt_records_json_out, runtime)
+        if live_writer is not None:
+            live_writer.complete(
+                final_artifacts={
+                    "result_json": args.result_json,
+                    "trace_json": args.trace_json,
+                    "l0_bundle_json": args.l0_bundle_json_out,
+                    "decision_evidence_json": args.decision_evidence_json_out,
+                    "l0_model_view_json": args.l0_model_view_json_out,
+                },
+            )
+        if args.summary and isinstance(result, CollectAllAnalysisResult):
+            _print_collect_all_summary(args.trace_json, result)
+        elif args.summary:
+            _print_summary(args.trace_json, result, run.trace)
+        print(json.dumps(result.to_payload(), sort_keys=True))
+    except BaseException as exc:
+        if live_writer is not None:
+            live_writer.fail(exc)
+        raise
+    finally:
+        l0_publisher.close()
+    return 0
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze one training log for restart policy.")
+    parser.add_argument("log_path")
+    parser.add_argument("--job-id")
+    parser.add_argument("--cycle-id", type=int)
+    parser.add_argument(
+        "--attempt-records-json-in",
+        help="Seed runtime history from a plain AttemptRecord JSON array",
+    )
+    parser.add_argument(
+        "--attempt-records-json-out",
+        help="Write the complete post-analysis AttemptRecord JSON array",
+    )
+    l1_group = parser.add_mutually_exclusive_group()
+    l1_group.add_argument(
+        "--enable-l1",
+        dest="enable_l1",
+        action="store_true",
+        default=None,
+        help="Run L1 model enrichment (the default)",
+    )
+    l1_group.add_argument(
+        "--disable-l1",
+        dest="enable_l1",
+        action="store_false",
+        help="Run deterministic-only analysis without L1 model enrichment",
+    )
+    parser.add_argument(
+        "--config",
+        help=(
+            "Run the versioned restart-agent configuration in this JSON file; "
+            "credential_ref values resolve through environment variables"
+        ),
+    )
+    parser.add_argument("--llm-base-url")
+    parser.add_argument("--llm-model")
+    parser.add_argument("--llm-api-key-file")
+    parser.add_argument("--llm-timeout-seconds", type=float)
+    parser.add_argument("--llm-max-output-tokens", type=int)
+    parser.add_argument("--llm-context-window-tokens", type=int)
+    parser.add_argument("--llm-max-tool-rounds", type=int)
+    parser.add_argument("--llm-temperature", type=float)
+    parser.add_argument("--llm-top-p", type=float)
+    parser.add_argument(
+        "--llm-thinking-mode",
+        choices=THINKING_MODES,
+        help="Provider thinking/reasoning knob policy; auto disables Qwen thinking",
+    )
+    parser.add_argument("--llm-reasoning-effort")
+    parser.add_argument(
+        "--disable-l1-tools",
+        action="store_true",
+        help="Do not advertise read-only L1 log tools to the model",
+    )
+    parser.add_argument(
+        "--trace-json",
+        help="Write the request, L0 bundle, and final response to this JSON file",
+    )
+    parser.add_argument(
+        "--result-json",
+        help="Write the final single-route or collect-all result to this JSON file",
+    )
+    parser.add_argument(
+        "--deterministic-json-out",
+        help="Write the deterministic recommendation when it becomes ready",
+    )
+    parser.add_argument(
+        "--route-artifact-manifest",
+        help="Write completed collect-all routes to caller-declared result/trace paths",
+    )
+    parser.add_argument(
+        "--l0-bundle-json-in",
+        help="Reuse a versioned L0 bundle previously built for this unchanged log",
+    )
+    parser.add_argument(
+        "--l0-bundle-json-out",
+        help="Write the versioned L0 bundle used by this analysis",
+    )
+    parser.add_argument(
+        "--decision-evidence-json-out",
+        help="Write canonical Decision Evidence when shared L0 completes",
+    )
+    parser.add_argument(
+        "--l0-model-view-json-out",
+        help="Write the bounded L0B model evidence view when shared L0 completes",
+    )
+    parser.add_argument(
+        "--incremental-artifact-dir",
+        help=(
+            "Publish collect-all lifecycle status and append-only events while "
+            "analysis is running"
+        ),
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print a compact human-readable analysis summary to stderr",
+    )
+    args = parser.parse_args(argv)
+    if args.incremental_artifact_dir and not args.config:
+        parser.error("--incremental-artifact-dir requires --config")
+    if args.route_artifact_manifest and not args.config:
+        parser.error("--route-artifact-manifest requires --config")
+    if args.config:
+        conflicting_options = _config_cli_conflicts(args)
+        if conflicting_options:
+            parser.error(
+                "--config owns model-route behavior; remove: " + ", ".join(conflicting_options)
+            )
+    return args
+
+
+def _config_cli_conflicts(args: argparse.Namespace) -> list[str]:
+    values = {
+        "--llm-base-url": args.llm_base_url,
+        "--llm-model": args.llm_model,
+        "--llm-api-key-file": args.llm_api_key_file,
+        "--llm-timeout-seconds": args.llm_timeout_seconds,
+        "--llm-max-output-tokens": args.llm_max_output_tokens,
+        "--llm-context-window-tokens": args.llm_context_window_tokens,
+        "--llm-max-tool-rounds": args.llm_max_tool_rounds,
+        "--llm-temperature": args.llm_temperature,
+        "--llm-top-p": args.llm_top_p,
+        "--llm-thinking-mode": args.llm_thinking_mode,
+        "--llm-reasoning-effort": args.llm_reasoning_effort,
+        "--disable-l1-tools": args.disable_l1_tools,
+    }
+    conflicts = [option for option, value in values.items() if value not in (None, False)]
+    if args.enable_l1 is not None:
+        conflicts.append("--enable-l1/--disable-l1")
+    return conflicts
+
+
+def _evidence_extractor_from_args(
+    args: argparse.Namespace,
+) -> LlmEvidenceExtractor | None:
+    if args.enable_l1 is False:
+        return None
+    config = LlmConfig.from_env(
+        base_url=args.llm_base_url,
+        model=args.llm_model,
+        api_key_file=args.llm_api_key_file,
+        timeout_seconds=args.llm_timeout_seconds,
+        max_output_tokens=args.llm_max_output_tokens,
+        context_window_tokens=args.llm_context_window_tokens,
+        max_tool_rounds=args.llm_max_tool_rounds,
+        tools_enabled=not args.disable_l1_tools,
+        thinking_mode=args.llm_thinking_mode,
+        reasoning_effort=args.llm_reasoning_effort,
+        temperature=args.llm_temperature,
+        top_p=args.llm_top_p,
+    )
+    return LlmEvidenceExtractor(config)
+
+
+def _load_attempt_records(path: str | None) -> tuple[AttemptRecord, ...]:
+    if path is None:
+        return ()
+    with Path(path).open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, list):
+        raise TypeError("attempt-record fixture must be a JSON array")
+    return normalize_attempt_records(value)
+
+
+def _write_attempt_records(path: str | None, runtime: RestartAgentRuntime) -> None:
+    if path is None:
+        return
+    write_json_atomic(
+        path,
+        [record.to_payload() for record in runtime.attempt_record_control.records()],
+    )
+
+
+def _write_trace_json(
+    trace_json: str,
+    request: RestartAgentRequest,
+    result: AnalysisResult,
+    analyzer_trace: dict[str, Any],
+    l0_bundle: Any,
+) -> None:
+    payload: dict[str, Any] = {
+        "schema_version": CLI_TRACE_SCHEMA_VERSION,
+        "request": request.to_payload(),
+        "analysis_result": result.to_payload(),
+        "analyzer_trace": _to_jsonable(analyzer_trace),
+        "l0_bundle": _to_jsonable(l0_bundle) if l0_bundle is not None else None,
+    }
+    write_json_atomic(trace_json, payload)
+
+
+def _write_collect_all_trace_json(
+    trace_json: str,
+    request: RestartAgentRequest,
+    result: CollectAllAnalysisResult,
+    analyzer_trace: dict[str, Any],
+    l0_bundle: Any,
+) -> None:
+    payload: dict[str, Any] = {
+        "schema_version": CLI_COLLECT_ALL_TRACE_SCHEMA_VERSION,
+        "request": request.to_payload(),
+        "collect_all_result": result.to_payload(),
+        "analyzer_trace": _to_jsonable(analyzer_trace),
+        "l0_bundle": _to_jsonable(l0_bundle) if l0_bundle is not None else None,
+    }
+    write_json_atomic(trace_json, payload)
+
+
+def _print_collect_all_summary(
+    trace_json: str | None,
+    result: CollectAllAnalysisResult,
+) -> None:
+    shared = result.shared_analysis
+    print(
+        "restart_agent collect_all: "
+        f"routes={len(result.model_results)} "
+        f"max_parallel={shared.get('max_parallel_models')} "
+        f"batch_wall_clock_s={shared.get('batch_wall_clock_s')} "
+        f"trace_json={trace_json or '<disabled>'}",
+        file=sys.stderr,
+    )
+    for route_result in result.model_results:
+        payload = route_result.analysis_result.to_payload()
+        primary = payload.get("primary_failure") or {}
+        print(
+            "restart_agent collect_all: "
+            f"route={route_result.route_id} "
+            f"model={route_result.model} "
+            f"status={route_result.execution_status} "
+            f"l1_usable={route_result.l1_usable} "
+            f"decision={payload.get('decision')} "
+            f"primary={primary.get('failure_class')}@{primary.get('line')}",
+            file=sys.stderr,
+        )
+
+
+def _print_summary(
+    trace_json: str | None,
+    result: AnalysisResult,
+    analyzer_trace: dict[str, Any],
+) -> None:
+    payload = result.to_payload()
+    primary = payload.get("primary_failure") or {}
+    retry_policy = payload.get("retry_policy") or {}
+    general_ceiling = retry_policy.get("general_root_ceiling") or {}
+    selected_budget = retry_policy.get("selected_rule_budget") or {}
+    selected_summary = ""
+    if selected_budget:
+        selected_summary = (
+            " "
+            f"selected_prior_matches={selected_budget.get('matching_prior_failures')} "
+            f"selected_allowed_retries={selected_budget.get('allowed_retries')}"
+        )
+    print(
+        "restart_agent summary: "
+        f"decision={payload.get('decision')} "
+        f"basis={payload.get('decision_basis')} "
+        f"rule={retry_policy.get('rule')} "
+        f"root_prior_matches={general_ceiling.get('matching_prior_failures')} "
+        f"root_allowed_retries={general_ceiling.get('allowed_retries')}"
+        f"{selected_summary} "
+        f"exhausted={retry_policy.get('retry_budget_exhausted')}",
+        file=sys.stderr,
+    )
+    if primary:
+        print(
+            "restart_agent summary: "
+            f"primary={primary.get('failure_class')} "
+            f"line={primary.get('line')} "
+            f"fingerprint={primary.get('root_fingerprint')}",
+            file=sys.stderr,
+        )
+    provenance = payload.get("result_provenance") or {}
+    if provenance:
+        print(
+            "restart_agent summary: "
+            f"source={provenance.get('evidence_source')} "
+            f"model_contribution={provenance.get('model_contribution')} "
+            f"quality={provenance.get('result_quality')} "
+            f"nvrx_use={provenance.get('nvrx_use')}",
+            file=sys.stderr,
+        )
+    print(
+        "restart_agent summary: "
+        f"secondary_failures={len(payload.get('secondary_failures') or [])} "
+        f"cascades={len(payload.get('cascades') or [])} "
+        f"trace_json={trace_json or '<disabled>'}",
+        file=sys.stderr,
+    )
+    timing = (analyzer_trace.get("timing") or {}) if analyzer_trace else {}
+    if timing:
+        print(
+            "restart_agent summary: "
+            f"timing_total_s={timing.get('total_wall_clock_s')} "
+            f"l0_s={timing.get('l0_wall_clock_s')} "
+            f"l0a_s={timing.get('l0a_wall_clock_s')} "
+            f"l0b_s={timing.get('l0b_wall_clock_s')} "
+            f"l1_s={timing.get('l1_wall_clock_s')} "
+            f"l1_model_s={timing.get('l1_model_call_wall_clock_s')} "
+            f"l1_tool_s={timing.get('l1_tool_wall_clock_s')}",
+            file=sys.stderr,
+        )
+    token_usage = (analyzer_trace.get("token_usage") or {}) if analyzer_trace else {}
+    if token_usage:
+        print(
+            "restart_agent summary: "
+            f"tokens_total={token_usage.get('total_tokens')} "
+            f"prompt={token_usage.get('prompt_tokens')} "
+            f"completion={token_usage.get('completion_tokens')} "
+            f"reasoning={token_usage.get('reasoning_tokens')} "
+            f"cached_prompt={token_usage.get('cached_prompt_tokens')}",
+            file=sys.stderr,
+        )
+    token_limit = (analyzer_trace.get("token_limit") or {}) if analyzer_trace else {}
+    if token_limit:
+        print(
+            "restart_agent summary: "
+            f"token_limit_hit={token_limit.get('hit')} "
+            f"token_limit_hit_count={token_limit.get('hit_count')}",
+            file=sys.stderr,
+        )
+    l1 = (analyzer_trace.get("l1") or {}) if analyzer_trace else {}
+    l2 = (analyzer_trace.get("l2_audit") or {}) if analyzer_trace else {}
+    if l1.get("enabled"):
+        print(
+            "restart_agent summary: "
+            f"l1_model={l1.get('model')} "
+            f"l1_response_parsed={l1.get('success')} "
+            f"l2_audit={l2.get('audit_status')} "
+            f"model_calls={len(l1.get('model_calls') or [])} "
+            f"tool_calls={len(l1.get('tool_calls') or [])}",
+            file=sys.stderr,
+        )
+        if l1.get("errors"):
+            print(
+                "restart_agent summary: "
+                f"l1_errors={json.dumps(l1.get('errors'), sort_keys=True)}",
+                file=sys.stderr,
+            )
+
+
+def _to_jsonable(value: Any) -> Any:
+    if isinstance(value, AnalysisResult):
+        return value.to_payload()
+    if is_dataclass(value):
+        return {field.name: _to_jsonable(getattr(value, field.name)) for field in fields(value)}
+    if isinstance(value, tuple):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, list):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/config.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/config.py
@@ -1,0 +1,563 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned restart-agent configuration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, replace
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .attempt_records import DEFAULT_MAX_ATTEMPTS_PER_JOB, DEFAULT_MAX_TOTAL_RECORDS
+from .infrastructure.log_source import (
+    DEFAULT_LOG_READ_CHUNK_BYTES,
+    SOURCE_READ_MODE_CHUNKED,
+    SOURCE_READ_MODES,
+    LocalLogSource,
+)
+from .l1 import (
+    DEFAULT_ADVERTISED_TOOLS,
+    DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+    EvidenceExtractor,
+    LlmConfig,
+    ModelRoute,
+)
+from .models import (
+    DeclaredRecoveryCapability,
+    normalize_declared_recovery_capabilities,
+    normalize_retry_policy,
+    validate_recovery_capability_budgets,
+)
+
+RESTART_AGENT_CONFIG_SCHEMA_VERSION = "restart_agent_config.v1"
+RESTART_AGENT_CONFIG_FIELDS = frozenset(
+    {
+        "schema_version",
+        "config_id",
+        "config_version",
+        "enrichment",
+        "routing",
+        "runtime",
+        "retry_policy",
+        "declared_recovery_capabilities",
+        "model_defaults",
+        "model_routes",
+    }
+)
+TOOL_ADVERTISEMENT_ORDER = (*DEFAULT_ADVERTISED_TOOLS, "get_evidence_objects")
+
+
+@dataclass(frozen=True)
+class ModelRouteSpec:
+    """Validated model-route data without a live provider implementation."""
+
+    route_id: str
+    llm_config: LlmConfig
+    model: str
+    endpoint: str
+    credential_ref: str
+
+
+EvidenceExtractorFactory = Callable[[LlmConfig], EvidenceExtractor]
+
+
+@dataclass(frozen=True)
+class HistoryConfig:
+    """Bounded current-process attempt-record configuration."""
+
+    enabled: bool = True
+    max_attempts_per_job: int = DEFAULT_MAX_ATTEMPTS_PER_JOB
+    max_total_records: int = DEFAULT_MAX_TOTAL_RECORDS
+
+
+@dataclass(frozen=True)
+class L0SourceConfig:
+    """Byte-delivery settings for the shared terminal/progressive L0 path."""
+
+    read_mode: str = SOURCE_READ_MODE_CHUNKED
+    chunk_size_bytes: int = DEFAULT_LOG_READ_CHUNK_BYTES
+
+
+@dataclass(frozen=True)
+class RestartAgentConfig:
+    """Resolved, credential-free restart-agent configuration."""
+
+    config_id: str
+    config_version: int
+    enrichment_enabled: bool
+    routing_mode: str
+    max_parallel_models: int
+    timeout_seconds: float
+    history: HistoryConfig
+    l0_source: L0SourceConfig
+    retry_policy: Mapping[str, Any]
+    declared_recovery_capabilities: tuple[DeclaredRecoveryCapability, ...]
+    model_route_specs: tuple[ModelRouteSpec, ...]
+    effective_config: Mapping[str, Any]
+    config_fingerprint: str
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "schema_version": RESTART_AGENT_CONFIG_SCHEMA_VERSION,
+            "config_id": self.config_id,
+            "config_version": self.config_version,
+            "config_fingerprint": self.config_fingerprint,
+            "enrichment": {"enabled": self.enrichment_enabled},
+            "routing_mode": self.routing_mode,
+            "max_parallel_models": self.max_parallel_models,
+            "timeout_seconds": self.timeout_seconds,
+            "history": {
+                "enabled": self.history.enabled,
+                "max_attempts_per_job": self.history.max_attempts_per_job,
+                "max_total_records": self.history.max_total_records,
+            },
+            "l0_source": {
+                "read_mode": self.l0_source.read_mode,
+                "chunk_size_bytes": self.l0_source.chunk_size_bytes,
+            },
+            "effective_config": self.effective_config,
+        }
+
+
+def load_restart_agent_config(
+    path: str | Path,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> RestartAgentConfig:
+    """Read and parse restart-agent configuration from disk."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return parse_restart_agent_config(payload, environ=environ)
+
+
+def parse_restart_agent_config(
+    payload: Mapping[str, Any],
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> RestartAgentConfig:
+    """Validate already-loaded configuration without performing file I/O."""
+
+    if not isinstance(payload, Mapping):
+        raise TypeError("restart-agent config must be an object")
+    if payload.get("schema_version") != RESTART_AGENT_CONFIG_SCHEMA_VERSION:
+        raise ValueError("restart-agent config schema_version is invalid")
+    unknown_fields = set(payload).difference(RESTART_AGENT_CONFIG_FIELDS)
+    if unknown_fields:
+        raise ValueError(
+            "restart-agent config has unsupported fields: " + ", ".join(sorted(unknown_fields))
+        )
+
+    config_id = _required_string(payload, "config_id", "restart-agent config")
+    config_version = payload.get("config_version")
+    if not isinstance(config_version, int) or isinstance(config_version, bool):
+        raise TypeError("restart-agent config config_version must be an integer")
+    if config_version < 1:
+        raise ValueError("restart-agent config config_version must be at least 1")
+
+    enrichment = _optional_mapping(payload, "enrichment")
+    unknown_enrichment = sorted(set(enrichment).difference({"enabled"}))
+    if unknown_enrichment:
+        raise ValueError("enrichment has unsupported fields: " + ", ".join(unknown_enrichment))
+    enrichment_enabled = enrichment.get("enabled", True)
+    if not isinstance(enrichment_enabled, bool):
+        raise TypeError("enrichment.enabled must be boolean")
+
+    routing = _optional_mapping(payload, "routing")
+    routing_mode = str(routing.get("mode") or "collect_all")
+    if routing_mode != "collect_all":
+        raise ValueError("restart-agent config routing.mode must be 'collect_all'")
+    retry_policy = normalize_retry_policy(_optional_mapping(payload, "retry_policy"))
+    declared_recovery_capabilities = normalize_declared_recovery_capabilities(
+        payload.get("declared_recovery_capabilities", ())
+    )
+    validate_recovery_capability_budgets(
+        declared_recovery_capabilities,
+        retry_policy,
+    )
+    history, l0_source = _parse_runtime_config(_optional_mapping(payload, "runtime"))
+
+    model_defaults = _optional_mapping(payload, "model_defaults")
+    raw_routes = payload.get("model_routes", [])
+    if not isinstance(raw_routes, list):
+        raise TypeError("restart-agent config model_routes must be an array")
+    if enrichment_enabled and not raw_routes:
+        raise ValueError(
+            "restart-agent config model_routes must be non-empty when enrichment is enabled"
+        )
+    if not enrichment_enabled and raw_routes:
+        raise ValueError(
+            "restart-agent config model_routes must be empty when enrichment is disabled"
+        )
+
+    environment = os.environ if environ is None else environ
+    model_route_specs: list[ModelRouteSpec] = []
+    effective_routes: list[dict[str, Any]] = []
+    route_ids: set[str] = set()
+    for raw_route in raw_routes:
+        if not isinstance(raw_route, Mapping):
+            raise TypeError("each model route must be an object")
+        route_spec, effective_route = _resolve_route(model_defaults, raw_route, environment)
+        if route_spec.route_id in route_ids:
+            raise ValueError(f"duplicate model route_id: {route_spec.route_id!r}")
+        route_ids.add(route_spec.route_id)
+        model_route_specs.append(route_spec)
+        effective_routes.append(effective_route)
+
+    max_parallel_models = routing.get("max_parallel_models", len(model_route_specs))
+    if not isinstance(max_parallel_models, int) or isinstance(max_parallel_models, bool):
+        raise TypeError("routing.max_parallel_models must be an integer")
+    minimum_parallel_models = 1 if enrichment_enabled else 0
+    if max_parallel_models < minimum_parallel_models:
+        raise ValueError(
+            "routing.max_parallel_models must be at least "
+            f"{minimum_parallel_models} when enrichment.enabled is "
+            f"{str(enrichment_enabled).lower()}"
+        )
+    max_parallel_models = min(max_parallel_models, len(model_route_specs))
+    timeout_seconds = routing.get("timeout_seconds", DEFAULT_ANALYSIS_TIMEOUT_SECONDS)
+    if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, (int, float)):
+        raise TypeError("routing.timeout_seconds must be a number")
+    timeout_seconds = float(timeout_seconds)
+    if timeout_seconds <= 0:
+        raise ValueError("routing.timeout_seconds must be greater than zero")
+
+    effective_config = {
+        "schema_version": RESTART_AGENT_CONFIG_SCHEMA_VERSION,
+        "enrichment": {"enabled": enrichment_enabled},
+        "routing": {
+            "mode": routing_mode,
+            "max_parallel_models": max_parallel_models,
+            "timeout_seconds": timeout_seconds,
+        },
+        "runtime": {
+            "history": {
+                "enabled": history.enabled,
+                "max_attempts_per_job": history.max_attempts_per_job,
+                "max_total_records": history.max_total_records,
+            },
+            "l0_source": {
+                "read_mode": l0_source.read_mode,
+                "chunk_size_bytes": l0_source.chunk_size_bytes,
+            },
+        },
+        "retry_policy": dict(retry_policy),
+        "declared_recovery_capabilities": [
+            capability.to_payload() for capability in declared_recovery_capabilities
+        ],
+        "model_routes": effective_routes,
+    }
+    return RestartAgentConfig(
+        config_id=config_id,
+        config_version=config_version,
+        enrichment_enabled=enrichment_enabled,
+        routing_mode=routing_mode,
+        max_parallel_models=max_parallel_models,
+        timeout_seconds=timeout_seconds,
+        history=history,
+        l0_source=l0_source,
+        retry_policy=retry_policy,
+        declared_recovery_capabilities=declared_recovery_capabilities,
+        model_route_specs=tuple(model_route_specs),
+        effective_config=effective_config,
+        config_fingerprint=_stable_hash(effective_config),
+    )
+
+
+def _parse_runtime_config(
+    runtime: Mapping[str, Any],
+) -> tuple[HistoryConfig, L0SourceConfig]:
+    unknown_runtime = sorted(set(runtime).difference({"history", "l0_source"}))
+    if unknown_runtime:
+        raise ValueError("runtime has unsupported fields: " + ", ".join(unknown_runtime))
+    history = _optional_mapping(runtime, "history")
+    unknown_history = sorted(
+        set(history).difference({"enabled", "max_attempts_per_job", "max_total_records"})
+    )
+    if unknown_history:
+        raise ValueError("runtime.history has unsupported fields: " + ", ".join(unknown_history))
+    enabled = history.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise TypeError("runtime.history.enabled must be boolean")
+    max_attempts_per_job = history.get("max_attempts_per_job", DEFAULT_MAX_ATTEMPTS_PER_JOB)
+    max_total_records = history.get("max_total_records", DEFAULT_MAX_TOTAL_RECORDS)
+    for field_name, value in (
+        ("max_attempts_per_job", max_attempts_per_job),
+        ("max_total_records", max_total_records),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"runtime.history.{field_name} must be an integer")
+        if value < 1:
+            raise ValueError(f"runtime.history.{field_name} must be greater than zero")
+    history_config = HistoryConfig(
+        enabled=enabled,
+        max_attempts_per_job=max_attempts_per_job,
+        max_total_records=max_total_records,
+    )
+    source = _optional_mapping(runtime, "l0_source")
+    unknown_source = sorted(set(source).difference({"read_mode", "chunk_size_bytes"}))
+    if unknown_source:
+        raise ValueError("runtime.l0_source has unsupported fields: " + ", ".join(unknown_source))
+    read_mode = source.get("read_mode", SOURCE_READ_MODE_CHUNKED)
+    if not isinstance(read_mode, str) or read_mode not in SOURCE_READ_MODES:
+        raise ValueError(
+            "runtime.l0_source.read_mode must be one of: " + ", ".join(sorted(SOURCE_READ_MODES))
+        )
+    chunk_size_bytes = source.get(
+        "chunk_size_bytes",
+        DEFAULT_LOG_READ_CHUNK_BYTES,
+    )
+    if isinstance(chunk_size_bytes, bool) or not isinstance(chunk_size_bytes, int):
+        raise TypeError("runtime.l0_source.chunk_size_bytes must be an integer")
+    if chunk_size_bytes < 1:
+        raise ValueError("runtime.l0_source.chunk_size_bytes must be greater than zero")
+    return history_config, L0SourceConfig(
+        read_mode=read_mode,
+        chunk_size_bytes=chunk_size_bytes,
+    )
+
+
+def _resolve_route(
+    defaults: Mapping[str, Any],
+    route: Mapping[str, Any],
+    environment: Mapping[str, str],
+) -> tuple[ModelRouteSpec, dict[str, Any]]:
+    route_id = _required_string(route, "route_id", "model route")
+    model = _setting(route, defaults, "model")
+    base_url = _setting(route, defaults, "base_url")
+    credential_ref = str(_setting(route, defaults, "credential_ref", default="LLM_API_KEY_FILE"))
+    api_key_file = environment.get(credential_ref)
+    if not api_key_file:
+        raise ValueError(f"model route {route_id!r} credential_ref {credential_ref!r} is not set")
+
+    request = _merged_group(defaults, route, "request")
+    tools = _merged_group(defaults, route, "tools")
+    reasoning = _merged_group(defaults, route, "reasoning")
+    reliability = _merged_group(defaults, route, "reliability")
+
+    tools_enabled = tools.get("enabled")
+    if tools_enabled is not None and not isinstance(tools_enabled, bool):
+        raise TypeError(f"model route {route_id!r} tools.enabled must be boolean")
+    advertised_tools = _advertised_tools(route_id, tools.get("advertisement"))
+
+    base_config = LlmConfig(api_key=None, api_key_file=api_key_file)
+    overrides = {
+        "base_url": _optional_string(base_url, f"model route {route_id!r} base_url"),
+        "model": _optional_string(model, f"model route {route_id!r} model"),
+        "timeout_seconds": _optional_number(request, "timeout_seconds"),
+        "max_output_tokens": _optional_int(request, "max_output_tokens"),
+        "context_window_tokens": _optional_int(request, "context_window_tokens"),
+        "context_safety_tokens": _optional_int(request, "context_safety_tokens"),
+        "temperature": _optional_number(request, "temperature"),
+        "top_p": _optional_number(request, "top_p"),
+        "tools_enabled": tools_enabled,
+        "advertised_tools": (tuple(advertised_tools) if advertised_tools is not None else None),
+        "max_tool_rounds": _optional_int(tools, "max_rounds"),
+        "thinking_mode": _optional_group_string(reasoning, "thinking_mode"),
+        "reasoning_effort": _optional_group_string(reasoning, "reasoning_effort"),
+        "max_retries": _optional_int(reliability, "max_retries"),
+        "retry_backoff_seconds": _optional_number(reliability, "retry_backoff_seconds"),
+    }
+    config = replace(
+        base_config,
+        **{key: value for key, value in overrides.items() if value is not None},
+    )
+    _validate_config(route_id, config)
+    model_route = ModelRouteSpec(
+        route_id=route_id,
+        llm_config=config,
+        model=config.model,
+        endpoint=config.base_url,
+        credential_ref=credential_ref,
+    )
+    effective_route = {
+        "route_id": route_id,
+        "model": config.model,
+        "base_url": config.base_url,
+        "credential_ref": credential_ref,
+        "request": {
+            "timeout_seconds": config.timeout_seconds,
+            "max_output_tokens": config.max_output_tokens,
+            "configured_context_window_tokens": config.context_window_tokens,
+            "effective_context_window_tokens": config.resolved_context_window_tokens(),
+            "context_safety_tokens": config.context_safety_tokens,
+            "temperature": config.temperature,
+            "top_p": config.top_p,
+            "temperature_sent": config.request_temperature() is not None,
+            "top_p_sent": config.request_top_p() is not None,
+        },
+        "tools": {
+            "enabled": config.tools_enabled,
+            "advertisement": {
+                name: name in config.advertised_tools for name in TOOL_ADVERTISEMENT_ORDER
+            },
+            "effective_advertised": (list(config.advertised_tools) if config.tools_enabled else []),
+            "max_rounds": config.max_tool_rounds,
+        },
+        "reasoning": {
+            "thinking_mode": config.thinking_mode,
+            "thinking_disabled": config.disable_thinking(),
+            "reasoning_effort": config.reasoning_effort,
+        },
+        "reliability": {
+            "max_retries": config.max_retries,
+            "retry_backoff_seconds": config.retry_backoff_seconds,
+        },
+    }
+    return model_route, effective_route
+
+
+def build_model_routes(
+    config: RestartAgentConfig,
+    evidence_extractor_factory: EvidenceExtractorFactory,
+) -> tuple[ModelRoute, ...]:
+    """Compose validated route data with a caller-selected L1 implementation."""
+
+    if not config.enrichment_enabled:
+        return ()
+    return tuple(
+        ModelRoute(
+            route_id=spec.route_id,
+            evidence_extractor=evidence_extractor_factory(spec.llm_config),
+            model=spec.model,
+            endpoint=spec.endpoint,
+            credential_ref=spec.credential_ref,
+        )
+        for spec in config.model_route_specs
+    )
+
+
+def build_log_source_factory(
+    config: RestartAgentConfig,
+) -> Callable[[str], LocalLogSource]:
+    """Bind validated L0 byte-delivery settings at the composition root."""
+
+    return partial(
+        LocalLogSource,
+        chunk_bytes=config.l0_source.chunk_size_bytes,
+        read_mode=config.l0_source.read_mode,
+    )
+
+
+def _advertised_tools(
+    route_id: str,
+    advertisement: Any,
+) -> tuple[str, ...] | None:
+    if advertisement is None:
+        return None
+    if not isinstance(advertisement, Mapping):
+        raise TypeError(f"model route {route_id!r} tools.advertisement must be an object")
+    unknown = set(advertisement).difference(TOOL_ADVERTISEMENT_ORDER)
+    if unknown:
+        raise ValueError(
+            f"model route {route_id!r} tools.advertisement has unknown tools: "
+            + ", ".join(sorted(unknown))
+        )
+    invalid = [name for name, enabled in advertisement.items() if not isinstance(enabled, bool)]
+    if invalid:
+        raise TypeError(
+            f"model route {route_id!r} tools.advertisement values must be boolean: "
+            + ", ".join(sorted(invalid))
+        )
+    resolved = {name: name in DEFAULT_ADVERTISED_TOOLS for name in TOOL_ADVERTISEMENT_ORDER}
+    resolved.update(advertisement)
+    return tuple(name for name in TOOL_ADVERTISEMENT_ORDER if resolved[name])
+
+
+def _validate_config(route_id: str, config: LlmConfig) -> None:
+    owner = f"model route {route_id!r}"
+    if config.timeout_seconds <= 0:
+        raise ValueError(f"{owner} request.timeout_seconds must be positive")
+    if config.max_output_tokens <= 0:
+        raise ValueError(f"{owner} request.max_output_tokens must be positive")
+    if config.context_window_tokens is not None and config.context_window_tokens <= 0:
+        raise ValueError(f"{owner} request.context_window_tokens must be positive")
+    if config.context_safety_tokens < 0:
+        raise ValueError(f"{owner} request.context_safety_tokens must not be negative")
+    if config.temperature is not None and not 0 <= config.temperature <= 2:
+        raise ValueError(f"{owner} request.temperature must be between 0 and 2")
+    if config.top_p is not None and not 0 <= config.top_p <= 1:
+        raise ValueError(f"{owner} request.top_p must be between 0 and 1")
+    if config.max_tool_rounds < 0:
+        raise ValueError(f"{owner} tools.max_rounds must not be negative")
+    if config.max_retries < 0:
+        raise ValueError(f"{owner} reliability.max_retries must not be negative")
+    if config.retry_backoff_seconds < 0:
+        raise ValueError(f"{owner} reliability.retry_backoff_seconds must not be negative")
+
+
+def _setting(
+    route: Mapping[str, Any],
+    defaults: Mapping[str, Any],
+    field: str,
+    *,
+    default: Any = None,
+) -> Any:
+    if field in route:
+        return route[field]
+    return defaults.get(field, default)
+
+
+def _merged_group(
+    defaults: Mapping[str, Any], route: Mapping[str, Any], field: str
+) -> dict[str, Any]:
+    merged = dict(_optional_mapping(defaults, field))
+    merged.update(_optional_mapping(route, field))
+    return merged
+
+
+def _optional_mapping(value: Mapping[str, Any], field: str) -> Mapping[str, Any]:
+    item = value.get(field)
+    if item is None:
+        return {}
+    if not isinstance(item, Mapping):
+        raise TypeError(f"{field} must be an object")
+    return item
+
+
+def _required_string(value: Mapping[str, Any], field: str, owner: str) -> str:
+    item = value.get(field)
+    if not isinstance(item, str) or not item.strip():
+        raise ValueError(f"{owner} requires non-empty {field}")
+    return item.strip()
+
+
+def _optional_string(value: Any, owner: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise TypeError(f"{owner} must be a non-empty string")
+    return value.strip()
+
+
+def _optional_group_string(value: Mapping[str, Any], field: str) -> str | None:
+    if field not in value:
+        return None
+    return _optional_string(value[field], field)
+
+
+def _optional_int(value: Mapping[str, Any], field: str) -> int | None:
+    item = value.get(field)
+    if item is None:
+        return None
+    if not isinstance(item, int) or isinstance(item, bool):
+        raise TypeError(f"{field} must be an integer")
+    return item
+
+
+def _optional_number(value: Mapping[str, Any], field: str) -> float | None:
+    item = value.get(field)
+    if item is None:
+        return None
+    if not isinstance(item, (int, float)) or isinstance(item, bool):
+        raise TypeError(f"{field} must be a number")
+    return float(item)
+
+
+def _stable_hash(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
@@ -1,0 +1,624 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed L2-L4 decision execution and external result assembly."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .attempt_records import AttemptRecordAssembler
+from .causality import build_result_cascades
+from .l1 import L1EvidenceResult, execution_status
+from .l2 import L2Result, build_attempt_failure_facts
+from .l3 import DETERMINISTIC_FACT_SELECTOR, HistoryEvaluationInput, evaluate_history
+from .l4 import L4PolicyInput, RetryPolicyEvaluation, evaluate_policy
+from .models import (
+    AnalysisExecutionContext,
+    AnalysisResult,
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    AttemptRecord,
+    CausalRole,
+    CoverageStatus,
+    Decision,
+    DecisionBasis,
+    DecisionEvidence,
+    FailureEvidence,
+    HistorySummary,
+    L0Bundle,
+    RetryPolicyConfig,
+)
+from .runtime import SYSTEM_CLOCK, Clock
+
+
+@dataclass(frozen=True)
+class DecisionOutcome:
+    """Typed result of failure-fact selection, history, and policy."""
+
+    result: AnalysisResult
+    primary: FailureEvidence | None
+    l2_primary: FailureEvidence | None
+    l2_audit: Mapping[str, Any]
+    history: HistorySummary
+    retry_policy: RetryPolicyEvaluation
+    attempt_record: AttemptRecord | None
+    deterministic_failure_facts: AttemptFailureFacts
+    selected_failure_facts: AttemptFailureFacts
+    l3_wall_clock_s: float
+    l4_wall_clock_s: float
+
+
+@dataclass(frozen=True)
+class _ResolvedFailure:
+    audit: Mapping[str, Any]
+    l2_primary: FailureEvidence | None
+    primary: FailureEvidence | None
+    enriched_failure_facts: AttemptFailureFacts | None
+
+
+def build_decision_outcome(
+    *,
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+    execution_context: AnalysisExecutionContext,
+    l1_configured: bool,
+    l1_result: L1EvidenceResult,
+    l1_output_health: Mapping[str, Any],
+    l2_result: L2Result,
+    candidate_kind: str,
+    l1_pending: bool,
+    route_id: str = "single",
+    clock: Clock = SYSTEM_CLOCK,
+) -> DecisionOutcome:
+    resolved = _resolve_attempt_failure_facts(
+        decision_evidence=decision_evidence,
+        l2_result=l2_result,
+    )
+
+    deterministic_facts = build_attempt_failure_facts(
+        decision_evidence.deterministic_primary_candidate,
+        decision_evidence,
+        source=AttemptFailureFactsSource.L0_DETERMINISTIC,
+    )
+    attempt_record = _attempt_record(
+        bundle=bundle,
+        decision_evidence=decision_evidence,
+        execution_context=execution_context,
+        enriched_failure_facts=resolved.enriched_failure_facts if l2_result.used else None,
+        route_id=route_id,
+    )
+    fact_selector = (
+        route_id
+        if l2_result.used and resolved.enriched_failure_facts is not None
+        else DETERMINISTIC_FACT_SELECTOR
+    )
+    selected_failure_facts = resolved.enriched_failure_facts or deterministic_facts
+
+    l3_started = clock.monotonic()
+    if attempt_record is None:
+        history = HistorySummary(
+            available=False,
+            availability_reason=execution_context.prior_attempts.availability_reason,
+        )
+    else:
+        history = evaluate_history(
+            HistoryEvaluationInput(
+                current_record=attempt_record,
+                fact_selector=fact_selector,
+                prior_attempts=execution_context.prior_attempts,
+            )
+        )
+    l3_wall_clock_s = round(clock.monotonic() - l3_started, 3)
+
+    l4_started = clock.monotonic()
+    l4_outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=resolved.primary,
+            history=history,
+            current_affected_entity=selected_failure_facts.affected_entity,
+            model_recovery_assessment=l2_result.model_recovery_assessment,
+            assessment_grounded=l2_result.recovery_assessment_policy_grounded,
+            retry_policy=RetryPolicyConfig.from_mapping(execution_context.retry_policy),
+            declared_recovery_capabilities=(execution_context.declared_recovery_capabilities),
+        )
+    )
+    primary = l4_outcome.primary
+    retry_policy = l4_outcome.retry_policy
+    result_provenance = _candidate_provenance(
+        primary=primary,
+        retry_policy=retry_policy,
+        l1_configured=l1_configured,
+        l1_result=l1_result,
+        l1_output_health=l1_output_health,
+        l2_audit=resolved.audit,
+        history=history,
+        candidate_kind=candidate_kind,
+        l1_pending=l1_pending,
+    )
+    result = _assemble_analysis_result(
+        bundle=bundle,
+        primary=primary,
+        retry_policy=retry_policy,
+        result_provenance=result_provenance,
+        l1_result=l1_result,
+        l1_output_health=l1_output_health,
+        l2_audit=resolved.audit,
+        history=history,
+        l1_configured=l1_configured,
+        candidate_kind=candidate_kind,
+    )
+    l4_wall_clock_s = round(clock.monotonic() - l4_started, 3)
+    return DecisionOutcome(
+        result=result,
+        primary=primary,
+        l2_primary=resolved.l2_primary,
+        l2_audit=resolved.audit,
+        attempt_record=attempt_record,
+        selected_failure_facts=selected_failure_facts,
+        history=history,
+        retry_policy=retry_policy,
+        deterministic_failure_facts=deterministic_facts,
+        l3_wall_clock_s=l3_wall_clock_s,
+        l4_wall_clock_s=l4_wall_clock_s,
+    )
+
+
+def _resolve_attempt_failure_facts(
+    *,
+    decision_evidence: DecisionEvidence,
+    l2_result: L2Result,
+) -> _ResolvedFailure:
+    audit = l2_result.to_payload()
+    l2_primary = l2_result.primary if l2_result.used else None
+    primary = (
+        l2_primary if l2_primary is not None else decision_evidence.deterministic_primary_candidate
+    )
+    return _ResolvedFailure(
+        audit=audit,
+        l2_primary=l2_primary,
+        primary=primary,
+        enriched_failure_facts=l2_result.enriched_failure_facts,
+    )
+
+
+def _attempt_record(
+    *,
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+    execution_context: AnalysisExecutionContext,
+    enriched_failure_facts: AttemptFailureFacts | None,
+    route_id: str,
+) -> AttemptRecord | None:
+    if execution_context.job_id is None or execution_context.cycle_id is None:
+        return None
+    assembler = AttemptRecordAssembler()
+    record = assembler.initial_record(
+        job_id=execution_context.job_id,
+        cycle_id=execution_context.cycle_id,
+        bundle=bundle,
+        decision_evidence=decision_evidence,
+    )
+    if enriched_failure_facts is not None:
+        record = assembler.with_enriched(
+            record,
+            route_id=route_id,
+            facts=enriched_failure_facts,
+        )
+    return record
+
+
+def _candidate_provenance(
+    *,
+    primary: FailureEvidence | None,
+    retry_policy: RetryPolicyEvaluation,
+    l1_configured: bool,
+    l1_result: L1EvidenceResult,
+    l1_output_health: Mapping[str, Any],
+    l2_audit: Mapping[str, Any],
+    history: HistorySummary,
+    candidate_kind: str,
+    l1_pending: bool,
+) -> dict[str, Any]:
+    provenance = _result_provenance(
+        primary=primary,
+        decision_basis=retry_policy.decision_basis,
+        l1_configured=l1_configured,
+        l1_result=l1_result,
+        l1_output_health=l1_output_health,
+        l2_audit=l2_audit,
+        history=history,
+        retry_policy=retry_policy,
+    )
+    provenance["candidate_kind"] = candidate_kind
+    if not l1_pending:
+        return provenance
+    provenance["model_contribution"] = "pending_not_used"
+    provenance["l1_execution_status"] = "in_flight"
+    provenance["l1_execution_issues"] = []
+    provenance["notes"] = [*list(provenance.get("notes") or []), "l1_pending"]
+    if (
+        provenance.get("result_quality") == "normal"
+        and provenance.get("history_contribution") != "recurrence_applied"
+    ):
+        provenance["result_quality"] = "degraded"
+        provenance["nvrx_use"] = "eligible_degraded"
+    return provenance
+
+
+def _assemble_analysis_result(
+    *,
+    bundle: L0Bundle,
+    primary: FailureEvidence | None,
+    retry_policy: RetryPolicyEvaluation,
+    result_provenance: Mapping[str, Any],
+    l1_result: L1EvidenceResult,
+    l1_output_health: Mapping[str, Any],
+    l2_audit: Mapping[str, Any],
+    history: HistorySummary,
+    l1_configured: bool,
+    candidate_kind: str,
+) -> AnalysisResult:
+    if primary is None and not l1_output_health["usable"] and l1_result.model:
+        malformed_provenance = _result_provenance(
+            primary=None,
+            decision_basis=DecisionBasis.MALFORMED_MODEL_OUTPUT.value,
+            l1_configured=l1_configured,
+            l1_result=l1_result,
+            l1_output_health=l1_output_health,
+            l2_audit=l2_audit,
+            history=history,
+            retry_policy=retry_policy,
+        )
+        malformed_provenance["candidate_kind"] = candidate_kind
+        return AnalysisResult(
+            decision=Decision.RESTART.value,
+            decision_basis=DecisionBasis.MALFORMED_MODEL_OUTPUT.value,
+            retry_policy=retry_policy.to_payload(),
+            failure_domain=retry_policy.failure_domain,
+            result_provenance=malformed_provenance,
+            primary_failure=None,
+            secondary_failures=(),
+            cascades=(),
+            evidence_coverage=_coverage_with_history(bundle.evidence_coverage, history.available),
+            evidence=(),
+            justification="L1 model evidence was malformed and no L0 primary was available.",
+        )
+    return AnalysisResult(
+        decision=retry_policy.decision,
+        decision_basis=retry_policy.decision_basis,
+        retry_policy=retry_policy.to_payload(),
+        failure_domain=retry_policy.failure_domain,
+        result_provenance=result_provenance,
+        primary_failure=primary.to_failure_payload() if primary is not None else None,
+        root_cause_assessment=_assessment(l2_audit, "root_cause_assessment"),
+        model_recovery_assessment=_assessment(l2_audit, "model_recovery_assessment"),
+        secondary_failures=_secondary_failures(
+            bundle,
+            primary,
+            l2_audit=l2_audit,
+        ),
+        cascades=build_result_cascades(bundle, primary, l2_audit),
+        evidence_coverage=_coverage_with_history(bundle.evidence_coverage, history.available),
+        evidence=_evidence(primary, l2_audit),
+        justification=_justification(primary, retry_policy.decision_basis, l2_audit),
+    )
+
+
+def _secondary_failures(
+    bundle: L0Bundle,
+    primary: FailureEvidence | None,
+    *,
+    l2_audit: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    if l2_audit.get("used"):
+        related = l2_audit.get("audited_related_failures")
+        if isinstance(related, (list, tuple)):
+            return tuple(
+                item
+                for item in related
+                if isinstance(item, Mapping)
+                and item.get("causal_role")
+                not in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}
+            )
+        return ()
+
+    primary_line = primary.line if primary else None
+    primary_fingerprint = primary.root_fingerprint if primary else None
+    primary_episode_chain_lines = _primary_episode_chain_lines(bundle, primary_line)
+    secondary = []
+    for match in bundle.registry_matches:
+        if match.line == primary_line and match.root_fingerprint == primary_fingerprint:
+            continue
+        if match.causal_role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}:
+            continue
+        if match.line in primary_episode_chain_lines:
+            continue
+        secondary.append(match.to_failure_payload())
+        if len(secondary) >= 5:
+            break
+    return tuple(secondary)
+
+
+def _primary_episode_chain_lines(bundle: L0Bundle, primary_line: int | None) -> set[int]:
+    if primary_line is None:
+        return set()
+    for episode in bundle.failure_episodes:
+        episode_lines = {
+            *episode.exception_chain_lines,
+            *(confirmation.line for confirmation in episode.cause_confirmations),
+        }
+        if episode.terminal_exception_line is not None:
+            episode_lines.add(episode.terminal_exception_line)
+        if primary_line in episode_lines:
+            return {line for line in episode_lines if line is not None}
+    return set()
+
+
+def _assessment(
+    l2_audit: Mapping[str, Any],
+    field: str,
+) -> Mapping[str, Any] | None:
+    if not l2_audit.get("used"):
+        return None
+    if field == "model_recovery_assessment" and not l2_audit.get("recovery_assessment_used"):
+        return None
+    value = l2_audit.get(field)
+    return dict(value) if isinstance(value, Mapping) else None
+
+
+def _coverage_with_history(coverage: Mapping[str, str], available: bool) -> dict[str, str]:
+    result = dict(coverage)
+    result["history"] = (
+        CoverageStatus.FOUND.value if available else CoverageStatus.NOT_AVAILABLE.value
+    )
+    return result
+
+
+def _evidence(
+    primary: FailureEvidence | None,
+    l2_audit: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    if l2_audit.get("used"):
+        grounded = l2_audit.get("grounded_evidence")
+        if isinstance(grounded, (list, tuple)):
+            return tuple(item for item in grounded if isinstance(item, Mapping))
+    if primary is None or primary.line is None or primary.quote is None:
+        return ()
+    return (
+        {
+            "line": primary.line,
+            "quote": primary.quote,
+            "supports": ["primary_failure"],
+        },
+    )
+
+
+def _justification(
+    primary: FailureEvidence | None,
+    decision_basis: str,
+    l2_audit: Mapping[str, Any],
+) -> str:
+    if primary is None:
+        return "No actionable failure signature was found in the available log."
+    if l2_audit.get("used"):
+        recovery = l2_audit.get("model_recovery_assessment")
+        if isinstance(recovery, Mapping):
+            rationale = recovery.get("rationale")
+            if isinstance(rationale, str) and rationale.strip():
+                return rationale
+        root_cause = l2_audit.get("root_cause_assessment")
+        if isinstance(root_cause, Mapping):
+            summary = root_cause.get("summary")
+            if isinstance(summary, str) and summary.strip():
+                return summary
+    return (
+        f"Line {primary.line} matched failure class {primary.failure_class}; "
+        f"policy basis is {decision_basis}."
+    )
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _result_provenance(
+    *,
+    primary: FailureEvidence | None,
+    decision_basis: str,
+    l1_configured: bool,
+    l1_result: L1EvidenceResult,
+    l1_output_health: Mapping[str, Any],
+    l2_audit: Mapping[str, Any],
+    history: HistorySummary,
+    retry_policy: RetryPolicyEvaluation,
+) -> dict[str, Any]:
+    model_contribution = _model_contribution(
+        l1_configured=l1_configured,
+        l1_result=l1_result,
+        l1_output_health=l1_output_health,
+        l2_audit=l2_audit,
+    )
+    history_contribution = _history_contribution(history, retry_policy)
+    evidence_source = _evidence_source(
+        primary=primary,
+        decision_basis=decision_basis,
+        model_used=bool(l2_audit.get("used")),
+        history_contribution=history_contribution,
+    )
+    result_quality = _result_quality(
+        primary=primary,
+        evidence_source=evidence_source,
+        model_contribution=model_contribution,
+        l2_audit=l2_audit,
+    )
+    notes = _result_provenance_notes(
+        model_contribution=model_contribution,
+        l1_result=l1_result,
+        l1_output_health=l1_output_health,
+        l2_audit=l2_audit,
+    )
+    l1_execution = execution_status(
+        configured=l1_configured,
+        result=l1_result,
+        health=l1_output_health,
+    )
+    return {
+        "evidence_source": evidence_source,
+        "model_contribution": model_contribution,
+        "history_contribution": history_contribution,
+        "result_quality": result_quality,
+        "nvrx_use": _nvrx_use(result_quality),
+        "l1_execution_status": l1_execution["status"],
+        "l1_execution_issues": l1_execution["issues"],
+        "notes": notes,
+    }
+
+
+def _evidence_source(
+    *,
+    primary: FailureEvidence | None,
+    decision_basis: str,
+    model_used: bool,
+    history_contribution: str,
+) -> str:
+    if decision_basis == DecisionBasis.LOG_UNAVAILABLE.value:
+        return "log_unavailable"
+    if primary is None and decision_basis == DecisionBasis.MALFORMED_MODEL_OUTPUT.value:
+        return "malformed_model_output"
+    if history_contribution in {"retry_budget_exhausted", "observed_advance"}:
+        return "history_over_l1" if model_used else "history_over_l0"
+    if model_used:
+        return "l1_model_audited"
+    if primary is not None:
+        return "l0_deterministic"
+    return "no_primary"
+
+
+def _model_contribution(
+    *,
+    l1_configured: bool,
+    l1_result: L1EvidenceResult,
+    l1_output_health: Mapping[str, Any],
+    l2_audit: Mapping[str, Any],
+) -> str:
+    if l2_audit.get("used"):
+        if l2_audit.get("audit_status") == "findings":
+            return "attempted_used_with_findings"
+        if l2_audit.get("audit_status") == "resolved":
+            return "attempted_used_with_resolved_findings"
+        return "attempted_used"
+    if not l1_configured:
+        return "not_enabled"
+    if not l1_result.model_calls and not l1_result.model:
+        return "not_needed_l0"
+    if l1_result.anomalies.get("provider_timeout"):
+        return "attempted_not_used_timeout"
+    if l1_result.anomalies.get("model_output_truncated"):
+        return "attempted_not_used_truncated"
+    if l1_result.anomalies.get("provider_error"):
+        return "attempted_not_used_provider_error"
+    if l1_output_health.get("status") in {"contract_invalid", "malformed"}:
+        return "attempted_not_used_malformed"
+    return "not_needed_l0"
+
+
+def _history_contribution(
+    history: HistorySummary,
+    retry_policy: RetryPolicyEvaluation,
+) -> str:
+    if not history.available:
+        return "not_available"
+    if retry_policy.decision_basis == DecisionBasis.RETRY_BUDGET_EXHAUSTED.value:
+        return "retry_budget_exhausted"
+    if any(
+        ledger is not None and ledger.applicable and ledger.observed_advance
+        for ledger in (
+            retry_policy.general_root_ceiling,
+            retry_policy.selected_rule_budget,
+        )
+    ):
+        return "observed_advance"
+    return "checked_no_effect"
+
+
+def _result_quality(
+    *,
+    primary: FailureEvidence | None,
+    evidence_source: str,
+    model_contribution: str,
+    l2_audit: Mapping[str, Any],
+) -> str:
+    if evidence_source in {
+        "log_unavailable",
+        "malformed_model_output",
+    }:
+        return "unusable"
+    if primary is None:
+        return "unusable"
+    if model_contribution.startswith("attempted_not_used") or (
+        model_contribution == "attempted_used_with_findings"
+        and _l2_material_finding_count(l2_audit) > 0
+    ):
+        return "degraded"
+    return "normal"
+
+
+def _l2_material_finding_count(audit: Mapping[str, Any]) -> int:
+    return sum(
+        1
+        for finding in audit.get("findings") or []
+        if isinstance(finding, Mapping) and finding.get("policy_material") is True
+    )
+
+
+def _nvrx_use(result_quality: str) -> str:
+    if result_quality == "unusable":
+        return "fallback_to_nvrx_default"
+    if result_quality == "degraded":
+        return "eligible_degraded"
+    return "eligible"
+
+
+def _result_provenance_notes(
+    *,
+    model_contribution: str,
+    l1_result: L1EvidenceResult,
+    l1_output_health: Mapping[str, Any],
+    l2_audit: Mapping[str, Any],
+) -> list[str]:
+    notes: list[str] = []
+    if model_contribution.startswith("attempted_not_used"):
+        notes.append(model_contribution.removeprefix("attempted_not_used_"))
+    if model_contribution == "attempted_used_with_findings":
+        notes.append(
+            "l2_audit_material_findings"
+            if _l2_material_finding_count(l2_audit)
+            else "l2_audit_non_material_findings"
+        )
+    if model_contribution == "attempted_used_with_resolved_findings":
+        notes.append("l2_audit_findings_resolved")
+    if l2_audit.get("l0_policy_downgraded"):
+        notes.append("l0_semantic_stop_downgraded")
+    if l1_result.unsupported_tool_requests:
+        notes.append("unsupported_tool_request")
+    if l1_result.anomalies.get("forced_final_evidence_call"):
+        notes.append("forced_final_evidence_call")
+    if l1_result.anomalies.get("contract_repair_requested"):
+        notes.append("contract_repair_requested")
+    if l1_output_health.get("status") == "contract_invalid":
+        notes.append("l1_contract_invalid")
+    return notes

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/execution.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/execution.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Return-owned execution artifacts for restart-agent callers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from .immutable import freeze_json_value
+from .models import (
+    AnalysisResult,
+    AttemptRecord,
+    CollectAllAnalysisResult,
+    DecisionCandidate,
+    DecisionEvidence,
+    L0Bundle,
+    L0ModelFacingView,
+)
+
+
+@dataclass(frozen=True)
+class L0Artifacts:
+    """Complete shared L0 products available before model-route fanout."""
+
+    bundle: L0Bundle
+    decision_evidence: DecisionEvidence
+    model_view: L0ModelFacingView | None
+    l0a_wall_clock_s: float
+    decision_evidence_wall_clock_s: float
+    l0b_wall_clock_s: float
+    l0_wall_clock_s: float
+    l0_reused: bool
+
+
+@dataclass(frozen=True)
+class AnalysisRun:
+    """One analysis result together with the exact artifacts that produced it."""
+
+    result: AnalysisResult
+    trace: Mapping[str, Any]
+    bundle: L0Bundle | None = None
+    decision_evidence: DecisionEvidence | None = None
+    model_view: L0ModelFacingView | None = None
+    deterministic_candidate: DecisionCandidate | None = None
+    attempt_record: AttemptRecord | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "trace", freeze_json_value(self.trace))
+
+
+@dataclass(frozen=True)
+class CollectAllAnalysisRun:
+    """One parallel route run and its shared deterministic artifacts."""
+
+    result: CollectAllAnalysisResult
+    trace: Mapping[str, Any]
+    bundle: L0Bundle | None = None
+    decision_evidence: DecisionEvidence | None = None
+    model_view: L0ModelFacingView | None = None
+    deterministic_candidate: DecisionCandidate | None = None
+    deterministic_attempt_record: AttemptRecord | None = None
+    attempt_records_by_route: Mapping[str, AttemptRecord] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "trace", freeze_json_value(self.trace))
+        object.__setattr__(
+            self,
+            "attempt_records_by_route",
+            freeze_json_value(self.attempt_records_by_route or {}),
+        )

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/identity.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/identity.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fingerprint and lightweight locality parsing helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Iterable
+
+from .models import AffectedEntity, AffectedEntityKind
+
+_EXCEPTION_TYPE_RE = re.compile(
+    r"\b([A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception|Failure|Fault))\s*:",
+)
+_PYTHON_FRAME_RE = re.compile(r'File "[^"]+", line \d+, in ([A-Za-z_][A-Za-z0-9_]*)')
+_ROUTING_PREFIX_RE = re.compile(r"^\s*\d+:\s*(?:\[rank\d+\]:\s*)?")
+_ISO_TIMESTAMP_PREFIX_RE = re.compile(
+    r"^\s*\[\d{4}-\d{2}-\d{2}[t\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?\]\s*",
+    re.I,
+)
+_NCCL_HOST_ROUTING_PREFIX_RE = re.compile(
+    r"^\s*[A-Za-z0-9_.-]+:\d+:\d+\s+\[\d+\]\s*",
+)
+_CONDITIONAL_DIAGNOSTIC_RE = re.compile(
+    r"\b(?:might|may|could) be caused by\b"
+    r"|\bit is possible that\b"
+    r"|\bpossibly due to\b"
+    r"|\bplease try\b",
+    re.I,
+)
+_FAILURE_ITERATION_RE = re.compile(r"\biteration\s*(?:=|:)?\s*(\d+)\b", re.I)
+
+_VOLATILE_PATTERN_SOURCES = (
+    # PyTorch c10d prefixes use severity plus month/day, for example E207 for
+    # an error emitted on February 7. It is routing metadata, not mechanism.
+    r"\b[ewif]\d{3,4}(?=\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?)",
+    r"\b\d{4}-\d{2}-\d{2}[t\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:z|[+-]\d{2}:?\d{2})?\b",
+    r"\b\d{2}:\d{2}:\d{2}(?:\.\d+)?\b",
+    r"\b0x[0-9a-f]+\b",
+    r"\bpid[=:\s-]*\d+\b",
+    r"\brank[=:\s_-]*\d+\b",
+    r"\bworker[=:\s_-]*\d+\b",
+    r"\btask[=:\s_-]*\d+\b",
+    r"\breplica[=:\s_-]*\d+\b",
+    r"\bcuda:\d+\b",
+    r"\bgpu[=:\s_-]*\d+\b",
+    r"\bdevice[=:\s_-]*\d+\b",
+    r"\bnode[-_.a-z0-9]*\d+\b",
+    r"\bnode[=:\s]+[a-z0-9_.-]+\b",
+    r"\biteration[=:\s_-]*\d+\b",
+    r"\bbucket[=:\s_#-]*\d+\b",
+    r"\b\d+(?:\.\d+)?\s*(?:b|kb|kib|mb|mib|gb|gib|tb|tib)\b",
+    r"\b\d+(?:\.\d+)?\s*(?:ms|s|sec|secs|seconds|min|minutes)\b",
+    r"\bretry[=:\s_-]*\d+\b",
+    r"\battempt[=:\s_-]*\d+\b",
+    r"\bline\s+\d+\b",
+)
+_VOLATILE_PATTERN = re.compile(
+    "|".join(f"(?:{source})" for source in _VOLATILE_PATTERN_SOURCES),
+    re.I,
+)
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+_UNDERSCORE_RUN_RE = re.compile(r"_+")
+_STANDALONE_NUMBER_RE = re.compile(r"(?<![a-z0-9])\d+(?![a-z0-9])")
+
+
+def path_hints(log_path: str, max_parts: int = 5) -> list[str]:
+    path = Path(log_path)
+    parts = [part for part in path.parts if part not in {"/", ""}]
+    return parts[-max_parts:]
+
+
+def normalize_token(text: str) -> str:
+    normalized = _VOLATILE_PATTERN.sub(" ", text.lower())
+    normalized = _NON_ALNUM_RE.sub("_", normalized)
+    normalized = _UNDERSCORE_RUN_RE.sub("_", normalized).strip("_")
+    return normalized
+
+
+def normalized_pattern(text: str) -> str:
+    normalized = normalize_token(text)
+    normalized = _STANDALONE_NUMBER_RE.sub("n", normalized)
+    normalized = _UNDERSCORE_RUN_RE.sub("_", normalized).strip("_")
+    return normalized
+
+
+def fingerprint_for(failure_class: str, components: Iterable[str]) -> str | None:
+    tokens = [normalize_token(failure_class)]
+    for component in components:
+        token = normalize_token(component)
+        if token:
+            tokens.append(token)
+    if len(tokens) == 1:
+        return None
+    return ":".join(tokens)
+
+
+def _strip_routing_prefix(text: str) -> str:
+    stripped = _ROUTING_PREFIX_RE.sub("", text)
+    stripped = _ISO_TIMESTAMP_PREFIX_RE.sub("", stripped)
+    return _NCCL_HOST_ROUTING_PREFIX_RE.sub("", stripped)
+
+
+def canonical_observed_fingerprint(
+    terminal_text: str,
+    context_before: Iterable[str] = (),
+) -> str | None:
+    """Build a stable history key from observed text, not model vocabulary."""
+
+    stripped = _strip_routing_prefix(terminal_text)
+    exception_match = _EXCEPTION_TYPE_RE.search(stripped)
+    exception_type = exception_match.group(1) if exception_match else "observed_failure"
+    callsite = None
+    for text in context_before:
+        frame_match = _PYTHON_FRAME_RE.search(text)
+        if frame_match:
+            callsite = frame_match.group(1)
+    components = [exception_type]
+    if callsite:
+        components.append(callsite)
+    pattern = normalized_pattern(_observed_mechanism_text(stripped))
+    if pattern:
+        components.append(pattern)
+    return fingerprint_for("observed", components)
+
+
+def _observed_mechanism_text(text: str) -> str:
+    match = _CONDITIONAL_DIAGNOSTIC_RE.search(text)
+    if match is None:
+        return text
+
+    exception_match = _EXCEPTION_TYPE_RE.search(text)
+    exception_end = exception_match.end() if exception_match else 0
+    sentence_start = max(
+        text.rfind(". ", exception_end, match.start()),
+        text.rfind("! ", exception_end, match.start()),
+        text.rfind("? ", exception_end, match.start()),
+    )
+    cut = sentence_start + 1 if sentence_start >= 0 else match.start()
+    return text[:cut].rstrip(" .,:;-")
+
+
+def grounded_artifact_path(value: object, *, texts: Iterable[str]) -> str | None:
+    """Return a model-proposed artifact path only when source text contains it."""
+
+    if not isinstance(value, str) or not value.strip():
+        return None
+    candidate = value.strip()
+    return candidate if any(candidate in text for text in texts) else None
+
+
+def extract_rank(text: str) -> str | None:
+    prefix_match = re.search(r"^\s*(\d+):\s+", text)
+    if prefix_match:
+        return prefix_match.group(1)
+    match = re.search(r"(?:^|[\s\[])(?:rank|global_rank)[=:\s_-]*(\d+)", text, re.I)
+    return match.group(1) if match else None
+
+
+def extract_gpu(text: str) -> str | None:
+    match = re.search(
+        r"\bcuda:(\d+)\b|\bgpu[=:\s_-]*(\d+)\b|\bdevice[=:\s]+(\d+)\b",
+        text,
+        re.I,
+    )
+    if not match:
+        return None
+    return next(group for group in match.groups() if group is not None)
+
+
+def extract_node(text: str) -> str | None:
+    match = re.search(r"\bnode[=:\s]+([a-z0-9_.-]+)", text, re.I)
+    return match.group(1) if match else None
+
+
+def extract_failure_iteration(text: str) -> int | None:
+    """Return an explicit iteration attached to a failure observation."""
+
+    match = _FAILURE_ITERATION_RE.search(_strip_routing_prefix(text))
+    return int(match.group(1)) if match else None
+
+
+def extract_data_position_fingerprint(text: str) -> str | None:
+    identity = extract_data_position_identity(text)
+    if identity is None:
+        return None
+    _kind, _separator, value = identity.partition(":")
+    return fingerprint_for("data_position", [value])
+
+
+def extract_data_position_identity(text: str) -> str | None:
+    """Return an exact typed data position suitable for entity comparison."""
+
+    patterns = (
+        ("token", r"\btoken_id[=:\s]+([a-z0-9_.-]+)"),
+        ("sample", r"\bsample_id[=:\s]+([a-z0-9_.-]+)"),
+        ("window", r"\bwindow_id[=:\s]+([a-z0-9_.-]+)"),
+        ("token", r"\btoken[=:]+([a-z0-9_.-]+)"),
+        ("sample", r"\bsample[=:]+([a-z0-9_.-]+)"),
+        ("window", r"\bwindow[=:]+([a-z0-9_.-]+)"),
+        ("token", r"\btoken\s+(\d+)\b"),
+        ("sample", r"\bsample\s+(\d+)\b"),
+        ("window", r"\bwindow\s+(\d+)\b"),
+    )
+    for kind, pattern in patterns:
+        match = re.search(pattern, text, re.I)
+        if match:
+            return f"{kind}:{match.group(1)}"
+    return None
+
+
+def build_affected_entity(
+    kind: AffectedEntityKind,
+    identity: str,
+    *,
+    evidence_line: int | None = None,
+) -> AffectedEntity:
+    """Build the canonical exact-entity identity shared by L0 and L2."""
+
+    digest = hashlib.sha256(f"{kind.value}\0{identity}".encode("utf-8")).hexdigest()
+    return AffectedEntity(
+        kind=kind,
+        identity=identity,
+        fingerprint=f"affected_entity:{kind.value}:{digest[:24]}",
+        evidence_line=evidence_line,
+    )

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/immutable.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/immutable.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable, JSON-compatible containers for shared pipeline payloads."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+class FrozenDict(dict):
+    """JSON-compatible dictionary that rejects mutation after construction."""
+
+    def _immutable(self, *args: Any, **kwargs: Any) -> None:
+        raise TypeError("frozen JSON payload cannot be mutated")
+
+    __setitem__ = _immutable
+    __delitem__ = _immutable
+    clear = _immutable
+    pop = _immutable
+    popitem = _immutable
+    setdefault = _immutable
+    update = _immutable
+    __ior__ = _immutable
+
+
+class FrozenList(list):
+    """JSON-compatible list that rejects mutation after construction."""
+
+    def _immutable(self, *args: Any, **kwargs: Any) -> None:
+        raise TypeError("frozen JSON payload cannot be mutated")
+
+    __setitem__ = _immutable
+    __delitem__ = _immutable
+    __iadd__ = _immutable
+    __imul__ = _immutable
+    append = _immutable
+    clear = _immutable
+    extend = _immutable
+    insert = _immutable
+    pop = _immutable
+    remove = _immutable
+    reverse = _immutable
+    sort = _immutable
+
+
+def freeze_json_value(value: Any) -> Any:
+    """Recursively freeze JSON-like stage payloads without breaking serialization."""
+
+    if isinstance(value, Mapping):
+        return FrozenDict({key: freeze_json_value(item) for key, item in value.items()})
+    if isinstance(value, (tuple, list)):
+        return FrozenList(freeze_json_value(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(freeze_json_value(item) for item in value)
+    return value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/__init__.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Filesystem and artifact publication adapters."""
+
+from .artifact_io import write_json_atomic
+from .l0_publisher import L0ArtifactPublisher
+from .live_artifacts import DETERMINISTIC_RECOMMENDATION_SCHEMA_VERSION, LiveArtifactWriter
+from .log_source import (
+    SOURCE_READ_MODE_CHUNKED,
+    SOURCE_READ_MODE_SINGLE_SNAPSHOT,
+    ChunkedLogReader,
+    IncrementalLineDecoder,
+    LocalLogSource,
+    LogSnapshot,
+    LogSource,
+    read_log_line,
+    read_log_lines,
+    read_log_text_lines,
+)
+from .route_publisher import RouteArtifactPublisher, load_route_artifact_manifest
+
+__all__ = [
+    "DETERMINISTIC_RECOMMENDATION_SCHEMA_VERSION",
+    "SOURCE_READ_MODE_CHUNKED",
+    "SOURCE_READ_MODE_SINGLE_SNAPSHOT",
+    "ChunkedLogReader",
+    "IncrementalLineDecoder",
+    "L0ArtifactPublisher",
+    "LiveArtifactWriter",
+    "LocalLogSource",
+    "LogSnapshot",
+    "LogSource",
+    "RouteArtifactPublisher",
+    "load_route_artifact_manifest",
+    "read_log_line",
+    "read_log_lines",
+    "read_log_text_lines",
+    "write_json_atomic",
+]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/artifact_io.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/artifact_io.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Atomic JSON persistence for restart-agent artifacts."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def write_json_atomic(path: str | Path, payload: Any) -> None:
+    """Write one complete JSON document using same-directory atomic replace."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.",
+        suffix=".tmp",
+        dir=output.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, output)
+    finally:
+        if temporary.exists():
+            temporary.unlink()

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/l0_publisher.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/l0_publisher.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Asynchronous persistence for complete shared L0 products."""
+
+from __future__ import annotations
+
+from concurrent.futures import Executor, Future
+from pathlib import Path
+from threading import Lock
+from typing import Callable, Mapping
+
+from ..execution import L0Artifacts
+from ..l0.codec import write_l0_bundle
+from ..runtime import THREAD_EXECUTOR_FACTORY, ExecutorFactory
+from .artifact_io import write_json_atomic
+
+L0PublishedCallback = Callable[[L0Artifacts, Mapping[str, str]], None]
+
+
+class L0ArtifactPublisher:
+    """Persist one L0 snapshot without delaying model-route fanout."""
+
+    def __init__(
+        self,
+        *,
+        bundle_path: str | Path | None = None,
+        decision_evidence_path: str | Path | None = None,
+        model_view_path: str | Path | None = None,
+        on_published: L0PublishedCallback | None = None,
+        executor_factory: ExecutorFactory = THREAD_EXECUTOR_FACTORY,
+    ) -> None:
+        self._bundle_path = Path(bundle_path) if bundle_path else None
+        self._decision_evidence_path = (
+            Path(decision_evidence_path) if decision_evidence_path else None
+        )
+        self._model_view_path = Path(model_view_path) if model_view_path else None
+        self._on_published = on_published
+        self._executor: Executor = executor_factory(
+            max_workers=1,
+            thread_name_prefix="restart-agent-l0-artifacts",
+        )
+        self._future: Future[Mapping[str, str]] | None = None
+        self._lock = Lock()
+
+    def publish(self, artifacts: L0Artifacts) -> None:
+        """Enqueue one complete L0 snapshot and return immediately."""
+
+        with self._lock:
+            if self._future is not None:
+                raise RuntimeError("L0 artifacts were already submitted for publication")
+            self._future = self._executor.submit(self._write, artifacts)
+
+    def wait(self) -> Mapping[str, str]:
+        """Wait for an enqueued snapshot and propagate persistence failures."""
+
+        with self._lock:
+            future = self._future
+        return future.result() if future is not None else {}
+
+    def close(self) -> None:
+        self._executor.shutdown(wait=True)
+
+    def _write(self, artifacts: L0Artifacts) -> Mapping[str, str]:
+        published: dict[str, str] = {}
+        if self._bundle_path is not None:
+            write_l0_bundle(self._bundle_path, artifacts.bundle)
+            published["l0_bundle"] = str(self._bundle_path)
+        if self._decision_evidence_path is not None:
+            write_json_atomic(
+                self._decision_evidence_path,
+                artifacts.decision_evidence.to_payload(),
+            )
+            published["decision_evidence"] = str(self._decision_evidence_path)
+        if self._model_view_path is not None and artifacts.model_view is not None:
+            write_json_atomic(
+                self._model_view_path,
+                artifacts.model_view.to_payload(),
+            )
+            published["l0_model_view"] = str(self._model_view_path)
+        if self._on_published is not None:
+            self._on_published(artifacts, published)
+        return published

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/live_artifacts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/live_artifacts.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Atomic, inspectable lifecycle artifacts for local collect-all execution."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from ..execution import L0Artifacts
+from ..runtime import SYSTEM_CLOCK, Clock
+from .artifact_io import write_json_atomic
+
+LIVE_STATUS_SCHEMA_VERSION = "restart_agent_live_status.v1"
+LIVE_EVENT_SCHEMA_VERSION = "restart_agent_live_event.v1"
+DETERMINISTIC_RECOMMENDATION_SCHEMA_VERSION = "restart_agent_deterministic_recommendation.v1"
+
+
+class LiveArtifactWriter:
+    """Publish complete snapshots as a collect-all analysis advances."""
+
+    def __init__(self, root: str | Path, *, clock: Clock = SYSTEM_CLOCK) -> None:
+        self.root = Path(root)
+        self.events_path = self.root / "events.jsonl"
+        self.status_path = self.root / "run_status.json"
+        self._lock = threading.Lock()
+        self._clock = clock
+        self._started_monotonic = clock.monotonic()
+        self._sequence = 0
+        self._status: dict[str, Any] = {}
+
+    def start(
+        self,
+        *,
+        routes: Sequence[Mapping[str, Any]],
+        config_metadata: Mapping[str, Any],
+    ) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        route_status: dict[str, Any] = {}
+        for route in routes:
+            route_id = str(route.get("route_id") or "unknown")
+            route_status[route_id] = {
+                "status": "pending",
+                "model": route.get("model"),
+                "endpoint": route.get("endpoint"),
+                "credential_ref": route.get("credential_ref"),
+            }
+        now = self._utc_now()
+        self._status = {
+            "schema_version": LIVE_STATUS_SCHEMA_VERSION,
+            "status": "running",
+            "started_at_utc": now,
+            "updated_at_utc": now,
+            "elapsed_s": 0.0,
+            "l0": {"status": "pending"},
+            "deterministic": {"status": "pending"},
+            "routes": route_status,
+            "completed_routes": 0,
+            "total_routes": len(route_status),
+            "config": _jsonable(config_metadata),
+        }
+        self.events_path.write_text("", encoding="utf-8")
+        write_json_atomic(self.status_path, self._status)
+        self._append_event("run_started", route_count=len(route_status))
+
+    def publish_l0_artifacts(
+        self,
+        artifacts: L0Artifacts,
+        artifact_paths: Mapping[str, str],
+    ) -> None:
+        """Record that canonical shared L0 artifacts are durable and inspectable."""
+
+        with self._lock:
+            display_paths = {
+                name: _display_path(path, relative_to=self.root.parent)
+                for name, path in artifact_paths.items()
+            }
+            self._status["l0"] = {
+                "status": "ready",
+                "artifacts": display_paths,
+                "l0_wall_clock_s": artifacts.l0_wall_clock_s,
+                "l0a_wall_clock_s": artifacts.l0a_wall_clock_s,
+                "decision_evidence_wall_clock_s": (artifacts.decision_evidence_wall_clock_s),
+                "l0b_wall_clock_s": artifacts.l0b_wall_clock_s,
+                "l0_reused": artifacts.l0_reused,
+            }
+            self._update_status()
+            self._append_event(
+                "l0_artifacts_ready",
+                artifacts=display_paths,
+                l0_wall_clock_s=artifacts.l0_wall_clock_s,
+                l0a_wall_clock_s=artifacts.l0a_wall_clock_s,
+                decision_evidence_wall_clock_s=(artifacts.decision_evidence_wall_clock_s),
+                l0b_wall_clock_s=artifacts.l0b_wall_clock_s,
+                l0_reused=artifacts.l0_reused,
+            )
+
+    def publish_deterministic(
+        self,
+        candidate: Mapping[str, Any],
+        *,
+        artifact_path: str | None,
+    ) -> None:
+        with self._lock:
+            result = _mapping(candidate.get("result"))
+            display_path = (
+                _display_path(artifact_path, relative_to=self.root.parent)
+                if artifact_path
+                else None
+            )
+            self._status["deterministic"] = {
+                "status": "ready",
+                "decision": result.get("decision"),
+                "decision_basis": result.get("decision_basis"),
+                "ready_wall_clock_s": candidate.get("ready_wall_clock_s"),
+                "artifact": display_path,
+            }
+            self._update_status()
+            self._append_event(
+                "deterministic_recommendation_ready",
+                decision=result.get("decision"),
+                decision_basis=result.get("decision_basis"),
+                ready_wall_clock_s=candidate.get("ready_wall_clock_s"),
+                artifact=display_path,
+            )
+
+    def publish_route(
+        self,
+        route_result: Mapping[str, Any],
+        *,
+        artifact_paths: Mapping[str, str],
+    ) -> None:
+        with self._lock:
+            route_id = str(route_result.get("route_id") or "unknown")
+            display_paths = {
+                name: _display_path(path, relative_to=self.root.parent)
+                for name, path in artifact_paths.items()
+            }
+            analysis_result = _mapping(route_result.get("analysis_result"))
+            route_state = dict(self._status.get("routes", {}).get(route_id) or {})
+            route_state.update(
+                {
+                    "status": route_result.get("execution_status"),
+                    "l1_usable": route_result.get("l1_usable"),
+                    "decision": analysis_result.get("decision"),
+                    "error": route_result.get("error"),
+                    "completed_at_utc": self._utc_now(),
+                    "result_artifact": display_paths.get("result_json"),
+                    "trace_artifact": display_paths.get("trace_json"),
+                }
+            )
+            self._status.setdefault("routes", {})[route_id] = route_state
+            self._status["completed_routes"] = sum(
+                route.get("status") != "pending"
+                for route in self._status.get("routes", {}).values()
+            )
+            self._update_status()
+            self._append_event(
+                "route_completed",
+                route_id=route_id,
+                model=route_result.get("model"),
+                execution_status=route_result.get("execution_status"),
+                l1_usable=route_result.get("l1_usable"),
+                decision=analysis_result.get("decision"),
+                result_artifact=display_paths.get("result_json"),
+                trace_artifact=display_paths.get("trace_json"),
+            )
+
+    def complete(
+        self,
+        *,
+        final_artifacts: Mapping[str, str | None],
+    ) -> None:
+        with self._lock:
+            if self._status.get("deterministic", {}).get("status") == "pending":
+                self._status["deterministic"] = {"status": "not_published"}
+            if self._status.get("l0", {}).get("status") == "pending":
+                self._status["l0"] = {"status": "not_published"}
+            self._status.update(
+                {
+                    "status": "completed",
+                    "completed_at_utc": self._utc_now(),
+                    "final_result_artifact": final_artifacts.get("result_json"),
+                    "final_artifacts": _jsonable(final_artifacts),
+                }
+            )
+            self._update_status()
+            self._append_event(
+                "run_completed",
+                completed_routes=self._status.get("completed_routes"),
+                total_routes=self._status.get("total_routes"),
+                artifact=final_artifacts.get("result_json"),
+            )
+
+    def fail(self, exc: BaseException) -> None:
+        with self._lock:
+            error = f"{type(exc).__name__}: {exc}"
+            self._status.update(
+                {
+                    "status": "failed",
+                    "failed_at_utc": self._utc_now(),
+                    "error": error,
+                }
+            )
+            self._update_status()
+            self._append_event("run_failed", error=error)
+
+    def _update_status(self) -> None:
+        self._status["updated_at_utc"] = self._utc_now()
+        self._status["elapsed_s"] = round(
+            self._clock.monotonic() - self._started_monotonic,
+            3,
+        )
+        write_json_atomic(self.status_path, self._status)
+
+    def _append_event(self, event: str, **fields: Any) -> None:
+        self._sequence += 1
+        payload = {
+            "schema_version": LIVE_EVENT_SCHEMA_VERSION,
+            "sequence": self._sequence,
+            "event": event,
+            "timestamp_utc": self._utc_now(),
+            "elapsed_s": round(
+                self._clock.monotonic() - self._started_monotonic,
+                3,
+            ),
+            **_jsonable(fields),
+        }
+        encoded = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+        descriptor = os.open(
+            self.events_path,
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            os.write(descriptor, encoded)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _utc_now(self) -> str:
+        return self._clock.now_utc().isoformat()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _display_path(path: str, *, relative_to: Path) -> str:
+    candidate = Path(path)
+    try:
+        return str(candidate.relative_to(relative_to))
+    except ValueError:
+        return str(candidate)
+
+
+def _jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return _jsonable(asdict(value))
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    return value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/log_source.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/log_source.py
@@ -1,0 +1,664 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded byte and logical-line access for restart-agent analysis."""
+
+from __future__ import annotations
+
+import os
+from array import array
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import BinaryIO, Callable, Iterator, Protocol, Sequence
+
+from ..models import LogLine
+
+DEFAULT_LOG_READ_CHUNK_BYTES = 1024 * 1024
+SOURCE_READ_MODE_CHUNKED = "chunked"
+SOURCE_READ_MODE_SINGLE_SNAPSHOT = "single_snapshot"
+SOURCE_READ_MODES = frozenset(
+    {
+        SOURCE_READ_MODE_CHUNKED,
+        SOURCE_READ_MODE_SINGLE_SNAPSHOT,
+    }
+)
+
+
+@dataclass(frozen=True)
+class SourceBoundary:
+    """Immutable source identity and byte boundary for one analysis snapshot."""
+
+    device: int
+    inode: int
+    byte_size: int
+    mtime_ns: int
+
+    def same_file(self, other: "SourceBoundary") -> bool:
+        return self.device == other.device and self.inode == other.inode
+
+    def to_payload(self) -> dict[str, int]:
+        return {
+            "device": self.device,
+            "inode": self.inode,
+            "byte_size": self.byte_size,
+            "mtime_ns": self.mtime_ns,
+        }
+
+
+@dataclass(frozen=True)
+class DecodedLine:
+    """One decoded physical line and its byte offsets in the source."""
+
+    text: str
+    start_offset: int
+    end_offset: int
+    next_offset: int
+    decode_replacement_count: int = 0
+
+
+class IncrementalLineDecoder:
+    """Turn arbitrary byte chunks into exactly-once LF-delimited physical lines."""
+
+    def __init__(self, *, encoding: str = "utf-8") -> None:
+        if encoding not in {"utf-8", "latin-1"}:
+            raise ValueError("encoding must be 'utf-8' or 'latin-1'")
+        self._encoding = encoding
+        self._pending = b""
+        self._bytes_received = 0
+        self._finalized = False
+        self._decode_replacement_count = 0
+        self._decode_replacement_line_count = 0
+
+    @property
+    def encoding(self) -> str:
+        return self._encoding
+
+    @property
+    def pending_bytes(self) -> int:
+        return len(self._pending)
+
+    @property
+    def decode_replacement_count(self) -> int:
+        return self._decode_replacement_count
+
+    @property
+    def decode_replacement_line_count(self) -> int:
+        return self._decode_replacement_line_count
+
+    def feed(self, chunk: bytes, *, final: bool = False) -> tuple[str, ...]:
+        """Decode complete lines, retaining an incomplete tail until later."""
+
+        return tuple(record.text for record in self.feed_records(chunk, final=final))
+
+    def feed_records(self, chunk: bytes, *, final: bool = False) -> tuple[DecodedLine, ...]:
+        """Decode complete lines with stable source-byte offsets."""
+
+        if self._finalized:
+            raise RuntimeError("line decoder is already finalized")
+        if not isinstance(chunk, bytes):
+            raise TypeError("chunk must be bytes")
+
+        data_start = self._bytes_received - len(self._pending)
+        self._bytes_received += len(chunk)
+        data = self._pending + chunk
+        lines: list[DecodedLine] = []
+        record_start = 0
+        while True:
+            lf_index = data.find(b"\n", record_start)
+            if lf_index < 0:
+                break
+            text_end = (
+                lf_index - 1
+                if lf_index > record_start and data[lf_index - 1] == ord("\r")
+                else lf_index
+            )
+            text, replacement_count = _decode_bytes(
+                data[record_start:text_end],
+                self._encoding,
+            )
+            lines.append(
+                DecodedLine(
+                    text=text,
+                    start_offset=data_start + record_start,
+                    end_offset=data_start + text_end,
+                    next_offset=data_start + lf_index + 1,
+                    decode_replacement_count=replacement_count,
+                )
+            )
+            self._record_decode_replacements(replacement_count)
+            record_start = lf_index + 1
+
+        self._pending = data[record_start:]
+        if final:
+            if self._pending:
+                text, replacement_count = _decode_bytes(self._pending, self._encoding)
+                lines.append(
+                    DecodedLine(
+                        text=text,
+                        start_offset=data_start + record_start,
+                        end_offset=data_start + len(data),
+                        next_offset=data_start + len(data),
+                        decode_replacement_count=replacement_count,
+                    )
+                )
+                self._record_decode_replacements(replacement_count)
+            self._pending = b""
+            self._finalized = True
+        return tuple(lines)
+
+    def _record_decode_replacements(self, count: int) -> None:
+        if count:
+            self._decode_replacement_count += count
+            self._decode_replacement_line_count += 1
+
+    def discard_pending(self) -> int:
+        """Finalize without treating an actively written tail as a complete line."""
+
+        if self._finalized:
+            raise RuntimeError("line decoder is already finalized")
+        discarded = len(self._pending)
+        self._pending = b""
+        self._finalized = True
+        return discarded
+
+
+class _LineStore(Protocol):
+    @property
+    def line_count(self) -> int: ...
+
+    @property
+    def storage_mode(self) -> str: ...
+
+    def line(self, line: int) -> str | None: ...
+
+    def log_lines(
+        self,
+        *,
+        start_line: int = 1,
+        end_line: int | None = None,
+    ) -> Iterator[LogLine]: ...
+
+
+class InMemoryLineStore:
+    """Physical lines retained directly for explicit snapshots and small tests."""
+
+    def __init__(self, lines: Sequence[str] = ()) -> None:
+        self._lines = list(lines)
+
+    @property
+    def line_count(self) -> int:
+        return len(self._lines)
+
+    @property
+    def storage_mode(self) -> str:
+        return "memory"
+
+    def append(self, text: str) -> None:
+        self._lines.append(text)
+
+    def line(self, line: int) -> str | None:
+        if line < 1 or line > self.line_count:
+            return None
+        return self._lines[line - 1]
+
+    def log_lines(
+        self,
+        *,
+        start_line: int = 1,
+        end_line: int | None = None,
+    ) -> Iterator[LogLine]:
+        start = max(1, start_line)
+        end = self.line_count if end_line is None else min(self.line_count, end_line)
+        for line_no in range(start, end + 1):
+            yield LogLine(line=line_no, text=self._lines[line_no - 1])
+
+
+class IndexedFileLineStore:
+    """Compact logical-line index over one captured local-file boundary."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        boundary: SourceBoundary,
+        encoding: str,
+        line_starts: Sequence[int] = (),
+        indexed_end_offset: int = 0,
+        read_chunk_bytes: int = DEFAULT_LOG_READ_CHUNK_BYTES,
+    ) -> None:
+        self._path = str(path)
+        self._boundary = boundary
+        self._encoding = encoding
+        self._line_starts = array("Q", line_starts)
+        self._indexed_end_offset = indexed_end_offset
+        self._read_chunk_bytes = read_chunk_bytes
+        self._lock = RLock()
+        self._handle = Path(path).open("rb")
+        ChunkedLogReader._validate_open_source(self._handle, boundary)
+
+    @property
+    def line_count(self) -> int:
+        return len(self._line_starts)
+
+    @property
+    def storage_mode(self) -> str:
+        return "indexed_file"
+
+    @property
+    def boundary(self) -> SourceBoundary:
+        return self._boundary
+
+    @property
+    def encoding(self) -> str:
+        return self._encoding
+
+    def update_boundary(self, boundary: SourceBoundary) -> None:
+        with self._lock:
+            if not self._boundary.same_file(boundary):
+                raise OSError("indexed source was replaced")
+            if boundary.byte_size < self._boundary.byte_size:
+                raise OSError("indexed source was truncated")
+            self._boundary = boundary
+
+    def append_record(self, record: DecodedLine) -> None:
+        with self._lock:
+            self._line_starts.append(record.start_offset)
+            self._indexed_end_offset = record.next_offset
+
+    def line(self, line: int) -> str | None:
+        if line < 1 or line > self.line_count:
+            return None
+        with self._lock:
+            start = self._line_starts[line - 1]
+            end = self._line_starts[line] if line < self.line_count else self._indexed_end_offset
+            raw = os.pread(self._handle.fileno(), end - start, start)
+        return _decode_record(raw, self._encoding)
+
+    def log_lines(
+        self,
+        *,
+        start_line: int = 1,
+        end_line: int | None = None,
+    ) -> Iterator[LogLine]:
+        start = max(1, start_line)
+        end = self.line_count if end_line is None else min(self.line_count, end_line)
+        if start > end:
+            return
+        with self._lock:
+            start_offset = self._line_starts[start - 1]
+            end_offset = (
+                self._line_starts[end] if end < self.line_count else self._indexed_end_offset
+            )
+            fd = self._handle.fileno()
+            encoding = self._encoding
+            chunk_bytes = self._read_chunk_bytes
+
+        decoder = IncrementalLineDecoder(encoding=encoding)
+        offset = start_offset
+        line_no = start
+        while offset < end_offset:
+            read_size = min(chunk_bytes, end_offset - offset)
+            chunk = os.pread(fd, read_size, offset)
+            if not chunk:
+                raise OSError("indexed source ended before its captured line boundary")
+            offset += len(chunk)
+            for text in decoder.feed(chunk):
+                yield LogLine(line=line_no, text=text)
+                line_no += 1
+        for text in decoder.feed(b"", final=True):
+            yield LogLine(line=line_no, text=text)
+            line_no += 1
+        if line_no != end + 1:
+            raise OSError("indexed source line count does not match its byte index")
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._handle.closed:
+                self._handle.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class ChunkedLogReader:
+    """Read a captured source boundary as fixed chunks or one test snapshot."""
+
+    def __init__(
+        self,
+        *,
+        chunk_bytes: int = DEFAULT_LOG_READ_CHUNK_BYTES,
+        read_mode: str = SOURCE_READ_MODE_CHUNKED,
+    ) -> None:
+        if isinstance(chunk_bytes, bool) or not isinstance(chunk_bytes, int):
+            raise TypeError("chunk_bytes must be an integer")
+        if chunk_bytes < 1:
+            raise ValueError("chunk_bytes must be greater than zero")
+        if read_mode not in SOURCE_READ_MODES:
+            raise ValueError("read_mode must be one of: " + ", ".join(sorted(SOURCE_READ_MODES)))
+        self._chunk_bytes = chunk_bytes
+        self._read_mode = read_mode
+
+    @property
+    def chunk_bytes(self) -> int:
+        return self._chunk_bytes
+
+    @property
+    def read_mode(self) -> str:
+        return self._read_mode
+
+    def boundary(self, log_path: str | Path) -> SourceBoundary:
+        path = Path(log_path)
+        with path.open("rb") as handle:
+            return _source_boundary(os.fstat(handle.fileno()))
+
+    def chunks(
+        self,
+        log_path: str | Path,
+        *,
+        boundary: SourceBoundary,
+        start_offset: int = 0,
+    ) -> Iterator[bytes]:
+        """Yield exactly the bytes in ``[start_offset, boundary.byte_size)``."""
+
+        if start_offset < 0 or start_offset > boundary.byte_size:
+            raise ValueError("start_offset is outside the captured source boundary")
+        with Path(log_path).open("rb") as handle:
+            self._validate_open_source(handle, boundary)
+            handle.seek(start_offset)
+            remaining = boundary.byte_size - start_offset
+            while remaining:
+                read_size = (
+                    remaining
+                    if self._read_mode == SOURCE_READ_MODE_SINGLE_SNAPSHOT
+                    else min(self._chunk_bytes, remaining)
+                )
+                chunk = handle.read(read_size)
+                if not chunk:
+                    raise OSError(
+                        "log file ended before captured boundary: "
+                        f"{boundary.byte_size - remaining}/{boundary.byte_size}"
+                    )
+                remaining -= len(chunk)
+                yield chunk
+
+    def snapshot(self, log_path: str | Path) -> "LogSnapshot":
+        """Capture one immutable boundary through the shared chunk decoder."""
+
+        path = str(log_path)
+        boundary = self.boundary(path)
+        if self._read_mode == SOURCE_READ_MODE_SINGLE_SNAPSHOT:
+            lines, encoding = self._decode_boundary(path, boundary)
+            return LogSnapshot(
+                path=path,
+                lines=lines,
+                byte_size=boundary.byte_size,
+                source_boundary=boundary,
+                encoding=encoding,
+                read_mode=self._read_mode,
+            )
+        store, encoding = self._index_boundary(path, boundary)
+        return LogSnapshot.from_line_store(
+            path=path,
+            line_store=store,
+            byte_size=boundary.byte_size,
+            source_boundary=boundary,
+            encoding=encoding,
+            read_mode=self._read_mode,
+        )
+
+    def _index_boundary(
+        self,
+        log_path: str,
+        boundary: SourceBoundary,
+    ) -> tuple[IndexedFileLineStore, str]:
+        return self._index_boundary_with_encoding(log_path, boundary, "utf-8"), "utf-8"
+
+    def _index_boundary_with_encoding(
+        self,
+        log_path: str,
+        boundary: SourceBoundary,
+        encoding: str,
+    ) -> IndexedFileLineStore:
+        decoder = IncrementalLineDecoder(encoding=encoding)
+        line_starts = array("Q")
+        indexed_end_offset = 0
+        for chunk in self.chunks(log_path, boundary=boundary):
+            for record in decoder.feed_records(chunk):
+                line_starts.append(record.start_offset)
+                indexed_end_offset = record.next_offset
+        for record in decoder.feed_records(b"", final=True):
+            line_starts.append(record.start_offset)
+            indexed_end_offset = record.next_offset
+        return IndexedFileLineStore(
+            log_path,
+            boundary=boundary,
+            encoding=encoding,
+            line_starts=line_starts,
+            indexed_end_offset=indexed_end_offset,
+            read_chunk_bytes=self._chunk_bytes,
+        )
+
+    def _decode_boundary(
+        self,
+        log_path: str,
+        boundary: SourceBoundary,
+    ) -> tuple[tuple[str, ...], str]:
+        return self._decode_boundary_with_encoding(log_path, boundary, "utf-8"), "utf-8"
+
+    def _decode_boundary_with_encoding(
+        self,
+        log_path: str,
+        boundary: SourceBoundary,
+        encoding: str,
+    ) -> tuple[str, ...]:
+        decoder = IncrementalLineDecoder(encoding=encoding)
+        lines: list[str] = []
+        for chunk in self.chunks(log_path, boundary=boundary):
+            lines.extend(decoder.feed(chunk))
+        lines.extend(decoder.feed(b"", final=True))
+        return tuple(lines)
+
+    @staticmethod
+    def _validate_open_source(handle: BinaryIO, boundary: SourceBoundary) -> None:
+        current = _source_boundary(os.fstat(handle.fileno()))
+        if not boundary.same_file(current):
+            raise OSError("log file was replaced after boundary capture")
+        if current.byte_size < boundary.byte_size:
+            raise OSError("log file was truncated after boundary capture")
+        if current.byte_size == boundary.byte_size and current.mtime_ns != boundary.mtime_ns:
+            raise OSError("log file was modified after boundary capture")
+
+
+class LogSnapshot:
+    """One immutable source boundary shared by all downstream stages."""
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        lines: Sequence[str],
+        byte_size: int,
+        source_boundary: SourceBoundary | None = None,
+        encoding: str = "utf-8",
+        read_mode: str = "provided_snapshot",
+    ) -> None:
+        self.path = path
+        self.byte_size = byte_size
+        self.source_boundary = source_boundary
+        self.encoding = encoding
+        self.read_mode = read_mode
+        self._line_store: _LineStore = InMemoryLineStore(lines)
+
+    @classmethod
+    def from_line_store(
+        cls,
+        *,
+        path: str,
+        line_store: _LineStore,
+        byte_size: int,
+        source_boundary: SourceBoundary | None = None,
+        encoding: str = "utf-8",
+        read_mode: str = "provided_snapshot",
+    ) -> "LogSnapshot":
+        snapshot = cls.__new__(cls)
+        snapshot.path = path
+        snapshot.byte_size = byte_size
+        snapshot.source_boundary = source_boundary
+        snapshot.encoding = encoding
+        snapshot.read_mode = read_mode
+        snapshot._line_store = line_store
+        return snapshot
+
+    @classmethod
+    def read(
+        cls,
+        log_path: str | Path,
+        *,
+        chunk_bytes: int = DEFAULT_LOG_READ_CHUNK_BYTES,
+        read_mode: str = SOURCE_READ_MODE_CHUNKED,
+    ) -> "LogSnapshot":
+        return ChunkedLogReader(
+            chunk_bytes=chunk_bytes,
+            read_mode=read_mode,
+        ).snapshot(log_path)
+
+    @property
+    def line_count(self) -> int:
+        return self._line_store.line_count
+
+    @property
+    def lines(self) -> tuple[str, ...]:
+        """Materialize all lines only for explicit compatibility/test callers."""
+
+        return tuple(item.text for item in self.log_lines())
+
+    @property
+    def storage_mode(self) -> str:
+        return self._line_store.storage_mode
+
+    def log_lines(
+        self,
+        *,
+        start_line: int = 1,
+        end_line: int | None = None,
+    ) -> Iterator[LogLine]:
+        yield from self._line_store.log_lines(
+            start_line=start_line,
+            end_line=end_line,
+        )
+
+    def line(self, line: int) -> str | None:
+        return self._line_store.line(line)
+
+    def context_before(self, line: int, *, limit: int) -> tuple[str, ...]:
+        end_line = max(0, min(line - 1, self.line_count))
+        start_line = max(1, end_line - limit + 1)
+        return tuple(
+            item.text
+            for item in self.log_lines(
+                start_line=start_line,
+                end_line=end_line,
+            )
+        )
+
+    def validate_source(self) -> None:
+        """Memory snapshots are immutable and need no later source validation."""
+
+
+class LogSource(Protocol):
+    """Storage-neutral source for one immutable analysis snapshot."""
+
+    @property
+    def path(self) -> str: ...
+
+    def unavailable_reason(self) -> str | None: ...
+
+    def snapshot(self) -> LogSnapshot: ...
+
+
+LogReaderFactory = Callable[[], ChunkedLogReader]
+
+
+class LocalLogSource:
+    """Read one analysis source from the local filesystem."""
+
+    def __init__(
+        self,
+        log_path: str | Path,
+        *,
+        chunk_bytes: int = DEFAULT_LOG_READ_CHUNK_BYTES,
+        read_mode: str = SOURCE_READ_MODE_CHUNKED,
+    ) -> None:
+        self._path = Path(log_path)
+        self._reader = ChunkedLogReader(
+            chunk_bytes=chunk_bytes,
+            read_mode=read_mode,
+        )
+
+    @property
+    def path(self) -> str:
+        return str(self._path)
+
+    @property
+    def chunk_reader(self) -> ChunkedLogReader:
+        return self._reader
+
+    def unavailable_reason(self) -> str | None:
+        if not self._path.exists():
+            return f"log path is missing: {self._path}"
+        if not self._path.is_file():
+            return f"log path is not a file: {self._path}"
+        try:
+            if self._path.stat().st_size == 0:
+                return f"log path is empty: {self._path}"
+            with self._path.open("rb") as handle:
+                handle.read(1)
+        except OSError as exc:
+            return f"log path is not readable: {exc}"
+        return None
+
+    def snapshot(self) -> LogSnapshot:
+        return self._reader.snapshot(self._path)
+
+
+def read_log_text_lines(log_path: str | Path) -> list[str]:
+    """Read logs as UTF-8 while replacing malformed source bytes."""
+
+    return list(LogSnapshot.read(log_path).lines)
+
+
+def read_log_lines(log_path: str | Path) -> list[LogLine]:
+    return list(LogSnapshot.read(log_path).log_lines())
+
+
+def read_log_line(log_path: str | Path, line: int) -> str | None:
+    return LogSnapshot.read(log_path).line(line)
+
+
+def _source_boundary(stat_result: os.stat_result) -> SourceBoundary:
+    return SourceBoundary(
+        device=stat_result.st_dev,
+        inode=stat_result.st_ino,
+        byte_size=stat_result.st_size,
+        mtime_ns=stat_result.st_mtime_ns,
+    )
+
+
+def _decode_record(raw: bytes, encoding: str) -> str:
+    if raw.endswith(b"\n"):
+        raw = raw[:-1]
+        if raw.endswith(b"\r"):
+            raw = raw[:-1]
+    return _decode_bytes(raw, encoding)[0]
+
+
+def _decode_bytes(raw: bytes, encoding: str) -> tuple[str, int]:
+    try:
+        return raw.decode(encoding, errors="strict"), 0
+    except UnicodeDecodeError:
+        text = raw.decode(encoding, errors="replace")
+        return text, max(1, text.count("\N{REPLACEMENT CHARACTER}"))

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/route_publisher.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/infrastructure/route_publisher.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Caller-directed persistence for independently completed model routes."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Any, Mapping, Sequence
+
+from ..execution import L0Artifacts
+from ..models import ModelAnalysisResult
+from ..observability.schemas import CLI_TRACE_SCHEMA_VERSION
+from .artifact_io import write_json_atomic
+
+ROUTE_ARTIFACT_MANIFEST_SCHEMA_VERSION = "restart_agent_route_artifacts.v1"
+
+
+@dataclass(frozen=True)
+class RouteArtifactPaths:
+    result_json: Path
+    trace_json: Path
+
+
+def load_route_artifact_manifest(
+    path: str | Path,
+    *,
+    expected_route_ids: Sequence[str],
+) -> Mapping[str, RouteArtifactPaths]:
+    manifest_path = Path(path)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("route artifact manifest must be an object")
+    if payload.get("schema_version") != ROUTE_ARTIFACT_MANIFEST_SCHEMA_VERSION:
+        raise ValueError("route artifact manifest schema_version is invalid")
+    routes = payload.get("routes")
+    if not isinstance(routes, Mapping):
+        raise ValueError("route artifact manifest routes must be an object")
+    expected = set(expected_route_ids)
+    observed = {str(route_id) for route_id in routes}
+    if observed != expected:
+        missing = sorted(expected - observed)
+        unknown = sorted(observed - expected)
+        raise ValueError(
+            "route artifact manifest route IDs do not match configuration: "
+            f"missing={missing}, unknown={unknown}"
+        )
+    result: dict[str, RouteArtifactPaths] = {}
+    claimed_paths: dict[Path, str] = {}
+    for route_id, value in routes.items():
+        if not isinstance(value, Mapping):
+            raise ValueError(f"route artifact paths for {route_id!r} must be an object")
+        route_paths = RouteArtifactPaths(
+            result_json=_resolve_output_path(
+                value.get("result_json"),
+                manifest_path=manifest_path,
+                field=f"routes.{route_id}.result_json",
+            ),
+            trace_json=_resolve_output_path(
+                value.get("trace_json"),
+                manifest_path=manifest_path,
+                field=f"routes.{route_id}.trace_json",
+            ),
+        )
+        for field, output_path in (
+            ("result_json", route_paths.result_json),
+            ("trace_json", route_paths.trace_json),
+        ):
+            owner = f"routes.{route_id}.{field}"
+            previous_owner = claimed_paths.get(output_path)
+            if previous_owner is not None:
+                raise ValueError(
+                    f"route artifact path {output_path} is shared by "
+                    f"{previous_owner} and {owner}"
+                )
+            claimed_paths[output_path] = owner
+        result[str(route_id)] = route_paths
+    return result
+
+
+class RouteArtifactPublisher:
+    """Write canonical route result/trace files before the batch completes."""
+
+    def __init__(
+        self,
+        paths: Mapping[str, RouteArtifactPaths],
+        *,
+        request: Mapping[str, Any],
+        batch_trace_path: str | Path | None,
+    ) -> None:
+        self._paths = dict(paths)
+        self._request = dict(request)
+        self._batch_trace_path = str(batch_trace_path) if batch_trace_path else None
+        self._l0_artifacts: L0Artifacts | None = None
+        self._published: set[str] = set()
+        self._lock = Lock()
+
+    def set_l0_artifacts(self, artifacts: L0Artifacts) -> None:
+        with self._lock:
+            if self._l0_artifacts is not None:
+                raise RuntimeError("route publisher L0 artifacts were already set")
+            self._l0_artifacts = artifacts
+
+    def publish(
+        self,
+        route_result: ModelAnalysisResult,
+        analyzer_trace: Mapping[str, Any],
+    ) -> Mapping[str, str]:
+        with self._lock:
+            paths = self._paths.get(route_result.route_id)
+            if paths is None:
+                raise ValueError(
+                    f"no artifact paths configured for route {route_result.route_id!r}"
+                )
+            if route_result.route_id in self._published:
+                raise RuntimeError(f"route {route_result.route_id!r} was already published")
+            l0_artifacts = self._l0_artifacts
+            analysis_result = route_result.analysis_result.to_payload()
+            trace_payload = {
+                "schema_version": CLI_TRACE_SCHEMA_VERSION,
+                "request": self._request,
+                "analysis_result": analysis_result,
+                "analyzer_trace": dict(analyzer_trace),
+                "l0_bundle": (asdict(l0_artifacts.bundle) if l0_artifacts is not None else None),
+                "collect_all_context": {
+                    "route_id": route_result.route_id,
+                    "execution_status": route_result.execution_status,
+                    "publication": "route_complete",
+                    "batch_trace": self._batch_trace_path,
+                },
+            }
+            # Result is the commit marker: when it appears, the trace is ready too.
+            write_json_atomic(paths.trace_json, trace_payload)
+            write_json_atomic(paths.result_json, analysis_result)
+            self._published.add(route_result.route_id)
+            return {
+                "result_json": str(paths.result_json),
+                "trace_json": str(paths.trace_json),
+            }
+
+
+def _resolve_output_path(
+    value: Any,
+    *,
+    manifest_path: Path,
+    field: str,
+) -> Path:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty path")
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = manifest_path.parent / path
+    return path.resolve()

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l0/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l0/__init__.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L0 deterministic log interpretation and evidence projection."""
+
+from .assembly import build_cascades_for_primary, build_l0_bundle
+from .codec import read_l0_bundle, write_l0_bundle
+from .decision import (
+    build_decision_evidence,
+    canonical_identity_anchor_line,
+    distributed_incident_for_line,
+)
+from .projection import build_l0_model_facing_view
+from .streaming import (
+    FinalizedL0A,
+    ProgressiveL0Accumulator,
+    ProgressiveL0State,
+    ProgressiveSourceUnavailable,
+    canonical_l0a_hash,
+    canonical_l0a_payload,
+    finalize_log_snapshot,
+)
+
+__all__ = [
+    "build_cascades_for_primary",
+    "build_decision_evidence",
+    "build_l0_bundle",
+    "build_l0_model_facing_view",
+    "canonical_identity_anchor_line",
+    "distributed_incident_for_line",
+    "FinalizedL0A",
+    "ProgressiveL0Accumulator",
+    "ProgressiveL0State",
+    "ProgressiveSourceUnavailable",
+    "canonical_l0a_hash",
+    "canonical_l0a_payload",
+    "finalize_log_snapshot",
+    "read_l0_bundle",
+    "write_l0_bundle",
+]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l0/assembly.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l0/assembly.py
@@ -1,0 +1,4795 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic evidence assembly for one interleaved training log."""
+
+from __future__ import annotations
+
+import re
+from bisect import bisect_left, bisect_right, insort
+from collections import OrderedDict, defaultdict, deque
+from dataclasses import dataclass, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping, Sequence, overload
+
+from ..identity import (
+    build_affected_entity,
+    canonical_observed_fingerprint,
+    extract_data_position_fingerprint,
+    extract_failure_iteration,
+    extract_gpu,
+    extract_node,
+    extract_rank,
+    fingerprint_for,
+    normalized_pattern,
+    path_hints,
+)
+from ..infrastructure.log_source import (
+    DecodedLine,
+    IndexedFileLineStore,
+    InMemoryLineStore,
+    LogSnapshot,
+)
+from ..models import (
+    AffectedEntityKind,
+    ArtifactComparisonLevel,
+    ArtifactObservationKind,
+    AssessmentStatus,
+    CandidateAnchor,
+    CascadeEvidence,
+    CausalRole,
+    ContextWindow,
+    CoverageStatus,
+    DistributedFailureIncident,
+    DistributedIncidentKind,
+    FailureEpisode,
+    FailureEvidence,
+    FaultOutcome,
+    JobMetadata,
+    L0Bundle,
+    LaterProgressAfterFaultObservation,
+    LogLine,
+    NormalizedOccurrenceGroup,
+    OperationArtifactComparisonEvidence,
+    PostFaultSummary,
+    ProgressFacts,
+    ProgressMarker,
+    RecoveryBehavior,
+    RegistryRole,
+    RunProgressSummary,
+)
+from .registry import (
+    SignatureRegistryRow,
+    diagnostic_context_kind,
+    diagnostic_uncertainty_kind,
+    match_registry,
+    root_fingerprint,
+    signature_for,
+)
+
+_MEGATRON_ITERATION_RE = re.compile(
+    r"^\s*(?:(?P<rank_prefix>\d+):\s*)?"
+    r"\[(?P<timestamp>[^\]]+)\]\s+iteration\s+"
+    r"(?P<iteration>\d+)\s*/\s*(?P<total_iterations>\d+)\s*\|\s*"
+    r"consumed samples:\s*(?P<consumed_samples>\d+)\s*\|",
+    re.I,
+)
+_CHECKPOINT_STEP_RE = re.compile(r"\bcheckpoint\b.*?\b(?:step|iter(?:ation)?)[=:\s#/]+(\d+)", re.I)
+_CHECKPOINT_RE = re.compile(r"\bcheckpoint\b.*\b(?:saved|complete|completed|success|wrote)\b", re.I)
+_CHECKPOINT_SAVED_ITERATION_RE = re.compile(
+    r"\bsuccessfully saved checkpoint from iteration\s+(?P<iteration>\d+)\b"
+    r"|\bsaved checkpoint from iteration\s+(?P<iteration_alt>\d+)\b",
+    re.I,
+)
+_CHECKPOINT_SAVE_START_RE = re.compile(
+    r"\bsaving checkpoint at iteration\s+(?P<iteration>\d+)\s+to\s+" r"(?P<artifact_path>\S+)",
+    re.I,
+)
+_CHECKPOINT_LOADED_RE = re.compile(r"\bsuccessfully loaded checkpoint\b", re.I)
+_CHECKPOINT_LOAD_COMPLETE_RE = re.compile(
+    r"\bsuccessfully loaded checkpoint(?:\s+from\s+(?P<artifact_path>\S+))?.*?"
+    r"\bat iteration\s+(?P<iteration>\d+)\b",
+    re.I,
+)
+_CHECKPOINT_LOAD_START_RE = re.compile(
+    r"\bloading\s+(?:a\s+)?(?:distributed\s+)?checkpoint\b"
+    r"(?:\s+from\s+(?P<artifact_path>\S+))?.*?"
+    r"\bat iteration\s+(?P<iteration>\d+)\b",
+    re.I,
+)
+_DATALOADER_READ_EVENT_RE = re.compile(
+    r"\b(?:dataloader|data loader|dataset reader)\b.*?"
+    r"(?P<outcome>successfully\s+(?:read|loaded|opened)|finished\s+reading|"
+    r"read\s+complete|reading|loading|opening|failed\s+(?:to\s+)?(?:read|load|open)|"
+    r"error\s+(?:while\s+)?(?:reading|loading|opening))\b.*?"
+    r"\b(?:file|shard|object|path)\b\s*(?:=|:|from)?\s*['\"]?"
+    r"(?P<physical_unit>/[^'\"\s,\]\)]+)",
+    re.I,
+)
+_CHECKPOINT_METADATA_LOADED_RE = re.compile(
+    r"\b(?:checkpoint|sharded_state_dict)\s+metadata\s+loaded\b",
+    re.I,
+)
+_CHECKPOINT_RESHARD_RE = re.compile(r"\bjob sharding has changed\b", re.I)
+_OPTIMIZER_SETUP_RE = re.compile(r"\bsetting up optimizer\b", re.I)
+_CUDA_GRAPH_BUILT_RE = re.compile(r"\bbuilt cuda graph(?:\(s\))?\b", re.I)
+_RECOVERY_RE = re.compile(
+    r"\b(?:retry succeeded|recovered|continuing|skipping|quarantine|resumed|successfully retried)\b",
+    re.I,
+)
+_TERMINAL_RE = re.compile(
+    r"\b(?:fatal|failed|aborted|terminated|exiting|uncaught|raise|runtimeerror|traceback)\b",
+    re.I,
+)
+_PHASE_CHECKPOINT_RE = re.compile(r"\bcheckpoint\b", re.I)
+_TRAINING_ITERATIONS_TOTAL_RE = re.compile(r"\bsetting training iterations to (?P<total>\d+)\b")
+_TRAINING_START_RE = re.compile(r"\[before the start of training step\] datetime:", re.I)
+_RERUN_ITERATION_RESET_RE = re.compile(
+    r"\bOverwriting rerun_state_machine\.current_iteration from -?\d+ to -?\d+",
+    re.I,
+)
+_RANK_GPU_MAPPING_WARNING_RE = re.compile(
+    r"Guessing device ID based on global rank\. This can cause a hang if rank to GPU "
+    r"mapping is heterogeneous",
+    re.I,
+)
+_NCCL_VERSION_RE = re.compile(r"\bNCCL version (?P<version>\S+)")
+_WORLD_SIZE_RE = re.compile(r"\bworld_size\b\s*(?:[.=:\-\s]+)\s*(?P<world_size>\d+)\b", re.I)
+_HIGH_SIGNAL_RE = re.compile(
+    r"\b(?:CRITICAL|FATAL|ERROR|Traceback|RuntimeError|AssertionError|AcceleratorError)\b"
+    r"|(?:raising|raised)\s+.*\b(?:gpu|accelerator|device)\b.*\berror\b"
+    r"|\b(?:assert(?:ion)? failed|out of bounds|bounds failure|timeout)\b",
+    re.I,
+)
+_STRUCTURED_LOG_PREFIX_RE = re.compile(
+    r"^\s*(?:\d+:\s*)?(?:\[[^\]]+\]\s*)?"
+    r"(?P<severity>DEBUG|INFO|WARN(?:ING)?|ERROR|CRITICAL|FATAL):"
+    r"(?P<logger>[A-Za-z_][A-Za-z0-9_.-]*):(?P<message>.*)$",
+    re.I,
+)
+_FAILURE_ANNOUNCEMENT_RE = re.compile(
+    r"\b(?:raising|raised|injecting|injected|simulating|simulated)\b.*"
+    r"\b(?:error|failure|fault)\b",
+    re.I,
+)
+_SPECIFIC_FAILURE_CUE_RE = re.compile(
+    r"\b(?:unexpected|mismatch|permission denied|access denied|no such file|not found|"
+    r"address already in use|connection reset|connection refused|unreachable|"
+    r"out of bounds|out of memory|bus error|checksum|corrupt(?:ion|ed)?|"
+    r"invalid|assert(?:ion)?|"
+    r"failed to|failure|timed out|timeout|errno)\b",
+    re.I,
+)
+_EXCEPTION_SUMMARY_RE = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception):",
+)
+_WATCHDOG_EXCEPTION_RE = re.compile(
+    r"\bwatchdog thread terminated with exception:\s*"
+    r"(?P<message>.*\b(?:CUDA|NCCL|c10)\s+error:.*)$",
+    re.I,
+)
+_CUDA_RUNTIME_STATUS_RE = re.compile(r"\bcudaError[A-Za-z0-9_]*:", re.I)
+_TRACEBACK_RE = re.compile(r"\bTraceback \(most recent call last\):", re.I)
+_TERMINAL_OPERATION_TIMEOUT_RE = re.compile(
+    r"\b(?:watchdog\s+)?(?:caught\s+)?(?:collective\s+)?operation\s+timeout\b"
+    r"|\boperation\b.*\btimed out\b",
+    re.I,
+)
+_TIMED_OPERATION_SIGNATURE_RE = re.compile(
+    r"\b(?:watchdog\s+caught\s+)?collective\s+operation\s+timeout:?\s*"
+    r"(?P<operation>Work[A-Za-z0-9_]+\([^)]*\))",
+    re.I,
+)
+_TIMED_OPERATION_FIELD_RE = re.compile(
+    r"\b(?P<name>SeqNum|OpType)=(?P<value>[A-Za-z0-9_.-]+)\b",
+    re.I,
+)
+_TIME_OF_DAY_RE = re.compile(
+    r"(?<!\d)(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})" r"(?:\.(?P<fraction>\d+))?",
+)
+_TIMEOUT_MS_RE = re.compile(r"\bTimeout\(ms\)=(?P<milliseconds>\d+)\b", re.I)
+_PROCESS_GROUP_TYPE_RE = re.compile(
+    r"\bPG\s+GUID\s+\d+\((?P<group_type>[^)]+)\)",
+    re.I,
+)
+_EXCEPTION_CHAIN_RE = re.compile(
+    r"The above exception was the direct cause of the following exception"
+    r"|During handling of the above exception, another exception occurred",
+    re.I,
+)
+_TEARDOWN_RE = re.compile(
+    r"\b(?:destroy_process_group|program exit|before program exit|exiting)\b",
+    re.I,
+)
+_BARE_PROCESS_KILLED_RE = re.compile(r"^\s*(?:\d+:\s*)?Killed\s*$", re.I)
+_PROCESS_TERMINATION_RE = re.compile(
+    r"\b(?:Producer process has been terminated|process has been terminated|terminated)\b"
+    r"|Fatal Python error:\s*(?:Aborted|Segmentation fault)\b",
+    re.I,
+)
+_SCHEDULER_CANCEL_RE = re.compile(
+    r"\b(?:CANCELLED AT|STEP\b.*\bCANCELLED|slurmstepd\b.*\bCANCELLED)\b",
+    re.I,
+)
+_CLEANUP_FRAME_RE = re.compile(
+    r"\b(?:_run_finalizers|finalizer|_cleanup|cleanup|shutdown|atexit|"
+    r"destroy_process_group|sem_unlink)\b",
+    re.I,
+)
+_ITERATION_VALUE_RE = re.compile(r"\biteration\s+(?P<iteration>\d+)\b", re.I)
+_CONFIG_PATH_RE = re.compile(
+    r"^\s*(?:\d+:\s*)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s+\.{2,}\s+" r"(?P<path>/\S+)"
+)
+_INLINE_PATH_RE = re.compile(
+    r"\b(?P<key>[A-Za-z_][A-Za-z0-9_]*)=(?P<quote>['\"]?)" r"(?P<path>/[^\s'\"(),]+)(?P=quote)"
+)
+_PERMISSION_DENIED_PATH_RE = re.compile(
+    r"\b(?:PermissionError\b.*\bpermission denied|permission denied)\b.*?"
+    r"(?P<quote>['\"])(?P<path>/[^'\"]+)(?P=quote)",
+    re.I,
+)
+_USER_NAMESPACE_RE = re.compile(r"/users/(?P<namespace>[^/]+)/", re.I)
+_READ_PATH_KEYS = {
+    "data_path",
+    "load",
+    "per_split_data_args_path",
+    "pretrained_checkpoint",
+    "tokenizer_model",
+}
+_WRITE_PATH_KEYS = {
+    "data_cache_path",
+    "log_dir",
+    "output_dir",
+    "save",
+    "tensorboard_dir",
+}
+_CACHE_PATH_KEYS = {"cache_dir", "hf_home", "path_to_cache"}
+CONTEXT_WINDOW_BEFORE_LINES = 40
+CONTEXT_WINDOW_AFTER_LINES = 140
+MAX_CONTEXT_WINDOW_SEEDS = 8
+MAX_CONTEXT_HIGH_SIGNAL_SEEDS = 3
+MAX_CANDIDATE_ANCHORS = 16
+MAX_HIGH_SIGNAL_ANCHORS = 8
+MAX_FAILURE_EPISODES = 3
+HIGH_SIGNAL_CLUSTER_GAP_LINES = 25
+NEARBY_EPISODE_PRECURSOR_LINES = 8
+REGISTRY_MATCH_HEAD_PER_PATTERN = 5
+REGISTRY_MATCH_TAIL_PER_PATTERN = 2
+DISTRIBUTED_TIMEOUT_WAVE_SECONDS = 5.0
+MAX_DISTRIBUTED_TIMEOUT_WAVE_SECONDS = 60.0
+MAX_DISTRIBUTED_INCIDENT_SAMPLE_LINES = 12
+MAX_DISTRIBUTED_INCIDENT_RANK_SAMPLES = 16
+MAX_PATH_ACCESS_FACTS = 40
+MAX_RECENT_TEARDOWN_CONTEXT_LINES = 49
+MAX_REDUCTION_TEXT_CACHE_LINES = 4096
+
+_TERMINAL_TRIGGER_TERMS = (
+    "fatal",
+    "failed",
+    "aborted",
+    "terminated",
+    "exiting",
+    "uncaught",
+    "raise",
+    "runtimeerror",
+    "traceback",
+)
+_HIGH_SIGNAL_TRIGGER_TERMS = (
+    "critical",
+    "fatal",
+    "error",
+    "traceback",
+    "assert",
+    "out of bounds",
+    "bounds failure",
+    "timeout",
+    "killed",
+)
+_DIAGNOSTIC_SEED_TRIGGER_TERMS = (
+    "cuda",
+    "stacktrace",
+    "might",
+    "may ",
+    "could",
+    "possible",
+    "please try",
+    "training iteration",
+    "training step",
+    "rerun_state_machine",
+    "device id",
+    "nccl version",
+    "world_size",
+)
+_RECOVERY_TRIGGER_TERMS = (
+    "retry",
+    "recover",
+    "continu",
+    "skip",
+    "quarantine",
+    "resum",
+)
+_FAILURE_ITERATION_TRIGGER_TERMS = ("error", "exception", "timeout")
+_CLEANUP_FRAME_TRIGGER_TERMS = (
+    "_run_finalizers",
+    "finalizer",
+    "_cleanup",
+    "cleanup",
+    "shutdown",
+    "atexit",
+    "destroy_process_group",
+    "sem_unlink",
+)
+
+
+@dataclass(frozen=True)
+class _OccurrenceSeed:
+    detector_id: str
+    normalized_shape: str
+    line: int
+    classification: str
+    registry_id: str | None = None
+    rank: str | None = None
+    node: str | None = None
+    gpu: str | None = None
+
+
+@dataclass(frozen=True)
+class _TimedOperationEvent:
+    line: int
+    text: str
+    timestamp_seconds: float | None
+    timestamp_text: str | None
+    configured_timeout_seconds: float | None
+    sequence_number: str
+    operation_type: str
+    rank: str | None
+
+
+@dataclass
+class _DistributedTimeoutWave:
+    events: list[_TimedOperationEvent]
+    timestamp_seconds: list[float]
+    first_configured_timeout_seconds: float | None
+    minimum_configured_timeout_seconds: float | None
+
+    @classmethod
+    def start(cls, event: _TimedOperationEvent) -> _DistributedTimeoutWave:
+        timestamps = [event.timestamp_seconds] if event.timestamp_seconds is not None else []
+        return cls(
+            events=[event],
+            timestamp_seconds=timestamps,
+            first_configured_timeout_seconds=event.configured_timeout_seconds,
+            minimum_configured_timeout_seconds=event.configured_timeout_seconds,
+        )
+
+    @property
+    def previous_line(self) -> int:
+        return self.events[-1].line
+
+    def append(self, event: _TimedOperationEvent) -> None:
+        self.events.append(event)
+        if event.timestamp_seconds is not None:
+            insort(self.timestamp_seconds, event.timestamp_seconds)
+        if event.configured_timeout_seconds is not None:
+            current_minimum = self.minimum_configured_timeout_seconds
+            self.minimum_configured_timeout_seconds = (
+                event.configured_timeout_seconds
+                if current_minimum is None
+                else min(current_minimum, event.configured_timeout_seconds)
+            )
+
+
+@dataclass(frozen=True)
+class _RegistryObservation:
+    """Cheap registry match retained before full evidence enrichment."""
+
+    row: SignatureRegistryRow
+    line: int
+    quote: str
+    signature: str
+    normalized_shape: str
+    fault_outcome: str
+    causal_role: str
+    rank: str | None
+    phase: str | None
+    node: str | None
+    gpu: str | None
+    teardown_exception: bool
+
+    @property
+    def registry_id(self) -> str:
+        return self.row.registry_id
+
+    @property
+    def role(self) -> str:
+        return RegistryRole.CASCADE_CANDIDATE.value if self.teardown_exception else self.row.role
+
+    @property
+    def failure_class(self) -> str:
+        return self.row.registry_id
+
+
+@dataclass(frozen=True)
+class _RecentTraceContext:
+    rank: str | None
+    cleanup_frame: bool
+    traceback_start: bool
+
+
+@dataclass
+class _ReductionTextView:
+    """Temporary source text shared by one L0 reduction."""
+
+    source_text_by_line: dict[int, str]
+
+
+@dataclass(frozen=True)
+class _DetectedEvidence:
+    path_access_facts: tuple[Mapping[str, object], ...]
+    path_namespace_summary: Mapping[str, object]
+    progress: ProgressFacts
+    registry_observations: tuple[_RegistryObservation, ...]
+    cause_confirmation_count: int
+    cause_confirmations: tuple[FailureEvidence, ...]
+    high_signal_lines: tuple[int, ...]
+    occurrence_groups: tuple[NormalizedOccurrenceGroup, ...]
+    distributed_failure_incidents: tuple[DistributedFailureIncident, ...]
+    registry_matches: tuple[FailureEvidence, ...]
+    dropped_registry_matches: int
+    primary: FailureEvidence | None
+    preliminary_failure_episodes: tuple[FailureEpisode, ...]
+    prompt_high_signal_lines: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _ContextualEvidence:
+    primary: FailureEvidence | None
+    context_windows: tuple[ContextWindow, ...]
+    failure_episodes: tuple[FailureEpisode, ...]
+    cascades: tuple[CascadeEvidence, ...]
+    post_fault_summaries: tuple[PostFaultSummary, ...]
+    candidate_anchors: tuple[CandidateAnchor, ...]
+    later_progress_after_fault_observations: tuple[LaterProgressAfterFaultObservation, ...]
+    job_metadata: JobMetadata
+    run_progress_summary: RunProgressSummary
+    operation_artifact_comparisons: tuple[OperationArtifactComparisonEvidence, ...]
+
+
+class L0ObservationAccumulator(Sequence[LogLine]):
+    """Append-only log observations reused by progressive L0A reductions."""
+
+    def __init__(
+        self,
+        *,
+        line_store: InMemoryLineStore | IndexedFileLineStore | LogSnapshot | None = None,
+    ) -> None:
+        self._line_store = line_store or InMemoryLineStore()
+        self._observed_count = 0
+        self.path_candidate_lines: list[LogLine] = []
+        self.progress_candidate_lines: list[LogLine] = []
+        self.terminal_lines: list[int] = []
+        self.registry_rows_by_line: dict[int, tuple[SignatureRegistryRow, ...]] = {}
+        self.teardown_exception_lines: set[int] = set()
+        self.diagnostic_occurrence_seeds: list[_OccurrenceSeed] = []
+        self.high_signal_lines: list[int] = []
+        self.episode_event_lines: dict[str, list[int]] = {
+            "teardown": [],
+            "process_termination": [],
+            "scheduler_cancel": [],
+        }
+        self.timed_operation_events: list[_TimedOperationEvent] = []
+        self.exception_summary_lines: list[LogLine] = []
+        self.checkpoint_save_lines: list[LogLine] = []
+        self.checkpoint_load_lines: list[LogLine] = []
+        self.dataloader_lines: list[LogLine] = []
+        self.explicit_world_size: int | None = None
+        self.explicit_world_size_line: int | None = None
+        self.observed_ranks: set[int] = set()
+        self.observed_nodes: set[str] = set()
+        self._recent_trace_context: deque[_RecentTraceContext] = deque(
+            maxlen=MAX_RECENT_TEARDOWN_CONTEXT_LINES
+        )
+        self._reduction_text_cache: OrderedDict[int, str] = OrderedDict()
+        self._reduction_text_view: _ReductionTextView | None = None
+
+    def __len__(self) -> int:
+        return self._line_store.line_count
+
+    @overload
+    def __getitem__(self, index: int) -> LogLine: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[LogLine]: ...
+
+    def __getitem__(self, index: int | slice) -> LogLine | list[LogLine]:
+        if isinstance(index, slice):
+            start, stop, step = index.indices(len(self))
+            return [self[item] for item in range(start, stop, step)]
+        normalized = index + len(self) if index < 0 else index
+        if normalized < 0 or normalized >= len(self):
+            raise IndexError("L0 observation index out of range")
+        text = self._line_store.line(normalized + 1)
+        if text is None:
+            raise IndexError("L0 observation index is not available")
+        return LogLine(line=normalized + 1, text=text)
+
+    def __iter__(self) -> Iterator[LogLine]:
+        return self._line_store.log_lines()
+
+    def append_text(self, text: str) -> LogLine:
+        if not isinstance(self._line_store, InMemoryLineStore):
+            raise TypeError("append_text requires an in-memory observation store")
+        item = LogLine(line=self._observed_count + 1, text=text)
+        self._line_store.append(text)
+        self._observe(item)
+        self._observed_count += 1
+        return item
+
+    def append(self, item: LogLine) -> None:
+        if not isinstance(self._line_store, InMemoryLineStore):
+            raise TypeError("append requires an in-memory observation store")
+        expected_line = self._observed_count + 1
+        if item.line != expected_line:
+            raise ValueError(f"L0 observation line must be {expected_line}, got {item.line}")
+        self._line_store.append(item.text)
+        self._observe(item)
+        self._observed_count += 1
+
+    def append_record(self, record: DecodedLine) -> LogLine:
+        if not isinstance(self._line_store, IndexedFileLineStore):
+            raise TypeError("append_record requires an indexed-file observation store")
+        item = LogLine(line=self._observed_count + 1, text=record.text)
+        self._line_store.append_record(record)
+        self._observe(item)
+        self._observed_count += 1
+        return item
+
+    def observe_existing(self, item: LogLine) -> None:
+        """Classify a line already owned by an immutable source snapshot."""
+
+        expected_line = self._observed_count + 1
+        if item.line != expected_line:
+            raise ValueError(f"L0 observation line must be {expected_line}, got {item.line}")
+        self._observe(item)
+        self._observed_count += 1
+
+    def snapshot_lines(self) -> tuple[str, ...]:
+        return tuple(item.text for item in self)
+
+    def text_map(self, line_numbers: Iterable[int]) -> dict[int, str]:
+        """Read selected source text through one reduction-scoped source view."""
+
+        requested = tuple(
+            line_no for line_no in dict.fromkeys(line_numbers) if 1 <= line_no <= len(self)
+        )
+        result: dict[int, str] = {}
+        missing: list[int] = []
+        for line_no in requested:
+            if line_no in self._reduction_text_cache:
+                self._reduction_text_cache.move_to_end(line_no)
+                result[line_no] = self._reduction_text_cache[line_no]
+            else:
+                missing.append(line_no)
+
+        source_view = self._reduction_text_view
+        for line_no in missing:
+            text = source_view.source_text_by_line.get(line_no) if source_view else None
+            if text is None:
+                text = self._line_store.line(line_no)
+            if text is not None:
+                if source_view is not None:
+                    source_view.source_text_by_line[line_no] = text
+                self._reduction_text_cache[line_no] = text
+                self._reduction_text_cache.move_to_end(line_no)
+                while len(self._reduction_text_cache) > MAX_REDUCTION_TEXT_CACHE_LINES:
+                    self._reduction_text_cache.popitem(last=False)
+                result[line_no] = text
+
+        return {line_no: result[line_no] for line_no in requested if line_no in result}
+
+    def _begin_reduction(self) -> None:
+        if self._reduction_text_view is not None:
+            raise RuntimeError("L0 reduction text view is already active")
+        self._reduction_text_cache.clear()
+        self._reduction_text_view = _ReductionTextView(source_text_by_line={})
+
+    def _end_reduction(self) -> None:
+        self._reduction_text_cache.clear()
+        self._reduction_text_view = None
+
+    def _observe(self, item: LogLine) -> None:
+        text = item.text
+        lowered = text.lower()
+        signal_text = _structured_log_signal_text(text)
+        signal_lowered = lowered if signal_text is text else signal_text.lower()
+        rank = _fast_numeric_rank(text, lowered)
+        rank_text = str(rank) if rank is not None else None
+        if "/" in text and (
+            _PERMISSION_DENIED_PATH_RE.search(text)
+            or _CONFIG_PATH_RE.search(text)
+            or _INLINE_PATH_RE.search(text)
+        ):
+            self.path_candidate_lines.append(item)
+
+        if _line_may_change_progress(text, lowered=signal_lowered):
+            self.progress_candidate_lines.append(item)
+
+        if _contains_any(lowered, _TERMINAL_TRIGGER_TERMS) and _TERMINAL_RE.search(text):
+            self.terminal_lines.append(item.line)
+
+        diagnostic_kind = (
+            diagnostic_context_kind(text) if "cuda" in lowered or "stacktrace" in lowered else None
+        )
+        if diagnostic_kind is None:
+            rows = tuple(
+                match_registry(
+                    text,
+                    diagnostic_checked=True,
+                    lowered=signal_lowered,
+                )
+            )
+            if rows:
+                self.registry_rows_by_line[item.line] = rows
+            if _contains_any(signal_lowered, _HIGH_SIGNAL_TRIGGER_TERMS) and (
+                _HIGH_SIGNAL_RE.search(signal_text) or _BARE_PROCESS_KILLED_RE.search(text)
+            ):
+                self.high_signal_lines.append(item.line)
+
+        if _line_may_have_diagnostic_seed(lowered):
+            self.diagnostic_occurrence_seeds.extend(
+                _diagnostic_seeds_for_line(
+                    item,
+                    diagnostic_kind=diagnostic_kind,
+                )
+            )
+
+        if (
+            "destroy_process_group" in lowered or "program exit" in lowered or "exiting" in lowered
+        ) and _TEARDOWN_RE.search(text):
+            self.episode_event_lines["teardown"].append(item.line)
+        if ("terminated" in lowered or "fatal python error" in lowered or "killed" in lowered) and (
+            _PROCESS_TERMINATION_RE.search(text) or _BARE_PROCESS_KILLED_RE.search(text)
+        ):
+            self.episode_event_lines["process_termination"].append(item.line)
+        if ("cancelled" in lowered or "slurmstepd" in lowered) and _SCHEDULER_CANCEL_RE.search(
+            text
+        ):
+            self.episode_event_lines["scheduler_cancel"].append(item.line)
+
+        if "timeout" in lowered or "timed out" in lowered:
+            timed_operation = _timed_operation_event(item)
+            if timed_operation is not None:
+                self.timed_operation_events.append(timed_operation)
+        exception_summary = bool(
+            (
+                "error" in signal_lowered
+                or "exception" in signal_lowered
+                or "assertion" in signal_lowered
+            )
+            and _EXCEPTION_SUMMARY_RE.search(text)
+        )
+        if exception_summary:
+            self.exception_summary_lines.append(item)
+            if _preclassified_exception_context_is_teardown(
+                rank_text,
+                reversed(self._recent_trace_context),
+            ):
+                self.teardown_exception_lines.add(item.line)
+        if (
+            "checkpoint" in lowered
+            and "saving" in lowered
+            and _CHECKPOINT_SAVE_START_RE.search(text)
+        ):
+            self.checkpoint_save_lines.append(item)
+        if "checkpoint" in lowered and (
+            _CHECKPOINT_LOAD_START_RE.search(text) or _CHECKPOINT_LOAD_COMPLETE_RE.search(text)
+        ):
+            self.checkpoint_load_lines.append(item)
+        if (
+            "dataloader" in lowered or "data loader" in lowered or "dataset reader" in lowered
+        ) and _DATALOADER_READ_EVENT_RE.search(text):
+            self.dataloader_lines.append(item)
+
+        if self.explicit_world_size is None and "world_size" in lowered:
+            world_size_match = _WORLD_SIZE_RE.search(text)
+            if world_size_match:
+                self.explicit_world_size = int(world_size_match.group("world_size"))
+                self.explicit_world_size_line = item.line
+        if rank is not None:
+            self.observed_ranks.add(rank)
+        node = extract_node(text) if "node" in lowered else None
+        if node:
+            self.observed_nodes.add(node)
+        self._recent_trace_context.append(
+            _RecentTraceContext(
+                rank=rank_text,
+                cleanup_frame=(
+                    _contains_any(lowered, _CLEANUP_FRAME_TRIGGER_TERMS)
+                    and bool(_CLEANUP_FRAME_RE.search(text))
+                ),
+                traceback_start=("traceback" in lowered and bool(_TRACEBACK_RE.search(text))),
+            )
+        )
+
+
+def _fast_numeric_rank(text: str, lowered: str) -> int | None:
+    stripped = text.lstrip()
+    prefix, separator, remainder = stripped.partition(":")
+    if separator and prefix.isdigit() and remainder.startswith((" ", "\t")):
+        return int(prefix)
+    if "rank" not in lowered:
+        return None
+    return _numeric_field(extract_rank(text))
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    for term in terms:
+        if term in text:
+            return True
+    return False
+
+
+def build_l0_bundle(
+    log_path: str | Path,
+    *,
+    source_log: LogSnapshot | None = None,
+) -> L0Bundle:
+    """Build current-log evidence without job history or policy context."""
+
+    log_path = str(log_path)
+    path = Path(log_path)
+    if source_log is not None and source_log.path != log_path:
+        raise ValueError("source log snapshot path does not match log_path")
+    snapshot = source_log or LogSnapshot.read(path)
+    observations = L0ObservationAccumulator(line_store=snapshot)
+    for item in snapshot.log_lines():
+        observations.observe_existing(item)
+    return build_l0_bundle_from_observations(
+        log_path,
+        byte_size=snapshot.byte_size,
+        observations=observations,
+    )
+
+
+def build_l0_bundle_from_observations(
+    log_path: str | Path,
+    *,
+    byte_size: int,
+    observations: L0ObservationAccumulator,
+) -> L0Bundle:
+    """Reduce append-only observations without rescanning the raw log."""
+
+    observations._begin_reduction()
+    try:
+        detected = _detect_evidence(observations)
+        contextual = _contextualize_evidence(observations, detected)
+        return _assemble_bundle(
+            str(log_path),
+            byte_size,
+            observations,
+            detected,
+            contextual,
+        )
+    finally:
+        observations._end_reduction()
+
+
+def _detect_evidence(lines: Sequence[LogLine]) -> _DetectedEvidence:
+    path_access_facts, path_namespace_summary = _collect_path_access_facts(lines)
+    progress, deterministic_occurrence_seeds = _collect_progress(lines)
+    terminal_lines = (
+        tuple(lines.terminal_lines)
+        if isinstance(lines, L0ObservationAccumulator)
+        else tuple(item.line for item in lines if _TERMINAL_RE.search(item.text))
+    )
+    episode_event_lines = _episode_event_lines(lines)
+    registry_observations = tuple(_collect_registry_observations(lines, progress, terminal_lines))
+    retained_observations, dropped_registry_matches = _compact_registry_observations(
+        registry_observations
+    )
+    registry_matches = tuple(
+        _enrich_registry_observation(lines, observation) for observation in retained_observations
+    )
+    cause_confirmation_observations = tuple(
+        observation
+        for observation in registry_observations
+        if observation.role == RegistryRole.CAUSE_CONFIRMATION.value
+    )
+    cause_confirmations = tuple(
+        _enrich_registry_observation(lines, observation)
+        for observation in _sample_registry_observations(cause_confirmation_observations)
+    )
+    diagnostic_occurrence_seeds = _collect_diagnostic_occurrence_seeds(lines)
+    high_signal_lines = _collect_high_signal_lines(lines)
+    occurrence_groups = tuple(
+        _build_occurrence_groups(
+            registry_observations,
+            (*deterministic_occurrence_seeds, *diagnostic_occurrence_seeds),
+        )
+    )
+    distributed_failure_incidents = tuple(
+        _build_distributed_failure_incidents(lines, progress, registry_observations)
+    )
+    primary = _select_primary_candidate(registry_matches)
+    preliminary_failure_episodes = tuple(
+        _build_failure_episodes(
+            lines,
+            high_signal_lines,
+            registry_matches,
+            progress,
+            context_windows=(),
+            event_lines=episode_event_lines,
+            cause_confirmations=cause_confirmations,
+            distributed_failure_incidents=distributed_failure_incidents,
+        )
+    )
+    secondary_episode_lines = _secondary_episode_high_signal_lines(
+        lines,
+        preliminary_failure_episodes,
+    )
+    prompt_high_signal_lines = tuple(
+        line_no for line_no in high_signal_lines if line_no not in secondary_episode_lines
+    )
+    return _DetectedEvidence(
+        path_access_facts=path_access_facts,
+        path_namespace_summary=path_namespace_summary,
+        progress=progress,
+        registry_observations=registry_observations,
+        cause_confirmation_count=len(cause_confirmation_observations),
+        cause_confirmations=cause_confirmations,
+        high_signal_lines=high_signal_lines,
+        occurrence_groups=occurrence_groups,
+        distributed_failure_incidents=distributed_failure_incidents,
+        registry_matches=tuple(registry_matches),
+        dropped_registry_matches=dropped_registry_matches,
+        primary=primary,
+        preliminary_failure_episodes=preliminary_failure_episodes,
+        prompt_high_signal_lines=prompt_high_signal_lines,
+    )
+
+
+def _contextualize_evidence(
+    lines: Sequence[LogLine],
+    detected: _DetectedEvidence,
+) -> _ContextualEvidence:
+    episode_event_lines = _episode_event_lines(lines)
+    context_windows = tuple(
+        _build_context_windows(
+            lines,
+            detected.occurrence_groups,
+            detected.registry_matches,
+            detected.prompt_high_signal_lines,
+            failure_episode_lines=_failure_episode_seed_lines(
+                detected.preliminary_failure_episodes
+            ),
+            cause_confirmation_lines=tuple(
+                match.line for match in detected.cause_confirmations if match.line is not None
+            ),
+        )
+    )
+    failure_episodes = tuple(
+        _build_failure_episodes(
+            lines,
+            detected.high_signal_lines,
+            detected.registry_matches,
+            detected.progress,
+            context_windows=context_windows,
+            event_lines=episode_event_lines,
+            cause_confirmations=detected.cause_confirmations,
+            distributed_failure_incidents=detected.distributed_failure_incidents,
+        )
+    )
+    primary = _canonicalize_episode_primary(
+        detected.primary,
+        (*detected.registry_matches, *detected.cause_confirmations),
+        failure_episodes,
+        lines,
+        detected.progress,
+    )
+    primary = _apply_distributed_incident_identity(
+        primary,
+        detected.distributed_failure_incidents,
+    )
+    cascades = tuple(
+        build_cascades_for_primary(
+            _materialize_cascade_matches(
+                lines,
+                detected.registry_observations,
+                primary,
+                detected.distributed_failure_incidents,
+            ),
+            primary,
+            detected.distributed_failure_incidents,
+        )
+    )
+    post_fault_summaries = tuple(
+        _build_post_fault_summaries(
+            lines,
+            detected.prompt_high_signal_lines,
+            failure_episodes,
+        )
+    )
+    candidate_anchors = tuple(
+        _build_candidate_anchors(
+            lines,
+            detected.prompt_high_signal_lines,
+            detected.registry_matches,
+            primary,
+            detected.progress,
+            context_windows,
+            failure_episodes,
+            detected.cause_confirmations,
+        )
+    )
+    later_progress = tuple(
+        _build_later_progress_after_fault_observations(
+            lines,
+            detected.registry_observations,
+            detected.progress,
+            failure_episodes,
+        )
+    )
+    job_metadata = _collect_job_metadata(lines)
+    run_progress_summary = _build_run_progress_summary(
+        detected.progress,
+        failure_episodes,
+        detected.distributed_failure_incidents,
+    )
+    operation_artifact_comparisons = tuple(
+        _build_operation_artifact_comparisons(
+            lines,
+            detected.progress,
+            primary,
+            detected.distributed_failure_incidents,
+        )
+    )
+    primary = _attach_operation_artifact_entity(primary, operation_artifact_comparisons)
+    return _ContextualEvidence(
+        primary=primary,
+        context_windows=context_windows,
+        failure_episodes=failure_episodes,
+        cascades=cascades,
+        post_fault_summaries=post_fault_summaries,
+        candidate_anchors=candidate_anchors,
+        later_progress_after_fault_observations=later_progress,
+        job_metadata=job_metadata,
+        run_progress_summary=run_progress_summary,
+        operation_artifact_comparisons=operation_artifact_comparisons,
+    )
+
+
+def _attach_operation_artifact_entity(
+    primary: FailureEvidence | None,
+    comparisons: Sequence[OperationArtifactComparisonEvidence],
+) -> FailureEvidence | None:
+    """Attach one unambiguous failing operation artifact to the L0 primary."""
+
+    if primary is None or primary.affected_entity is not None or primary.line is None:
+        return primary
+    matching = [
+        item
+        for item in comparisons
+        if item.failure_line == primary.line
+        and (item.physical_unit_id is not None or item.logical_artifact_id is not None)
+    ]
+    identities = {
+        identity
+        for item in matching
+        if (identity := _operation_artifact_identity(item)) is not None
+    }
+    if len(identities) != 1:
+        return primary
+    identity = identities.pop()
+    evidence_lines = [
+        line
+        for item in matching
+        for line in (item.failure_line, item.current_start_line)
+        if line is not None
+    ]
+    return replace(
+        primary,
+        affected_entity=build_affected_entity(
+            AffectedEntityKind.ARTIFACT,
+            identity,
+            evidence_line=min(evidence_lines) if evidence_lines else primary.line,
+        ),
+    )
+
+
+def _operation_artifact_identity(
+    comparison: OperationArtifactComparisonEvidence,
+) -> str | None:
+    logical = comparison.logical_artifact_id
+    physical = comparison.physical_unit_id
+    identity = logical or physical
+    if identity is None:
+        return None
+    if logical is not None and physical is not None:
+        identity = f"{identity}#physical_unit={physical}"
+    if comparison.data_region is not None:
+        identity = f"{identity}#data_region={comparison.data_region}"
+    return identity
+
+
+def _assemble_bundle(
+    log_path: str,
+    byte_size: int,
+    lines: Sequence[LogLine],
+    detected: _DetectedEvidence,
+    contextual: _ContextualEvidence,
+) -> L0Bundle:
+    coverage = dict(
+        _coverage(
+            path_hint_count=len(path_hints(log_path)),
+            path_access_fact_count=len(detected.path_access_facts),
+            occurrence_group_count=len(detected.occurrence_groups),
+            context_count=len(contextual.context_windows),
+            candidate_anchor_count=len(contextual.candidate_anchors),
+            failure_episode_count=len(contextual.failure_episodes),
+            distributed_incident_count=len(detected.distributed_failure_incidents),
+            progress=detected.progress,
+            job_metadata=contextual.job_metadata,
+            primary=contextual.primary,
+            cascade_count=len(contextual.cascades),
+        )
+    )
+    coverage["operation_artifact_comparisons"] = (
+        "found" if contextual.operation_artifact_comparisons else "not_found"
+    )
+    return L0Bundle(
+        log_path=log_path,
+        byte_size=byte_size,
+        line_count=len(lines),
+        path_hints=tuple(path_hints(log_path)),
+        path_access_facts=detected.path_access_facts,
+        path_namespace_summary=detected.path_namespace_summary,
+        occurrence_groups=detected.occurrence_groups,
+        context_windows=contextual.context_windows,
+        candidate_anchors=contextual.candidate_anchors,
+        registry_matches=detected.registry_matches,
+        deterministic_primary_candidate=contextual.primary,
+        cascades=contextual.cascades,
+        cause_confirmations=detected.cause_confirmations,
+        failure_episodes=contextual.failure_episodes,
+        distributed_failure_incidents=detected.distributed_failure_incidents,
+        post_fault_summaries=contextual.post_fault_summaries,
+        progress=detected.progress,
+        run_progress_summary=contextual.run_progress_summary,
+        operation_artifact_comparisons=contextual.operation_artifact_comparisons,
+        later_progress_after_fault_observations=(
+            contextual.later_progress_after_fault_observations
+        ),
+        job_metadata=contextual.job_metadata,
+        evidence_coverage=coverage,
+        selection_summary=_selection_summary(lines, detected, contextual),
+        anomalies={"line_numbering": _line_numbering_anomaly()},
+    )
+
+
+def _selection_summary(
+    lines: Sequence[LogLine],
+    detected: _DetectedEvidence,
+    contextual: _ContextualEvidence,
+) -> Mapping[str, object]:
+    run = contextual.run_progress_summary
+    operations = contextual.operation_artifact_comparisons
+    later_progress = contextual.later_progress_after_fault_observations
+    return {
+        "raw_lines": len(lines),
+        "candidate_lines_after_filters": len(detected.registry_observations),
+        "retained_registry_matches": len(detected.registry_matches),
+        "dropped_duplicate_registry_matches": detected.dropped_registry_matches,
+        "candidate_anchors": len(contextual.candidate_anchors),
+        "failure_episodes": len(contextual.failure_episodes),
+        "distributed_failure_incidents": len(detected.distributed_failure_incidents),
+        "high_signal_lines": len(detected.high_signal_lines),
+        "occurrence_groups": len(detected.occurrence_groups),
+        "world_size_source": contextual.job_metadata.world_size_source,
+        "observed_rank_count": contextual.job_metadata.observed_rank_count,
+        "progress_marker_count": run.progress_marker_count,
+        "checkpoint_marker_count": run.checkpoint_marker_count,
+        "setup_marker_count": run.setup_marker_count,
+        "latest_observed_failure_iteration": run.latest_observed_failure_iteration,
+        "observed_iterations_after_checkpoint_load": run.observed_iterations_after_checkpoint_load,
+        "operation_artifact_comparison_count": len(operations),
+        "exact_physical_unit_comparison_count": sum(
+            1
+            for item in operations
+            if item.comparison_level == ArtifactComparisonLevel.EXACT_PHYSICAL_UNIT.value
+        ),
+        "later_progress_after_fault_observation_count": len(later_progress),
+        "later_progress_after_fault_event_count": sum(item.event_count for item in later_progress),
+        "cause_confirmation_count": detected.cause_confirmation_count,
+        "primary_selection_basis": _primary_selection_basis(detected, contextual),
+        "primary_selection_line": (
+            contextual.primary.line if contextual.primary is not None else None
+        ),
+        "path_access_fact_count": len(detected.path_access_facts),
+        "path_namespace_mismatch_observed": bool(
+            detected.path_namespace_summary.get("failed_vs_configured_write_mismatch")
+        ),
+        "dropped_noise_lines": 0,
+        "sampled_candidate_lines": sum(
+            max(0, group.count - len(group.sample_lines)) for group in detected.occurrence_groups
+        ),
+        "caps_hit": (["registry_matches_per_pattern"] if detected.dropped_registry_matches else []),
+        "primary_after_context_available": _has_after_context(contextual.primary, lines),
+        "cited_error_only_evidence": False,
+    }
+
+
+def _line_numbering_anomaly() -> Mapping[str, str]:
+    return {
+        "scheme": "linux_physical_lines",
+        "line_field": (
+            "1-based physical line split on LF; a preceding CR is removed for "
+            "CRLF, while bare CR remains line content"
+        ),
+        "shell_tool_note": (
+            "Line numbers align with Linux tools that count LF-delimited "
+            "records. Rank prefixes may also look like '<rank>:'."
+        ),
+    }
+
+
+def _primary_selection_basis(
+    detected: _DetectedEvidence,
+    contextual: _ContextualEvidence,
+) -> str:
+    primary = contextual.primary
+    if primary is None:
+        return "not_available"
+    if any(confirmation.line == primary.line for confirmation in detected.cause_confirmations):
+        return "explicit_cause_confirmation"
+    if detected.primary is not None and detected.primary.line == primary.line:
+        if any(
+            episode.identity_anchor_line == primary.line
+            or episode.terminal_exception_line == primary.line
+            for episode in contextual.failure_episodes
+        ):
+            return "registry_root_confirmed_by_failure_episode"
+        return "registry_root_candidate"
+    if any(
+        episode.identity_anchor_line == primary.line
+        or episode.terminal_exception_line == primary.line
+        for episode in contextual.failure_episodes
+    ):
+        return "failure_episode_identity"
+    return "contextual_observed_failure"
+
+
+def _collect_path_access_facts(
+    lines: Sequence[LogLine],
+) -> tuple[tuple[Mapping[str, object], ...], Mapping[str, object]]:
+    facts: list[dict[str, object]] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add_fact(
+        item: LogLine,
+        *,
+        path: str,
+        role: str,
+        access_intent: str,
+        source: str,
+    ) -> None:
+        normalized_path = path.rstrip(":;].")
+        key = (role, normalized_path)
+        if key in seen or len(facts) >= MAX_PATH_ACCESS_FACTS:
+            return
+        seen.add(key)
+        namespace_match = _USER_NAMESPACE_RE.search(normalized_path)
+        facts.append(
+            {
+                "line": item.line,
+                "path": normalized_path,
+                "role": role,
+                "access_intent": access_intent,
+                "source": source,
+                "user_namespace": (namespace_match.group("namespace") if namespace_match else None),
+            }
+        )
+
+    source_lines = (
+        lines.path_candidate_lines if isinstance(lines, L0ObservationAccumulator) else lines
+    )
+    for item in source_lines:
+        permission_match = _PERMISSION_DENIED_PATH_RE.search(item.text)
+        if permission_match is not None:
+            failed_path = permission_match.group("path")
+            add_fact(
+                item,
+                path=failed_path,
+                role="failed_access",
+                access_intent=(
+                    "write_or_create" if failed_path.lower().endswith(".lock") else "unknown"
+                ),
+                source="permission_denied_exception",
+            )
+
+        config_match = _CONFIG_PATH_RE.search(item.text)
+        if config_match is not None:
+            role, access_intent = _configured_path_role(config_match.group("key"))
+            if role is not None:
+                add_fact(
+                    item,
+                    path=config_match.group("path"),
+                    role=role,
+                    access_intent=access_intent,
+                    source=f"config:{config_match.group('key').lower()}",
+                )
+
+        for inline_match in _INLINE_PATH_RE.finditer(item.text):
+            role, access_intent = _configured_path_role(inline_match.group("key"))
+            if role is None:
+                continue
+            add_fact(
+                item,
+                path=inline_match.group("path"),
+                role=role,
+                access_intent=access_intent,
+                source=f"inline_config:{inline_match.group('key').lower()}",
+            )
+
+    namespaces_by_role: dict[str, list[str]] = {}
+    for fact in facts:
+        namespace = fact.get("user_namespace")
+        if not namespace:
+            continue
+        role = str(fact["role"])
+        namespaces_by_role.setdefault(role, [])
+        if namespace not in namespaces_by_role[role]:
+            namespaces_by_role[role].append(str(namespace))
+    for namespaces in namespaces_by_role.values():
+        namespaces.sort()
+
+    failed_namespaces = set(namespaces_by_role.get("failed_access", []))
+    configured_write_namespaces = set(namespaces_by_role.get("configured_write", []))
+    configured_write_namespaces.update(namespaces_by_role.get("configured_cache_write", []))
+    all_namespaces = sorted(
+        {namespace for namespaces in namespaces_by_role.values() for namespace in namespaces}
+    )
+    summary: dict[str, object] = {
+        "namespaces_by_role": namespaces_by_role,
+        "all_user_namespaces": all_namespaces,
+        "cross_namespace_paths_observed": len(all_namespaces) > 1,
+        "failed_vs_configured_write_mismatch": bool(
+            failed_namespaces
+            and configured_write_namespaces
+            and failed_namespaces.isdisjoint(configured_write_namespaces)
+        ),
+        "effective_user": None,
+        "ownership_verified": False,
+        "interpretation": (
+            "Path namespaces are deterministic string evidence only; they do not prove "
+            "the effective process user, file owner, mode, or ACL."
+        ),
+    }
+    return tuple(facts), summary
+
+
+def _configured_path_role(key: str) -> tuple[str | None, str]:
+    normalized = key.lower()
+    if normalized in _READ_PATH_KEYS:
+        return "configured_read", "read"
+    if normalized in _WRITE_PATH_KEYS:
+        return "configured_write", "write"
+    if normalized in _CACHE_PATH_KEYS:
+        return "configured_cache_write", "write_or_create"
+    return None, "unknown"
+
+
+def _collect_progress(
+    lines: Iterable[LogLine],
+) -> tuple[ProgressFacts, tuple[_OccurrenceSeed, ...]]:
+    progress_lines: list[int] = []
+    checkpoint_lines: list[int] = []
+    setup_lines: list[int] = []
+    recovery_lines: list[int] = []
+    progress_markers: list[ProgressMarker] = []
+    checkpoint_markers: list[ProgressMarker] = []
+    setup_markers: list[ProgressMarker] = []
+    occurrence_seeds: list[_OccurrenceSeed] = []
+    seen_setup_markers: set[tuple[str, int | str | None]] = set()
+    highest_completed_step: int | None = None
+    last_progress_line: int | None = None
+    last_checkpoint_step: int | None = None
+    last_checkpoint_line: int | None = None
+    latest_observed_failure_iteration: int | None = None
+    latest_observed_failure_iteration_line: int | None = None
+    training_progress_dialect_recognized = False
+    checkpoint_progress_dialect_recognized = False
+
+    source_lines = (
+        lines.progress_candidate_lines if isinstance(lines, L0ObservationAccumulator) else lines
+    )
+    for item in source_lines:
+        training_progress_dialect_recognized = bool(
+            training_progress_dialect_recognized
+            or _MEGATRON_ITERATION_RE.search(item.text)
+            or _TRAINING_ITERATIONS_TOTAL_RE.search(item.text)
+            or _TRAINING_START_RE.search(item.text)
+            or _RERUN_ITERATION_RESET_RE.search(item.text)
+        )
+        checkpoint_progress_dialect_recognized = bool(
+            checkpoint_progress_dialect_recognized
+            or _checkpoint_progress_dialect_recognized(item.text)
+        )
+        failure_iteration = _observed_failure_iteration(item.text)
+        if failure_iteration is not None:
+            latest_observed_failure_iteration = failure_iteration
+            latest_observed_failure_iteration_line = item.line
+
+        iteration_marker = _iteration_progress_marker(item, len(progress_markers) + 1)
+        if iteration_marker is not None:
+            progress_lines.append(item.line)
+            progress_markers.append(iteration_marker)
+            highest_completed_step = max(highest_completed_step or 0, int(iteration_marker.value))
+            last_progress_line = item.line
+            occurrence_seeds.append(
+                _progress_occurrence_seed(
+                    item,
+                    detector_id="megatron_iteration_summary.v1",
+                    normalized_shape="megatron iteration summary",
+                    classification="progress",
+                )
+            )
+
+        checkpoint_marker = _checkpoint_progress_marker(item, len(checkpoint_markers) + 1)
+        if checkpoint_marker is not None:
+            checkpoint_lines.append(item.line)
+            checkpoint_markers.append(checkpoint_marker)
+            checkpoint_step = int(checkpoint_marker.value)
+            last_checkpoint_line = item.line
+            last_checkpoint_step = max(last_checkpoint_step or 0, checkpoint_step)
+            occurrence_seeds.append(
+                _progress_occurrence_seed(
+                    item,
+                    detector_id="checkpoint_complete.v1",
+                    normalized_shape="checkpoint completion",
+                    classification="checkpoint",
+                )
+            )
+
+        setup_detection = _setup_progress_marker(item, len(setup_markers) + 1)
+        if setup_detection is not None:
+            setup_marker, marker_key, pattern_id, normalized = setup_detection
+            if marker_key not in seen_setup_markers:
+                seen_setup_markers.add(marker_key)
+                setup_lines.append(item.line)
+                setup_markers.append(setup_marker)
+            occurrence_seeds.append(
+                _progress_occurrence_seed(
+                    item,
+                    detector_id=pattern_id,
+                    normalized_shape=normalized,
+                    classification="setup_progress",
+                )
+            )
+
+        if _RECOVERY_RE.search(item.text):
+            recovery_lines.append(item.line)
+            occurrence_seeds.append(
+                _progress_occurrence_seed(
+                    item,
+                    detector_id="recovery_marker.v1",
+                    normalized_shape="recovery marker",
+                    classification="recovery",
+                )
+            )
+
+    return (
+        ProgressFacts(
+            highest_completed_step=highest_completed_step,
+            last_progress_line=last_progress_line,
+            last_checkpoint_step=last_checkpoint_step,
+            last_checkpoint_line=last_checkpoint_line,
+            latest_observed_failure_iteration=latest_observed_failure_iteration,
+            latest_observed_failure_iteration_line=latest_observed_failure_iteration_line,
+            progress_lines=tuple(progress_lines),
+            checkpoint_lines=tuple(checkpoint_lines),
+            setup_lines=tuple(setup_lines),
+            recovery_lines=tuple(recovery_lines),
+            progress_markers=tuple(progress_markers),
+            checkpoint_markers=tuple(checkpoint_markers),
+            setup_markers=tuple(setup_markers),
+            training_progress_dialect_recognized=training_progress_dialect_recognized,
+            checkpoint_progress_dialect_recognized=checkpoint_progress_dialect_recognized,
+        ),
+        tuple(occurrence_seeds),
+    )
+
+
+def _line_may_change_progress(text: str, *, lowered: str | None = None) -> bool:
+    lowered = lowered if lowered is not None else text.lower()
+    if "iteration" in lowered and (
+        _MEGATRON_ITERATION_RE.search(text)
+        or _TRAINING_ITERATIONS_TOTAL_RE.search(text)
+        or _RERUN_ITERATION_RESET_RE.search(text)
+        or _CHECKPOINT_SAVED_ITERATION_RE.search(text)
+    ):
+        return True
+    if "training step" in lowered and _TRAINING_START_RE.search(text):
+        return True
+    if "checkpoint" in lowered and _checkpoint_progress_dialect_recognized(text):
+        return True
+    if "optimizer" in lowered and _OPTIMIZER_SETUP_RE.search(text):
+        return True
+    if "cuda graph" in lowered and _CUDA_GRAPH_BUILT_RE.search(text):
+        return True
+    if _contains_any(lowered, _RECOVERY_TRIGGER_TERMS) and _RECOVERY_RE.search(text):
+        return True
+    return bool(
+        _contains_any(lowered, _FAILURE_ITERATION_TRIGGER_TERMS)
+        and _observed_failure_iteration(text) is not None
+    )
+
+
+def _iteration_progress_marker(item: LogLine, marker_number: int) -> ProgressMarker | None:
+    match = _MEGATRON_ITERATION_RE.search(item.text)
+    if match is None:
+        return None
+    return ProgressMarker(
+        marker_id=f"pm-{marker_number}",
+        marker_type="iteration",
+        value=int(match.group("iteration")),
+        state="completed",
+        line=item.line,
+        quote=item.text,
+        timestamp=match.group("timestamp"),
+        rank=extract_rank(item.text),
+        node=extract_node(item.text),
+        gpu=extract_gpu(item.text),
+        pattern_id="megatron_iteration_summary.v1",
+        secondary_value={
+            "total_iterations": int(match.group("total_iterations")),
+            "consumed_samples": int(match.group("consumed_samples")),
+        },
+    )
+
+
+def _checkpoint_progress_marker(item: LogLine, marker_number: int) -> ProgressMarker | None:
+    step = _checkpoint_step(item.text)
+    if step is None:
+        return None
+    return ProgressMarker(
+        marker_id=f"ckpt-{marker_number}",
+        marker_type="checkpoint",
+        value=step,
+        state="completed",
+        line=item.line,
+        quote=item.text,
+        rank=extract_rank(item.text),
+        node=extract_node(item.text),
+        gpu=extract_gpu(item.text),
+        pattern_id="checkpoint_complete.v1",
+    )
+
+
+def _setup_progress_marker(
+    item: LogLine,
+    marker_number: int,
+) -> tuple[ProgressMarker, tuple[str, int | str | None], str, str] | None:
+    detected = _setup_marker(item.text)
+    if detected is None:
+        return None
+    marker_type, value, state, pattern_id, normalized = detected
+    marker = ProgressMarker(
+        marker_id=f"setup-{marker_number}",
+        marker_type=marker_type,
+        value=value,
+        state=state,
+        line=item.line,
+        quote=item.text,
+        rank=extract_rank(item.text),
+        node=extract_node(item.text),
+        gpu=extract_gpu(item.text),
+        pattern_id=pattern_id,
+    )
+    return marker, (marker_type, value), pattern_id, normalized
+
+
+def _progress_occurrence_seed(
+    item: LogLine,
+    *,
+    detector_id: str,
+    normalized_shape: str,
+    classification: str,
+) -> _OccurrenceSeed:
+    return _OccurrenceSeed(
+        detector_id=detector_id,
+        normalized_shape=normalized_shape,
+        line=item.line,
+        classification=classification,
+        rank=extract_rank(item.text),
+        node=extract_node(item.text),
+        gpu=extract_gpu(item.text),
+    )
+
+
+def _checkpoint_step(text: str) -> int | None:
+    saved_iteration = _CHECKPOINT_SAVED_ITERATION_RE.search(text)
+    if saved_iteration:
+        value = saved_iteration.group("iteration") or saved_iteration.group("iteration_alt")
+        return int(value)
+    if not _CHECKPOINT_RE.search(text):
+        return None
+    explicit_step = _CHECKPOINT_STEP_RE.search(text)
+    if explicit_step:
+        return int(explicit_step.group(1))
+    return None
+
+
+def _checkpoint_progress_dialect_recognized(text: str) -> bool:
+    return any(
+        pattern.search(text)
+        for pattern in (
+            _CHECKPOINT_RE,
+            _CHECKPOINT_SAVE_START_RE,
+            _CHECKPOINT_LOADED_RE,
+            _CHECKPOINT_LOAD_COMPLETE_RE,
+            _CHECKPOINT_LOAD_START_RE,
+            _CHECKPOINT_METADATA_LOADED_RE,
+            _CHECKPOINT_RESHARD_RE,
+        )
+    )
+
+
+def _setup_marker(
+    text: str,
+) -> tuple[str, int | str | None, str, str, str] | None:
+    if _CHECKPOINT_LOADED_RE.search(text):
+        iteration = _ITERATION_VALUE_RE.search(text)
+        return (
+            "checkpoint_load",
+            int(iteration.group("iteration")) if iteration else None,
+            "completed",
+            "checkpoint_load_complete.v1",
+            "checkpoint load completed",
+        )
+    checkpoint_start = _CHECKPOINT_LOAD_START_RE.search(text)
+    if checkpoint_start:
+        return (
+            "checkpoint_load_start",
+            int(checkpoint_start.group("iteration")),
+            "started",
+            "checkpoint_load_start.v1",
+            "checkpoint load started",
+        )
+    if _CHECKPOINT_RESHARD_RE.search(text):
+        return (
+            "checkpoint_reshard",
+            None,
+            "observed",
+            "checkpoint_reshard.v1",
+            "checkpoint sharding change observed",
+        )
+    if _CHECKPOINT_METADATA_LOADED_RE.search(text):
+        return (
+            "checkpoint_metadata_load",
+            None,
+            "completed",
+            "checkpoint_metadata_load_complete.v1",
+            "checkpoint metadata load completed",
+        )
+    if _OPTIMIZER_SETUP_RE.search(text):
+        return (
+            "optimizer_setup",
+            None,
+            "started",
+            "optimizer_setup_start.v1",
+            "optimizer setup started",
+        )
+    if _CUDA_GRAPH_BUILT_RE.search(text):
+        return (
+            "cuda_graph_build",
+            None,
+            "completed",
+            "cuda_graph_build_complete.v1",
+            "cuda graph build completed",
+        )
+    return None
+
+
+def _collect_registry_observations(
+    lines: Sequence[LogLine],
+    progress: ProgressFacts,
+    terminal_lines: Sequence[int],
+) -> list[_RegistryObservation]:
+    result: list[_RegistryObservation] = []
+    source_lines = (
+        (lines[line_no - 1] for line_no in lines.registry_rows_by_line)
+        if isinstance(lines, L0ObservationAccumulator)
+        else iter(lines)
+    )
+    for item in source_lines:
+        if (
+            not isinstance(lines, L0ObservationAccumulator)
+            and diagnostic_context_kind(item.text) is not None
+        ):
+            continue
+        rows = (
+            list(lines.registry_rows_by_line[item.line])
+            if isinstance(lines, L0ObservationAccumulator)
+            else match_registry(item.text, diagnostic_checked=True)
+        )
+        if not rows:
+            continue
+        teardown_exception = bool(
+            any(row.registry_id == "observed_exception" for row in rows)
+            and _exception_is_teardown(lines, item.line)
+        )
+        if teardown_exception:
+            rows = [row for row in rows if row.registry_id == "observed_exception"]
+        rank = extract_rank(item.text)
+        node = extract_node(item.text)
+        gpu = extract_gpu(item.text)
+        outcome = _candidate_outcome(item.line, item.text, progress, terminal_lines)
+        phase = (
+            "teardown" if teardown_exception else _phase_for_line(item.line, item.text, progress)
+        )
+        normalized_shape = normalized_pattern(item.text)
+        for row in rows:
+            signature = signature_for(row, item.text)
+            result.append(
+                _RegistryObservation(
+                    row=row,
+                    line=item.line,
+                    quote=item.text,
+                    signature=signature,
+                    normalized_shape=normalized_shape,
+                    fault_outcome=outcome,
+                    causal_role=(
+                        CausalRole.TEARDOWN.value
+                        if teardown_exception
+                        else (
+                            CausalRole.CASCADE.value
+                            if row.role == RegistryRole.CASCADE_CANDIDATE.value
+                            else CausalRole.UNKNOWN.value
+                        )
+                    ),
+                    rank=rank,
+                    phase=phase,
+                    node=node,
+                    gpu=gpu,
+                    teardown_exception=teardown_exception,
+                )
+            )
+    return result
+
+
+def _enrich_registry_observation(
+    lines: Sequence[LogLine],
+    observation: _RegistryObservation,
+) -> FailureEvidence:
+    observed_fingerprint, fingerprint_source = _registry_observation_fingerprint(
+        lines,
+        observation,
+    )
+    return FailureEvidence(
+        failure_class=observation.failure_class,
+        signature=observation.signature,
+        root_fingerprint=observed_fingerprint,
+        fault_outcome=observation.fault_outcome,
+        causal_role=observation.causal_role,
+        line=observation.line,
+        quote=observation.quote,
+        rank=observation.rank,
+        phase=observation.phase,
+        node=observation.node,
+        gpu=observation.gpu,
+        failure_iteration=extract_failure_iteration(observation.quote),
+        data_position_fingerprint=extract_data_position_fingerprint(observation.quote),
+        registry_id=observation.registry_id,
+        role=observation.role,
+        recovery_behavior=observation.row.recovery_behavior,
+        root_fingerprint_source=fingerprint_source,
+    )
+
+
+def _registry_observation_fingerprint(
+    lines: Sequence[LogLine],
+    observation: _RegistryObservation,
+) -> tuple[str | None, str]:
+    stable_fingerprint = _stable_registry_observation_fingerprint(observation)
+    if stable_fingerprint is not None:
+        return stable_fingerprint
+
+    context_start = max(0, observation.line - 16)
+    return (
+        canonical_observed_fingerprint(
+            observation.quote,
+            tuple(line.text for line in lines[context_start : observation.line - 1]),
+        ),
+        "observed_exception",
+    )
+
+
+def _stable_registry_observation_fingerprint(
+    observation: _RegistryObservation,
+) -> tuple[str | None, str] | None:
+    if observation.teardown_exception:
+        return (
+            fingerprint_for("teardown_cleanup", [observation.signature]),
+            "l0_teardown_structure",
+        )
+    if observation.registry_id != "observed_exception":
+        return root_fingerprint(observation.row, observation.quote), "l0_registry"
+    return None
+
+
+def _compact_registry_observations(
+    observations: Sequence[_RegistryObservation],
+) -> tuple[list[_RegistryObservation], int]:
+    groups: OrderedDict[tuple[str, str], list[_RegistryObservation]] = OrderedDict()
+    for observation in observations:
+        key = (observation.registry_id, observation.normalized_shape)
+        groups.setdefault(key, []).append(observation)
+
+    retained: list[_RegistryObservation] = []
+    for group in groups.values():
+        if len(group) <= REGISTRY_MATCH_HEAD_PER_PATTERN + REGISTRY_MATCH_TAIL_PER_PATTERN:
+            retained.extend(group)
+            continue
+        retained.extend(group[:REGISTRY_MATCH_HEAD_PER_PATTERN])
+        retained.extend(group[-REGISTRY_MATCH_TAIL_PER_PATTERN:])
+    retained.sort(key=lambda observation: observation.line)
+    return retained, len(observations) - len(retained)
+
+
+def _sample_registry_observations(
+    observations: Sequence[_RegistryObservation],
+) -> tuple[_RegistryObservation, ...]:
+    if len(observations) <= 3:
+        return tuple(observations)
+    return (*observations[:2], observations[-1])
+
+
+def _collect_diagnostic_occurrence_seeds(
+    lines: Iterable[LogLine],
+) -> tuple[_OccurrenceSeed, ...]:
+    if isinstance(lines, L0ObservationAccumulator):
+        return tuple(lines.diagnostic_occurrence_seeds)
+
+    seeds: list[_OccurrenceSeed] = []
+    for item in lines:
+        seeds.extend(_diagnostic_seeds_for_line(item))
+    return tuple(seeds)
+
+
+def _line_may_have_diagnostic_seed(lowered: str) -> bool:
+    return _contains_any(lowered, _DIAGNOSTIC_SEED_TRIGGER_TERMS)
+
+
+def _diagnostic_seeds_for_line(
+    item: LogLine,
+    *,
+    diagnostic_kind: str | None = None,
+) -> tuple[_OccurrenceSeed, ...]:
+    text = item.text
+    seeds: list[_OccurrenceSeed] = []
+    if diagnostic_kind is None:
+        diagnostic_kind = diagnostic_context_kind(text)
+    if diagnostic_kind is not None:
+        seeds.append(
+            _diagnostic_seed(
+                item,
+                detector_id=f"{diagnostic_kind}.v1",
+                normalized_shape=diagnostic_kind,
+                classification="diagnostic_context",
+            )
+        )
+    uncertainty_kind = diagnostic_uncertainty_kind(text)
+    if uncertainty_kind is not None:
+        seeds.append(
+            _diagnostic_seed(
+                item,
+                detector_id=f"{uncertainty_kind}.v1",
+                normalized_shape=uncertainty_kind,
+                classification="diagnostic_hypothesis",
+            )
+        )
+    for pattern, detector_id, shape, classification in (
+        (
+            _TRAINING_ITERATIONS_TOTAL_RE,
+            "megatron_training_iterations_total.v1",
+            "setting training iterations",
+            "lifecycle",
+        ),
+        (
+            _TRAINING_START_RE,
+            "megatron_training_start_datetime.v1",
+            "before start of training step datetime",
+            "lifecycle",
+        ),
+        (
+            _RERUN_ITERATION_RESET_RE,
+            "megatron_rerun_iteration_reset.v1",
+            "rerun current iteration reset",
+            "lifecycle",
+        ),
+        (
+            _RANK_GPU_MAPPING_WARNING_RE,
+            "rank_gpu_mapping_warning.v1",
+            "guessing device id based on global rank",
+            "diagnostic",
+        ),
+        (
+            _NCCL_VERSION_RE,
+            "nccl_version.v1",
+            "nccl version",
+            "diagnostic",
+        ),
+        (
+            _WORLD_SIZE_RE,
+            "world_size_config.v1",
+            "world size config",
+            "job_metadata",
+        ),
+    ):
+        if pattern.search(text):
+            seeds.append(
+                _diagnostic_seed(
+                    item,
+                    detector_id=detector_id,
+                    normalized_shape=shape,
+                    classification=classification,
+                )
+            )
+    return tuple(seeds)
+
+
+def _collect_high_signal_lines(lines: Iterable[LogLine]) -> tuple[int, ...]:
+    if isinstance(lines, L0ObservationAccumulator):
+        return tuple(lines.high_signal_lines)
+
+    result: list[int] = []
+    for item in lines:
+        if diagnostic_context_kind(item.text) is not None:
+            continue
+        signal_text = _structured_log_signal_text(item.text)
+        if _HIGH_SIGNAL_RE.search(signal_text) or _BARE_PROCESS_KILLED_RE.search(item.text):
+            result.append(item.line)
+    return tuple(result)
+
+
+def _structured_log_signal_text(text: str) -> str:
+    """Exclude logger names from severity and message signal matching."""
+
+    match = _STRUCTURED_LOG_PREFIX_RE.match(text)
+    if match is None:
+        return text
+    severity = match.group("severity").upper()
+    message = match.group("message")
+    if severity in {"ERROR", "CRITICAL", "FATAL"}:
+        return f"{severity}: {message}"
+    return message
+
+
+def _select_high_signal_lines(
+    lines: Sequence[LogLine],
+    high_signal_lines: Sequence[int],
+    *,
+    limit: int,
+) -> tuple[int, ...]:
+    if not high_signal_lines or limit <= 0:
+        return ()
+
+    text_by_line = _line_text_map(lines, high_signal_lines)
+    selected: list[int] = []
+
+    def add(line_no: int | None) -> None:
+        if line_no is None or line_no not in text_by_line:
+            return
+        if line_no in selected:
+            return
+        if any(abs(line_no - existing) <= HIGH_SIGNAL_CLUSTER_GAP_LINES for existing in selected):
+            return
+        selected.append(line_no)
+
+    add(high_signal_lines[0])
+
+    terminal_ranked = sorted(
+        high_signal_lines,
+        key=lambda line_no: (
+            -_high_signal_priority(text_by_line.get(line_no, "")),
+            -line_no,
+        ),
+    )
+    for line_no in terminal_ranked:
+        if len(selected) >= limit - 1:
+            break
+        add(line_no)
+
+    for line_no in reversed(high_signal_lines):
+        if len(selected) >= limit:
+            break
+        add(line_no)
+
+    if len(selected) < limit:
+        for line_no in high_signal_lines:
+            if len(selected) >= limit:
+                break
+            if line_no not in selected:
+                selected.append(line_no)
+
+    return tuple(sorted(selected[:limit]))
+
+
+def _high_signal_priority(text: str) -> int:
+    lowered = text.lower()
+    if "traceback" in lowered:
+        return 100
+    if _BARE_PROCESS_KILLED_RE.search(text):
+        return 98
+    if "runtimeerror" in lowered or "exception" in lowered:
+        return 95
+    if "fatal" in lowered or "critical" in lowered:
+        return 90
+    if "assert" in lowered or "out of bounds" in lowered or "bounds failure" in lowered:
+        return 85
+    if "error" in lowered:
+        return 70
+    if "timeout" in lowered:
+        return 60
+    return 10
+
+
+def _diagnostic_seed(
+    item: LogLine,
+    *,
+    detector_id: str,
+    normalized_shape: str,
+    classification: str,
+) -> _OccurrenceSeed:
+    return _OccurrenceSeed(
+        detector_id=detector_id,
+        normalized_shape=normalized_shape,
+        line=item.line,
+        classification=classification,
+        rank=extract_rank(item.text),
+        node=extract_node(item.text),
+        gpu=extract_gpu(item.text),
+    )
+
+
+def _candidate_outcome(
+    line_no: int,
+    text: str,
+    progress: ProgressFacts,
+    terminal_lines: Sequence[int],
+) -> str:
+    if _has_later(progress.progress_lines, line_no) or _has_later(
+        progress.checkpoint_lines, line_no
+    ):
+        return FaultOutcome.PROGRESSED_AFTER.value
+    if _has_later(progress.recovery_lines, line_no):
+        return FaultOutcome.RECOVERED.value
+    if _TERMINAL_RE.search(text) or _has_later(terminal_lines, line_no):
+        return FaultOutcome.TERMINAL.value
+    if terminal_lines and line_no >= max(1, terminal_lines[-1] - 80):
+        return FaultOutcome.TERMINAL.value
+    return FaultOutcome.UNRESOLVED.value
+
+
+def _has_later(line_numbers: Sequence[int], line_no: int) -> bool:
+    return bisect_right(line_numbers, line_no) < len(line_numbers)
+
+
+def _observed_failure_iteration(text: str) -> int | None:
+    if not (
+        _EXCEPTION_SUMMARY_RE.search(text)
+        or _WATCHDOG_EXCEPTION_RE.search(text)
+        or _CUDA_RUNTIME_STATUS_RE.search(text)
+        or _TERMINAL_OPERATION_TIMEOUT_RE.search(text)
+    ):
+        return None
+    return extract_failure_iteration(text)
+
+
+def _exception_is_teardown(lines: Sequence[LogLine], line_no: int) -> bool:
+    if isinstance(lines, L0ObservationAccumulator):
+        return line_no in lines.teardown_exception_lines
+    if line_no < 1 or line_no > len(lines):
+        return False
+    terminal = lines[line_no - 1]
+    return _exception_context_is_teardown(
+        terminal,
+        reversed(lines[max(0, line_no - 50) : line_no - 1]),
+    )
+
+
+def _exception_context_is_teardown(
+    terminal: LogLine,
+    prior_lines: Iterable[LogLine],
+) -> bool:
+    if not _EXCEPTION_SUMMARY_RE.search(terminal.text):
+        return False
+    preferred_rank = extract_rank(terminal.text)
+    cleanup_frame_found = False
+    for item in prior_lines:
+        item_rank = extract_rank(item.text)
+        if preferred_rank is not None and item_rank not in {None, preferred_rank}:
+            continue
+        cleanup_frame_found = cleanup_frame_found or bool(_CLEANUP_FRAME_RE.search(item.text))
+        if _TRACEBACK_RE.search(item.text):
+            return cleanup_frame_found
+    return False
+
+
+def _preclassified_exception_context_is_teardown(
+    preferred_rank: str | None,
+    prior_context: Iterable[_RecentTraceContext],
+) -> bool:
+    cleanup_frame_found = False
+    for context in prior_context:
+        if preferred_rank is not None and context.rank not in {None, preferred_rank}:
+            continue
+        cleanup_frame_found = cleanup_frame_found or context.cleanup_frame
+        if context.traceback_start:
+            return cleanup_frame_found
+    return False
+
+
+def _phase_for_line(line_no: int, text: str, progress: ProgressFacts) -> str | None:
+    if _PHASE_CHECKPOINT_RE.search(text):
+        return "checkpoint"
+    failure_iteration = _observed_failure_iteration(text)
+    if failure_iteration is not None:
+        checkpoint_load = next(
+            (
+                marker
+                for marker in reversed(progress.setup_markers)
+                if marker.line <= line_no
+                and marker.marker_type in {"checkpoint_load", "checkpoint_load_start"}
+                and isinstance(marker.value, int)
+            ),
+            None,
+        )
+        if checkpoint_load is not None and failure_iteration >= int(checkpoint_load.value):
+            return (
+                "first_iter"
+                if failure_iteration - int(checkpoint_load.value) <= 1
+                else "steady_mid"
+            )
+        return "first_iter" if failure_iteration <= 1 else "steady_mid"
+    if progress.last_progress_line is None or line_no < progress.progress_lines[0]:
+        return "setup"
+    if line_no <= progress.progress_lines[0]:
+        return "first_iter"
+    return "steady_mid"
+
+
+def _build_occurrence_groups(
+    observations: Sequence[_RegistryObservation],
+    occurrence_seeds: Sequence[_OccurrenceSeed],
+) -> list[NormalizedOccurrenceGroup]:
+    groups: OrderedDict[tuple[str | None, str], list[_RegistryObservation | _OccurrenceSeed]] = (
+        OrderedDict()
+    )
+    for seed in occurrence_seeds:
+        groups.setdefault((seed.registry_id, seed.normalized_shape), []).append(seed)
+    for observation in observations:
+        pattern_identity = observation.normalized_shape
+        if observation.causal_role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}:
+            stable_fingerprint = _stable_registry_observation_fingerprint(observation)
+            if (
+                stable_fingerprint is not None
+                and stable_fingerprint[0]
+                and stable_fingerprint[1].startswith("l0_")
+            ):
+                fingerprint, _ = stable_fingerprint
+                pattern_identity = f"stable:{fingerprint}"
+        key = (observation.registry_id, pattern_identity)
+        groups.setdefault(key, []).append(observation)
+
+    result: list[NormalizedOccurrenceGroup] = []
+    for index, ((registry_id, _), group_matches) in enumerate(groups.items(), start=1):
+        first = group_matches[0]
+        first_line = first.line or 0
+        pattern = first.normalized_shape
+        result.append(
+            NormalizedOccurrenceGroup(
+                occurrence_group_id=f"og-{index}",
+                normalized_shape=pattern,
+                first_line=first_line,
+                count=len(group_matches),
+                sample_lines=tuple(
+                    match.line for match in group_matches[:5] if match.line is not None
+                ),
+                rank_spread=tuple(sorted({match.rank for match in group_matches if match.rank})),
+                node_spread=tuple(sorted({match.node for match in group_matches if match.node})),
+                gpu_spread=tuple(sorted({match.gpu for match in group_matches if match.gpu})),
+                registry_id=registry_id,
+                classification=_classification_for(first),
+                classification_source="deterministic",
+            )
+        )
+    return result
+
+
+def _classification_for(match: _RegistryObservation | _OccurrenceSeed) -> str:
+    if isinstance(match, _OccurrenceSeed):
+        return match.classification
+    if match.role == RegistryRole.CAUSE_CONFIRMATION.value:
+        return "cause_confirmation"
+    if match.causal_role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}:
+        return "cascade"
+    return "error"
+
+
+def _select_primary_candidate(
+    matches: Sequence[FailureEvidence],
+) -> FailureEvidence | None:
+    root_matches = [
+        match
+        for match in matches
+        if match.role in {RegistryRole.ROOT_CANDIDATE.value, RegistryRole.EITHER.value}
+        and match.fault_outcome
+        not in {FaultOutcome.RECOVERED.value, FaultOutcome.PROGRESSED_AFTER.value}
+    ]
+    if root_matches:
+        return sorted(root_matches, key=lambda match: match.line or 0)[0]
+
+    progressed_roots = [
+        match
+        for match in matches
+        if match.role in {RegistryRole.ROOT_CANDIDATE.value, RegistryRole.EITHER.value}
+    ]
+    if progressed_roots:
+        return sorted(progressed_roots, key=lambda match: match.line or 0)[0]
+    return None
+
+
+def _canonicalize_episode_primary(
+    primary: FailureEvidence | None,
+    matches: Sequence[FailureEvidence],
+    episodes: Sequence[FailureEpisode],
+    lines: Sequence[LogLine],
+    progress: ProgressFacts,
+) -> FailureEvidence | None:
+    for episode in episodes:
+        terminal_line = episode.terminal_exception_line
+        identity_line = episode.identity_anchor_line or terminal_line
+        observed_lines = {
+            *episode.precursor_lines,
+            *episode.exception_chain_lines,
+            terminal_line,
+            identity_line,
+        }
+        if terminal_line is None:
+            continue
+        if primary is not None and primary.line not in observed_lines:
+            continue
+        if (
+            primary is None
+            and _BARE_PROCESS_KILLED_RE.search(episode.terminal_exception_quote or "")
+            and not episode.cause_confirmations
+        ):
+            continue
+        assert identity_line is not None
+        identity_match = next(
+            (
+                match
+                for match in matches
+                if match.line == identity_line
+                and match.role
+                in {
+                    RegistryRole.ROOT_CANDIDATE.value,
+                    RegistryRole.EITHER.value,
+                    RegistryRole.CAUSE_CONFIRMATION.value,
+                }
+            ),
+            None,
+        )
+        if identity_match is not None:
+            return replace(
+                identity_match,
+                fault_outcome=episode.status,
+                causal_role=CausalRole.INITIATING.value,
+                failure_iteration=(
+                    identity_match.failure_iteration or episode.terminal_exception_iteration
+                ),
+                role=RegistryRole.ROOT_CANDIDATE.value,
+            )
+        if not 1 <= identity_line <= len(lines):
+            continue
+        identity_text = lines[identity_line - 1].text
+        terminal_match = next(
+            (match for match in matches if match.line == terminal_line),
+            None,
+        )
+        context_start = max(0, identity_line - 17)
+        return FailureEvidence(
+            failure_class="observed_failure",
+            signature=identity_text.strip(),
+            root_fingerprint=canonical_observed_fingerprint(
+                identity_text,
+                tuple(item.text for item in lines[context_start : identity_line - 1]),
+            ),
+            fault_outcome=episode.status,
+            causal_role=CausalRole.INITIATING.value,
+            line=identity_line,
+            quote=identity_text,
+            rank=extract_rank(identity_text),
+            phase=(
+                terminal_match.phase
+                if terminal_match is not None and terminal_match.phase
+                else _phase_for_line(identity_line, identity_text, progress)
+            ),
+            node=extract_node(identity_text),
+            gpu=extract_gpu(identity_text),
+            failure_iteration=(
+                extract_failure_iteration(identity_text) or episode.terminal_exception_iteration
+            ),
+            data_position_fingerprint=extract_data_position_fingerprint(identity_text),
+            role=RegistryRole.ROOT_CANDIDATE.value,
+            recovery_behavior=(
+                primary.recovery_behavior if primary is not None else RecoveryBehavior.NONE.value
+            ),
+            root_fingerprint_source="observed_exception",
+        )
+    return primary
+
+
+def _build_failure_episodes(
+    lines: Sequence[LogLine],
+    high_signal_lines: Sequence[int],
+    matches: Sequence[FailureEvidence],
+    progress: ProgressFacts,
+    *,
+    context_windows: Sequence[ContextWindow],
+    event_lines: Mapping[str, Sequence[int]],
+    cause_confirmations: Sequence[FailureEvidence],
+    distributed_failure_incidents: Sequence[DistributedFailureIncident],
+) -> list[FailureEpisode]:
+    if not high_signal_lines:
+        return []
+
+    text_by_line = _line_text_map(lines, high_signal_lines)
+    latest_progress = _last_progress_marker(progress)
+    min_line = (latest_progress.line if latest_progress else 0) + 1
+    terminal_lines = [
+        line_no
+        for line_no in high_signal_lines
+        if line_no >= min_line and _terminal_episode_priority(text_by_line.get(line_no, "")) > 0
+    ]
+    if not terminal_lines and latest_progress is not None:
+        terminal_lines = [
+            line_no
+            for line_no in high_signal_lines
+            if _terminal_episode_priority(text_by_line.get(line_no, "")) > 0
+        ]
+    if not terminal_lines:
+        return []
+
+    starts: list[int] = []
+    seen_terminal_keys: set[str] = set()
+    for line_no in terminal_lines:
+        start_line = _traceback_start_for_line(lines, line_no, lower_bound=min_line)
+        terminal_key = (
+            f"traceback:{start_line}"
+            if _TRACEBACK_RE.search(text_by_line.get(start_line, ""))
+            else _terminal_episode_key(text_by_line.get(line_no, ""))
+        )
+        if terminal_key in seen_terminal_keys:
+            continue
+        seen_terminal_keys.add(terminal_key)
+        if start_line in starts:
+            continue
+        starts.append(start_line)
+        if len(starts) >= MAX_FAILURE_EPISODES:
+            break
+
+    episodes: list[FailureEpisode] = []
+    for start_line in starts:
+        last_progress = _nearest_prior_progress_marker(progress, start_line)
+        terminal_line = _terminal_exception_line(lines, start_line)
+        terminal_text = _text_for_line(lines, terminal_line or start_line)
+        progress_after = _first_progress_after(progress, last_progress, start_line)
+        first_teardown_line = _first_later_line(event_lines["teardown"], start_line)
+        first_process_termination_line = _first_at_or_after_line(
+            event_lines["process_termination"], start_line
+        )
+        first_scheduler_cancel_line = _first_later_line(event_lines["scheduler_cancel"], start_line)
+        downstream_cascade = _first_downstream_cascade(matches, start_line)
+        status = _failure_episode_status(
+            terminal_line=terminal_line,
+            progress_after=progress_after,
+            first_teardown_line=first_teardown_line,
+            first_process_termination_line=first_process_termination_line,
+            first_scheduler_cancel_line=first_scheduler_cancel_line,
+            downstream_cascade=downstream_cascade,
+        )
+        end_line = max(
+            candidate
+            for candidate in (
+                start_line,
+                terminal_line,
+                first_teardown_line,
+                first_process_termination_line,
+                first_scheduler_cancel_line,
+                downstream_cascade.line if downstream_cascade else None,
+            )
+            if candidate is not None
+        )
+        episodes.append(
+            FailureEpisode(
+                episode_id=f"fe-{len(episodes) + 1}",
+                status=status,
+                start_line=start_line,
+                end_line=end_line,
+                first_exception_line=start_line,
+                terminal_exception_line=terminal_line,
+                terminal_exception_quote=terminal_text,
+                terminal_exception_iteration=_iteration_value(terminal_text),
+                terminal_exception_causal_role_hint=_traceback_causal_role_hint(
+                    lines,
+                    start_line,
+                    terminal_line,
+                ),
+                exception_rank=extract_rank(terminal_text or text_by_line.get(start_line, "")),
+                exception_node=extract_node(terminal_text or text_by_line.get(start_line, "")),
+                exception_gpu=extract_gpu(terminal_text or text_by_line.get(start_line, "")),
+                last_progress_before=last_progress,
+                first_progress_after=progress_after,
+                first_teardown_line=first_teardown_line,
+                first_process_termination_line=first_process_termination_line,
+                first_scheduler_cancel_line=first_scheduler_cancel_line,
+                first_downstream_cascade=downstream_cascade,
+                context_window_ids=_context_window_ids_for_episode(
+                    context_windows,
+                    start_line,
+                    terminal_line,
+                ),
+                reason=_failure_episode_reason(
+                    status,
+                    prior_progress_observed=last_progress is not None,
+                ),
+            )
+        )
+    consolidated = _consolidate_failure_episodes(
+        lines,
+        episodes,
+        progress,
+        distributed_failure_incidents,
+    )
+    with_precursors = _attach_timeout_aligned_precursors(
+        lines,
+        consolidated,
+        high_signal_lines,
+        progress,
+    )
+    with_precursors = _attach_nearby_high_signal_precursors(
+        lines,
+        with_precursors,
+        high_signal_lines,
+        progress,
+    )
+    return _attach_cause_confirmations(
+        with_precursors,
+        cause_confirmations,
+        context_windows,
+    )
+
+
+def _consolidate_failure_episodes(
+    lines: Sequence[LogLine],
+    episodes: Sequence[FailureEpisode],
+    progress: ProgressFacts,
+    distributed_failure_incidents: Sequence[DistributedFailureIncident],
+) -> list[FailureEpisode]:
+    if len(episodes) < 2:
+        return list(episodes)
+
+    groups: list[list[tuple[FailureEpisode, str | None]]] = []
+    current: list[tuple[FailureEpisode, str | None]] = [(episodes[0], None)]
+    for episode in episodes[1:]:
+        previous = current[-1][0]
+        relation = _episode_relation(
+            lines,
+            previous,
+            episode,
+            progress,
+            distributed_failure_incidents,
+        )
+        if relation is None:
+            groups.append(current)
+            current = [(episode, None)]
+        else:
+            current.append((episode, relation))
+    groups.append(current)
+
+    consolidated: list[FailureEpisode] = []
+    for group in groups:
+        members = [item[0] for item in group]
+        if len(members) == 1:
+            consolidated.append(members[0])
+            continue
+
+        duplicate_lines = {
+            previous.terminal_exception_line
+            for previous, current_item in zip(members, group[1:])
+            if current_item[1] == "serialized_duplicate"
+            and previous.terminal_exception_line is not None
+        }
+        duplicate_lines.update(
+            member.terminal_exception_line
+            for member, relation in group
+            if relation in {"distributed_fanout", "duplicate_rendering"}
+            and member.terminal_exception_line is not None
+        )
+        wrapper_lines = {
+            member.terminal_exception_line
+            for member, relation in group
+            if relation in {"outer_wrapper", "teardown_follow_on"}
+            and member.terminal_exception_line is not None
+        }
+        causal = next(
+            (
+                member
+                for member in members
+                if member.terminal_exception_line not in duplicate_lines
+                and member.terminal_exception_line not in wrapper_lines
+            ),
+            members[0],
+        )
+        downstream = min(
+            (
+                member.first_downstream_cascade
+                for member in members
+                if member.first_downstream_cascade is not None
+                and member.first_downstream_cascade.line is not None
+            ),
+            key=lambda item: item.line or 0,
+            default=None,
+        )
+        context_ids = tuple(
+            dict.fromkeys(
+                window_id for member in members for window_id in member.context_window_ids
+            )
+        )
+        relations = {relation for _, relation in group if relation is not None}
+        if relations.issubset({"distributed_fanout", "distributed_timeout_wave"}):
+            reason = (
+                "consolidated distributed timeout wave; earliest observed terminal "
+                f"timeout at line {causal.terminal_exception_line}"
+            )
+        else:
+            reason = (
+                "consolidated exception chain; canonical causal exception at "
+                f"line {causal.terminal_exception_line}"
+            )
+        consolidated.append(
+            FailureEpisode(
+                episode_id=f"fe-{len(consolidated) + 1}",
+                status=(
+                    FaultOutcome.PROGRESSED_AFTER.value
+                    if any(member.first_progress_after is not None for member in members)
+                    else causal.status
+                ),
+                start_line=min(member.start_line for member in members),
+                end_line=max(member.end_line for member in members),
+                first_exception_line=min(member.first_exception_line for member in members),
+                terminal_exception_line=causal.terminal_exception_line,
+                terminal_exception_quote=causal.terminal_exception_quote,
+                terminal_exception_iteration=causal.terminal_exception_iteration,
+                terminal_exception_causal_role_hint=(causal.terminal_exception_causal_role_hint),
+                precursor_lines=tuple(
+                    dict.fromkeys(
+                        line_no for member in members for line_no in member.precursor_lines
+                    )
+                ),
+                identity_anchor_line=causal.identity_anchor_line,
+                identity_anchor_reason=causal.identity_anchor_reason,
+                exception_chain_lines=tuple(
+                    member.terminal_exception_line
+                    for member in members
+                    if member.terminal_exception_line is not None
+                ),
+                duplicate_rendering_lines=tuple(sorted(duplicate_lines)),
+                wrapper_exception_lines=tuple(sorted(wrapper_lines)),
+                exception_rank=causal.exception_rank,
+                exception_node=causal.exception_node,
+                exception_gpu=causal.exception_gpu,
+                last_progress_before=causal.last_progress_before,
+                first_progress_after=min(
+                    (
+                        member.first_progress_after
+                        for member in members
+                        if member.first_progress_after is not None
+                    ),
+                    key=lambda marker: marker.line,
+                    default=None,
+                ),
+                first_teardown_line=_minimum_optional(
+                    member.first_teardown_line for member in members
+                ),
+                first_process_termination_line=_minimum_optional(
+                    member.first_process_termination_line for member in members
+                ),
+                first_scheduler_cancel_line=_minimum_optional(
+                    member.first_scheduler_cancel_line for member in members
+                ),
+                first_downstream_cascade=downstream,
+                context_window_ids=context_ids,
+                reason=reason,
+            )
+        )
+    return consolidated
+
+
+def _episode_relation(
+    lines: Sequence[LogLine],
+    previous: FailureEpisode,
+    current: FailureEpisode,
+    progress: ProgressFacts,
+    distributed_failure_incidents: Sequence[DistributedFailureIncident],
+) -> str | None:
+    previous_terminal = previous.terminal_exception_line or previous.start_line
+    current_start = current.start_line
+    if current_start <= previous_terminal:
+        return None
+    if any(previous_terminal < line_no < current_start for line_no in progress.progress_lines):
+        return None
+    current_terminal = current.terminal_exception_line or current.start_line
+    if any(
+        previous_terminal in incident.member_event_lines
+        and current_terminal in incident.member_event_lines
+        for incident in distributed_failure_incidents
+    ):
+        return "distributed_fanout"
+    previous_watchdog = _WATCHDOG_EXCEPTION_RE.search(previous.terminal_exception_quote or "")
+    current_watchdog = _WATCHDOG_EXCEPTION_RE.search(current.terminal_exception_quote or "")
+    if (
+        previous_watchdog is not None
+        and current_watchdog is not None
+        and normalized_pattern(previous_watchdog.group("message"))
+        == normalized_pattern(current_watchdog.group("message"))
+        and previous.exception_rank == current.exception_rank
+    ):
+        return "duplicate_rendering"
+    previous_operation = _timed_operation_identity(previous.terminal_exception_quote)
+    current_operation = _timed_operation_identity(current.terminal_exception_quote)
+    if previous_operation is not None and previous_operation == current_operation:
+        return "distributed_fanout"
+    if (
+        previous_operation is not None
+        and current_operation is not None
+        and _same_timeout_detection_wave(
+            previous.terminal_exception_quote,
+            current.terminal_exception_quote,
+        )
+    ):
+        return "distributed_timeout_wave"
+    prior_terminal_markers = (
+        previous.first_teardown_line,
+        previous.first_process_termination_line,
+        previous.first_scheduler_cancel_line,
+    )
+    if current.terminal_exception_causal_role_hint == CausalRole.TEARDOWN.value:
+        if (
+            previous.terminal_exception_causal_role_hint == CausalRole.TEARDOWN.value
+            or current_start <= previous.end_line
+            or any(
+                marker is not None and marker < current_start for marker in prior_terminal_markers
+            )
+        ):
+            return "teardown_follow_on"
+    between = lines[previous_terminal:current_start]
+    if any(_EXCEPTION_CHAIN_RE.search(item.text) for item in between):
+        return "outer_wrapper"
+    if (
+        current_start - previous.start_line <= 10
+        and _serialized_traceback(previous.terminal_exception_quote)
+        and previous.exception_rank == current.exception_rank
+    ):
+        return "serialized_duplicate"
+    return None
+
+
+def _same_timeout_detection_wave(first: str | None, second: str | None) -> bool:
+    if not first or not second:
+        return False
+    first_time = _time_of_day_seconds(first)
+    second_time = _time_of_day_seconds(second)
+    if first_time is None or second_time is None:
+        return False
+    first_timeout = _configured_timeout_seconds(first)
+    second_timeout = _configured_timeout_seconds(second)
+    if (
+        first_timeout is not None
+        and second_timeout is not None
+        and abs(first_timeout - second_timeout) > 1.0
+    ):
+        return False
+    tolerance = _distributed_timeout_wave_tolerance(first_timeout, second_timeout)
+    return _time_of_day_distance(first_time, second_time) <= tolerance
+
+
+def _timed_operation_identity(text: str | None) -> tuple[tuple[str, str], ...] | None:
+    fields = _timed_operation_fields(text)
+    if fields is None:
+        return None
+    return tuple((name, fields[name]) for name in ("seqnum", "optype"))
+
+
+def _timed_operation_fields(text: str | None) -> dict[str, str] | None:
+    if not text or not _TERMINAL_OPERATION_TIMEOUT_RE.search(text):
+        return None
+    fields = {
+        match.group("name").lower(): match.group("value").lower()
+        for match in _TIMED_OPERATION_FIELD_RE.finditer(text)
+    }
+    if not {"seqnum", "optype"}.issubset(fields):
+        return None
+    return fields
+
+
+def _timed_operation_event(item: LogLine) -> _TimedOperationEvent | None:
+    fields = _timed_operation_fields(item.text)
+    if fields is None:
+        return None
+    return _TimedOperationEvent(
+        line=item.line,
+        text=item.text,
+        timestamp_seconds=_time_of_day_seconds(item.text),
+        timestamp_text=_time_of_day_text(item.text),
+        configured_timeout_seconds=_configured_timeout_seconds(item.text),
+        sequence_number=fields["seqnum"],
+        operation_type=fields["optype"].lstrip("_"),
+        rank=extract_rank(item.text),
+    )
+
+
+def _build_distributed_failure_incidents(
+    lines: Sequence[LogLine],
+    progress: ProgressFacts,
+    observations: Sequence[_RegistryObservation],
+) -> list[DistributedFailureIncident]:
+    incidents = _build_collective_timeout_incidents(lines, progress)
+    incidents.extend(
+        _build_distributed_exception_fanout_incidents(
+            lines,
+            progress,
+            observations,
+            first_incident_number=len(incidents) + 1,
+            excluded_lines={
+                line_no for incident in incidents for line_no in incident.member_event_lines
+            },
+        )
+    )
+    return incidents
+
+
+def _build_collective_timeout_incidents(
+    lines: Sequence[LogLine],
+    progress: ProgressFacts,
+) -> list[DistributedFailureIncident]:
+    if isinstance(lines, L0ObservationAccumulator):
+        events = list(lines.timed_operation_events)
+    else:
+        events = [event for item in lines if (event := _timed_operation_event(item)) is not None]
+    if not events:
+        return []
+
+    groups = _group_distributed_timeout_waves(events, progress)
+
+    incidents: list[DistributedFailureIncident] = []
+    for group in groups:
+        primary = min(group, key=lambda event: event.line)
+        last_progress = _nearest_prior_progress_marker(progress, primary.line)
+        first_detection = min(
+            (event for event in group if event.timestamp_seconds is not None),
+            key=lambda event: event.timestamp_seconds or 0.0,
+            default=primary,
+        )
+        configured_timeout = _common_configured_timeout(group)
+        seconds_since_progress = _elapsed_time_of_day(
+            last_progress.timestamp if last_progress is not None else None,
+            first_detection.text,
+        )
+        detection_lag = (
+            max(0.0, seconds_since_progress - configured_timeout)
+            if seconds_since_progress is not None and configured_timeout is not None
+            else None
+        )
+        phase = _incident_phase_for_line(primary.line, primary.text, progress)
+        operation_signatures = tuple(
+            sorted(
+                {f"optype={event.operation_type},seqnum={event.sequence_number}" for event in group}
+            )
+        )
+        operation_types = tuple(sorted({event.operation_type for event in group}))
+        ranks = tuple(
+            sorted(
+                {event.rank for event in group if event.rank is not None},
+                key=_rank_sort_key,
+            )
+        )
+        later_progress = _first_progress_after(
+            progress, last_progress, max(event.line for event in group)
+        )
+        status = (
+            FaultOutcome.PROGRESSED_AFTER.value
+            if later_progress is not None
+            else FaultOutcome.TERMINAL.value
+        )
+        history_fingerprint = fingerprint_for(
+            "distributed_incident",
+            ["collective_operation_timeout", phase or "unknown_phase"],
+        )
+        incidents.append(
+            DistributedFailureIncident(
+                incident_id=f"di-{len(incidents) + 1}",
+                incident_kind=DistributedIncidentKind.DISTRIBUTED_MECHANISM.value,
+                incident_type="distributed_collective_timeout_wave",
+                status=status,
+                first_observed_line=min(event.line for event in group),
+                last_observed_line=max(event.line for event in group),
+                primary_observed_line=primary.line,
+                primary_observed_quote=primary.text,
+                member_event_lines=tuple(event.line for event in group),
+                sample_lines=_distributed_incident_sample_lines(group),
+                event_count=len(group),
+                unique_operation_count=len(operation_signatures),
+                operation_types=operation_types,
+                operation_signatures=operation_signatures,
+                observed_rank_count=len(ranks),
+                rank_spread=ranks[:MAX_DISTRIBUTED_INCIDENT_RANK_SAMPLES],
+                process_group_types=_process_group_types_for_wave(lines, group),
+                phase=phase,
+                configured_timeout_seconds=configured_timeout,
+                last_progress_line=(last_progress.line if last_progress is not None else None),
+                last_progress_timestamp=(
+                    last_progress.timestamp if last_progress is not None else None
+                ),
+                first_detection_timestamp=first_detection.timestamp_text,
+                seconds_since_last_progress=_rounded_seconds(seconds_since_progress),
+                detection_lag_seconds=_rounded_seconds(detection_lag),
+                history_fingerprint=history_fingerprint,
+            )
+        )
+    return incidents
+
+
+def _build_distributed_exception_fanout_incidents(
+    lines: Sequence[LogLine],
+    progress: ProgressFacts,
+    observations: Sequence[_RegistryObservation],
+    *,
+    first_incident_number: int,
+    excluded_lines: set[int],
+) -> list[DistributedFailureIncident]:
+    grouped: OrderedDict[tuple[str, str], dict[int, _RegistryObservation]] = OrderedDict()
+    for observation in observations:
+        if (
+            observation.registry_id != "observed_exception"
+            or observation.line in excluded_lines
+            or observation.rank is None
+        ):
+            continue
+        text = observation.quote
+        if not _EXCEPTION_SUMMARY_RE.search(text):
+            continue
+        prior_progress = _nearest_prior_progress_marker(progress, observation.line)
+        progress_segment = str(prior_progress.line if prior_progress is not None else 0)
+        grouped.setdefault(
+            (progress_segment, observation.normalized_shape),
+            {},
+        )[observation.line] = observation
+
+    incidents: list[DistributedFailureIncident] = []
+    for (_, pattern), by_line in grouped.items():
+        members = [by_line[line_no] for line_no in sorted(by_line)]
+        ranks = tuple(
+            sorted(
+                {member.rank for member in members if member.rank is not None},
+                key=_rank_sort_key,
+            )
+        )
+        if len(members) < 2 or len(ranks) < 2:
+            continue
+        primary = members[0]
+        primary_line = primary.line or 0
+        last_line = members[-1].line or primary_line
+        last_progress = _nearest_prior_progress_marker(progress, primary_line)
+        later_progress = _first_progress_after(progress, last_progress, last_line)
+        primary_text = primary.quote or _text_for_line(lines, primary_line) or primary.signature
+        exception_match = _EXCEPTION_SUMMARY_RE.search(primary_text)
+        exception_type = (
+            exception_match.group(0).rstrip(":") if exception_match is not None else "exception"
+        )
+        history_fingerprint, _ = _registry_observation_fingerprint(lines, primary)
+        incidents.append(
+            DistributedFailureIncident(
+                incident_id=f"di-{first_incident_number + len(incidents)}",
+                incident_kind=DistributedIncidentKind.DISTRIBUTED_FANOUT.value,
+                incident_type="distributed_exception_fanout",
+                status=(
+                    FaultOutcome.PROGRESSED_AFTER.value
+                    if later_progress is not None
+                    else FaultOutcome.TERMINAL.value
+                ),
+                first_observed_line=primary_line,
+                last_observed_line=last_line,
+                primary_observed_line=primary_line,
+                primary_observed_quote=primary_text,
+                member_event_lines=tuple(
+                    member.line for member in members if member.line is not None
+                ),
+                sample_lines=_sample_line_numbers(
+                    tuple(member.line for member in members if member.line is not None),
+                    MAX_DISTRIBUTED_INCIDENT_SAMPLE_LINES,
+                ),
+                event_count=len(members),
+                unique_operation_count=1,
+                operation_types=(exception_type,),
+                operation_signatures=(pattern,),
+                observed_rank_count=len(ranks),
+                rank_spread=ranks[:MAX_DISTRIBUTED_INCIDENT_RANK_SAMPLES],
+                phase=primary.phase
+                or _incident_phase_for_line(
+                    primary_line,
+                    primary_text,
+                    progress,
+                ),
+                last_progress_line=(last_progress.line if last_progress is not None else None),
+                last_progress_timestamp=(
+                    last_progress.timestamp if last_progress is not None else None
+                ),
+                history_fingerprint=history_fingerprint,
+                history_fingerprint_source="l0_distributed_exception_fanout",
+                root_cause_status=AssessmentStatus.UNKNOWN.value,
+                interpretation="same_attempt_rank_fanout_not_cross_cycle_recurrence",
+            )
+        )
+    return incidents
+
+
+def _group_distributed_timeout_waves(
+    events: Sequence[_TimedOperationEvent],
+    progress: ProgressFacts,
+) -> list[list[_TimedOperationEvent]]:
+    progress_lines = tuple(sorted((*progress.progress_lines, *progress.checkpoint_lines)))
+    groups: list[list[_TimedOperationEvent]] = []
+    current_wave = _DistributedTimeoutWave.start(events[0])
+    for event in events[1:]:
+        if _timeout_event_belongs_to_wave(current_wave, event, progress_lines):
+            current_wave.append(event)
+            continue
+        groups.append(current_wave.events)
+        current_wave = _DistributedTimeoutWave.start(event)
+    groups.append(current_wave.events)
+    return groups
+
+
+def _timeout_event_belongs_to_wave(
+    current_wave: _DistributedTimeoutWave,
+    current: _TimedOperationEvent,
+    progress_lines: Sequence[int],
+) -> bool:
+    next_progress_index = bisect_right(progress_lines, current_wave.previous_line)
+    if (
+        next_progress_index < len(progress_lines)
+        and progress_lines[next_progress_index] < current.line
+    ):
+        return False
+    if (
+        current_wave.first_configured_timeout_seconds is not None
+        and current.configured_timeout_seconds is not None
+        and abs(current_wave.first_configured_timeout_seconds - current.configured_timeout_seconds)
+        > 1.0
+    ):
+        return False
+    if current_wave.timestamp_seconds and current.timestamp_seconds is not None:
+        tolerance = _distributed_timeout_wave_tolerance(
+            current_wave.minimum_configured_timeout_seconds,
+            current.configured_timeout_seconds,
+        )
+        return (
+            _nearest_time_of_day_distance(
+                current_wave.timestamp_seconds,
+                current.timestamp_seconds,
+            )
+            <= tolerance
+        )
+    return current.line - current_wave.previous_line <= 1000
+
+
+def _common_configured_timeout(events: Sequence[_TimedOperationEvent]) -> float | None:
+    counts: dict[float, int] = defaultdict(int)
+    for event in events:
+        if event.configured_timeout_seconds is not None:
+            counts[event.configured_timeout_seconds] += 1
+    if not counts:
+        return None
+    return max(counts, key=lambda timeout: (counts[timeout], -timeout))
+
+
+def _distributed_incident_sample_lines(
+    events: Sequence[_TimedOperationEvent],
+) -> tuple[int, ...]:
+    selected: list[int] = []
+    seen_signatures: set[tuple[str, str]] = set()
+    for event in events:
+        signature = (event.operation_type, event.sequence_number)
+        if signature in seen_signatures:
+            continue
+        seen_signatures.add(signature)
+        selected.append(event.line)
+    for line_no in (events[0].line, events[-1].line):
+        if line_no not in selected:
+            selected.append(line_no)
+    return tuple(sorted(selected)[:MAX_DISTRIBUTED_INCIDENT_SAMPLE_LINES])
+
+
+def _sample_line_numbers(line_numbers: Sequence[int], limit: int) -> tuple[int, ...]:
+    ordered = tuple(sorted(dict.fromkeys(line_numbers)))
+    if len(ordered) <= limit:
+        return ordered
+    head_count = max(1, limit - 1)
+    return (*ordered[:head_count], ordered[-1])
+
+
+def _process_group_types_for_wave(
+    lines: Sequence[LogLine],
+    events: Sequence[_TimedOperationEvent],
+) -> tuple[str, ...]:
+    event_times = sorted(
+        event.timestamp_seconds for event in events if event.timestamp_seconds is not None
+    )
+    if not event_times:
+        return ()
+    tolerance = _distributed_timeout_wave_tolerance(
+        *(event.configured_timeout_seconds for event in events)
+    )
+    lower_line = max(1, min(event.line for event in events) - 100)
+    upper_line = min(len(lines), max(event.line for event in events) + 500)
+    group_types: set[str] = set()
+    for item in lines[lower_line - 1 : upper_line]:
+        match = _PROCESS_GROUP_TYPE_RE.search(item.text)
+        timestamp = _time_of_day_seconds(item.text)
+        if match is None or timestamp is None:
+            continue
+        if _nearest_time_of_day_distance(event_times, timestamp) > tolerance:
+            continue
+        group_types.add(match.group("group_type").lower())
+    return tuple(sorted(group_types))
+
+
+def _apply_distributed_incident_identity(
+    primary: FailureEvidence | None,
+    incidents: Sequence[DistributedFailureIncident],
+) -> FailureEvidence | None:
+    if primary is None or primary.line is None:
+        return primary
+    for incident in incidents:
+        if primary.line not in incident.member_event_lines:
+            continue
+        return replace(
+            primary,
+            root_fingerprint=incident.history_fingerprint,
+            root_fingerprint_source=incident.history_fingerprint_source,
+        )
+    return primary
+
+
+def _incident_phase_for_line(
+    line_no: int,
+    text: str,
+    progress: ProgressFacts,
+) -> str | None:
+    prior_setup = [marker for marker in progress.setup_markers if marker.line <= line_no]
+    prior_progress = [marker for marker in progress.progress_markers if marker.line <= line_no]
+    if prior_setup:
+        latest_setup = max(prior_setup, key=lambda marker: marker.line)
+        latest_progress_line = max(
+            (marker.line for marker in prior_progress),
+            default=0,
+        )
+        if latest_setup.line > latest_progress_line:
+            return latest_setup.marker_type
+    return _phase_for_line(line_no, text, progress)
+
+
+def _time_of_day_text(text: str) -> str | None:
+    match = _TIME_OF_DAY_RE.search(text)
+    return match.group(0) if match is not None else None
+
+
+def _elapsed_time_of_day(start: str | None, end_text: str | None) -> float | None:
+    if not start or not end_text:
+        return None
+    start_seconds = _time_of_day_seconds(start)
+    end_seconds = _time_of_day_seconds(end_text)
+    if start_seconds is None or end_seconds is None:
+        return None
+    elapsed = end_seconds - start_seconds
+    if elapsed < 0:
+        elapsed += 24 * 60 * 60
+    return elapsed
+
+
+def _time_of_day_distance(first: float, second: float) -> float:
+    distance = abs(first - second)
+    return min(distance, 24 * 60 * 60 - distance)
+
+
+def _nearest_time_of_day_distance(
+    sorted_reference_times: Sequence[float],
+    target: float,
+) -> float:
+    insertion_index = bisect_left(sorted_reference_times, target)
+    following = sorted_reference_times[insertion_index % len(sorted_reference_times)]
+    preceding = sorted_reference_times[(insertion_index - 1) % len(sorted_reference_times)]
+    return min(
+        _time_of_day_distance(preceding, target),
+        _time_of_day_distance(following, target),
+    )
+
+
+def _distributed_timeout_wave_tolerance(*timeouts: float | None) -> float:
+    configured = [timeout for timeout in timeouts if timeout is not None]
+    if not configured:
+        return DISTRIBUTED_TIMEOUT_WAVE_SECONDS
+    return max(
+        DISTRIBUTED_TIMEOUT_WAVE_SECONDS,
+        min(MAX_DISTRIBUTED_TIMEOUT_WAVE_SECONDS, min(configured) * 0.1),
+    )
+
+
+def _rounded_seconds(value: float | None) -> float | None:
+    return round(value, 3) if value is not None else None
+
+
+def _rank_sort_key(value: str) -> tuple[int, int | str]:
+    return (0, int(value)) if value.isdigit() else (1, value)
+
+
+def _attach_timeout_aligned_precursors(
+    lines: Sequence[LogLine],
+    episodes: Sequence[FailureEpisode],
+    high_signal_lines: Sequence[int],
+    progress: ProgressFacts,
+) -> list[FailureEpisode]:
+    text_by_line = _line_text_map(lines, high_signal_lines)
+    result: list[FailureEpisode] = []
+    for episode in episodes:
+        terminal_line = episode.terminal_exception_line
+        terminal_text = episode.terminal_exception_quote or ""
+        timeout_seconds = _configured_timeout_seconds(terminal_text)
+        terminal_time = _time_of_day_seconds(terminal_text)
+        if terminal_line is None or timeout_seconds is None or terminal_time is None:
+            result.append(
+                replace(
+                    episode,
+                    identity_anchor_line=episode.identity_anchor_line or terminal_line,
+                    identity_anchor_reason=(episode.identity_anchor_reason or "terminal_exception"),
+                )
+            )
+            continue
+
+        last_progress_line = (
+            episode.last_progress_before.line if episode.last_progress_before is not None else 0
+        )
+        precursor_lines: list[int] = []
+        for line_no in high_signal_lines:
+            if not last_progress_line < line_no < terminal_line:
+                continue
+            candidate_text = text_by_line.get(line_no, "")
+            if (
+                _TERMINAL_OPERATION_TIMEOUT_RE.search(candidate_text)
+                or _TRACEBACK_RE.search(candidate_text)
+                or _CLEANUP_FRAME_RE.search(candidate_text)
+            ):
+                continue
+            candidate_time = _time_of_day_seconds(candidate_text)
+            if candidate_time is None:
+                continue
+            elapsed = terminal_time - candidate_time
+            if elapsed < 0:
+                elapsed += 24 * 60 * 60
+            tolerance = max(5.0, min(60.0, timeout_seconds * 0.1))
+            if abs(elapsed - timeout_seconds) <= tolerance:
+                precursor_lines.append(line_no)
+
+        if precursor_lines:
+            identity_anchor_line = min(precursor_lines)
+            identity_anchor_reason = "observed_precursor_aligned_with_terminal_timeout"
+        else:
+            identity_anchor_line = episode.identity_anchor_line or terminal_line
+            identity_anchor_reason = episode.identity_anchor_reason or "terminal_exception"
+        result.append(
+            replace(
+                episode,
+                precursor_lines=tuple(dict.fromkeys((*episode.precursor_lines, *precursor_lines))),
+                identity_anchor_line=identity_anchor_line,
+                identity_anchor_reason=identity_anchor_reason,
+            )
+        )
+    return result
+
+
+def _attach_nearby_high_signal_precursors(
+    lines: Sequence[LogLine],
+    episodes: Sequence[FailureEpisode],
+    high_signal_lines: Sequence[int],
+    progress: ProgressFacts,
+) -> list[FailureEpisode]:
+    """Attach a nearby observed error that explains a following traceback or wrapper."""
+
+    text_by_line = _line_text_map(lines, high_signal_lines)
+    result: list[FailureEpisode] = []
+    for episode in episodes:
+        if episode.precursor_lines:
+            result.append(episode)
+            continue
+        lower_bound = max(
+            episode.start_line - NEARBY_EPISODE_PRECURSOR_LINES,
+            (episode.last_progress_before.line + 1) if episode.last_progress_before else 1,
+        )
+        candidates = [
+            line_no
+            for line_no in high_signal_lines
+            if lower_bound <= line_no < episode.start_line
+            and _terminal_episode_priority(text_by_line.get(line_no, "")) == 0
+            and _high_signal_priority(text_by_line.get(line_no, "")) >= 70
+            and _SPECIFIC_FAILURE_CUE_RE.search(text_by_line.get(line_no, ""))
+            and not _FAILURE_ANNOUNCEMENT_RE.search(text_by_line.get(line_no, ""))
+            and not _CLEANUP_FRAME_RE.search(text_by_line.get(line_no, ""))
+            and not any(
+                line_no < progress_line < episode.start_line
+                for progress_line in (*progress.progress_lines, *progress.checkpoint_lines)
+            )
+        ]
+        if not candidates:
+            result.append(episode)
+            continue
+        identity_anchor_line = min(candidates)
+        result.append(
+            replace(
+                episode,
+                precursor_lines=tuple(dict.fromkeys((*episode.precursor_lines, *candidates))),
+                identity_anchor_line=identity_anchor_line,
+                identity_anchor_reason="nearby_high_signal_error_precedes_failure_episode",
+            )
+        )
+    return result
+
+
+def _attach_cause_confirmations(
+    episodes: Sequence[FailureEpisode],
+    confirmations: Sequence[FailureEvidence],
+    context_windows: Sequence[ContextWindow],
+) -> list[FailureEpisode]:
+    if not episodes or not confirmations:
+        return list(episodes)
+
+    assigned: dict[int, list[FailureEvidence]] = defaultdict(list)
+    for confirmation in sorted(confirmations, key=lambda item: item.line or 0):
+        if confirmation.line is None:
+            continue
+        eligible = [
+            (index, episode)
+            for index, episode in enumerate(episodes)
+            if episode.start_line <= confirmation.line
+            and (
+                episode.first_progress_after is None
+                or episode.first_progress_after.line > confirmation.line
+            )
+        ]
+        if not eligible:
+            continue
+        termination_episodes = [
+            item
+            for item in eligible
+            if _BARE_PROCESS_KILLED_RE.search(item[1].terminal_exception_quote or "")
+            or (
+                item[1].first_process_termination_line is not None
+                and item[1].first_process_termination_line <= confirmation.line
+            )
+        ]
+        selected_index, _ = max(
+            termination_episodes or eligible,
+            key=lambda item: item[1].start_line,
+        )
+        assigned[selected_index].append(confirmation)
+
+    result: list[FailureEpisode] = []
+    for index, episode in enumerate(episodes):
+        sampled = _sample_cause_confirmations(assigned.get(index, ()))
+        if not sampled:
+            result.append(episode)
+            continue
+        confirmation_lines = tuple(item.line for item in sampled if item.line is not None)
+        context_ids = list(episode.context_window_ids)
+        for line_no in confirmation_lines:
+            for window_id in _context_window_ids_for_line(context_windows, line_no):
+                if window_id not in context_ids:
+                    context_ids.append(window_id)
+        result.append(
+            replace(
+                episode,
+                end_line=max(episode.end_line, *confirmation_lines),
+                identity_anchor_line=confirmation_lines[0],
+                identity_anchor_reason="explicit_cause_confirmation",
+                cause_confirmations=sampled,
+                context_window_ids=tuple(context_ids),
+            )
+        )
+    return result
+
+
+def _sample_cause_confirmations(
+    confirmations: Sequence[FailureEvidence],
+) -> tuple[FailureEvidence, ...]:
+    if len(confirmations) <= 3:
+        return tuple(confirmations)
+    return tuple((*confirmations[:2], confirmations[-1]))
+
+
+def _configured_timeout_seconds(text: str) -> float | None:
+    match = _TIMEOUT_MS_RE.search(text)
+    if match is None:
+        return None
+    return int(match.group("milliseconds")) / 1000.0
+
+
+def _time_of_day_seconds(text: str) -> float | None:
+    match = _TIME_OF_DAY_RE.search(text)
+    if match is None:
+        return None
+    fraction = match.group("fraction") or ""
+    fractional_seconds = float(f"0.{fraction}") if fraction else 0.0
+    return (
+        int(match.group("hour")) * 3600
+        + int(match.group("minute")) * 60
+        + int(match.group("second"))
+        + fractional_seconds
+    )
+
+
+def _serialized_traceback(text: str | None) -> bool:
+    if not text:
+        return False
+    return bool(_TRACEBACK_RE.search(text) and ("\\n" in text or text.lstrip().startswith("[")))
+
+
+def _minimum_optional(values: Iterable[int | None]) -> int | None:
+    present = [value for value in values if value is not None]
+    return min(present) if present else None
+
+
+def _last_progress_marker(progress: ProgressFacts) -> ProgressMarker | None:
+    markers = [*progress.progress_markers, *progress.checkpoint_markers]
+    if not markers:
+        return None
+    return max(markers, key=lambda marker: marker.line)
+
+
+def _nearest_prior_progress_marker(
+    progress: ProgressFacts,
+    line_no: int,
+) -> ProgressMarker | None:
+    markers = [
+        marker
+        for marker in [*progress.progress_markers, *progress.checkpoint_markers]
+        if marker.line < line_no
+    ]
+    if not markers:
+        return None
+    return max(markers, key=lambda marker: marker.line)
+
+
+def _terminal_episode_priority(text: str) -> int:
+    if _TRACEBACK_RE.search(text):
+        return 100
+    if _EXCEPTION_SUMMARY_RE.search(text):
+        return 95
+    if _WATCHDOG_EXCEPTION_RE.search(text):
+        return 94
+    if _CUDA_RUNTIME_STATUS_RE.search(text):
+        return 94
+    if _BARE_PROCESS_KILLED_RE.search(text):
+        return 90
+    if _TERMINAL_OPERATION_TIMEOUT_RE.search(text):
+        return 80
+    return 0
+
+
+def _traceback_start_for_line(
+    lines: Sequence[LogLine],
+    line_no: int,
+    *,
+    lower_bound: int,
+) -> int:
+    if 1 <= line_no <= len(lines) and _TRACEBACK_RE.search(lines[line_no - 1].text):
+        return line_no
+    start_index = max(0, line_no - 41)
+    end_index = max(0, line_no - 1)
+    for item in reversed(lines[start_index:end_index]):
+        if item.line < lower_bound:
+            break
+        if _TRACEBACK_RE.search(item.text):
+            return item.line
+    return line_no
+
+
+def _terminal_exception_line(lines: Sequence[LogLine], start_line: int) -> int | None:
+    for item in lines[start_line - 1 : min(len(lines), start_line + 120)]:
+        if _EXCEPTION_SUMMARY_RE.search(item.text):
+            return item.line
+        if _WATCHDOG_EXCEPTION_RE.search(item.text):
+            return item.line
+        if _CUDA_RUNTIME_STATUS_RE.search(item.text):
+            return item.line
+        if item.line == start_line and _TERMINAL_OPERATION_TIMEOUT_RE.search(item.text):
+            return item.line
+    return start_line
+
+
+def _traceback_causal_role_hint(
+    lines: Sequence[LogLine],
+    start_line: int,
+    terminal_line: int | None,
+) -> str:
+    if terminal_line is None:
+        return CausalRole.UNKNOWN.value
+    if terminal_line >= start_line and _exception_is_teardown(lines, terminal_line):
+        return CausalRole.TEARDOWN.value
+    return CausalRole.UNKNOWN.value
+
+
+def _first_progress_after(
+    progress: ProgressFacts,
+    last_progress: ProgressMarker | None,
+    line_no: int,
+) -> ProgressMarker | None:
+    markers = sorted(
+        [*progress.progress_markers, *progress.checkpoint_markers],
+        key=lambda marker: marker.line,
+    )
+    for marker in markers:
+        if marker.line <= line_no:
+            continue
+        if _compatible_progress_advance(last_progress, marker):
+            return marker
+    return None
+
+
+def _compatible_progress_advance(
+    previous: ProgressMarker | None,
+    candidate: ProgressMarker,
+) -> bool:
+    if candidate.value is None:
+        return False
+    if previous is None:
+        return True
+    if candidate.marker_type != previous.marker_type:
+        return True
+    if not isinstance(candidate.value, int) or not isinstance(previous.value, int):
+        return candidate.value != previous.value
+    return candidate.value > previous.value
+
+
+def _episode_event_lines(lines: Sequence[LogLine]) -> dict[str, tuple[int, ...]]:
+    if isinstance(lines, L0ObservationAccumulator):
+        return {
+            name: tuple(line_numbers) for name, line_numbers in lines.episode_event_lines.items()
+        }
+
+    result: dict[str, list[int]] = {
+        "teardown": [],
+        "process_termination": [],
+        "scheduler_cancel": [],
+    }
+    for item in lines:
+        if _TEARDOWN_RE.search(item.text):
+            result["teardown"].append(item.line)
+        if _PROCESS_TERMINATION_RE.search(item.text) or _BARE_PROCESS_KILLED_RE.search(item.text):
+            result["process_termination"].append(item.line)
+        if _SCHEDULER_CANCEL_RE.search(item.text):
+            result["scheduler_cancel"].append(item.line)
+    return {name: tuple(line_numbers) for name, line_numbers in result.items()}
+
+
+def _first_later_line(line_numbers: Sequence[int], line_no: int) -> int | None:
+    index = bisect_right(line_numbers, line_no)
+    return line_numbers[index] if index < len(line_numbers) else None
+
+
+def _first_at_or_after_line(line_numbers: Sequence[int], line_no: int) -> int | None:
+    for candidate in line_numbers:
+        if candidate >= line_no:
+            return candidate
+    return None
+
+
+def _terminal_episode_key(text: str) -> str:
+    operation = _TIMED_OPERATION_SIGNATURE_RE.search(text)
+    if operation:
+        return "timed_operation:" + normalized_pattern(operation.group("operation"))
+    return normalized_pattern(text)
+
+
+def _failure_episode_status(
+    *,
+    terminal_line: int | None,
+    progress_after: ProgressMarker | None,
+    first_teardown_line: int | None,
+    first_process_termination_line: int | None,
+    first_scheduler_cancel_line: int | None,
+    downstream_cascade: FailureEvidence | None,
+) -> str:
+    if progress_after is not None:
+        return FaultOutcome.PROGRESSED_AFTER.value
+    if terminal_line is not None and (
+        first_teardown_line is not None
+        or first_process_termination_line is not None
+        or first_scheduler_cancel_line is not None
+        or downstream_cascade is not None
+    ):
+        return FaultOutcome.TERMINAL.value
+    if terminal_line is not None:
+        return FaultOutcome.TERMINAL.value
+    return FaultOutcome.UNRESOLVED.value
+
+
+def _failure_episode_reason(status: str, *, prior_progress_observed: bool) -> str:
+    if status == FaultOutcome.PROGRESSED_AFTER.value:
+        return "compatible application or checkpoint progress appears after the episode"
+    if status == FaultOutcome.TERMINAL.value:
+        prefix = (
+            "terminal-looking exception after observed prior progress"
+            if prior_progress_observed
+            else "terminal-looking exception; no prior progress marker was observed"
+        )
+        return f"{prefix}, with no later compatible progress"
+    return "terminal-looking exception without enough later context"
+
+
+def _build_post_fault_summaries(
+    lines: Sequence[LogLine],
+    high_signal_lines: Sequence[int],
+    episodes: Sequence[FailureEpisode],
+) -> list[PostFaultSummary]:
+    episode_patterns = {
+        episode.episode_id: normalized_pattern(_text_for_line(lines, anchor_line))
+        for episode in episodes
+        for anchor_line in [episode.terminal_exception_line]
+        if anchor_line is not None
+    }
+    target_patterns = {pattern for pattern in episode_patterns.values() if pattern}
+    matching_by_pattern: dict[str, list[int]] = defaultdict(list)
+    if target_patterns:
+        source_lines = (
+            lines.exception_summary_lines if isinstance(lines, L0ObservationAccumulator) else lines
+        )
+        for item in source_lines:
+            if not _EXCEPTION_SUMMARY_RE.search(item.text):
+                continue
+            pattern = normalized_pattern(item.text)
+            if pattern in target_patterns:
+                matching_by_pattern[pattern].append(item.line)
+    summaries: list[PostFaultSummary] = []
+    for episode in episodes:
+        anchor_line = episode.terminal_exception_line
+        if anchor_line is None:
+            continue
+        anchor_pattern = episode_patterns.get(episode.episode_id, "")
+        pattern_lines = matching_by_pattern.get(anchor_pattern, [])
+        matching_lines = pattern_lines[bisect_right(pattern_lines, anchor_line) :]
+        later_high_signal = high_signal_lines[bisect_right(high_signal_lines, anchor_line) :]
+        last_high_signal_line = later_high_signal[-1] if later_high_signal else None
+        summaries.append(
+            PostFaultSummary(
+                episode_id=episode.episode_id,
+                anchor_line=anchor_line,
+                lines_after_anchor=max(0, len(lines) - anchor_line),
+                progress_after_observed=episode.first_progress_after is not None,
+                first_progress_after_line=(
+                    episode.first_progress_after.line
+                    if episode.first_progress_after is not None
+                    else None
+                ),
+                later_matching_exception_count=len(matching_lines),
+                later_matching_exception_lines=tuple(matching_lines[:20]),
+                later_high_signal_count=len(later_high_signal),
+                last_high_signal_line=last_high_signal_line,
+                last_high_signal_quote=(
+                    _text_for_line(lines, last_high_signal_line)
+                    if last_high_signal_line is not None
+                    else None
+                ),
+                first_teardown_line=episode.first_teardown_line,
+                first_process_termination_line=episode.first_process_termination_line,
+                first_scheduler_cancel_line=episode.first_scheduler_cancel_line,
+                first_cascade_line=(
+                    episode.first_downstream_cascade.line
+                    if episode.first_downstream_cascade is not None
+                    else None
+                ),
+            )
+        )
+    return summaries
+
+
+def _iteration_value(text: str | None) -> int | None:
+    if text is None:
+        return None
+    match = _ITERATION_VALUE_RE.search(text)
+    return int(match.group("iteration")) if match else None
+
+
+def _failure_episode_seed_lines(episodes: Sequence[FailureEpisode]) -> tuple[int, ...]:
+    result: list[int] = []
+    for episode in episodes:
+        for line_no in (episode.start_line, episode.terminal_exception_line):
+            if line_no is not None and line_no not in result:
+                result.append(line_no)
+    return tuple(result)
+
+
+def _secondary_episode_high_signal_lines(
+    lines: Sequence[LogLine],
+    episodes: Sequence[FailureEpisode],
+) -> set[int]:
+    result: set[int] = set()
+    for episode in episodes:
+        for line_no in (
+            *episode.duplicate_rendering_lines,
+            *episode.wrapper_exception_lines,
+        ):
+            result.add(line_no)
+            result.add(
+                _traceback_start_for_line(
+                    lines,
+                    line_no,
+                    lower_bound=max(1, line_no - 120),
+                )
+            )
+    return result
+
+
+def _context_window_ids_for_episode(
+    context_windows: Sequence[ContextWindow],
+    start_line: int,
+    terminal_line: int | None,
+) -> tuple[str, ...]:
+    lines = [start_line]
+    if terminal_line is not None:
+        lines.append(terminal_line)
+    result: list[str] = []
+    for line_no in lines:
+        for window_id in _context_window_ids_for_line(context_windows, line_no):
+            if window_id not in result:
+                result.append(window_id)
+    return tuple(result)
+
+
+def _build_context_windows(
+    lines: Sequence[LogLine],
+    occurrence_groups: Sequence[NormalizedOccurrenceGroup],
+    matches: Sequence[FailureEvidence],
+    high_signal_lines: Sequence[int] = (),
+    failure_episode_lines: Sequence[int] = (),
+    cause_confirmation_lines: Sequence[int] = (),
+) -> list[ContextWindow]:
+    occurrence_group_by_line: dict[int, str] = {}
+    for group in occurrence_groups:
+        for line_no in group.sample_lines:
+            occurrence_group_by_line[line_no] = group.occurrence_group_id
+
+    seed_lines: list[tuple[int, str]] = []
+    seen_seed_lines: set[int] = set()
+
+    def add_seed(line_no: int | None, source: str) -> None:
+        if line_no is None or line_no in seen_seed_lines:
+            return
+        seed_lines.append((line_no, source))
+        seen_seed_lines.add(line_no)
+
+    for line_no in failure_episode_lines:
+        add_seed(line_no, "failure_episode")
+
+    for line_no in cause_confirmation_lines:
+        add_seed(line_no, "cause_confirmation")
+
+    for line_no in _select_high_signal_lines(
+        lines,
+        high_signal_lines,
+        limit=MAX_CONTEXT_HIGH_SIGNAL_SEEDS,
+    ):
+        add_seed(line_no, "high_signal")
+
+    seen_registry_groups: set[tuple[str | None, str]] = set()
+    for match in matches:
+        group_key = (
+            match.registry_id,
+            normalized_pattern(match.quote or match.signature),
+        )
+        if group_key in seen_registry_groups:
+            continue
+        seen_registry_groups.add(group_key)
+        add_seed(match.line, "registry_candidate")
+        if len(seed_lines) >= MAX_CONTEXT_WINDOW_SEEDS:
+            break
+
+    windows: list[ContextWindow] = []
+    for index, (seed, selected_by) in enumerate(seed_lines, start=1):
+        start = max(1, seed - CONTEXT_WINDOW_BEFORE_LINES)
+        end = min(len(lines), seed + CONTEXT_WINDOW_AFTER_LINES)
+        window_lines = tuple(lines[start - 1 : end])
+        occurrence_group_id = occurrence_group_by_line.get(seed)
+        windows.append(
+            ContextWindow(
+                window_id=f"w-{index}",
+                selected_by=selected_by,
+                start_line=start,
+                end_line=end,
+                seed_lines=(seed,),
+                occurrence_group_ids=(occurrence_group_id,) if occurrence_group_id else (),
+                lines=window_lines,
+                truncated=False,
+            )
+        )
+    return windows
+
+
+def _build_candidate_anchors(
+    lines: Sequence[LogLine],
+    high_signal_lines: Sequence[int],
+    matches: Sequence[FailureEvidence],
+    primary: FailureEvidence | None,
+    progress: ProgressFacts,
+    context_windows: Sequence[ContextWindow],
+    failure_episodes: Sequence[FailureEpisode],
+    cause_confirmations: Sequence[FailureEvidence],
+) -> list[CandidateAnchor]:
+    anchors: OrderedDict[int, list[str]] = OrderedDict()
+
+    def add_anchor(line_no: int | None, source: str) -> None:
+        if line_no is None or line_no < 1 or line_no > len(lines):
+            return
+        sources = anchors.setdefault(line_no, [])
+        if source not in sources:
+            sources.append(source)
+
+    for line_no in _select_high_signal_lines(
+        lines,
+        high_signal_lines,
+        limit=MAX_HIGH_SIGNAL_ANCHORS,
+    ):
+        add_anchor(line_no, "high_signal")
+    for episode in failure_episodes:
+        add_anchor(episode.start_line, "failure_episode")
+        add_anchor(episode.terminal_exception_line, "terminal_exception")
+    for confirmation in cause_confirmations:
+        add_anchor(confirmation.line, "cause_confirmation")
+    if primary is not None:
+        add_anchor(primary.line, "registry_selection")
+    seen_registry_groups: set[tuple[str | None, str]] = set()
+    for match in matches:
+        group_key = (
+            match.registry_id,
+            normalized_pattern(match.quote or match.signature),
+        )
+        if group_key in seen_registry_groups:
+            continue
+        seen_registry_groups.add(group_key)
+        add_anchor(match.line, "registry_candidate")
+        if len(anchors) >= MAX_CANDIDATE_ANCHORS:
+            break
+
+    match_by_line: dict[int, FailureEvidence] = {}
+    for match in matches:
+        if match.line is not None and match.line not in match_by_line:
+            match_by_line[match.line] = match
+
+    result: list[CandidateAnchor] = []
+    episode_role_by_line: dict[int, str] = {}
+    for episode in failure_episodes:
+        if episode.terminal_exception_line is not None:
+            episode_role_by_line[episode.terminal_exception_line] = (
+                episode.terminal_exception_causal_role_hint
+            )
+        for wrapper_line in episode.wrapper_exception_lines:
+            episode_role_by_line[wrapper_line] = CausalRole.TEARDOWN.value
+    for index, (line_no, sources) in enumerate(
+        sorted(anchors.items(), key=lambda item: item[0])[:MAX_CANDIDATE_ANCHORS],
+        start=1,
+    ):
+        prior_progress_line = _nearest_prior_line(progress.progress_lines, line_no)
+        later_progress_line = _nearest_next_line(progress.progress_lines, line_no)
+        anchor_text = _text_for_line(lines, line_no)
+        anchor_rank = extract_rank(anchor_text)
+        later_progress_rank = _rank_for_line(lines, later_progress_line)
+        result.append(
+            CandidateAnchor(
+                anchor_id=f"ca-{index}",
+                line=line_no,
+                quote=anchor_text,
+                sources=tuple(sources),
+                high_signal="high_signal" in sources,
+                causal_role_hint=episode_role_by_line.get(
+                    line_no,
+                    CausalRole.UNKNOWN.value,
+                ),
+                anchor_rank=anchor_rank,
+                taxonomy_match=match_by_line.get(line_no),
+                prior_observed_progress_line=prior_progress_line,
+                later_observed_progress_line=later_progress_line,
+                prior_progress_rank=_rank_for_line(lines, prior_progress_line),
+                later_progress_rank=later_progress_rank,
+                later_progress_rank_relation=_rank_relation(anchor_rank, later_progress_rank),
+                later_observation_proves_recovery=False,
+                first_downstream_registry_match=_first_downstream_match(matches, line_no),
+                first_downstream_cascade=_first_downstream_cascade(matches, line_no),
+                context_window_ids=_context_window_ids_for_line(context_windows, line_no),
+            )
+        )
+    return result
+
+
+def _nearest_prior_line(line_numbers: Sequence[int], line_no: int) -> int | None:
+    prior = [candidate for candidate in line_numbers if candidate < line_no]
+    return max(prior) if prior else None
+
+
+def _nearest_next_line(line_numbers: Sequence[int], line_no: int) -> int | None:
+    after = [candidate for candidate in line_numbers if candidate > line_no]
+    return min(after) if after else None
+
+
+def _text_for_line(lines: Sequence[LogLine], line_no: int | None) -> str:
+    if line_no is None or line_no < 1 or line_no > len(lines):
+        return ""
+    return lines[line_no - 1].text
+
+
+def _line_text_map(
+    lines: Sequence[LogLine],
+    line_numbers: Iterable[int],
+) -> dict[int, str]:
+    if isinstance(lines, L0ObservationAccumulator):
+        return lines.text_map(line_numbers)
+    return {
+        line_no: _text_for_line(lines, line_no)
+        for line_no in dict.fromkeys(line_numbers)
+        if 1 <= line_no <= len(lines)
+    }
+
+
+def _rank_for_line(lines: Sequence[LogLine], line_no: int | None) -> str | None:
+    return extract_rank(_text_for_line(lines, line_no))
+
+
+def _rank_relation(anchor_rank: str | None, progress_rank: str | None) -> str | None:
+    if progress_rank is None:
+        return None
+    if anchor_rank is None:
+        return "anchor_rank_unknown"
+    if anchor_rank == progress_rank:
+        return "same_rank"
+    return "different_rank"
+
+
+def _first_downstream_match(
+    matches: Sequence[FailureEvidence],
+    line_no: int,
+) -> FailureEvidence | None:
+    downstream = [match for match in matches if match.line is not None and match.line > line_no]
+    return min(downstream, key=lambda match: match.line or 0) if downstream else None
+
+
+def _first_downstream_cascade(
+    matches: Sequence[FailureEvidence],
+    line_no: int,
+) -> FailureEvidence | None:
+    downstream = [
+        match
+        for match in matches
+        if match.line is not None
+        and match.line > line_no
+        and (
+            match.causal_role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}
+            or match.role == RegistryRole.CASCADE_CANDIDATE.value
+            or match.registry_id == "observed_distributed_operation_timeout"
+        )
+    ]
+    return min(downstream, key=lambda match: match.line or 0) if downstream else None
+
+
+def _context_window_ids_for_line(
+    context_windows: Sequence[ContextWindow],
+    line_no: int,
+) -> tuple[str, ...]:
+    return tuple(
+        window.window_id
+        for window in context_windows
+        if window.start_line <= line_no <= window.end_line
+    )
+
+
+def _materialize_cascade_matches(
+    lines: Sequence[LogLine],
+    observations: Sequence[_RegistryObservation],
+    primary: FailureEvidence | None,
+    distributed_incidents: Sequence[DistributedFailureIncident] = (),
+) -> tuple[FailureEvidence, ...]:
+    if primary is None or primary.line is None:
+        return ()
+
+    primary_incident_member_lines: set[int] = set()
+    downstream_incident_member_lines: set[int] = set()
+    downstream_incident_primary_lines: set[int] = set()
+    for incident in distributed_incidents:
+        if primary.line in incident.member_event_lines:
+            primary_incident_member_lines.update(incident.member_event_lines)
+            continue
+        if incident.first_observed_line <= primary.line:
+            continue
+        downstream_incident_member_lines.update(incident.member_event_lines)
+        downstream_incident_primary_lines.add(incident.primary_observed_line)
+
+    materialized: list[FailureEvidence] = []
+    for observation in observations:
+        if observation.line <= primary.line:
+            continue
+        if observation.line in primary_incident_member_lines:
+            continue
+        if (
+            observation.line in downstream_incident_member_lines
+            and observation.line not in downstream_incident_primary_lines
+        ):
+            continue
+        if (
+            observation.causal_role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}
+            or observation.role == RegistryRole.CASCADE_CANDIDATE.value
+            or observation.registry_id == "observed_distributed_operation_timeout"
+            or observation.line in downstream_incident_primary_lines
+        ):
+            materialized.append(
+                _enrich_registry_observation(
+                    lines,
+                    observation,
+                )
+            )
+    return tuple(materialized)
+
+
+def build_cascades_for_primary(
+    matches: Sequence[FailureEvidence],
+    primary: FailureEvidence | None,
+    distributed_incidents: Sequence[DistributedFailureIncident] = (),
+) -> list[CascadeEvidence]:
+    """Build cascades from materialized evidence for post-L1 public results."""
+
+    if primary is None or primary.line is None:
+        return []
+
+    primary_incident_member_lines: set[int] = set()
+    downstream_incident_member_lines: set[int] = set()
+    cascades: list[CascadeEvidence] = []
+    for incident in distributed_incidents:
+        if primary.line in incident.member_event_lines:
+            primary_incident_member_lines.update(incident.member_event_lines)
+            continue
+        if incident.first_observed_line <= primary.line:
+            continue
+        downstream_incident_member_lines.update(incident.member_event_lines)
+        first_match = next(
+            (match for match in matches if match.line == incident.primary_observed_line),
+            None,
+        )
+        cascades.append(
+            CascadeEvidence(
+                failure_class=(
+                    first_match.failure_class if first_match is not None else incident.incident_type
+                ),
+                cascade_fingerprint=incident.history_fingerprint,
+                causal_role=CausalRole.CASCADE.value,
+                first_line=incident.first_observed_line,
+                last_line=incident.last_observed_line,
+                count=incident.event_count,
+                sample_lines=incident.sample_lines,
+                rank_spread=incident.rank_spread,
+                reason=(
+                    "distributed fanout appears after primary candidate at line " f"{primary.line}"
+                ),
+            )
+        )
+
+    groups: dict[tuple[str, str | None, str], list[FailureEvidence]] = defaultdict(list)
+    for match in matches:
+        if match.line is None or match.line <= primary.line:
+            continue
+        if match.line in primary_incident_member_lines:
+            continue
+        if match.line in downstream_incident_member_lines:
+            continue
+        if (
+            match.causal_role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}
+            or match.role == RegistryRole.CASCADE_CANDIDATE.value
+            or match.registry_id == "observed_distributed_operation_timeout"
+        ):
+            causal_role = (
+                match.causal_role
+                if match.causal_role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value}
+                else CausalRole.CASCADE.value
+            )
+            groups[(match.failure_class, match.root_fingerprint, causal_role)].append(match)
+
+    for (failure_class, fingerprint, causal_role), group in sorted(
+        groups.items(), key=lambda item: item[1][0].line or 0
+    ):
+        group_lines = [match.line for match in group if match.line is not None]
+        cascades.append(
+            CascadeEvidence(
+                failure_class=failure_class,
+                cascade_fingerprint=fingerprint,
+                causal_role=causal_role,
+                first_line=min(group_lines),
+                last_line=max(group_lines),
+                count=len(group),
+                sample_lines=tuple(group_lines[:5]),
+                rank_spread=tuple(sorted({match.rank for match in group if match.rank})),
+                node_spread=tuple(sorted({match.node for match in group if match.node})),
+                gpu_spread=tuple(sorted({match.gpu for match in group if match.gpu})),
+                reason=f"appears after primary candidate at line {primary.line}",
+            )
+        )
+    return cascades
+
+
+def _collect_job_metadata(lines: Sequence[LogLine]) -> JobMetadata:
+    if isinstance(lines, L0ObservationAccumulator):
+        explicit_world_size = lines.explicit_world_size
+        explicit_world_size_line = lines.explicit_world_size_line
+        ranks = lines.observed_ranks
+        nodes = lines.observed_nodes
+        return _job_metadata_from_observations(
+            explicit_world_size,
+            explicit_world_size_line,
+            ranks,
+            nodes,
+        )
+
+    explicit_world_size: int | None = None
+    explicit_world_size_line: int | None = None
+    ranks: set[int] = set()
+    nodes: set[str] = set()
+
+    for item in lines:
+        text = item.text
+        if explicit_world_size is None:
+            world_size_match = _WORLD_SIZE_RE.search(text)
+            if world_size_match:
+                explicit_world_size = int(world_size_match.group("world_size"))
+                explicit_world_size_line = item.line
+
+        rank = _numeric_field(extract_rank(text))
+        if rank is not None:
+            ranks.add(rank)
+
+        node = extract_node(text)
+        if node:
+            nodes.add(node)
+
+    return _job_metadata_from_observations(
+        explicit_world_size,
+        explicit_world_size_line,
+        ranks,
+        nodes,
+    )
+
+
+def _job_metadata_from_observations(
+    explicit_world_size: int | None,
+    explicit_world_size_line: int | None,
+    ranks: set[int],
+    nodes: set[str],
+) -> JobMetadata:
+    observed_rank_min = min(ranks) if ranks else None
+    observed_rank_max = max(ranks) if ranks else None
+    lower_bound = observed_rank_max + 1 if observed_rank_max is not None else None
+    if explicit_world_size is not None:
+        world_size_source = "explicit"
+        world_size_confidence = "explicit"
+    elif lower_bound is not None:
+        world_size_source = "observed_rank_lower_bound"
+        world_size_confidence = "observed_lower_bound"
+    else:
+        world_size_source = "not_found"
+        world_size_confidence = "not_found"
+
+    return JobMetadata(
+        explicit_world_size=explicit_world_size,
+        explicit_world_size_line=explicit_world_size_line,
+        observed_rank_min=observed_rank_min,
+        observed_rank_max=observed_rank_max,
+        observed_rank_count=len(ranks),
+        inferred_world_size_lower_bound=lower_bound,
+        world_size_source=world_size_source,
+        world_size_confidence=world_size_confidence,
+        observed_node_count=len(nodes),
+        rank_to_gpu_mapping_available=False,
+    )
+
+
+def _build_run_progress_summary(
+    progress: ProgressFacts,
+    failure_episodes: Sequence[FailureEpisode],
+    distributed_incidents: Sequence[DistributedFailureIncident],
+) -> RunProgressSummary:
+    iteration_markers = [
+        marker
+        for marker in progress.progress_markers
+        if marker.marker_type == "iteration" and isinstance(marker.value, int)
+    ]
+    checkpoints = [
+        marker for marker in progress.checkpoint_markers if isinstance(marker.value, int)
+    ]
+    checkpoint_loads = [
+        marker
+        for marker in progress.setup_markers
+        if marker.marker_type in {"checkpoint_load", "checkpoint_load_start"}
+        and marker.state in {"completed", "started"}
+        and isinstance(marker.value, int)
+    ]
+    checkpoint_load_iteration = checkpoint_loads[-1].value if checkpoint_loads else None
+    checkpoint_load_line = checkpoint_loads[-1].line if checkpoint_loads else None
+    observed_failure_iteration = progress.latest_observed_failure_iteration
+    observed_iterations_after_checkpoint_load = (
+        observed_failure_iteration - int(checkpoint_load_iteration)
+        if observed_failure_iteration is not None
+        and checkpoint_load_iteration is not None
+        and observed_failure_iteration >= int(checkpoint_load_iteration)
+        else None
+    )
+    last_setup = progress.setup_markers[-1] if progress.setup_markers else None
+    first_terminal_incident = next(
+        (
+            incident
+            for incident in distributed_incidents
+            if incident.status == FaultOutcome.TERMINAL.value
+        ),
+        None,
+    )
+    terminal_fields = {
+        "first_terminal_incident_line": (
+            first_terminal_incident.primary_observed_line if first_terminal_incident else None
+        ),
+        "first_terminal_incident_timestamp": (
+            first_terminal_incident.first_detection_timestamp if first_terminal_incident else None
+        ),
+        "configured_terminal_timeout_seconds": (
+            first_terminal_incident.configured_timeout_seconds if first_terminal_incident else None
+        ),
+        "seconds_from_last_progress_to_terminal_incident": (
+            first_terminal_incident.seconds_since_last_progress if first_terminal_incident else None
+        ),
+        "terminal_detection_lag_seconds": (
+            first_terminal_incident.detection_lag_seconds if first_terminal_incident else None
+        ),
+    }
+    if not iteration_markers:
+        return RunProgressSummary(
+            progress_marker_count=len(progress.progress_markers),
+            checkpoint_marker_count=len(progress.checkpoint_markers),
+            setup_marker_count=len(progress.setup_markers),
+            last_checkpoint_iteration=checkpoints[-1].value if checkpoints else None,
+            last_checkpoint_line=checkpoints[-1].line if checkpoints else None,
+            checkpoint_load_iteration=checkpoint_load_iteration,
+            checkpoint_load_line=checkpoint_load_line,
+            latest_observed_failure_iteration=observed_failure_iteration,
+            latest_observed_failure_iteration_line=(
+                progress.latest_observed_failure_iteration_line
+            ),
+            observed_iterations_after_checkpoint_load=(observed_iterations_after_checkpoint_load),
+            last_setup_marker_type=last_setup.marker_type if last_setup else None,
+            last_setup_line=last_setup.line if last_setup else None,
+            progress_after_failure_episode=_progress_after_failure_episode(failure_episodes),
+            **terminal_fields,
+        )
+
+    first = iteration_markers[0]
+    last = iteration_markers[-1]
+    first_iteration = int(first.value)
+    last_iteration = int(last.value)
+    first_consumed_samples = _secondary_int(first, "consumed_samples")
+    last_consumed_samples = _secondary_int(last, "consumed_samples")
+    return RunProgressSummary(
+        first_iteration=first_iteration,
+        first_iteration_line=first.line,
+        first_iteration_timestamp=first.timestamp,
+        last_iteration=last_iteration,
+        last_iteration_line=last.line,
+        last_iteration_timestamp=last.timestamp,
+        iteration_delta=last_iteration - first_iteration,
+        total_iterations=_secondary_int(last, "total_iterations"),
+        first_consumed_samples=first_consumed_samples,
+        last_consumed_samples=last_consumed_samples,
+        consumed_samples_delta=(
+            last_consumed_samples - first_consumed_samples
+            if first_consumed_samples is not None and last_consumed_samples is not None
+            else None
+        ),
+        progress_marker_count=len(progress.progress_markers),
+        checkpoint_marker_count=len(progress.checkpoint_markers),
+        setup_marker_count=len(progress.setup_markers),
+        last_checkpoint_iteration=checkpoints[-1].value if checkpoints else None,
+        last_checkpoint_line=checkpoints[-1].line if checkpoints else None,
+        checkpoint_load_iteration=checkpoint_load_iteration,
+        checkpoint_load_line=checkpoint_load_line,
+        latest_observed_failure_iteration=observed_failure_iteration,
+        latest_observed_failure_iteration_line=progress.latest_observed_failure_iteration_line,
+        observed_iterations_after_checkpoint_load=observed_iterations_after_checkpoint_load,
+        last_setup_marker_type=last_setup.marker_type if last_setup else None,
+        last_setup_line=last_setup.line if last_setup else None,
+        successful_runtime_seconds=_elapsed_seconds(first.timestamp, last.timestamp),
+        iterations_since_checkpoint=(
+            last_iteration - int(checkpoints[-1].value)
+            if checkpoints and int(checkpoints[-1].value) <= last_iteration
+            else None
+        ),
+        progress_after_failure_episode=_progress_after_failure_episode(failure_episodes),
+        **terminal_fields,
+    )
+
+
+def _build_operation_artifact_comparisons(
+    lines: Sequence[LogLine],
+    progress: ProgressFacts,
+    primary: FailureEvidence | None,
+    distributed_incidents: Sequence[DistributedFailureIncident],
+) -> tuple[OperationArtifactComparisonEvidence, ...]:
+    return (
+        *_build_checkpoint_save_comparisons(
+            lines,
+            progress,
+            primary,
+            distributed_incidents,
+        ),
+        *_build_checkpoint_load_comparisons(lines, primary),
+        *_build_dataloader_read_comparisons(lines),
+    )
+
+
+def _build_checkpoint_save_comparisons(
+    lines: Sequence[LogLine],
+    progress: ProgressFacts,
+    primary: FailureEvidence | None,
+    distributed_incidents: Sequence[DistributedFailureIncident],
+) -> tuple[OperationArtifactComparisonEvidence, ...]:
+    starts_by_artifact: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    source_lines = (
+        lines.checkpoint_save_lines if isinstance(lines, L0ObservationAccumulator) else lines
+    )
+    for item in source_lines:
+        match = _CHECKPOINT_SAVE_START_RE.search(item.text)
+        if match is None:
+            continue
+        artifact_path = _normalized_artifact_path(match.group("artifact_path"))
+        starts_by_artifact[artifact_path].append((item.line, int(match.group("iteration"))))
+    if not starts_by_artifact:
+        return ()
+
+    completion_markers = tuple(
+        marker for marker in progress.checkpoint_markers if isinstance(marker.value, int)
+    )
+    terminal_lines = sorted(
+        {
+            incident.primary_observed_line
+            for incident in distributed_incidents
+            if incident.status == FaultOutcome.TERMINAL.value
+        }
+        | ({primary.line} if primary is not None and primary.line is not None else set())
+    )
+    comparisons: list[OperationArtifactComparisonEvidence] = []
+    for artifact_path, starts in sorted(starts_by_artifact.items()):
+        starts.sort()
+        completions: list[tuple[int, int]] = []
+        for index, (start_line, value) in enumerate(starts):
+            next_start_line = starts[index + 1][0] if index + 1 < len(starts) else None
+            completion = next(
+                (
+                    marker
+                    for marker in completion_markers
+                    if marker.value == value
+                    and marker.line > start_line
+                    and (next_start_line is None or marker.line < next_start_line)
+                ),
+                None,
+            )
+            if completion is not None:
+                completions.append((completion.line, value))
+
+        current_start_line, current_value = starts[-1]
+        terminal_line = next(
+            (line for line in terminal_lines if line > current_start_line),
+            None,
+        )
+        current_completion_line = next(
+            (
+                line
+                for line, value in completions
+                if value == current_value and line > current_start_line
+            ),
+            None,
+        )
+        if current_completion_line is not None:
+            current_outcome = "completed"
+            failure_line = None
+        elif terminal_line is not None and terminal_line > current_start_line:
+            current_outcome = "started_not_completed"
+            failure_line = terminal_line
+        else:
+            current_outcome = "started_unresolved"
+            failure_line = None
+
+        successes = [(line, value) for line, value in completions if line < current_start_line]
+        current_logical_id = _checkpoint_artifact_id(artifact_path, current_value)
+        success_pairs = tuple(
+            (_checkpoint_artifact_id(artifact_path, value), None) for _, value in successes
+        )
+        comparison_level, comparison_counts = _artifact_comparison_summary(
+            current_logical_artifact_id=current_logical_id,
+            current_physical_unit_id=None,
+            success_identities=success_pairs,
+        )
+        relevant_lines = (
+            *(line for line, _ in successes),
+            *((failure_line,) if failure_line is not None else ()),
+        )
+        line_by_number = _line_text_map(lines, relevant_lines)
+        comparisons.append(
+            OperationArtifactComparisonEvidence(
+                operation="checkpoint_save",
+                artifact_path=artifact_path,
+                logical_artifact_id=current_logical_id,
+                observation_kind=ArtifactObservationKind.CURRENT_LOG_COMPARISON.value,
+                comparison_level=comparison_level,
+                comparison_counts=comparison_counts,
+                success_count=len(successes),
+                success_logical_artifact_ids=tuple(value for value, _ in success_pairs),
+                success_lines=tuple(line for line, _ in successes),
+                successful_observer_ranks=_observer_ranks(
+                    line_by_number,
+                    (line for line, _ in successes),
+                ),
+                failed_observer_ranks=_observer_ranks(
+                    line_by_number,
+                    (failure_line,) if failure_line is not None else (),
+                ),
+                current_start_line=current_start_line,
+                current_completion_line=current_completion_line,
+                current_outcome=current_outcome,
+                failure_line=failure_line,
+                interpretation=_comparison_interpretation(comparison_level),
+            )
+        )
+    return tuple(comparisons)
+
+
+def _build_checkpoint_load_comparisons(
+    lines: Sequence[LogLine],
+    primary: FailureEvidence | None,
+) -> tuple[OperationArtifactComparisonEvidence, ...]:
+    starts: list[tuple[int, str | None, int]] = []
+    completions: list[tuple[int, str | None, int, str | None]] = []
+    source_lines = (
+        lines.checkpoint_load_lines if isinstance(lines, L0ObservationAccumulator) else lines
+    )
+    for item in source_lines:
+        start = _CHECKPOINT_LOAD_START_RE.search(item.text)
+        if start is not None:
+            starts.append(
+                (
+                    item.line,
+                    _optional_artifact_path(start.group("artifact_path")),
+                    int(start.group("iteration")),
+                )
+            )
+        completion = _CHECKPOINT_LOAD_COMPLETE_RE.search(item.text)
+        if completion is not None:
+            completions.append(
+                (
+                    item.line,
+                    _optional_artifact_path(completion.group("artifact_path")),
+                    int(completion.group("iteration")),
+                    extract_rank(item.text),
+                )
+            )
+    if not starts:
+        return ()
+
+    known_paths_by_iteration: dict[int, set[str]] = defaultdict(set)
+    for _, path, iteration in starts:
+        if path is not None:
+            known_paths_by_iteration[iteration].add(path)
+    resolved_completions: list[tuple[int, str | None, int, str | None]] = []
+    for line, path, iteration, rank in completions:
+        if path is None and len(known_paths_by_iteration[iteration]) == 1:
+            path = next(iter(known_paths_by_iteration[iteration]))
+        resolved_completions.append((line, path, iteration, rank))
+
+    grouped_starts: dict[str | None, list[tuple[int, int]]] = defaultdict(list)
+    for line, path, iteration in starts:
+        grouped_starts[path].append((line, iteration))
+
+    primary_text = " ".join(
+        value
+        for value in (
+            primary.failure_class if primary is not None else None,
+            primary.signature if primary is not None else None,
+            primary.quote if primary is not None else None,
+            primary.phase if primary is not None else None,
+        )
+        if value
+    )
+    primary_is_checkpoint_load = bool(
+        primary is not None
+        and primary.line is not None
+        and re.search(
+            r"\b(?:checkpoint|deserial|decode|state[_ ]dict|tensor_to_object)\b",
+            primary_text,
+            re.I,
+        )
+    )
+    comparisons: list[OperationArtifactComparisonEvidence] = []
+    for artifact_path, artifact_starts in sorted(
+        grouped_starts.items(),
+        key=lambda item: (item[0] or "", item[1][-1][0]),
+    ):
+        artifact_starts.sort()
+        current_start_line, current_iteration = artifact_starts[-1]
+        failure_line = (
+            primary.line
+            if primary_is_checkpoint_load
+            and primary is not None
+            and primary.line is not None
+            and primary.line > current_start_line
+            else None
+        )
+        current_logical_id = _checkpoint_artifact_id(artifact_path, current_iteration)
+        success_rows: list[tuple[int, str, str | None]] = []
+        current_completion_line = None
+        for line, path, iteration, rank in resolved_completions:
+            if artifact_path is not None and path != artifact_path:
+                continue
+            logical_id = _checkpoint_artifact_id(path, iteration)
+            if line > current_start_line and iteration == current_iteration:
+                current_completion_line = current_completion_line or line
+                if failure_line is not None and line < failure_line:
+                    success_rows.append((line, logical_id, rank))
+            elif line < current_start_line:
+                success_rows.append((line, logical_id, rank))
+
+        if failure_line is not None and current_completion_line is not None:
+            current_outcome = "mixed_success_and_failure"
+        elif failure_line is not None:
+            current_outcome = "started_not_completed"
+        elif current_completion_line is not None:
+            current_outcome = "completed"
+        else:
+            current_outcome = "started_unresolved"
+        success_pairs = tuple((logical_id, None) for _, logical_id, _ in success_rows)
+        comparison_level, comparison_counts = _artifact_comparison_summary(
+            current_logical_artifact_id=current_logical_id,
+            current_physical_unit_id=None,
+            success_identities=success_pairs,
+        )
+        successful_ranks = tuple(
+            sorted(
+                {rank for _, _, rank in success_rows if rank is not None},
+                key=_rank_sort_key,
+            )
+        )
+        failed_rank = (
+            primary.rank
+            if primary is not None and primary.line == failure_line
+            else extract_rank(_text_for_line(lines, failure_line))
+        )
+        failed_ranks = (failed_rank,) if failed_rank is not None else ()
+        observation_kind = (
+            ArtifactObservationKind.DISTRIBUTED_FANOUT.value
+            if successful_ranks and failed_ranks and set(successful_ranks) != set(failed_ranks)
+            else ArtifactObservationKind.CURRENT_LOG_COMPARISON.value
+        )
+        comparisons.append(
+            OperationArtifactComparisonEvidence(
+                operation="checkpoint_load",
+                artifact_path=artifact_path,
+                logical_artifact_id=current_logical_id,
+                observation_kind=observation_kind,
+                comparison_level=comparison_level,
+                comparison_counts=comparison_counts,
+                success_count=len(success_rows),
+                success_logical_artifact_ids=tuple(logical_id for _, logical_id, _ in success_rows),
+                success_lines=tuple(line for line, _, _ in success_rows),
+                successful_observer_ranks=successful_ranks,
+                failed_observer_ranks=failed_ranks,
+                current_start_line=current_start_line,
+                current_completion_line=current_completion_line,
+                current_outcome=current_outcome,
+                failure_line=failure_line,
+                interpretation=_comparison_interpretation(comparison_level),
+            )
+        )
+    return tuple(comparisons)
+
+
+def _build_dataloader_read_comparisons(
+    lines: Sequence[LogLine],
+) -> tuple[OperationArtifactComparisonEvidence, ...]:
+    events_by_unit: dict[str, list[tuple[int, str, str | None, str | None, str | None]]] = (
+        defaultdict(list)
+    )
+    source_lines = lines.dataloader_lines if isinstance(lines, L0ObservationAccumulator) else lines
+    for item in source_lines:
+        match = _DATALOADER_READ_EVENT_RE.search(item.text)
+        if match is None:
+            continue
+        outcome_text = match.group("outcome").lower()
+        if "success" in outcome_text or "finished" in outcome_text or "complete" in outcome_text:
+            outcome = "success"
+        elif "failed" in outcome_text or "error" in outcome_text:
+            outcome = "failure"
+        else:
+            outcome = "start"
+        physical_unit = _normalized_artifact_path(match.group("physical_unit"))
+        events_by_unit[physical_unit].append(
+            (
+                item.line,
+                outcome,
+                extract_rank(item.text),
+                _data_region_identity(item.text),
+                _integrity_marker(item.text),
+            )
+        )
+
+    comparisons: list[OperationArtifactComparisonEvidence] = []
+    all_successes = [
+        (unit, event)
+        for unit, unit_events in events_by_unit.items()
+        for event in unit_events
+        if event[1] == "success"
+    ]
+    for physical_unit, events in sorted(events_by_unit.items()):
+        events.sort()
+        failures = [event for event in events if event[1] == "failure"]
+        if not failures:
+            continue
+        failure_line, _, failure_rank, data_region, integrity_marker = failures[-1]
+        starts = [event for event in events if event[1] == "start" and event[0] < failure_line]
+        current_start_line = starts[-1][0] if starts else None
+        successes = [(unit, event) for unit, event in all_successes if event[0] < failure_line]
+        same_unit_successes = [item for item in successes if item[0] == physical_unit]
+        success_pairs = tuple((None, unit) for unit, _ in successes)
+        comparison_level, comparison_counts = _artifact_comparison_summary(
+            current_logical_artifact_id=None,
+            current_physical_unit_id=physical_unit,
+            success_identities=success_pairs,
+        )
+        successful_ranks = tuple(
+            sorted(
+                {rank for _, (_, _, rank, _, _) in successes if rank is not None},
+                key=_rank_sort_key,
+            )
+        )
+        same_unit_successful_ranks = {
+            rank for _, (_, _, rank, _, _) in same_unit_successes if rank is not None
+        }
+        failed_ranks = (failure_rank,) if failure_rank is not None else ()
+        observation_kind = (
+            ArtifactObservationKind.DISTRIBUTED_FANOUT.value
+            if same_unit_successes
+            and same_unit_successful_ranks
+            and failed_ranks
+            and same_unit_successful_ranks != set(failed_ranks)
+            else ArtifactObservationKind.CURRENT_LOG_COMPARISON.value
+        )
+        comparisons.append(
+            OperationArtifactComparisonEvidence(
+                operation="dataloader_read",
+                artifact_path=physical_unit,
+                physical_unit_id=physical_unit,
+                data_region=data_region,
+                integrity_marker=integrity_marker,
+                observation_kind=observation_kind,
+                comparison_level=comparison_level,
+                comparison_counts=comparison_counts,
+                success_count=len(successes),
+                success_physical_unit_ids=tuple(unit for unit, _ in successes),
+                success_data_regions=tuple(
+                    region for _, (_, _, _, region, _) in successes if region is not None
+                ),
+                success_integrity_markers=tuple(
+                    marker for _, (_, _, _, _, marker) in successes if marker is not None
+                ),
+                success_lines=tuple(line for _, (line, _, _, _, _) in successes),
+                successful_observer_ranks=successful_ranks,
+                failed_observer_ranks=failed_ranks,
+                current_start_line=current_start_line,
+                current_outcome=(
+                    "mixed_success_and_failure" if same_unit_successes else "started_not_completed"
+                ),
+                failure_line=failure_line,
+                interpretation=_comparison_interpretation(comparison_level),
+            )
+        )
+    return tuple(comparisons)
+
+
+def _checkpoint_artifact_id(artifact_path: str | None, iteration: int) -> str:
+    path = artifact_path or "unknown_path"
+    return f"{path}#checkpoint_iteration={iteration}"
+
+
+def _optional_artifact_path(value: str | None) -> str | None:
+    return _normalized_artifact_path(value) if value else None
+
+
+def _normalized_artifact_path(value: str) -> str:
+    stripped = value.strip().rstrip(",;:)]}")
+    if stripped != "/":
+        stripped = stripped.rstrip("/")
+    return stripped
+
+
+def _artifact_comparison_summary(
+    *,
+    current_logical_artifact_id: str | None,
+    current_physical_unit_id: str | None,
+    success_identities: Sequence[tuple[str | None, str | None]],
+) -> tuple[str, Mapping[str, int]]:
+    counts = {level.value: 0 for level in ArtifactComparisonLevel}
+    for logical_artifact_id, physical_unit_id in success_identities:
+        if current_physical_unit_id and physical_unit_id == current_physical_unit_id:
+            level = ArtifactComparisonLevel.EXACT_PHYSICAL_UNIT.value
+        elif current_logical_artifact_id and logical_artifact_id == current_logical_artifact_id:
+            level = ArtifactComparisonLevel.SAME_LOGICAL_ARTIFACT_OTHER_OR_UNKNOWN_UNIT.value
+        elif logical_artifact_id or physical_unit_id:
+            level = ArtifactComparisonLevel.SAME_OPERATION_DIFFERENT_ARTIFACT.value
+        else:
+            level = ArtifactComparisonLevel.UNKNOWN_COMPARABILITY.value
+        counts[level] += 1
+    for level in (
+        ArtifactComparisonLevel.EXACT_PHYSICAL_UNIT.value,
+        ArtifactComparisonLevel.SAME_LOGICAL_ARTIFACT_OTHER_OR_UNKNOWN_UNIT.value,
+        ArtifactComparisonLevel.SAME_OPERATION_DIFFERENT_ARTIFACT.value,
+        ArtifactComparisonLevel.UNKNOWN_COMPARABILITY.value,
+    ):
+        if counts[level]:
+            return level, counts
+    return ArtifactComparisonLevel.UNKNOWN_COMPARABILITY.value, counts
+
+
+def _comparison_interpretation(level: str) -> str:
+    return {
+        ArtifactComparisonLevel.EXACT_PHYSICAL_UNIT.value: (
+            "same_physical_unit_success_observed; data_region_and_observer_locality_remain_explicit"
+        ),
+        ArtifactComparisonLevel.SAME_LOGICAL_ARTIFACT_OTHER_OR_UNKNOWN_UNIT.value: (
+            "same_logical_artifact_success_observed_on_another_or_unknown_shard"
+        ),
+        ArtifactComparisonLevel.SAME_OPERATION_DIFFERENT_ARTIFACT.value: (
+            "operation_pipeline_was_runnable; current_artifact_health_not_established"
+        ),
+        ArtifactComparisonLevel.UNKNOWN_COMPARABILITY.value: (
+            "identity_is_insufficient_for_artifact_health_inference"
+        ),
+    }[level]
+
+
+def _observer_ranks(
+    line_by_number: Mapping[int, str],
+    line_numbers: Iterable[int],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                rank
+                for line in line_numbers
+                if (rank := extract_rank(line_by_number.get(line, ""))) is not None
+            },
+            key=_rank_sort_key,
+        )
+    )
+
+
+def _rank_sort_key(value: str) -> tuple[int, int | str]:
+    return (0, int(value)) if value.isdigit() else (1, value)
+
+
+def _data_region_identity(text: str) -> str | None:
+    match = re.search(
+        r"\b(?P<kind>offset|byte(?:\s+position)?|sample|record|index|token)\b"
+        r"\s*(?:=|:)\s*(?P<value>\d+)\b",
+        text,
+        re.I,
+    )
+    if match is None:
+        return None
+    kind = re.sub(r"\s+", "_", match.group("kind").lower())
+    return f"{kind}={match.group('value')}"
+
+
+def _integrity_marker(text: str) -> str | None:
+    match = re.search(r"\b(?:checksum|crc|hash)\b[^,;\n]{0,120}", text, re.I)
+    return match.group(0).strip() if match is not None else None
+
+
+def _elapsed_seconds(start: str | None, end: str | None) -> float | None:
+    if not start or not end:
+        return None
+    try:
+        elapsed = (datetime.fromisoformat(end) - datetime.fromisoformat(start)).total_seconds()
+    except ValueError:
+        return None
+    return max(0.0, elapsed)
+
+
+def _build_later_progress_after_fault_observations(
+    lines: Sequence[LogLine],
+    observations: Sequence[_RegistryObservation],
+    progress: ProgressFacts,
+    failure_episodes: Sequence[FailureEpisode],
+) -> list[LaterProgressAfterFaultObservation]:
+    progress_lines = sorted({*progress.progress_lines, *progress.checkpoint_lines})
+    fingerprint_cache: dict[tuple[int, str], str | None] = {}
+
+    def fingerprint(observation: _RegistryObservation) -> str | None:
+        key = (observation.line, observation.registry_id)
+        if key not in fingerprint_cache:
+            fingerprint_cache[key] = _registry_observation_fingerprint(
+                lines,
+                observation,
+            )[0]
+        return fingerprint_cache[key]
+
+    terminal_fingerprints = {
+        fingerprint(observation)
+        for observation in observations
+        if any(
+            episode.start_line <= observation.line <= episode.end_line
+            for episode in failure_episodes
+        )
+        if fingerprint(observation)
+    }
+    groups: OrderedDict[tuple[str, str | None], list[tuple[int, int]]] = OrderedDict()
+    for observation in observations:
+        if observation.causal_role in {
+            CausalRole.CASCADE.value,
+            CausalRole.TEARDOWN.value,
+        } or observation.fault_outcome not in {
+            FaultOutcome.PROGRESSED_AFTER.value,
+            FaultOutcome.RECOVERED.value,
+        }:
+            continue
+        later_progress = _nearest_next_line(progress_lines, observation.line)
+        if later_progress is None:
+            continue
+        groups.setdefault(
+            (observation.failure_class, fingerprint(observation)),
+            [],
+        ).append((observation.line, later_progress))
+
+    result: list[LaterProgressAfterFaultObservation] = []
+    for (failure_class, fingerprint), progress_observations in groups.items():
+        result.append(
+            LaterProgressAfterFaultObservation(
+                failure_class=failure_class,
+                root_fingerprint=fingerprint,
+                event_count=len(progress_observations),
+                sample_event_lines=tuple(line for line, _ in progress_observations[:5]),
+                sample_later_progress_lines=tuple(line for _, line in progress_observations[:5]),
+                matches_terminal_fingerprint=bool(
+                    fingerprint and fingerprint in terminal_fingerprints
+                ),
+            )
+        )
+    return result
+
+
+def _numeric_field(value: str | None) -> int | None:
+    if value is None:
+        return None
+    return int(value) if value.isdigit() else None
+
+
+def _secondary_int(marker: ProgressMarker, name: str) -> int | None:
+    value = marker.secondary_value.get(name)
+    return value if isinstance(value, int) else None
+
+
+def _progress_after_failure_episode(
+    failure_episodes: Sequence[FailureEpisode],
+) -> bool | None:
+    if not failure_episodes:
+        return None
+    return any(
+        episode.status == FaultOutcome.PROGRESSED_AFTER.value
+        or episode.first_progress_after is not None
+        for episode in failure_episodes
+    )
+
+
+def _coverage(
+    *,
+    path_hint_count: int,
+    path_access_fact_count: int,
+    occurrence_group_count: int,
+    context_count: int,
+    candidate_anchor_count: int,
+    failure_episode_count: int,
+    distributed_incident_count: int,
+    progress: ProgressFacts,
+    job_metadata: JobMetadata,
+    primary: FailureEvidence | None,
+    cascade_count: int,
+) -> dict[str, str]:
+    return {
+        "path_hints": (
+            CoverageStatus.CHECKED.value if path_hint_count else CoverageStatus.NOT_FOUND.value
+        ),
+        "path_access_facts": (
+            CoverageStatus.FOUND.value if path_access_fact_count else CoverageStatus.NOT_FOUND.value
+        ),
+        "occurrence_groups": (
+            CoverageStatus.FOUND.value if occurrence_group_count else CoverageStatus.NOT_FOUND.value
+        ),
+        "context_windows": (
+            CoverageStatus.FOUND.value if context_count else CoverageStatus.NOT_FOUND.value
+        ),
+        "candidate_anchors": (
+            CoverageStatus.FOUND.value if candidate_anchor_count else CoverageStatus.NOT_FOUND.value
+        ),
+        "application_progress": (
+            CoverageStatus.FOUND.value
+            if progress.progress_lines
+            else CoverageStatus.NOT_FOUND.value
+        ),
+        "checkpoint_progress": (
+            CoverageStatus.FOUND.value
+            if progress.checkpoint_lines
+            else CoverageStatus.NOT_FOUND.value
+        ),
+        "setup_progress": (
+            CoverageStatus.FOUND.value if progress.setup_lines else CoverageStatus.NOT_FOUND.value
+        ),
+        "observed_failure_iteration": (
+            CoverageStatus.FOUND.value
+            if progress.latest_observed_failure_iteration is not None
+            else CoverageStatus.NOT_FOUND.value
+        ),
+        "progress_segments": (
+            CoverageStatus.FOUND.value if failure_episode_count else CoverageStatus.NOT_FOUND.value
+        ),
+        "distributed_failure_incidents": (
+            CoverageStatus.FOUND.value
+            if distributed_incident_count
+            else CoverageStatus.NOT_FOUND.value
+        ),
+        "job_metadata": (
+            CoverageStatus.FOUND.value
+            if (
+                job_metadata.explicit_world_size is not None
+                or job_metadata.inferred_world_size_lower_bound is not None
+            )
+            else CoverageStatus.NOT_FOUND.value
+        ),
+        "first_failure_candidate": (
+            CoverageStatus.FOUND.value if candidate_anchor_count else CoverageStatus.NOT_FOUND.value
+        ),
+        "deterministic_taxonomy_primary": (
+            CoverageStatus.FOUND.value if primary else CoverageStatus.NOT_FOUND.value
+        ),
+        "cascade": CoverageStatus.FOUND.value if cascade_count else CoverageStatus.NOT_FOUND.value,
+    }
+
+
+def _has_after_context(primary: FailureEvidence | None, lines: Sequence[LogLine]) -> bool:
+    return bool(primary and primary.line and primary.line < len(lines))

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l0/codec.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l0/codec.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned JSON persistence for deterministic L0 bundle replay."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Mapping
+
+from ..infrastructure.artifact_io import write_json_atomic
+from ..models import (
+    AffectedEntity,
+    AffectedEntityKind,
+    CandidateAnchor,
+    CascadeEvidence,
+    ContextWindow,
+    DistributedFailureIncident,
+    FailureEpisode,
+    FailureEvidence,
+    JobMetadata,
+    L0Bundle,
+    LaterProgressAfterFaultObservation,
+    LogLine,
+    NormalizedOccurrenceGroup,
+    OperationArtifactComparisonEvidence,
+    PostFaultSummary,
+    ProgressFacts,
+    ProgressMarker,
+    RunProgressSummary,
+)
+
+BUNDLE_RECORD_SCHEMA_VERSION = "restart_agent_l0_bundle.v1"
+
+
+def write_l0_bundle(path: str | Path, bundle: L0Bundle) -> None:
+    source = Path(bundle.log_path)
+    stat = source.stat()
+    payload = {
+        "schema_version": BUNDLE_RECORD_SCHEMA_VERSION,
+        "source": {
+            "log_path": bundle.log_path,
+            "byte_size": stat.st_size,
+            "mtime_ns": stat.st_mtime_ns,
+        },
+        "bundle": asdict(bundle),
+    }
+    write_json_atomic(path, payload)
+
+
+def read_l0_bundle(path: str | Path, *, expected_log_path: str) -> L0Bundle:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("L0 bundle record must be an object")
+    if payload.get("schema_version") != BUNDLE_RECORD_SCHEMA_VERSION:
+        raise ValueError("L0 bundle record schema_version is invalid")
+    source = _mapping(payload.get("source"), "source")
+    if str(source.get("log_path")) != expected_log_path:
+        raise ValueError("L0 bundle source log_path does not match runtime input")
+    stat = Path(expected_log_path).stat()
+    if int(source.get("byte_size", -1)) != stat.st_size:
+        raise ValueError("source log byte size changed after L0 bundle construction")
+    if int(source.get("mtime_ns", -1)) != stat.st_mtime_ns:
+        raise ValueError("source log mtime changed after L0 bundle construction")
+    return _bundle(_mapping(payload.get("bundle"), "bundle"))
+
+
+def _bundle(value: Mapping[str, Any]) -> L0Bundle:
+    return L0Bundle(
+        log_path=str(value["log_path"]),
+        byte_size=int(value["byte_size"]),
+        line_count=int(value["line_count"]),
+        path_hints=tuple(value.get("path_hints") or ()),
+        path_access_facts=tuple(
+            dict(_mapping(item, "path_access_fact"))
+            for item in value.get("path_access_facts") or ()
+        ),
+        path_namespace_summary=dict(value.get("path_namespace_summary") or {}),
+        occurrence_groups=tuple(
+            _occurrence_group(item) for item in value.get("occurrence_groups") or ()
+        ),
+        context_windows=tuple(_window(item) for item in value.get("context_windows") or ()),
+        candidate_anchors=tuple(_anchor(item) for item in value.get("candidate_anchors") or ()),
+        registry_matches=tuple(_failure(item) for item in value.get("registry_matches") or ()),
+        deterministic_primary_candidate=(
+            _failure(value["deterministic_primary_candidate"])
+            if value.get("deterministic_primary_candidate")
+            else None
+        ),
+        cascades=tuple(_cascade(item) for item in value.get("cascades") or ()),
+        cause_confirmations=tuple(
+            _failure(item) for item in value.get("cause_confirmations") or ()
+        ),
+        failure_episodes=tuple(_episode(item) for item in value.get("failure_episodes") or ()),
+        distributed_failure_incidents=tuple(
+            _distributed_incident(item) for item in value.get("distributed_failure_incidents") or ()
+        ),
+        post_fault_summaries=tuple(
+            _post_fault(item) for item in value.get("post_fault_summaries") or ()
+        ),
+        progress=_progress(_mapping(value.get("progress") or {}, "progress")),
+        run_progress_summary=RunProgressSummary(
+            **_mapping(value.get("run_progress_summary") or {}, "run_progress_summary")
+        ),
+        operation_artifact_comparisons=tuple(
+            _operation_artifact_comparison(item)
+            for item in value.get("operation_artifact_comparisons") or ()
+        ),
+        later_progress_after_fault_observations=tuple(
+            _later_progress_after_fault_observation(item)
+            for item in value.get("later_progress_after_fault_observations") or ()
+        ),
+        job_metadata=JobMetadata(**_mapping(value.get("job_metadata") or {}, "job_metadata")),
+        evidence_coverage=dict(value.get("evidence_coverage") or {}),
+        selection_summary=dict(value.get("selection_summary") or {}),
+        anomalies=dict(value.get("anomalies") or {}),
+    )
+
+
+def _failure(value: Any) -> FailureEvidence:
+    payload = dict(_mapping(value, "failure"))
+    affected_entity = payload.get("affected_entity")
+    if affected_entity is not None:
+        entity = _mapping(affected_entity, "failure.affected_entity")
+        payload["affected_entity"] = AffectedEntity(
+            kind=AffectedEntityKind(str(entity["kind"])),
+            identity=str(entity["identity"]),
+            fingerprint=str(entity["fingerprint"]),
+            evidence_line=(
+                int(entity["evidence_line"]) if entity.get("evidence_line") is not None else None
+            ),
+        )
+    return FailureEvidence(**payload)
+
+
+def _cascade(value: Any) -> CascadeEvidence:
+    payload = dict(_mapping(value, "cascade"))
+    for field in ("sample_lines", "rank_spread", "node_spread", "gpu_spread"):
+        payload[field] = tuple(payload.get(field) or ())
+    return CascadeEvidence(**payload)
+
+
+def _occurrence_group(value: Any) -> NormalizedOccurrenceGroup:
+    payload = dict(_mapping(value, "normalized_occurrence_group"))
+    for field in ("sample_lines", "rank_spread", "node_spread", "gpu_spread"):
+        payload[field] = tuple(payload.get(field) or ())
+    return NormalizedOccurrenceGroup(**payload)
+
+
+def _window(value: Any) -> ContextWindow:
+    payload = dict(_mapping(value, "context_window"))
+    payload["seed_lines"] = tuple(payload.get("seed_lines") or ())
+    payload["occurrence_group_ids"] = tuple(payload.get("occurrence_group_ids") or ())
+    payload["lines"] = tuple(
+        LogLine(**_mapping(item, "log_line")) for item in payload.get("lines") or ()
+    )
+    return ContextWindow(**payload)
+
+
+def _anchor(value: Any) -> CandidateAnchor:
+    payload = dict(_mapping(value, "candidate_anchor"))
+    payload["sources"] = tuple(payload.get("sources") or ())
+    payload["context_window_ids"] = tuple(payload.get("context_window_ids") or ())
+    for field in (
+        "taxonomy_match",
+        "first_downstream_registry_match",
+        "first_downstream_cascade",
+    ):
+        payload[field] = _failure(payload[field]) if payload.get(field) else None
+    return CandidateAnchor(**payload)
+
+
+def _marker(value: Any) -> ProgressMarker:
+    payload = dict(_mapping(value, "progress_marker"))
+    payload["secondary_value"] = dict(payload.get("secondary_value") or {})
+    return ProgressMarker(**payload)
+
+
+def _episode(value: Any) -> FailureEpisode:
+    payload = dict(_mapping(value, "failure_episode"))
+    payload["last_progress_before"] = (
+        _marker(payload["last_progress_before"]) if payload.get("last_progress_before") else None
+    )
+    payload["first_progress_after"] = (
+        _marker(payload["first_progress_after"]) if payload.get("first_progress_after") else None
+    )
+    payload["first_downstream_cascade"] = (
+        _failure(payload["first_downstream_cascade"])
+        if payload.get("first_downstream_cascade")
+        else None
+    )
+    payload["cause_confirmations"] = tuple(
+        _failure(item) for item in payload.get("cause_confirmations") or ()
+    )
+    payload["context_window_ids"] = tuple(payload.get("context_window_ids") or ())
+    for field in (
+        "precursor_lines",
+        "exception_chain_lines",
+        "duplicate_rendering_lines",
+        "wrapper_exception_lines",
+    ):
+        payload[field] = tuple(payload.get(field) or ())
+    return FailureEpisode(**payload)
+
+
+def _distributed_incident(value: Any) -> DistributedFailureIncident:
+    payload = dict(_mapping(value, "distributed_failure_incident"))
+    for field in (
+        "member_event_lines",
+        "sample_lines",
+        "operation_types",
+        "operation_signatures",
+        "rank_spread",
+        "process_group_types",
+    ):
+        payload[field] = tuple(payload.get(field) or ())
+    return DistributedFailureIncident(**payload)
+
+
+def _later_progress_after_fault_observation(
+    value: Any,
+) -> LaterProgressAfterFaultObservation:
+    payload = dict(_mapping(value, "later_progress_after_fault_observation"))
+    payload["sample_event_lines"] = tuple(payload.get("sample_event_lines") or ())
+    payload["sample_later_progress_lines"] = tuple(payload.get("sample_later_progress_lines") or ())
+    return LaterProgressAfterFaultObservation(**payload)
+
+
+def _operation_artifact_comparison(value: Any) -> OperationArtifactComparisonEvidence:
+    payload = dict(_mapping(value, "operation_artifact_comparison"))
+    for field in (
+        "success_logical_artifact_ids",
+        "success_physical_unit_ids",
+        "success_data_regions",
+        "success_integrity_markers",
+        "success_lines",
+        "successful_observer_ranks",
+        "failed_observer_ranks",
+    ):
+        payload[field] = tuple(payload.get(field) or ())
+    payload["comparison_counts"] = dict(payload.get("comparison_counts") or {})
+    return OperationArtifactComparisonEvidence(**payload)
+
+
+def _post_fault(value: Any) -> PostFaultSummary:
+    payload = dict(_mapping(value, "post_fault_summary"))
+    payload["later_matching_exception_lines"] = tuple(
+        payload.get("later_matching_exception_lines") or ()
+    )
+    return PostFaultSummary(**payload)
+
+
+def _progress(value: Mapping[str, Any]) -> ProgressFacts:
+    payload = dict(value)
+    for field in (
+        "progress_lines",
+        "checkpoint_lines",
+        "setup_lines",
+        "recovery_lines",
+    ):
+        payload[field] = tuple(payload.get(field) or ())
+    payload["progress_markers"] = tuple(
+        _marker(item) for item in payload.get("progress_markers") or ()
+    )
+    payload["checkpoint_markers"] = tuple(
+        _marker(item) for item in payload.get("checkpoint_markers") or ()
+    )
+    payload["setup_markers"] = tuple(_marker(item) for item in payload.get("setup_markers") or ())
+    return ProgressFacts(**payload)
+
+
+def _mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    return value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l0/decision.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l0/decision.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic Decision Evidence selection from the complete L0A bundle."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+from ..models import DecisionEvidence, FailureEpisode, L0Bundle
+
+
+@dataclass(frozen=True)
+class _DecisionSelection:
+    primary: Any | None
+    primary_line: int | None
+    identity_line: int | None
+    identity_reason: str
+    episode: FailureEpisode | None
+    incident: Any | None
+    root_fingerprint: str | None
+    root_fingerprint_source: str | None
+    references: Mapping[str, Any]
+
+
+def build_decision_evidence(bundle: L0Bundle) -> DecisionEvidence:
+    """Select canonical policy-relevant facts and L0A references once."""
+
+    selected = _select_decision_context(bundle)
+    primary = selected.primary
+    primary_line = selected.primary_line
+    identity_line = selected.identity_line
+    episode = selected.episode
+    incident = selected.incident
+    root_fingerprint = selected.root_fingerprint
+
+    run = bundle.run_progress_summary
+    progress = bundle.progress
+    terminal_observations = [
+        asdict(observation)
+        for observation in bundle.later_progress_after_fault_observations
+        if primary is not None
+        and (
+            observation.matches_terminal_fingerprint
+            or observation.root_fingerprint == root_fingerprint
+            or observation.failure_class == primary.failure_class
+        )
+    ]
+
+    return DecisionEvidence(
+        deterministic_primary_candidate=primary,
+        canonical_observed_identity={
+            "available": primary is not None,
+            "failure_class": primary.failure_class if primary is not None else None,
+            "signature": primary.signature if primary is not None else None,
+            "identity_anchor_line": identity_line,
+            "identity_anchor_reason": selected.identity_reason,
+            "root_fingerprint": root_fingerprint,
+            "root_fingerprint_source": selected.root_fingerprint_source,
+            "registry_id": primary.registry_id if primary is not None else None,
+        },
+        selected_evidence_references=selected.references,
+        failure_position={
+            "primary_line": primary_line,
+            "identity_anchor_line": identity_line,
+            "failure_iteration": primary.failure_iteration if primary is not None else None,
+            "phase": primary.phase if primary is not None else None,
+            "fault_outcome": primary.fault_outcome if primary is not None else None,
+            "causal_role": primary.causal_role if primary is not None else None,
+            "data_position_fingerprint": (
+                primary.data_position_fingerprint if primary is not None else None
+            ),
+            "first_terminal_incident_line": run.first_terminal_incident_line,
+            "latest_observed_failure_iteration": run.latest_observed_failure_iteration,
+            "latest_observed_failure_iteration_line": (run.latest_observed_failure_iteration_line),
+        },
+        progress_checkpoint_state={
+            "first_iteration": run.first_iteration,
+            "last_iteration": run.last_iteration,
+            "iteration_delta": run.iteration_delta,
+            "successful_runtime_seconds": run.successful_runtime_seconds,
+            "highest_completed_step": progress.highest_completed_step,
+            "last_progress_line": progress.last_progress_line,
+            "latest_observed_failure_iteration": (progress.latest_observed_failure_iteration),
+            "latest_observed_failure_iteration_line": (
+                progress.latest_observed_failure_iteration_line
+            ),
+            "last_checkpoint_iteration": run.last_checkpoint_iteration,
+            "last_checkpoint_line": run.last_checkpoint_line,
+            "checkpoint_load_iteration": run.checkpoint_load_iteration,
+            "checkpoint_load_line": run.checkpoint_load_line,
+            "iterations_since_checkpoint": run.iterations_since_checkpoint,
+            "observed_iterations_after_checkpoint_load": (
+                run.observed_iterations_after_checkpoint_load
+            ),
+            "progress_after_failure_episode": run.progress_after_failure_episode,
+            "progress_marker_count": run.progress_marker_count,
+            "checkpoint_marker_count": run.checkpoint_marker_count,
+            "setup_marker_count": run.setup_marker_count,
+        },
+        operation_artifact_facts=tuple(
+            asdict(item) for item in bundle.operation_artifact_comparisons
+        ),
+        later_progress_recovery={
+            "matching_observations": terminal_observations,
+            "recovery_lines": list(progress.recovery_lines),
+            "progress_after_failure_episode": run.progress_after_failure_episode,
+        },
+        locality={
+            "rank": primary.rank if primary is not None else None,
+            "node": primary.node if primary is not None else None,
+            "gpu": primary.gpu if primary is not None else None,
+            "distributed_incident_kind": (incident.incident_kind if incident is not None else None),
+            "distributed_incident_type": (incident.incident_type if incident is not None else None),
+            "observed_rank_count": (incident.observed_rank_count if incident is not None else 0),
+            "rank_spread": list(incident.rank_spread) if incident is not None else [],
+            "job_metadata": asdict(bundle.job_metadata),
+        },
+        coverage_lossiness={
+            "evidence_coverage": dict(bundle.evidence_coverage),
+            "selection_summary": dict(bundle.selection_summary),
+        },
+        provenance={
+            "source": "l0a_deterministic_selection",
+            "log_line_count": bundle.line_count,
+            "log_byte_size": bundle.byte_size,
+            "log_rescanned": False,
+            "model_used": False,
+        },
+    )
+
+
+def _select_decision_context(bundle: L0Bundle) -> _DecisionSelection:
+    primary = bundle.deterministic_primary_candidate
+    primary_line = primary.line if primary is not None else None
+    identity_line = primary_line
+    identity_reason = "no_deterministic_primary"
+    if primary_line is not None:
+        identity_line, identity_reason = canonical_identity_anchor_line(
+            bundle,
+            primary_line,
+            selection_label="deterministic_primary",
+        )
+
+    episode = _failure_episode_for_lines(bundle, primary_line, identity_line)
+    incident = (
+        distributed_incident_for_line(bundle, identity_line) if identity_line is not None else None
+    )
+    identity_match = _registry_match_for_line(bundle, identity_line)
+    root_fingerprint = None
+    root_fingerprint_source = None
+    if incident is not None and incident.history_fingerprint:
+        root_fingerprint = incident.history_fingerprint
+        root_fingerprint_source = incident.history_fingerprint_source
+    elif identity_match is not None and identity_match.root_fingerprint:
+        root_fingerprint = identity_match.root_fingerprint
+        root_fingerprint_source = identity_match.root_fingerprint_source
+    elif primary is not None:
+        root_fingerprint = primary.root_fingerprint
+        root_fingerprint_source = primary.root_fingerprint_source
+
+    referenced_lines = {line for line in (primary_line, identity_line) if line is not None}
+    if episode is not None:
+        referenced_lines.update(episode.precursor_lines)
+        referenced_lines.update(episode.exception_chain_lines)
+        if episode.terminal_exception_line is not None:
+            referenced_lines.add(episode.terminal_exception_line)
+    anchors = tuple(
+        anchor for anchor in bundle.candidate_anchors if anchor.line in referenced_lines
+    )
+    window_ids = {window_id for anchor in anchors for window_id in anchor.context_window_ids}
+    if episode is not None:
+        window_ids.update(episode.context_window_ids)
+    window_ids.update(
+        window.window_id
+        for window in bundle.context_windows
+        if any(window.start_line <= line <= window.end_line for line in referenced_lines)
+    )
+    occurrence_group_ids = {
+        group.occurrence_group_id
+        for group in bundle.occurrence_groups
+        if bool(referenced_lines.intersection({group.first_line, *group.sample_lines}))
+        or (
+            primary is not None
+            and primary.registry_id is not None
+            and group.registry_id == primary.registry_id
+        )
+    }
+    references = {
+        "semantics": "provenance_only",
+        "resolution": "get_evidence_objects_when_advertised",
+        "source_lines": sorted(referenced_lines),
+        "candidate_anchor_ids": [anchor.anchor_id for anchor in anchors],
+        "context_window_ids": sorted(window_ids),
+        "failure_episode_ids": [episode.episode_id] if episode is not None else [],
+        "distributed_incident_ids": [incident.incident_id] if incident is not None else [],
+        "occurrence_group_ids": sorted(occurrence_group_ids),
+    }
+    return _DecisionSelection(
+        primary=primary,
+        primary_line=primary_line,
+        identity_line=identity_line,
+        identity_reason=identity_reason,
+        episode=episode,
+        incident=incident,
+        root_fingerprint=root_fingerprint,
+        root_fingerprint_source=root_fingerprint_source,
+        references=references,
+    )
+
+
+def canonical_identity_anchor_line(
+    bundle: L0Bundle,
+    line: int,
+    *,
+    selection_label: str,
+) -> tuple[int, str]:
+    """Return the stable identity anchor within the matching failure episode."""
+
+    candidates: list[tuple[int, int, int, str]] = []
+    for episode in bundle.failure_episodes:
+        terminal_line = episode.terminal_exception_line
+        if terminal_line is None:
+            continue
+        chain_end = max((*episode.exception_chain_lines, terminal_line))
+        observed_episode_lines = {
+            *episode.precursor_lines,
+            *episode.exception_chain_lines,
+            *(confirmation.line for confirmation in episode.cause_confirmations),
+            terminal_line,
+        }
+        if line in observed_episode_lines or episode.start_line - 1 <= line <= chain_end:
+            anchor_line = episode.identity_anchor_line or terminal_line
+            candidates.append(
+                (
+                    abs(anchor_line - line),
+                    anchor_line - min((*episode.precursor_lines, episode.start_line)),
+                    anchor_line,
+                    episode.identity_anchor_reason or "terminal_exception",
+                )
+            )
+    if not candidates:
+        return line, f"{selection_label}_line"
+
+    _, _, anchor_line, anchor_reason = min(candidates)
+    if anchor_line == line:
+        return line, f"{selection_label}_is_episode_identity_anchor:{anchor_reason}"
+    return anchor_line, f"failure_episode_identity_anchor:{anchor_reason}"
+
+
+def distributed_incident_for_line(bundle: L0Bundle, line: int) -> Any | None:
+    for incident in bundle.distributed_failure_incidents:
+        if line == incident.primary_observed_line or line in incident.member_event_lines:
+            return incident
+    return None
+
+
+def _failure_episode_for_lines(
+    bundle: L0Bundle,
+    *lines: int | None,
+) -> FailureEpisode | None:
+    observed_lines = {line for line in lines if line is not None}
+    for episode in bundle.failure_episodes:
+        episode_lines = {
+            episode.first_exception_line,
+            episode.terminal_exception_line,
+            episode.identity_anchor_line,
+            *episode.precursor_lines,
+            *episode.exception_chain_lines,
+        }
+        if observed_lines.intersection(line for line in episode_lines if line is not None):
+            return episode
+        if any(episode.start_line <= line <= episode.end_line for line in observed_lines):
+            return episode
+    return None
+
+
+def _registry_match_for_line(bundle: L0Bundle, line: int | None) -> Any | None:
+    if line is None:
+        return None
+    return next((match for match in bundle.registry_matches if match.line == line), None)

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l0/projection.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l0/projection.py
@@ -1,0 +1,1071 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic L0B projection for the initial model-facing evidence view."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+from ..identity import normalized_pattern
+from ..models import CausalRole, DecisionEvidence, L0Bundle, L0ModelFacingView
+from .registry import diagnostic_context_kind, diagnostic_uncertainty_kind
+
+PROMPT_PATTERN_MAX_CHARS = 240
+PROMPT_QUOTE_MAX_CHARS = 500
+PROMPT_CONTEXT_LINE_MAX_CHARS = 360
+PROMPT_CONTEXT_PREVIEW_LINES = 8
+PROMPT_CONTEXT_MAX_WINDOWS = 4
+PROMPT_CONTEXT_EXCERPT_MAX_LINES = 240
+PROMPT_CONTEXT_EXCERPT_MAX_CHARS = 50_000
+PROMPT_CONTEXT_MERGE_GAP_LINES = 5
+PROMPT_CONTEXT_HEAD_LINES = 3
+PROMPT_CONTEXT_TAIL_LINES = 2
+PROMPT_CONTEXT_HIGH_SIGNAL_LINES = 3
+PROMPT_OCCURRENCE_GROUP_MAX = 30
+PROMPT_REGISTRY_CANDIDATE_GROUP_MAX = 20
+PROMPT_CANDIDATE_ANCHOR_MAX = 20
+PROMPT_FAILURE_EPISODE_MAX = 10
+PROMPT_DISTRIBUTED_INCIDENT_MAX = 10
+PROMPT_CAUSE_CONFIRMATION_MAX = 10
+PROMPT_LATER_PROGRESS_OBSERVATION_MAX = 10
+PROMPT_POST_FAULT_SUMMARY_MAX = 10
+PROMPT_CASCADE_MAX = 20
+PROMPT_CONTEXT_HIGH_SIGNAL_RE = re.compile(
+    r"\b(?:CRITICAL|FATAL|ERROR|Traceback|RuntimeError|AssertionError|AcceleratorError)\b"
+    r"|(?:raising|raised)\s+.*\b(?:gpu|accelerator|device)\b.*\berror\b"
+    r"|\b(?:assert(?:ion)? failed|out of bounds|bounds failure|timeout)\b",
+    re.IGNORECASE,
+)
+ESTIMATED_CHARS_PER_EVIDENCE_TOKEN = 3
+
+
+def build_l0_model_facing_view(
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+) -> L0ModelFacingView:
+    """Build the deterministic, attention-efficient L0B projection once."""
+
+    evidence_bundle = _model_evidence_for_projection(bundle, decision_evidence)
+    attempt_execution_context = _attempt_execution_context(bundle)
+    serialized_evidence = json.dumps(
+        {
+            "decision_evidence": decision_evidence.to_payload(),
+            "attempt_execution_context": attempt_execution_context,
+            "evidence_bundle": evidence_bundle,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    projection_metrics = _projection_metrics(
+        bundle,
+        decision_evidence,
+        evidence_bundle,
+        serialized_evidence,
+    )
+    return L0ModelFacingView(
+        decision_evidence=decision_evidence,
+        evidence_bundle=evidence_bundle,
+        attempt_execution_context=attempt_execution_context,
+        projection_metrics=projection_metrics,
+    )
+
+
+def _projection_metrics(
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+    evidence_bundle: dict[str, Any],
+    serialized_evidence: str,
+) -> dict[str, Any]:
+    context_windows = list(evidence_bundle.get("context_windows") or ())
+    context_stats = _context_projection_stats(bundle, context_windows)
+    selection_counts = _projection_selection_counts(
+        bundle,
+        evidence_bundle,
+        projected_context_window_count=len(context_windows),
+        selected_source_window_count=context_stats["selected_source_window_count"],
+    )
+    budget_utilization = _projection_budget_utilization(
+        evidence_bundle,
+        max_window_lines=context_stats["max_window_lines"],
+        max_window_characters=context_stats["max_window_characters"],
+        selected_source_window_count=context_stats["selected_source_window_count"],
+    )
+    compaction_counts = _projection_compaction_counts(
+        bundle,
+        context_windows,
+        context_stats,
+    )
+    integrity_checks = _projection_integrity_checks(
+        bundle,
+        decision_evidence,
+        context_windows,
+        selection_counts,
+        budget_utilization,
+        unresolved_projected_window_ids=context_stats["unresolved_projected_window_ids"],
+    )
+    return {
+        "view_size": {
+            "compact_json_characters": len(serialized_evidence),
+            "estimated_tokens": (len(serialized_evidence) + ESTIMATED_CHARS_PER_EVIDENCE_TOKEN - 1)
+            // ESTIMATED_CHARS_PER_EVIDENCE_TOKEN,
+            "estimation_characters_per_token": ESTIMATED_CHARS_PER_EVIDENCE_TOKEN,
+        },
+        "budget_utilization": budget_utilization,
+        "selection_counts": selection_counts,
+        "compaction_counts": compaction_counts,
+        "projection_integrity": {
+            "status": "ok" if all(integrity_checks.values()) else "failed",
+            "checks": integrity_checks,
+            "unresolved_projected_window_ids": context_stats["unresolved_projected_window_ids"],
+            "deterministic_payload_sha256": (
+                "sha256:" + hashlib.sha256(serialized_evidence.encode("utf-8")).hexdigest()
+            ),
+        },
+    }
+
+
+def _context_projection_stats(
+    bundle: L0Bundle,
+    context_windows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    projected_source_window_ids = {
+        source_id
+        for window in context_windows
+        for source_id in str(window.get("window_id") or "").split("+")
+        if source_id
+    }
+    known_window_ids = {window.window_id for window in bundle.context_windows}
+    return {
+        "selected_source_window_count": len(
+            projected_source_window_ids.intersection(known_window_ids)
+        ),
+        "unresolved_projected_window_ids": sorted(projected_source_window_ids - known_window_ids),
+        "source_context_lines": sum(
+            int(window.get("source_line_count") or 0) for window in context_windows
+        ),
+        "model_facing_context_lines": sum(
+            int(window.get("lines_in_prompt") or 0) for window in context_windows
+        ),
+        "max_window_lines": max(
+            (int(window.get("lines_in_prompt") or 0) for window in context_windows),
+            default=0,
+        ),
+        "max_window_characters": max(
+            (
+                sum(len(str(line.get("text") or "")) for line in window.get("lines") or ())
+                for window in context_windows
+            ),
+            default=0,
+        ),
+    }
+
+
+def _projection_selection_counts(
+    bundle: L0Bundle,
+    evidence_bundle: dict[str, Any],
+    *,
+    projected_context_window_count: int,
+    selected_source_window_count: int,
+) -> dict[str, dict[str, Any]]:
+    return {
+        "context_windows": _selection_count(
+            len(bundle.context_windows),
+            selected_source_window_count,
+            PROMPT_CONTEXT_MAX_WINDOWS,
+            projected=projected_context_window_count,
+        ),
+        "occurrence_groups": _selection_count(
+            len(bundle.occurrence_groups),
+            len(evidence_bundle.get("occurrence_groups") or ()),
+            PROMPT_OCCURRENCE_GROUP_MAX,
+        ),
+        "registry_candidate_groups": _selection_count(
+            _eligible_registry_candidate_group_count(bundle),
+            len(evidence_bundle.get("registry_candidate_groups") or ()),
+            PROMPT_REGISTRY_CANDIDATE_GROUP_MAX,
+        ),
+        "candidate_anchors": _selection_count(
+            len(bundle.candidate_anchors),
+            len(evidence_bundle.get("candidate_anchors") or ()),
+            PROMPT_CANDIDATE_ANCHOR_MAX,
+        ),
+        "failure_episodes": _selection_count(
+            len(bundle.failure_episodes),
+            len(evidence_bundle.get("failure_episodes") or ()),
+            PROMPT_FAILURE_EPISODE_MAX,
+        ),
+        "distributed_incidents": _selection_count(
+            len(bundle.distributed_failure_incidents),
+            len(evidence_bundle.get("distributed_failure_incidents") or ()),
+            PROMPT_DISTRIBUTED_INCIDENT_MAX,
+        ),
+        "cause_confirmations": _selection_count(
+            len(bundle.cause_confirmations),
+            len(evidence_bundle.get("cause_confirmations") or ()),
+            PROMPT_CAUSE_CONFIRMATION_MAX,
+        ),
+        "later_progress_observations": _selection_count(
+            len(bundle.later_progress_after_fault_observations),
+            len(evidence_bundle.get("later_progress_after_fault_observations") or ()),
+            PROMPT_LATER_PROGRESS_OBSERVATION_MAX,
+        ),
+        "post_fault_summaries": _selection_count(
+            len(bundle.post_fault_summaries),
+            len(evidence_bundle.get("post_fault_summaries") or ()),
+            PROMPT_POST_FAULT_SUMMARY_MAX,
+        ),
+        "cascades": _selection_count(
+            len(bundle.cascades),
+            len(evidence_bundle.get("cascades") or ()),
+            PROMPT_CASCADE_MAX,
+        ),
+    }
+
+
+def _projection_budget_utilization(
+    evidence_bundle: dict[str, Any],
+    *,
+    max_window_lines: int,
+    max_window_characters: int,
+    selected_source_window_count: int,
+) -> dict[str, Any]:
+    return {
+        "context_window_slots": _budget_usage(
+            selected_source_window_count,
+            PROMPT_CONTEXT_MAX_WINDOWS,
+        ),
+        "occurrence_group_slots": _budget_usage(
+            len(evidence_bundle.get("occurrence_groups") or ()),
+            PROMPT_OCCURRENCE_GROUP_MAX,
+        ),
+        "candidate_anchor_slots": _budget_usage(
+            len(evidence_bundle.get("candidate_anchors") or ()),
+            PROMPT_CANDIDATE_ANCHOR_MAX,
+        ),
+        "failure_episode_slots": _budget_usage(
+            len(evidence_bundle.get("failure_episodes") or ()),
+            PROMPT_FAILURE_EPISODE_MAX,
+        ),
+        "max_window_lines": _budget_usage(
+            max_window_lines,
+            PROMPT_CONTEXT_EXCERPT_MAX_LINES,
+        ),
+        "max_window_characters": _budget_usage(
+            max_window_characters,
+            PROMPT_CONTEXT_EXCERPT_MAX_CHARS,
+        ),
+        "overall_view_limit_configured": False,
+        "overall_view_utilization_pct": None,
+    }
+
+
+def _projection_compaction_counts(
+    bundle: L0Bundle,
+    context_windows: list[dict[str, Any]],
+    context_stats: dict[str, Any],
+) -> dict[str, int]:
+    selected_count = int(context_stats["selected_source_window_count"])
+    source_line_count = int(context_stats["source_context_lines"])
+    model_line_count = int(context_stats["model_facing_context_lines"])
+    return {
+        "source_context_windows_selected": selected_count,
+        "projected_context_windows_after_merge": len(context_windows),
+        "context_windows_merged": max(0, selected_count - len(context_windows)),
+        "context_windows_omitted": max(
+            0,
+            len(bundle.context_windows) - selected_count,
+        ),
+        "source_context_lines": source_line_count,
+        "model_facing_context_lines": model_line_count,
+        "context_lines_omitted": max(0, source_line_count - model_line_count),
+        "truncated_context_windows": sum(
+            1 for window in context_windows if window.get("truncated")
+        ),
+        "truncated_model_facing_lines": sum(
+            1
+            for window in context_windows
+            for line in window.get("lines") or ()
+            if line.get("line_truncated")
+        ),
+    }
+
+
+def _projection_integrity_checks(
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+    context_windows: list[dict[str, Any]],
+    selection_counts: dict[str, dict[str, Any]],
+    budget_utilization: dict[str, Any],
+    *,
+    unresolved_projected_window_ids: list[str],
+) -> dict[str, bool]:
+    return {
+        "payload_serializable": True,
+        "decision_evidence_references_resolve": _decision_evidence_references_resolve(
+            bundle,
+            decision_evidence,
+        ),
+        "projected_context_references_resolve": not unresolved_projected_window_ids,
+        "projected_line_numbers_valid": _projected_line_numbers_valid(
+            context_windows,
+            bundle.line_count,
+        ),
+        "selection_accounting_consistent": all(
+            int(counts["available"]) == int(counts["selected"]) + int(counts["omitted"])
+            for counts in selection_counts.values()
+        ),
+        "within_declared_section_limits": all(
+            value.get("utilization_pct") is None or float(value["utilization_pct"]) <= 100.0
+            for value in budget_utilization.values()
+            if isinstance(value, dict)
+        ),
+        "lossiness_accounted": all(
+            "omitted" in counts and "limit" in counts for counts in selection_counts.values()
+        ),
+    }
+
+
+def _selection_count(
+    available: int,
+    selected: int,
+    limit: int,
+    *,
+    projected: int | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "available": available,
+        "selected": selected,
+        "omitted": max(0, available - selected),
+        "limit": limit,
+    }
+    if projected is not None:
+        result["projected_after_merge"] = projected
+    return result
+
+
+def _budget_usage(used: int, limit: int) -> dict[str, Any]:
+    return {
+        "used": used,
+        "limit": limit,
+        "utilization_pct": round((used / limit) * 100, 1) if limit else None,
+    }
+
+
+def _eligible_registry_candidate_group_count(bundle: L0Bundle) -> int:
+    registry_shapes = {
+        (match.registry_id, normalized_pattern(match.quote or match.signature))
+        for match in bundle.registry_matches
+    }
+    return sum(
+        1
+        for group in bundle.occurrence_groups
+        if group.registry_id is not None
+        and (group.registry_id, group.normalized_shape) in registry_shapes
+    )
+
+
+def _decision_evidence_references_resolve(
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+) -> bool:
+    references = decision_evidence.selected_evidence_references
+    known = {
+        "candidate_anchor_ids": {item.anchor_id for item in bundle.candidate_anchors},
+        "context_window_ids": {item.window_id for item in bundle.context_windows},
+        "failure_episode_ids": {item.episode_id for item in bundle.failure_episodes},
+        "distributed_incident_ids": {
+            item.incident_id for item in bundle.distributed_failure_incidents
+        },
+        "occurrence_group_ids": {item.occurrence_group_id for item in bundle.occurrence_groups},
+    }
+    for name, known_ids in known.items():
+        if not set(references.get(name) or ()).issubset(known_ids):
+            return False
+    return all(
+        isinstance(line, int) and 1 <= line <= bundle.line_count
+        for line in references.get("source_lines") or ()
+    )
+
+
+def _projected_line_numbers_valid(
+    context_windows: list[dict[str, Any]],
+    line_count: int,
+) -> bool:
+    for window in context_windows:
+        start = int(window.get("start_line") or 0)
+        end = int(window.get("end_line") or 0)
+        lines = [int(line.get("line") or 0) for line in window.get("lines") or ()]
+        if start < 1 or end < start or end > line_count:
+            return False
+        if lines != sorted(lines):
+            return False
+        if any(line < start or line > end for line in lines):
+            return False
+    return True
+
+
+def _model_evidence_for_projection(
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+) -> dict[str, Any]:
+    primary = decision_evidence.deterministic_primary_candidate
+    context_windows = _context_windows_for_prompt(
+        bundle,
+        primary_line=primary.line if primary is not None else None,
+    )
+    return {
+        "byte_size": bundle.byte_size,
+        "line_count": bundle.line_count,
+        "path_access_facts": [dict(item) for item in bundle.path_access_facts],
+        "path_namespace_summary": dict(bundle.path_namespace_summary),
+        "occurrence_groups": _occurrence_groups_for_prompt(bundle),
+        "registry_candidate_groups": _registry_candidate_groups_for_prompt(bundle),
+        "registry_candidate": _registry_hint_for_prompt(
+            primary,
+            causal_role_hint=_causal_role_hint_for_line(
+                bundle,
+                primary.line if primary is not None else None,
+            ),
+        ),
+        "candidate_anchors": _candidate_anchors_for_prompt(bundle, context_windows),
+        "failure_episodes": [
+            _failure_episode_for_prompt(episode)
+            for episode in bundle.failure_episodes[:PROMPT_FAILURE_EPISODE_MAX]
+        ],
+        "distributed_failure_incidents": _distributed_incidents_for_prompt(bundle),
+        "cause_confirmations": [
+            _cause_confirmation_for_prompt(confirmation)
+            for confirmation in bundle.cause_confirmations[:PROMPT_CAUSE_CONFIRMATION_MAX]
+        ],
+        "later_progress_after_fault_observations": (
+            _later_progress_after_fault_observations_for_prompt(bundle)
+        ),
+        "post_fault_summaries": _post_fault_summaries_for_prompt(bundle),
+        "cascades": _cascades_for_prompt(bundle),
+        "context_windows": context_windows,
+        "progress": _progress_for_prompt(bundle),
+        "run_progress_summary": _run_progress_summary_for_prompt(bundle.run_progress_summary),
+        "job_metadata": _job_metadata_for_prompt(bundle.job_metadata),
+        "evidence_coverage": dict(bundle.evidence_coverage),
+        "selection_summary": dict(bundle.selection_summary),
+    }
+
+
+def _occurrence_groups_for_prompt(bundle: L0Bundle) -> list[dict[str, Any]]:
+    return [
+        {
+            "occurrence_group_id": group.occurrence_group_id,
+            "normalized_shape": _truncate_text(group.normalized_shape, PROMPT_PATTERN_MAX_CHARS),
+            "first_line": group.first_line,
+            "count": group.count,
+            "sample_lines": list(group.sample_lines),
+            "registry_id": group.registry_id,
+            "classification": group.classification,
+        }
+        for group in bundle.occurrence_groups[:PROMPT_OCCURRENCE_GROUP_MAX]
+    ]
+
+
+def _distributed_incidents_for_prompt(bundle: L0Bundle) -> list[dict[str, Any]]:
+    return [
+        {
+            "incident_id": incident.incident_id,
+            "incident_kind": incident.incident_kind,
+            "incident_type": incident.incident_type,
+            "status": incident.status,
+            "primary_observed_line": incident.primary_observed_line,
+            "primary_observed_quote": _truncate_text(
+                incident.primary_observed_quote,
+                PROMPT_QUOTE_MAX_CHARS,
+            ),
+            "sample_lines": list(incident.sample_lines),
+            "event_count": incident.event_count,
+            "unique_operation_count": incident.unique_operation_count,
+            "operation_types": list(incident.operation_types),
+            "operation_signatures": list(incident.operation_signatures),
+            "observed_rank_count": incident.observed_rank_count,
+            "rank_spread_sample": list(incident.rank_spread),
+            "process_group_types": list(incident.process_group_types),
+            "phase": incident.phase,
+            "configured_timeout_seconds": incident.configured_timeout_seconds,
+            "last_progress_line": incident.last_progress_line,
+            "last_progress_timestamp": incident.last_progress_timestamp,
+            "first_detection_timestamp": incident.first_detection_timestamp,
+            "seconds_since_last_progress": incident.seconds_since_last_progress,
+            "detection_lag_seconds": incident.detection_lag_seconds,
+            "root_cause_status": incident.root_cause_status,
+            "interpretation": incident.interpretation,
+        }
+        for incident in bundle.distributed_failure_incidents[:PROMPT_DISTRIBUTED_INCIDENT_MAX]
+    ]
+
+
+def _post_fault_summaries_for_prompt(bundle: L0Bundle) -> list[dict[str, Any]]:
+    return [
+        {
+            "episode_id": summary.episode_id,
+            "anchor_line": summary.anchor_line,
+            "lines_after_anchor": summary.lines_after_anchor,
+            "progress_after_observed": summary.progress_after_observed,
+            "first_progress_after_line": summary.first_progress_after_line,
+            "later_matching_exception_count": summary.later_matching_exception_count,
+            "later_matching_exception_lines": list(summary.later_matching_exception_lines),
+            "later_high_signal_count": summary.later_high_signal_count,
+            "last_high_signal_line": summary.last_high_signal_line,
+            "last_high_signal_quote": _truncate_text(
+                summary.last_high_signal_quote,
+                PROMPT_QUOTE_MAX_CHARS,
+            ),
+            "first_teardown_line": summary.first_teardown_line,
+            "first_process_termination_line": summary.first_process_termination_line,
+            "first_scheduler_cancel_line": summary.first_scheduler_cancel_line,
+            "first_cascade_line": summary.first_cascade_line,
+        }
+        for summary in bundle.post_fault_summaries[:PROMPT_POST_FAULT_SUMMARY_MAX]
+    ]
+
+
+def _cascades_for_prompt(bundle: L0Bundle) -> list[dict[str, Any]]:
+    return [
+        {
+            "failure_class": cascade.failure_class,
+            "cascade_fingerprint": cascade.cascade_fingerprint,
+            "first_line": cascade.first_line,
+            "last_line": cascade.last_line,
+            "count": cascade.count,
+            "sample_lines": list(cascade.sample_lines),
+            "rank_spread": list(cascade.rank_spread),
+            "node_spread": list(cascade.node_spread),
+            "gpu_spread": list(cascade.gpu_spread),
+            "reason": cascade.reason,
+        }
+        for cascade in bundle.cascades[:PROMPT_CASCADE_MAX]
+    ]
+
+
+def _progress_for_prompt(bundle: L0Bundle) -> dict[str, Any]:
+    progress = bundle.progress
+    return {
+        "highest_completed_step": progress.highest_completed_step,
+        "last_progress_line": progress.last_progress_line,
+        "last_checkpoint_step": progress.last_checkpoint_step,
+        "last_checkpoint_line": progress.last_checkpoint_line,
+        "latest_observed_failure_iteration": progress.latest_observed_failure_iteration,
+        "latest_observed_failure_iteration_line": progress.latest_observed_failure_iteration_line,
+        "progress_lines": list(progress.progress_lines[-50:]),
+        "checkpoint_lines": list(progress.checkpoint_lines[-50:]),
+        "setup_lines": list(progress.setup_lines[-50:]),
+        "recovery_lines": list(progress.recovery_lines[:50]),
+        "recent_progress_markers": [
+            _progress_marker_for_prompt(marker) for marker in progress.progress_markers[-20:]
+        ],
+        "recent_checkpoint_markers": [
+            _progress_marker_for_prompt(marker) for marker in progress.checkpoint_markers[-10:]
+        ],
+        "recent_setup_markers": [
+            _progress_marker_for_prompt(marker) for marker in progress.setup_markers[-10:]
+        ],
+    }
+
+
+def _run_progress_summary_for_prompt(summary: Any) -> dict[str, Any]:
+    return {
+        "first_iteration": summary.first_iteration,
+        "first_iteration_line": summary.first_iteration_line,
+        "first_iteration_timestamp": summary.first_iteration_timestamp,
+        "last_iteration": summary.last_iteration,
+        "last_iteration_line": summary.last_iteration_line,
+        "last_iteration_timestamp": summary.last_iteration_timestamp,
+        "iteration_delta": summary.iteration_delta,
+        "total_iterations": summary.total_iterations,
+        "first_consumed_samples": summary.first_consumed_samples,
+        "last_consumed_samples": summary.last_consumed_samples,
+        "consumed_samples_delta": summary.consumed_samples_delta,
+        "progress_marker_count": summary.progress_marker_count,
+        "checkpoint_marker_count": summary.checkpoint_marker_count,
+        "setup_marker_count": summary.setup_marker_count,
+        "last_checkpoint_iteration": summary.last_checkpoint_iteration,
+        "last_checkpoint_line": summary.last_checkpoint_line,
+        "checkpoint_load_iteration": summary.checkpoint_load_iteration,
+        "checkpoint_load_line": summary.checkpoint_load_line,
+        "latest_observed_failure_iteration": summary.latest_observed_failure_iteration,
+        "latest_observed_failure_iteration_line": (summary.latest_observed_failure_iteration_line),
+        "observed_iterations_after_checkpoint_load": (
+            summary.observed_iterations_after_checkpoint_load
+        ),
+        "last_setup_marker_type": summary.last_setup_marker_type,
+        "last_setup_line": summary.last_setup_line,
+        "successful_runtime_seconds": summary.successful_runtime_seconds,
+        "iterations_since_checkpoint": summary.iterations_since_checkpoint,
+        "progress_after_failure_episode": summary.progress_after_failure_episode,
+        "first_terminal_incident_line": summary.first_terminal_incident_line,
+        "first_terminal_incident_timestamp": summary.first_terminal_incident_timestamp,
+        "configured_terminal_timeout_seconds": summary.configured_terminal_timeout_seconds,
+        "seconds_from_last_progress_to_terminal_incident": (
+            summary.seconds_from_last_progress_to_terminal_incident
+        ),
+        "terminal_detection_lag_seconds": summary.terminal_detection_lag_seconds,
+    }
+
+
+def _attempt_execution_context(bundle: L0Bundle) -> dict[str, Any]:
+    summary = bundle.run_progress_summary
+    return {
+        "scope": "current_log_only",
+        "terminal_timing": {
+            "configured_terminal_timeout_seconds": summary.configured_terminal_timeout_seconds,
+            "seconds_from_last_progress_to_terminal_incident": (
+                summary.seconds_from_last_progress_to_terminal_incident
+            ),
+            "terminal_detection_lag_seconds": summary.terminal_detection_lag_seconds,
+        },
+    }
+
+
+def _later_progress_after_fault_observations_for_prompt(
+    bundle: L0Bundle,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "failure_class": item.failure_class,
+            "root_fingerprint": item.root_fingerprint,
+            "event_count": item.event_count,
+            "sample_event_lines": list(item.sample_event_lines),
+            "sample_later_progress_lines": list(item.sample_later_progress_lines),
+            "matches_terminal_fingerprint": item.matches_terminal_fingerprint,
+            "ordering_basis": item.ordering_basis,
+            "interpretation": item.interpretation,
+            "component_recovery_proven": item.component_recovery_proven,
+        }
+        for item in bundle.later_progress_after_fault_observations[
+            :PROMPT_LATER_PROGRESS_OBSERVATION_MAX
+        ]
+    ]
+
+
+def _job_metadata_for_prompt(metadata: Any) -> dict[str, Any]:
+    return {
+        "explicit_world_size": metadata.explicit_world_size,
+        "explicit_world_size_line": metadata.explicit_world_size_line,
+        "observed_rank_min": metadata.observed_rank_min,
+        "observed_rank_max": metadata.observed_rank_max,
+        "observed_rank_count": metadata.observed_rank_count,
+        "inferred_world_size_lower_bound": metadata.inferred_world_size_lower_bound,
+        "world_size_source": metadata.world_size_source,
+        "world_size_confidence": metadata.world_size_confidence,
+        "observed_node_count": metadata.observed_node_count,
+        "rank_to_gpu_mapping_available": metadata.rank_to_gpu_mapping_available,
+    }
+
+
+def _candidate_anchors_for_prompt(
+    bundle: L0Bundle,
+    context_windows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    lines_in_prompt = {
+        line["line"]
+        for window in context_windows
+        for line in window.get("lines", [])
+        if isinstance(line, dict) and "line" in line
+    }
+    return [
+        {
+            "anchor_id": anchor.anchor_id,
+            "line": anchor.line,
+            "quote": _truncate_text(anchor.quote, PROMPT_QUOTE_MAX_CHARS),
+            "sources": list(anchor.sources),
+            "high_signal": anchor.high_signal,
+            "causal_role_hint": anchor.causal_role_hint,
+            "anchor_rank": anchor.anchor_rank,
+            "taxonomy_hint": _registry_hint_for_prompt(
+                anchor.taxonomy_match,
+                causal_role_hint=anchor.causal_role_hint,
+            ),
+            "nearby_progress_observations": {
+                "prior_observed_progress_line": anchor.prior_observed_progress_line,
+                "later_observed_progress_line": anchor.later_observed_progress_line,
+                "prior_progress_rank": anchor.prior_progress_rank,
+                "later_progress_rank": anchor.later_progress_rank,
+                "later_progress_rank_relation": anchor.later_progress_rank_relation,
+                "later_observation_proves_recovery": (anchor.later_observation_proves_recovery),
+            },
+            "first_downstream_registry_hint": _registry_hint_for_prompt(
+                anchor.first_downstream_registry_match,
+                causal_role_hint=_causal_role_hint_for_line(
+                    bundle,
+                    (
+                        anchor.first_downstream_registry_match.line
+                        if anchor.first_downstream_registry_match
+                        else None
+                    ),
+                ),
+            ),
+            "first_downstream_cascade": _failure_for_prompt(anchor.first_downstream_cascade),
+            "context_window_ids": list(anchor.context_window_ids),
+            "covered_by_excerpt": anchor.line in lines_in_prompt,
+        }
+        for anchor in bundle.candidate_anchors[:PROMPT_CANDIDATE_ANCHOR_MAX]
+    ]
+
+
+def _failure_episode_for_prompt(episode: Any) -> dict[str, Any]:
+    return {
+        "episode_id": episode.episode_id,
+        "status": episode.status,
+        "start_line": episode.start_line,
+        "end_line": episode.end_line,
+        "first_exception_line": episode.first_exception_line,
+        "terminal_exception_line": episode.terminal_exception_line,
+        "terminal_exception_quote": _truncate_text(
+            episode.terminal_exception_quote,
+            PROMPT_QUOTE_MAX_CHARS,
+        ),
+        "terminal_exception_iteration": episode.terminal_exception_iteration,
+        "terminal_exception_causal_role_hint": (episode.terminal_exception_causal_role_hint),
+        "precursor_lines": list(episode.precursor_lines),
+        "identity_anchor_line": episode.identity_anchor_line,
+        "identity_anchor_reason": episode.identity_anchor_reason,
+        "exception_chain_lines": list(episode.exception_chain_lines),
+        "duplicate_rendering_lines": list(episode.duplicate_rendering_lines),
+        "wrapper_exception_lines": list(episode.wrapper_exception_lines),
+        "exception_rank": episode.exception_rank,
+        "exception_node": episode.exception_node,
+        "exception_gpu": episode.exception_gpu,
+        "last_progress_before": _progress_marker_for_prompt(episode.last_progress_before),
+        "first_progress_after": _progress_marker_for_prompt(episode.first_progress_after),
+        "first_teardown_line": episode.first_teardown_line,
+        "first_process_termination_line": episode.first_process_termination_line,
+        "first_scheduler_cancel_line": episode.first_scheduler_cancel_line,
+        "first_downstream_cascade": _failure_for_prompt(episode.first_downstream_cascade),
+        "cause_confirmations": [
+            _cause_confirmation_for_prompt(confirmation)
+            for confirmation in episode.cause_confirmations
+        ],
+        "context_window_ids": list(episode.context_window_ids),
+        "reason": episode.reason,
+    }
+
+
+def _progress_marker_for_prompt(marker: Any | None) -> dict[str, Any] | None:
+    if marker is None:
+        return None
+    return {
+        "marker_id": marker.marker_id,
+        "marker_type": marker.marker_type,
+        "value": marker.value,
+        "state": marker.state,
+        "line": marker.line,
+        "quote": _truncate_text(marker.quote, PROMPT_QUOTE_MAX_CHARS),
+        "timestamp": marker.timestamp,
+        "rank": marker.rank,
+        "node": marker.node,
+        "gpu": marker.gpu,
+        "pattern_id": marker.pattern_id,
+        "secondary_value": dict(marker.secondary_value),
+    }
+
+
+def _failure_for_prompt(match: Any | None) -> dict[str, Any] | None:
+    if match is None:
+        return None
+    return {
+        **match.to_failure_payload(),
+        "quote": _truncate_text(match.quote, PROMPT_QUOTE_MAX_CHARS),
+        "registry_id": match.registry_id,
+        "role": match.role,
+    }
+
+
+def _cause_confirmation_for_prompt(match: Any) -> dict[str, Any]:
+    return {
+        "confirmation_kind": match.failure_class,
+        "signature": match.signature,
+        "line": match.line,
+        "quote": _truncate_text(match.quote, PROMPT_QUOTE_MAX_CHARS),
+        "rank": match.rank,
+        "node": match.node,
+        "phase": match.phase,
+        "registry_id": match.registry_id,
+    }
+
+
+def _registry_candidate_groups_for_prompt(bundle: L0Bundle) -> list[dict[str, Any]]:
+    matches_by_pattern: dict[tuple[str | None, str], Any] = {}
+    for match in bundle.registry_matches:
+        key = (match.registry_id, normalized_pattern(match.quote or match.signature))
+        matches_by_pattern.setdefault(key, match)
+
+    result: list[dict[str, Any]] = []
+    for group in bundle.occurrence_groups:
+        if group.registry_id is None:
+            continue
+        match = matches_by_pattern.get((group.registry_id, group.normalized_shape))
+        if match is None:
+            continue
+        result.append(
+            {
+                "registry_id": match.registry_id,
+                "failure_class_hint": match.failure_class,
+                "signature_hint": match.signature,
+                "first_line": group.first_line,
+                "representative_quote": _truncate_text(
+                    match.quote,
+                    PROMPT_QUOTE_MAX_CHARS,
+                ),
+                "count": group.count,
+                "sample_lines": list(group.sample_lines),
+                "rank_spread": list(group.rank_spread[:8]),
+                "causal_role_hint": _causal_role_hint_for_line(bundle, match.line),
+                "provisional": True,
+            }
+        )
+    return result[:PROMPT_REGISTRY_CANDIDATE_GROUP_MAX]
+
+
+def _registry_hint_for_prompt(
+    match: Any | None,
+    *,
+    causal_role_hint: str = CausalRole.UNKNOWN.value,
+) -> dict[str, Any] | None:
+    if match is None:
+        return None
+    return {
+        "failure_class_hint": match.failure_class,
+        "signature_hint": match.signature,
+        "line": match.line,
+        "quote": _truncate_text(match.quote, PROMPT_QUOTE_MAX_CHARS),
+        "rank": match.rank,
+        "phase": match.phase,
+        "failure_iteration": match.failure_iteration,
+        "registry_id": match.registry_id,
+        "causal_role_hint": causal_role_hint,
+        "provisional": True,
+    }
+
+
+def _causal_role_hint_for_line(bundle: L0Bundle, line: int | None) -> str:
+    if line is None:
+        return CausalRole.UNKNOWN.value
+    for episode in bundle.failure_episodes:
+        if episode.terminal_exception_line == line:
+            return episode.terminal_exception_causal_role_hint
+        if line in episode.wrapper_exception_lines:
+            return CausalRole.TEARDOWN.value
+    return CausalRole.UNKNOWN.value
+
+
+def _context_windows_for_prompt(
+    bundle: L0Bundle,
+    *,
+    primary_line: int | None,
+) -> list[dict[str, Any]]:
+    selected_windows = _seed_context_windows(bundle.context_windows, primary_line=primary_line)
+    for window in sorted(
+        bundle.context_windows,
+        key=lambda window: (
+            -_context_window_score(window, primary_line=primary_line),
+            window.start_line,
+            window.end_line,
+        ),
+    ):
+        if len(selected_windows) >= PROMPT_CONTEXT_MAX_WINDOWS:
+            break
+        if window not in selected_windows:
+            selected_windows.append(window)
+
+    merged_windows = _merge_context_windows(selected_windows)
+    return [_context_window_payload(window) for window in merged_windows]
+
+
+def _seed_context_windows(windows: Any, *, primary_line: int | None) -> list[Any]:
+    selected: list[Any] = []
+    earliest_high_signal = _earliest_high_signal_window(windows)
+    if earliest_high_signal is not None:
+        selected.append(earliest_high_signal)
+    if primary_line is not None:
+        primary_windows = [
+            window for window in windows if window.start_line <= primary_line <= window.end_line
+        ]
+        if primary_windows:
+            primary_window = sorted(primary_windows, key=lambda window: window.start_line)[0]
+            if primary_window not in selected:
+                selected.append(primary_window)
+    return selected
+
+
+def _earliest_high_signal_window(windows: Any) -> Any | None:
+    best: tuple[int, Any] | None = None
+    for window in windows:
+        signal_lines = [item.line for item in window.lines if _is_high_signal_line(item)]
+        if not signal_lines:
+            continue
+        candidate = (min(signal_lines), window)
+        if best is None or candidate[0] < best[0]:
+            best = candidate
+    return best[1] if best else None
+
+
+def _context_window_score(window: Any, *, primary_line: int | None) -> int:
+    score = 0
+    if primary_line is not None and window.start_line <= primary_line <= window.end_line:
+        score += 1000
+    score += len(window.seed_lines) * 10
+    score += min(sum(1 for item in window.lines if _is_high_signal_line(item)), 10) * 20
+    return score
+
+
+def _merge_context_windows(windows: list[Any]) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    for window in sorted(windows, key=lambda item: (item.start_line, item.end_line)):
+        current = {
+            "window_id": window.window_id,
+            "selected_by": window.selected_by,
+            "start_line": window.start_line,
+            "end_line": window.end_line,
+            "seed_lines": set(window.seed_lines),
+            "occurrence_group_ids": set(window.occurrence_group_ids),
+            "truncated": window.truncated,
+            "lines_by_number": {item.line: item for item in window.lines},
+        }
+        if (
+            merged
+            and current["start_line"] <= merged[-1]["end_line"] + PROMPT_CONTEXT_MERGE_GAP_LINES
+        ):
+            previous = merged[-1]
+            previous["window_id"] = f"{previous['window_id']}+{current['window_id']}"
+            previous["selected_by"] = _merge_selected_by(
+                str(previous["selected_by"]), str(current["selected_by"])
+            )
+            previous["end_line"] = max(int(previous["end_line"]), int(current["end_line"]))
+            previous["seed_lines"].update(current["seed_lines"])
+            previous["occurrence_group_ids"].update(current["occurrence_group_ids"])
+            previous["truncated"] = bool(previous["truncated"] or current["truncated"])
+            previous["lines_by_number"].update(current["lines_by_number"])
+            continue
+        merged.append(current)
+    return merged[:PROMPT_CONTEXT_MAX_WINDOWS]
+
+
+def _merge_selected_by(first: str, second: str) -> str:
+    if first == second:
+        return first
+    parts = []
+    for value in (first, second):
+        for part in value.split("+"):
+            if part not in parts:
+                parts.append(part)
+    return "+".join(parts)
+
+
+def _context_window_payload(window: dict[str, Any]) -> dict[str, Any]:
+    lines = [window["lines_by_number"][line] for line in sorted(window["lines_by_number"])]
+    excerpt, excerpt_truncated = _window_excerpt_lines(lines)
+    return {
+        "window_id": window["window_id"],
+        "selected_by": window["selected_by"],
+        "start_line": window["start_line"],
+        "end_line": window["end_line"],
+        "seed_lines": sorted(window["seed_lines"]),
+        "occurrence_group_ids": sorted(window["occurrence_group_ids"]),
+        "prompt_view": "bounded_excerpt",
+        "source_line_count": len(lines),
+        "lines_in_prompt": len(excerpt),
+        "truncated": bool(window["truncated"] or excerpt_truncated),
+        "lines": excerpt,
+    }
+
+
+def _window_excerpt_lines(lines: Any) -> tuple[list[dict[str, Any]], bool]:
+    result: list[dict[str, Any]] = []
+    used_chars = 0
+    truncated = False
+    for item in list(lines):
+        if len(result) >= PROMPT_CONTEXT_EXCERPT_MAX_LINES:
+            truncated = True
+            break
+        text = _truncate_text(item.text, PROMPT_CONTEXT_LINE_MAX_CHARS)
+        next_used = used_chars + len(text or "")
+        if next_used > PROMPT_CONTEXT_EXCERPT_MAX_CHARS:
+            truncated = True
+            break
+        result.append(
+            {
+                "line": item.line,
+                "text": text,
+                "line_truncated": len(item.text) > PROMPT_CONTEXT_LINE_MAX_CHARS,
+                "line_role": _prompt_line_role(item.text),
+                "diagnostic_kind": diagnostic_context_kind(item.text),
+                "diagnostic_uncertainty_kind": diagnostic_uncertainty_kind(item.text),
+            }
+        )
+        used_chars = next_used
+    return result, truncated
+
+
+def _prompt_line_role(text: str) -> str:
+    if diagnostic_context_kind(text) is not None:
+        return "diagnostic_context"
+    if diagnostic_uncertainty_kind(text) is not None:
+        return "observed_log_with_causal_hypothesis"
+    return "observed_log"
+
+
+def _window_preview_lines(
+    lines: Any,
+    seed_lines: Any,
+) -> list[dict[str, Any]]:
+    line_list = list(lines)
+    seed_set = set(seed_lines)
+    selected_lines: set[int] = set()
+
+    def add_items(items: Any) -> None:
+        for item in items:
+            if len(selected_lines) >= PROMPT_CONTEXT_PREVIEW_LINES:
+                return
+            selected_lines.add(item.line)
+
+    add_items(item for item in line_list if item.line in seed_set)
+    add_items(_high_signal_lines(line_list, limit=PROMPT_CONTEXT_HIGH_SIGNAL_LINES))
+    add_items(line_list[:PROMPT_CONTEXT_HEAD_LINES])
+    add_items(line_list[-PROMPT_CONTEXT_TAIL_LINES:])
+
+    result: list[dict[str, Any]] = []
+    for item in line_list:
+        if item.line not in selected_lines:
+            continue
+        result.append(
+            {
+                "line": item.line,
+                "text": _truncate_text(item.text, PROMPT_CONTEXT_LINE_MAX_CHARS),
+                "line_truncated": len(item.text) > PROMPT_CONTEXT_LINE_MAX_CHARS,
+            }
+        )
+    return result
+
+
+def _high_signal_lines(lines: list[Any], *, limit: int) -> list[Any]:
+    result: list[Any] = []
+    for item in lines:
+        if _is_high_signal_line(item):
+            result.append(item)
+            if len(result) >= limit:
+                break
+    return result
+
+
+def _is_high_signal_line(item: Any) -> bool:
+    if diagnostic_context_kind(item.text) is not None:
+        return False
+    return bool(PROMPT_CONTEXT_HIGH_SIGNAL_RE.search(item.text))
+
+
+def _truncate_text(value: str | None, max_chars: int) -> str | None:
+    if value is None:
+        return None
+    if len(value) <= max_chars:
+        return value
+    return value[:max_chars] + "...[truncated]"

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l0/registry.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l0/registry.py
@@ -1,0 +1,417 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Supplemental signatures and diagnostic-line roles for L0 assembly."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Pattern
+
+from ..identity import fingerprint_for
+from ..models import RecoveryBehavior, RegistryRole
+
+
+@dataclass(frozen=True)
+class SignatureRegistryRow:
+    registry_id: str
+    pattern: Pattern[str]
+    role: str
+    recovery_behavior: str = RecoveryBehavior.NONE.value
+
+
+_DIAGNOSTIC_CONTEXT_PATTERNS: tuple[tuple[str, Pattern[str]], ...] = (
+    (
+        "cuda_async_reporting_advice",
+        re.compile(
+            r"CUDA kernel errors might be asynchronously reported"
+            r"|stacktrace (?:below )?might be incorrect",
+            re.I,
+        ),
+    ),
+    (
+        "cuda_launch_blocking_advice",
+        re.compile(r"(?:consider|set|passing).*CUDA_LAUNCH_BLOCKING", re.I),
+    ),
+    (
+        "cuda_dsa_compile_advice",
+        re.compile(r"Compile with [`']?TORCH_USE_CUDA_DSA", re.I),
+    ),
+)
+
+_CONDITIONAL_CAUSE_RE = re.compile(
+    r"\b(?:might|may|could) be caused by\b"
+    r"|\bit is possible that\b"
+    r"|\bpossibly due to\b"
+    r"|\bplease try\b",
+    re.I,
+)
+
+_DISTRIBUTED_OPERATION_TIMEOUT_RE = re.compile(
+    r"\b(?:watchdog\s+)?(?:caught\s+)?(?:collective\s+)?operation\s+timeout\b"
+    r"|\boperation\b.*\btimed out\b",
+    re.I,
+)
+
+
+MVP_SIGNATURES: tuple[SignatureRegistryRow, ...] = (
+    SignatureRegistryRow(
+        registry_id="gpu_hardware_fault",
+        pattern=re.compile(
+            r"\bXid\b|ECC.*(?:uncorrectable|DBE)|GPU.*(?:off bus|fallen off)"
+            r"|NVLink.{0,24}(?:link down|uncorrectable(?: error)?|CRC error|recovery failed)"
+            r"|NVLink\s+fatal\s+(?:error|failure)"
+            r"|PCIe.{0,24}(?:AER(?: fatal)?|link down|fatal error|uncorrectable(?: error)?)"
+            r"|thermal.{0,80}(?:shutdown|violation|fault)",
+            re.I,
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="peer_gpu_memory_access_failure",
+        pattern=re.compile(
+            r"invalid access of peer GPU memory(?:\s+over\s+NVLink)?",
+            re.I,
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="infra_policy_event",
+        pattern=re.compile(
+            r"SLURM.*(?:preempt|node failure|NODE_FAIL)|\bpreempted\b|\bnode failure\b",
+            re.I,
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="time_limit",
+        pattern=re.compile(
+            r"\bDUE TO TIME LIMIT\b"
+            r"|\b(?:time limit|wall[- ]?time(?: limit)?)\s+"
+            r"(?:reached|exceeded|expired)\b"
+            r"|\b(?:cancelled|canceled|terminated|killed)\b[^\n]{0,120}"
+            r"\b(?:time limit|wall[- ]?time)\b",
+            re.I,
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="user_cancelled",
+        pattern=re.compile(r"\bscancel\b|\bcancelled by user\b|\buser .*cancel", re.I),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="observed_exception",
+        pattern=re.compile(
+            r"\b[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception):(?:\s|$)"
+            r"|\bAssertion(?:Error)?\b.*\bfailed\b",
+            re.I,
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="configuration_validation_failure",
+        pattern=re.compile(
+            r"\binvalid (?:option|config(?:uration)?)\b" r"|\bmissing (?:config(?:uration)?|key)\b",
+            re.I,
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="argument_validation_failure",
+        pattern=re.compile(r"\binvalid argument\b", re.I),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="artifact_or_path_not_found",
+        pattern=re.compile(r"\bNo such file or directory\b", re.I),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="checkpoint_compatibility_mismatch",
+        pattern=re.compile(r"\bcheckpoint\b.{0,160}\bmismatch\b", re.I),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="shape_mismatch",
+        pattern=re.compile(r"\bshape mismatch\b", re.I),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="filesystem_permission_denied",
+        pattern=re.compile(r"\bPermissionError\b|\bpermission denied\b|\bEACCES\b", re.I),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="cuda_oom",
+        pattern=re.compile(r"CUDA out of memory|CUBLAS_STATUS_ALLOC_FAILED", re.I),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="nan_or_inf",
+        pattern=re.compile(
+            r"(?:loss|grad(?:ient)?|activation)[=:\s]+(?:nan|[-+]?inf(?:inity)?)\b"
+            r"|(?:nan|[-+]?inf(?:inity)?)\s+(?:loss|grad(?:ient)?|detected|encountered)"
+            r"|non[- ]finite",
+            re.I,
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="bad_token_or_window",
+        pattern=re.compile(
+            r"bad token|bad sample|token window|skip(?:ping)? .*token|quarantine .*token",
+            re.I,
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+        recovery_behavior=RecoveryBehavior.RETRY_THEN_SKIP.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="framework_crash",
+        pattern=re.compile(
+            r"segmentation fault|\bsegfault\b|illegal instruction|core dumped", re.I
+        ),
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="linux_oom_kill_confirmation",
+        pattern=re.compile(
+            r"\bDetected\s+\d+\s+oom_kill events\b"
+            r"|\b(?:Out of memory|Memory cgroup out of memory):\s+Killed process\b"
+            r"|\bSome of the step tasks have been OOM Killed\b",
+            re.I,
+        ),
+        role=RegistryRole.CAUSE_CONFIRMATION.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="observed_distributed_operation_timeout",
+        pattern=_DISTRIBUTED_OPERATION_TIMEOUT_RE,
+        role=RegistryRole.ROOT_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="nccl_cascade",
+        pattern=re.compile(
+            r"^(?!.*(?:watchdog\s+)?(?:caught\s+)?(?:collective\s+)?operation\s+timeout)"
+            r".*NCCL.*(?:timeout|watchdog|abort|unhandled system error)",
+            re.I,
+        ),
+        role=RegistryRole.CASCADE_CANDIDATE.value,
+    ),
+    SignatureRegistryRow(
+        registry_id="cuda_previous_error_cascade",
+        pattern=re.compile(
+            r"operation failed due to a previous error during capture" r"|NCCL WARN Cuda failure",
+            re.I,
+        ),
+        role=RegistryRole.CASCADE_CANDIDATE.value,
+    ),
+)
+
+_REGISTRY_TRIGGER_TERMS = (
+    "error",
+    "exception",
+    "nccl",
+    "checkpoint",
+    "failed",
+    "assert",
+    "out of memory",
+    "xid",
+    "ecc",
+    "gpu",
+    "nvlink",
+    "pcie",
+    "thermal",
+    "slurm",
+    "preempt",
+    "node fail",
+    "time limit",
+    "wall-time",
+    "walltime",
+    "scancel",
+    "cancelled by user",
+    "no such file",
+    "permission denied",
+    "invalid ",
+    "missing ",
+    "shape mismatch",
+    "cublas_status_alloc_failed",
+    "bad token",
+    "bad sample",
+    "token window",
+    "skipping",
+    "quarantine",
+    "segmentation fault",
+    "segfault",
+    "illegal instruction",
+    "core dumped",
+    "oom_kill",
+    "oom killed",
+    "out of memory: killed process",
+    "memory cgroup out of memory",
+    "watchdog",
+)
+_NONFINITE_TRIGGER_RE = re.compile(
+    r"(?<![a-z0-9_])(?:nan|[-+]?inf(?:inity)?)(?![a-z0-9_])" r"|non[- ]?finite",
+    re.I,
+)
+
+_ROW_TRIGGER_TERMS: dict[str, tuple[str, ...]] = {
+    "gpu_hardware_fault": ("xid", "ecc", "gpu", "nvlink", "pcie", "thermal"),
+    "peer_gpu_memory_access_failure": ("peer gpu",),
+    "infra_policy_event": ("slurm", "preempt", "node fail", "node_fail"),
+    "time_limit": ("time limit", "wall-time", "walltime", "wall time"),
+    "user_cancelled": ("scancel", "cancelled by user", "user "),
+    "observed_exception": ("error", "exception", "assertion"),
+    "configuration_validation_failure": ("invalid ", "missing "),
+    "argument_validation_failure": ("invalid argument",),
+    "artifact_or_path_not_found": ("no such file or directory",),
+    "checkpoint_compatibility_mismatch": ("checkpoint",),
+    "shape_mismatch": ("shape mismatch",),
+    "filesystem_permission_denied": ("permissionerror", "permission denied", "eacces"),
+    "cuda_oom": ("cuda out of memory", "cublas_status_alloc_failed"),
+    "bad_token_or_window": (
+        "bad token",
+        "bad sample",
+        "token window",
+        "skipping",
+        "skip ",
+        "quarantine",
+    ),
+    "framework_crash": (
+        "segmentation fault",
+        "segfault",
+        "illegal instruction",
+        "core dumped",
+    ),
+    "linux_oom_kill_confirmation": (
+        "oom_kill",
+        "oom killed",
+        "out of memory",
+        "memory cgroup",
+    ),
+    "observed_distributed_operation_timeout": ("timeout", "timed out"),
+    "nccl_cascade": ("nccl",),
+    "cuda_previous_error_cascade": ("previous error", "nccl warn cuda failure"),
+}
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    for term in terms:
+        if term in text:
+            return True
+    return False
+
+
+def _row_triggered(
+    registry_id: str,
+    lowered: str,
+    *,
+    has_nonfinite_trigger: bool,
+) -> bool:
+    if registry_id == "nan_or_inf":
+        return has_nonfinite_trigger
+    return _contains_any(lowered, _ROW_TRIGGER_TERMS[registry_id])
+
+
+def match_registry(
+    line: str,
+    *,
+    diagnostic_checked: bool = False,
+    lowered: str | None = None,
+) -> list[SignatureRegistryRow]:
+    lowered = lowered if lowered is not None else line.lower()
+    has_nonfinite_trigger = _NONFINITE_TRIGGER_RE.search(lowered) is not None
+    if not _contains_any(lowered, _REGISTRY_TRIGGER_TERMS) and not has_nonfinite_trigger:
+        return []
+    if not diagnostic_checked and diagnostic_context_kind(line) is not None:
+        return []
+    return [
+        row
+        for row in MVP_SIGNATURES
+        if _row_triggered(
+            row.registry_id,
+            lowered,
+            has_nonfinite_trigger=has_nonfinite_trigger,
+        )
+        and row.pattern.search(line)
+    ]
+
+
+def diagnostic_context_kind(line: str) -> str | None:
+    """Return the stable role for non-causal CUDA/PyTorch debugging advice."""
+
+    for kind, pattern in _DIAGNOSTIC_CONTEXT_PATTERNS:
+        if pattern.search(line):
+            return kind
+    return None
+
+
+def diagnostic_uncertainty_kind(line: str) -> str | None:
+    """Identify causal suggestions without hiding the observed error line."""
+
+    if _CONDITIONAL_CAUSE_RE.search(line):
+        return "conditional_cause_language"
+    return None
+
+
+def signature_for(row: SignatureRegistryRow, line: str) -> str:
+    match = row.pattern.search(line)
+    if match is None:
+        return line.strip()
+    return match.group(0).strip()
+
+
+def fingerprint_components(row: SignatureRegistryRow, line: str) -> list[str]:
+    lowered = line.lower()
+    if row.registry_id == "cuda_oom":
+        return ["allocation_failure"]
+    if row.registry_id == "nccl_cascade":
+        if "watchdog" in lowered:
+            return ["watchdog_timeout"]
+        return ["comm_abort"]
+    if row.registry_id == "observed_distributed_operation_timeout":
+        return ["collective_operation_timeout"]
+    if row.registry_id == "cuda_previous_error_cascade":
+        return ["previous_capture_error"]
+    if row.registry_id == "time_limit":
+        return ["time_limit"]
+    if row.registry_id == "bad_token_or_window":
+        return ["bad_token_or_window"]
+    if row.registry_id == "nan_or_inf":
+        if "grad norm" in lowered or "gradient" in lowered:
+            return ["non_finite_gradient"]
+        if "loss" in lowered:
+            return ["non_finite_loss"]
+        return ["non_finite_signal"]
+    if row.registry_id == "gpu_hardware_fault":
+        return ["hardware_event"]
+    if row.registry_id == "peer_gpu_memory_access_failure":
+        return ["peer_gpu_memory_access"]
+    if row.registry_id == "infra_policy_event":
+        return ["scheduler_or_node_event"]
+    if row.registry_id == "user_cancelled":
+        return ["user_cancelled"]
+    if row.registry_id == "configuration_validation_failure":
+        if "invalid option" in lowered:
+            return ["invalid_option"]
+        if "invalid config" in lowered or "invalid configuration" in lowered:
+            return ["invalid_configuration"]
+        if "missing key" in lowered:
+            return ["missing_key"]
+        return ["missing_configuration"]
+    if row.registry_id == "argument_validation_failure":
+        return ["invalid_argument"]
+    if row.registry_id == "artifact_or_path_not_found":
+        return ["not_found"]
+    if row.registry_id == "checkpoint_compatibility_mismatch":
+        return ["compatibility_mismatch"]
+    if row.registry_id == "shape_mismatch":
+        return ["shape_mismatch"]
+    return [signature_for(row, line)]
+
+
+def root_fingerprint(row: SignatureRegistryRow, line: str) -> str | None:
+    if row.registry_id == "observed_exception":
+        return None
+    return fingerprint_for(row.registry_id, fingerprint_components(row, line))

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l0/streaming.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l0/streaming.py
@@ -1,0 +1,460 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One resumable L0A byte-to-evidence path for terminal and progressive use."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from threading import RLock
+from typing import Any, Mapping
+
+from ..infrastructure.log_source import (
+    ChunkedLogReader,
+    DecodedLine,
+    IncrementalLineDecoder,
+    IndexedFileLineStore,
+    LogSnapshot,
+    SourceBoundary,
+)
+from ..models import DecisionEvidence, L0Bundle
+from ..runtime import SYSTEM_CLOCK, Clock
+from .assembly import L0ObservationAccumulator, build_l0_bundle_from_observations
+from .decision import build_decision_evidence
+
+
+class ProgressiveSourceUnavailable(OSError):
+    """Raised when finalization has no usable source bytes."""
+
+
+@dataclass(frozen=True)
+class ProgressiveL0State:
+    """Observable state for one resumable L0A accumulator."""
+
+    phase: str
+    source_boundary: SourceBoundary | None
+    read_mode: str
+    chunk_bytes: int
+    encoding: str
+    line_count: int
+    pending_line_bytes: int
+    discarded_incomplete_tail_bytes: int
+    read_offset: int
+    poll_count: int
+    chunk_count: int
+    growth_count: int
+    unchanged_poll_count: int
+    missing_poll_count: int
+    reset_count: int
+    decode_replacement_count: int
+    decode_replacement_line_count: int
+    bytes_ingested: int
+    bytes_reread: int
+    l0a_build_count: int
+    source_decode_wall_clock_s: float
+    source_index_classify_wall_clock_s: float
+    source_ingest_wall_clock_s: float
+    l0a_reduction_wall_clock_s: float
+    last_growth_monotonic: float | None
+    last_poll_monotonic: float | None
+    last_error: str | None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "source_boundary": (
+                self.source_boundary.to_payload() if self.source_boundary is not None else None
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class _L0Checkpoint:
+    bundle: L0Bundle
+    decision_evidence: DecisionEvidence
+    source_boundary: SourceBoundary
+    l0a_wall_clock_s: float
+    decision_evidence_wall_clock_s: float
+
+
+@dataclass(frozen=True)
+class FinalizedL0A:
+    """Canonical L0A evidence and immutable source boundary."""
+
+    bundle: L0Bundle
+    decision_evidence: DecisionEvidence
+    source_log: LogSnapshot
+    source_boundary: SourceBoundary
+    l0a_wall_clock_s: float
+    decision_evidence_wall_clock_s: float
+    precomputed: bool
+    progressive_metrics: Mapping[str, Any]
+    canonical_hash: str
+
+
+class ProgressiveL0Accumulator:
+    """Incrementally ingest source bytes and reduce reusable L0A checkpoints."""
+
+    def __init__(
+        self,
+        log_path: str,
+        *,
+        reader: ChunkedLogReader | None = None,
+        clock: Clock = SYSTEM_CLOCK,
+    ) -> None:
+        self._log_path = log_path
+        self._reader = reader or ChunkedLogReader()
+        self._clock = clock
+        self._lock = RLock()
+        self._boundary: SourceBoundary | None = None
+        self._read_offset = 0
+        self._encoding = "utf-8"
+        self._decoder = IncrementalLineDecoder(encoding=self._encoding)
+        self._observations = L0ObservationAccumulator()
+        self._source_store: IndexedFileLineStore | None = None
+        self._checkpoint: _L0Checkpoint | None = None
+        self._phase = "registered"
+        self._poll_count = 0
+        self._chunk_count = 0
+        self._growth_count = 0
+        self._unchanged_poll_count = 0
+        self._missing_poll_count = 0
+        self._reset_count = 0
+        self._bytes_ingested = 0
+        self._bytes_reread = 0
+        self._l0a_build_count = 0
+        self._source_decode_wall_clock_s = 0.0
+        self._source_index_classify_wall_clock_s = 0.0
+        self._l0a_reduction_wall_clock_s = 0.0
+        self._last_growth_monotonic: float | None = None
+        self._last_poll_monotonic: float | None = None
+        self._last_error: str | None = None
+        self._discarded_incomplete_tail_bytes = 0
+        self._finalized = False
+
+    @property
+    def log_path(self) -> str:
+        return self._log_path
+
+    def state(self) -> ProgressiveL0State:
+        with self._lock:
+            return ProgressiveL0State(
+                phase=self._phase,
+                source_boundary=self._boundary,
+                read_mode=self._reader.read_mode,
+                chunk_bytes=self._reader.chunk_bytes,
+                encoding=self._encoding,
+                line_count=len(self._observations),
+                pending_line_bytes=self._decoder.pending_bytes,
+                discarded_incomplete_tail_bytes=self._discarded_incomplete_tail_bytes,
+                read_offset=self._read_offset,
+                poll_count=self._poll_count,
+                chunk_count=self._chunk_count,
+                growth_count=self._growth_count,
+                unchanged_poll_count=self._unchanged_poll_count,
+                missing_poll_count=self._missing_poll_count,
+                reset_count=self._reset_count,
+                decode_replacement_count=self._decoder.decode_replacement_count,
+                decode_replacement_line_count=(self._decoder.decode_replacement_line_count),
+                bytes_ingested=self._bytes_ingested,
+                bytes_reread=self._bytes_reread,
+                l0a_build_count=self._l0a_build_count,
+                source_decode_wall_clock_s=round(
+                    self._source_decode_wall_clock_s,
+                    6,
+                ),
+                source_index_classify_wall_clock_s=round(
+                    self._source_index_classify_wall_clock_s,
+                    6,
+                ),
+                source_ingest_wall_clock_s=round(
+                    self._source_decode_wall_clock_s + self._source_index_classify_wall_clock_s,
+                    6,
+                ),
+                l0a_reduction_wall_clock_s=round(
+                    self._l0a_reduction_wall_clock_s,
+                    6,
+                ),
+                last_growth_monotonic=self._last_growth_monotonic,
+                last_poll_monotonic=self._last_poll_monotonic,
+                last_error=self._last_error,
+            )
+
+    def refresh(self, *, precompute: bool = True) -> bool:
+        """Ingest new bytes, optionally reducing an updated L0A checkpoint."""
+
+        with self._lock:
+            if self._finalized:
+                raise RuntimeError("cannot refresh finalized L0A state")
+            self._phase = "precomputing"
+            self._poll_count += 1
+            self._last_poll_monotonic = self._clock.monotonic()
+            try:
+                boundary = self._reader.boundary(self._log_path)
+            except FileNotFoundError:
+                self._missing_poll_count += 1
+                self._phase = "waiting"
+                self._last_error = None
+                return False
+            except OSError as exc:
+                self._phase = "waiting"
+                self._last_error = f"{type(exc).__name__}: {exc}"
+                raise
+
+            change_kind = _boundary_change(self._boundary, boundary)
+            if change_kind == "unchanged":
+                self._unchanged_poll_count += 1
+                if (
+                    precompute
+                    and boundary.byte_size
+                    and (self._checkpoint is None or self._checkpoint.source_boundary != boundary)
+                ):
+                    self._build_checkpoint()
+                self._phase = "waiting"
+                self._last_error = None
+                return False
+
+            previous = self._boundary
+            if change_kind in {"initial", "growth"}:
+                if previous is None:
+                    self._bytes_ingested += boundary.byte_size
+                else:
+                    self._bytes_ingested += boundary.byte_size - previous.byte_size
+            else:
+                self._reset_count += 1
+                self._bytes_reread += boundary.byte_size
+                self._reset_analysis(encoding="utf-8")
+
+            self._ingest_to_boundary(boundary)
+
+            self._boundary = boundary
+            self._growth_count += 1
+            self._last_growth_monotonic = self._clock.monotonic()
+            self._last_error = None
+            if boundary.byte_size and precompute:
+                self._build_checkpoint()
+            elif not boundary.byte_size:
+                self._checkpoint = None
+            self._phase = "waiting"
+            return True
+
+    def finalize(self, *, include_incomplete_tail: bool = True) -> FinalizedL0A:
+        """Finalize one boundary, optionally excluding an actively written tail."""
+
+        with self._lock:
+            if self._finalized:
+                raise RuntimeError("L0A state is already finalized")
+            self._phase = "finalizing"
+            try:
+                changed = self.refresh(precompute=False)
+            except OSError:
+                self._reset_analysis(encoding="utf-8")
+                self._boundary = None
+                self._reset_count += 1
+                changed = self.refresh(precompute=False)
+
+            boundary = self._boundary
+            if boundary is None:
+                raise ProgressiveSourceUnavailable(f"log path is missing: {self._log_path}")
+            if boundary.byte_size == 0:
+                raise ProgressiveSourceUnavailable(f"log path is empty: {self._log_path}")
+
+            decode_started = self._clock.monotonic()
+            final_records = (
+                self._decoder.feed_records(b"", final=True) if include_incomplete_tail else ()
+            )
+            self._source_decode_wall_clock_s += self._clock.monotonic() - decode_started
+            if not include_incomplete_tail:
+                self._discarded_incomplete_tail_bytes = self._decoder.discard_pending()
+            self._append_records(final_records)
+            if final_records:
+                changed = True
+            reused_checkpoint = (
+                not changed
+                and self._checkpoint is not None
+                and self._checkpoint.source_boundary == boundary
+            )
+            if not reused_checkpoint:
+                self._build_checkpoint()
+
+            checkpoint = self._checkpoint
+            if checkpoint is None:
+                raise AssertionError("L0A finalization did not produce a checkpoint")
+
+            self._finalized = True
+            self._phase = "completed"
+            precomputed = reused_checkpoint
+            source_store = self._source_store
+            if source_store is None:
+                raise AssertionError("L0A finalization did not create a source index")
+            source_log = LogSnapshot.from_line_store(
+                path=self._log_path,
+                line_store=source_store,
+                byte_size=boundary.byte_size,
+                source_boundary=boundary,
+                encoding=self._encoding,
+                read_mode=self._reader.read_mode,
+            )
+            metrics = self.state().to_payload()
+            return FinalizedL0A(
+                bundle=checkpoint.bundle,
+                decision_evidence=checkpoint.decision_evidence,
+                source_log=source_log,
+                source_boundary=boundary,
+                l0a_wall_clock_s=(0.0 if precomputed else checkpoint.l0a_wall_clock_s),
+                decision_evidence_wall_clock_s=(
+                    0.0 if precomputed else checkpoint.decision_evidence_wall_clock_s
+                ),
+                precomputed=precomputed,
+                progressive_metrics=metrics,
+                canonical_hash=canonical_l0a_hash(
+                    checkpoint.bundle,
+                    checkpoint.decision_evidence,
+                ),
+            )
+
+    def _ingest_to_boundary(self, boundary: SourceBoundary) -> None:
+        if self._source_store is None:
+            self._source_store = IndexedFileLineStore(
+                self._log_path,
+                boundary=boundary,
+                encoding=self._encoding,
+                read_chunk_bytes=self._reader.chunk_bytes,
+            )
+            self._observations = L0ObservationAccumulator(line_store=self._source_store)
+        else:
+            self._source_store.update_boundary(boundary)
+        for chunk in self._reader.chunks(
+            self._log_path,
+            boundary=boundary,
+            start_offset=self._read_offset,
+        ):
+            self._chunk_count += 1
+            self._read_offset += len(chunk)
+            decode_started = self._clock.monotonic()
+            records = self._decoder.feed_records(chunk)
+            self._source_decode_wall_clock_s += self._clock.monotonic() - decode_started
+            self._append_records(records)
+
+    def _append_records(self, records: tuple[DecodedLine, ...]) -> None:
+        classify_started = self._clock.monotonic()
+        for record in records:
+            self._observations.append_record(record)
+        self._source_index_classify_wall_clock_s += self._clock.monotonic() - classify_started
+
+    def _reset_analysis(self, *, encoding: str) -> None:
+        if self._source_store is not None:
+            self._source_store.close()
+        self._read_offset = 0
+        self._encoding = encoding
+        self._decoder = IncrementalLineDecoder(encoding=encoding)
+        self._observations = L0ObservationAccumulator()
+        self._source_store = None
+        self._checkpoint = None
+
+    def _build_checkpoint(self) -> None:
+        boundary = self._boundary
+        if boundary is None:
+            raise AssertionError("cannot build an L0A checkpoint without a source boundary")
+        l0a_started = self._clock.monotonic()
+        bundle = build_l0_bundle_from_observations(
+            self._log_path,
+            byte_size=self._read_offset,
+            observations=self._observations,
+        )
+        l0a_wall_clock_s = self._clock.monotonic() - l0a_started
+        decision_started = self._clock.monotonic()
+        decision_evidence = build_decision_evidence(bundle)
+        decision_wall_clock_s = self._clock.monotonic() - decision_started
+        self._checkpoint = _L0Checkpoint(
+            bundle=bundle,
+            decision_evidence=decision_evidence,
+            source_boundary=boundary,
+            l0a_wall_clock_s=round(l0a_wall_clock_s, 3),
+            decision_evidence_wall_clock_s=round(decision_wall_clock_s, 3),
+        )
+        self._l0a_build_count += 1
+        self._l0a_reduction_wall_clock_s += l0a_wall_clock_s + decision_wall_clock_s
+
+
+def finalize_log_snapshot(
+    source_log: LogSnapshot,
+    *,
+    l0_bundle: L0Bundle | None = None,
+    clock: Clock = SYSTEM_CLOCK,
+) -> FinalizedL0A:
+    """Finalize an immutable snapshot through the same observation reducer."""
+
+    l0a_started = clock.monotonic()
+    if l0_bundle is None:
+        observations = L0ObservationAccumulator(line_store=source_log)
+        for item in source_log.log_lines():
+            observations.observe_existing(item)
+        bundle = build_l0_bundle_from_observations(
+            source_log.path,
+            byte_size=source_log.byte_size,
+            observations=observations,
+        )
+    else:
+        bundle = l0_bundle
+    l0a_wall_clock_s = clock.monotonic() - l0a_started
+    decision_started = clock.monotonic()
+    decision_evidence = build_decision_evidence(bundle)
+    decision_wall_clock_s = clock.monotonic() - decision_started
+    boundary = source_log.source_boundary or SourceBoundary(
+        device=0,
+        inode=0,
+        byte_size=source_log.byte_size,
+        mtime_ns=0,
+    )
+    return FinalizedL0A(
+        bundle=bundle,
+        decision_evidence=decision_evidence,
+        source_log=source_log,
+        source_boundary=boundary,
+        l0a_wall_clock_s=round(l0a_wall_clock_s, 3),
+        decision_evidence_wall_clock_s=round(decision_wall_clock_s, 3),
+        precomputed=l0_bundle is not None,
+        progressive_metrics={},
+        canonical_hash=canonical_l0a_hash(bundle, decision_evidence),
+    )
+
+
+def canonical_l0a_payload(
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+) -> dict[str, Any]:
+    """Return the policy-relevant L0A projection used by equivalence tests."""
+
+    return {
+        "l0_bundle": asdict(bundle),
+        "decision_evidence": decision_evidence.to_payload(),
+    }
+
+
+def canonical_l0a_hash(
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+) -> str:
+    payload = canonical_l0a_payload(bundle, decision_evidence)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _boundary_change(
+    previous: SourceBoundary | None,
+    current: SourceBoundary,
+) -> str:
+    if previous is None:
+        return "initial"
+    if not previous.same_file(current):
+        return "replaced"
+    if current.byte_size < previous.byte_size:
+        return "truncated"
+    if current.byte_size == previous.byte_size and current.mtime_ns == previous.mtime_ns:
+        return "unchanged"
+    if current.byte_size > previous.byte_size:
+        return "growth"
+    return "modified_without_growth"

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/__init__.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L1 semantic recovery assessment and provider adapters."""
+
+from .contracts import (
+    DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+    EvidenceExtractor,
+    EvidenceTools,
+    L1EvidenceContext,
+    L1EvidenceResult,
+    ModelRoute,
+)
+from .execution import deadline_exceeded_result, execution_status, extract_timed, output_health
+from .openai_compatible import (
+    DEFAULT_ADVERTISED_TOOLS,
+    THINKING_MODES,
+    ChatTransport,
+    ConfigCredentialProvider,
+    CredentialProvider,
+    HttpClient,
+    LlmConfig,
+    LlmEvidenceExtractor,
+    OpenAICompatibleTransport,
+)
+from .provider_profiles import NVIDIA_INFERENCE_HUB, ProviderProfile
+from .response_contract import L1_RESPONSE_CONTRACT, model_response_schema
+from .tools import EvidenceToolsFactory, LogTools, build_l1_evidence_context
+from .validation import model_evidence_contract_errors
+
+__all__ = [
+    "DEFAULT_ADVERTISED_TOOLS",
+    "DEFAULT_ANALYSIS_TIMEOUT_SECONDS",
+    "ChatTransport",
+    "ConfigCredentialProvider",
+    "CredentialProvider",
+    "EvidenceExtractor",
+    "EvidenceTools",
+    "EvidenceToolsFactory",
+    "L1EvidenceContext",
+    "L1EvidenceResult",
+    "L1_RESPONSE_CONTRACT",
+    "LlmConfig",
+    "LlmEvidenceExtractor",
+    "HttpClient",
+    "LogTools",
+    "ModelRoute",
+    "NVIDIA_INFERENCE_HUB",
+    "OpenAICompatibleTransport",
+    "ProviderProfile",
+    "THINKING_MODES",
+    "build_l1_evidence_context",
+    "deadline_exceeded_result",
+    "execution_status",
+    "extract_timed",
+    "model_evidence_contract_errors",
+    "model_response_schema",
+    "output_health",
+]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/contracts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/contracts.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider-neutral contracts between restart-agent pipeline stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, Sequence
+
+from ..immutable import freeze_json_value
+from ..models import L0ModelFacingView
+
+DEFAULT_ANALYSIS_TIMEOUT_SECONDS = 240.0
+
+
+class EvidenceTools(Protocol):
+    """Read-only evidence expansion capabilities available to L1 adapters."""
+
+    def overview(self) -> dict[str, Any]: ...
+
+    def grep_log(
+        self,
+        pattern: str,
+        *,
+        ignore_case: bool = True,
+        max_matches: int = 50,
+    ) -> dict[str, Any]: ...
+
+    def read_window(
+        self,
+        center_line: int,
+        *,
+        before: int = 20,
+        after: int = 80,
+    ) -> dict[str, Any]: ...
+
+    def get_evidence_objects(self, refs: Sequence[str]) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class L1EvidenceResult:
+    """Raw, provider-neutral result returned by one L1 evidence extractor."""
+
+    evidence: Mapping[str, Any] | None
+    model: str
+    raw_model_output: str | None = None
+    success: bool = False
+    malformed: bool = False
+    errors: tuple[str, ...] = ()
+    model_calls: tuple[Mapping[str, Any], ...] = ()
+    tool_calls: tuple[Mapping[str, Any], ...] = ()
+    unsupported_tool_requests: tuple[Mapping[str, Any], ...] = ()
+    transcript_events: tuple[Mapping[str, Any], ...] = ()
+    anomalies: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.evidence is not None:
+            object.__setattr__(self, "evidence", freeze_json_value(self.evidence))
+        for name in (
+            "model_calls",
+            "tool_calls",
+            "unsupported_tool_requests",
+            "transcript_events",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                tuple(freeze_json_value(item) for item in getattr(self, name)),
+            )
+        object.__setattr__(self, "anomalies", freeze_json_value(self.anomalies))
+
+    @classmethod
+    def disabled(cls) -> "L1EvidenceResult":
+        return cls(
+            evidence=None,
+            model="",
+            success=False,
+            anomalies={"l1_enabled": False},
+        )
+
+    def to_trace(self) -> dict[str, Any]:
+        return {
+            "enabled": bool(self.model),
+            "model": self.model or None,
+            "success": self.success,
+            "malformed": self.malformed,
+            "errors": list(self.errors),
+            "raw_model_output": self.raw_model_output,
+            "parsed_evidence": dict(self.evidence) if self.evidence is not None else None,
+            "model_calls": [dict(item) for item in self.model_calls],
+            "tool_calls": [dict(item) for item in self.tool_calls],
+            "unsupported_tool_requests": [dict(item) for item in self.unsupported_tool_requests],
+            "interaction_transcript": [dict(item) for item in self.transcript_events],
+            "anomalies": dict(self.anomalies),
+        }
+
+
+@dataclass(frozen=True)
+class L1EvidenceContext:
+    """The bounded L0B model view and controlled read-only expansion tools."""
+
+    model_view: L0ModelFacingView
+    tools: EvidenceTools
+
+
+class EvidenceExtractor(Protocol):
+    """Infrastructure adapter that converts L0B evidence into an L1 result."""
+
+    def extract_evidence(
+        self,
+        context: L1EvidenceContext,
+        *,
+        deadline_monotonic: float | None = None,
+    ) -> L1EvidenceResult:
+        """Interpret the model view and optionally use controlled tools."""
+
+
+@dataclass(frozen=True)
+class ModelRoute:
+    """One independently configured L1 route for parallel analysis."""
+
+    route_id: str
+    evidence_extractor: EvidenceExtractor
+    model: str | None = None
+    endpoint: str | None = None
+    credential_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.route_id.strip():
+            raise ValueError("model route_id must not be empty")

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/execution.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/execution.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L1 invocation boundary, output health, and deadline degradation."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..infrastructure.log_source import LogSnapshot
+from ..models import L0Bundle, L0ModelFacingView
+from ..runtime import SYSTEM_CLOCK, Clock
+from .contracts import EvidenceExtractor, L1EvidenceResult
+from .tools import EvidenceToolsFactory, build_l1_evidence_context
+from .validation import model_evidence_contract_errors
+
+
+def extract_timed(
+    extractor: EvidenceExtractor,
+    bundle: L0Bundle,
+    model_view: L0ModelFacingView,
+    source_log: LogSnapshot,
+    deadline_monotonic: float | None,
+    tools_factory: EvidenceToolsFactory | None = None,
+    clock: Clock = SYSTEM_CLOCK,
+) -> tuple[L1EvidenceResult, float, float]:
+    """Invoke one extractor and contain provider-specific exceptions."""
+
+    started = clock.monotonic()
+    try:
+        result = extractor.extract_evidence(
+            build_l1_evidence_context(
+                bundle,
+                model_view,
+                source_log,
+                tools_factory=tools_factory,
+            ),
+            deadline_monotonic=deadline_monotonic,
+        )
+    except Exception as exc:  # defensive boundary for custom extractors
+        result = L1EvidenceResult(
+            evidence=None,
+            model=type(extractor).__name__,
+            success=False,
+            errors=(f"{type(exc).__name__}: {exc}",),
+            anomalies={
+                "l1_enabled": True,
+                "provider_error": True,
+                "provider_error_type": "extractor_exception",
+            },
+        )
+    completed = clock.monotonic()
+    return result, round(completed - started, 3), completed
+
+
+def deadline_exceeded_result(*, model: str) -> L1EvidenceResult:
+    """Represent an L1 route that did not complete inside the analysis budget."""
+
+    error = "analysis deadline exceeded before L1 completed"
+    return L1EvidenceResult(
+        evidence=None,
+        model=model,
+        success=False,
+        errors=(error,),
+        anomalies={
+            "l1_enabled": True,
+            "provider_error": True,
+            "provider_error_type": "analysis_deadline_exceeded",
+            "provider_timeout": True,
+            "deadline_exceeded": True,
+        },
+    )
+
+
+def output_health(l1_result: L1EvidenceResult) -> dict[str, Any]:
+    """Classify whether an L1 response is usable by L2."""
+
+    if not l1_result.model and not l1_result.anomalies.get("l1_enabled"):
+        return {"status": "not_run", "usable": False, "errors": []}
+    if l1_result.anomalies.get("provider_timeout"):
+        return {
+            "status": "provider_timeout",
+            "usable": False,
+            "errors": list(l1_result.errors) or ["LLM provider timed out"],
+        }
+    if l1_result.anomalies.get("model_output_truncated"):
+        return {
+            "status": "truncated",
+            "usable": False,
+            "errors": list(l1_result.errors) or ["model output was truncated"],
+        }
+    if not l1_result.success or l1_result.evidence is None:
+        status = "provider_error" if l1_result.anomalies.get("provider_error") else "malformed"
+        return {"status": status, "usable": False, "errors": list(l1_result.errors)}
+    contract_errors = model_evidence_contract_errors(l1_result.evidence)
+    if contract_errors:
+        return {
+            "status": "contract_invalid",
+            "usable": False,
+            "errors": contract_errors,
+        }
+    return {"status": "usable", "usable": True, "errors": []}
+
+
+def execution_status(
+    *,
+    configured: bool,
+    result: L1EvidenceResult,
+    health: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Summarize model/endpoint execution independently of semantic quality."""
+
+    if not configured:
+        return {"status": "not_run", "issues": []}
+
+    issues: list[str] = []
+    failed_calls = [call for call in result.model_calls if not call.get("success")]
+    if failed_calls:
+        issues.append("model_call_failed")
+    if any(call.get("retry_scheduled") for call in failed_calls):
+        issues.append("retry_used")
+    if any(call.get("timeout") for call in failed_calls):
+        issues.append("provider_timeout")
+    if any(call.get("error_type") == "context_window_exceeded" for call in failed_calls):
+        issues.append("client_context_budget_exceeded")
+    if any(
+        call.get("http_status") and call.get("error_type") != "context_window_exceeded"
+        for call in failed_calls
+    ):
+        issues.append("provider_http_error")
+    if result.unsupported_tool_requests:
+        issues.append("unsupported_tool_request")
+
+    if not health.get("usable"):
+        issues.append(str(health.get("status") or "unusable"))
+        return {"status": "failed", "issues": list(dict.fromkeys(issues))}
+    if issues:
+        return {"status": "degraded", "issues": list(dict.fromkeys(issues))}
+    return {"status": "ok", "issues": []}

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/openai_compatible.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/openai_compatible.py
@@ -1,0 +1,1939 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI-compatible L1 model evidence extraction and read-only tool loop."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import math
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+import httpx
+
+from ..models import L1_EVIDENCE_SCHEMA_VERSION, L0ModelFacingView
+from ..runtime import SYSTEM_CLOCK, SYSTEM_SLEEPER, Clock, Sleeper
+from .contracts import L1EvidenceContext, L1EvidenceResult
+from .prompts import SYSTEM_PROMPT
+from .provider_profiles import NVIDIA_INFERENCE_HUB
+from .response_contract import model_response_schema
+from .tools import LogTools
+from .validation import model_evidence_contract_errors
+
+DEFAULT_BASE_URL = NVIDIA_INFERENCE_HUB.base_url
+DEFAULT_MODEL = NVIDIA_INFERENCE_HUB.model
+DEFAULT_OMIT_SAMPLING_PARAMS_MODEL_RE = r"gpt-5\.5"
+THINKING_MODES = ("auto", "disable", "allow")
+MAX_ERROR_DETAIL_CHARS = 4000
+DEFAULT_LLM_MAX_RETRIES = 1
+DEFAULT_LLM_RETRY_BACKOFF_SECONDS = 0.5
+DEFAULT_LLM_MAX_OUTPUT_TOKENS = 64_000
+DEFAULT_CONTEXT_SAFETY_TOKENS = 4_096
+ESTIMATED_CHARS_PER_INPUT_TOKEN = 3
+CONTEXT_TOKEN_ESTIMATE_MULTIPLIER = 1.15
+DEFAULT_ADVERTISED_TOOLS = ("overview", "grep_log", "read_window")
+IMPLEMENTED_TOOL_NAMES = frozenset((*DEFAULT_ADVERTISED_TOOLS, "get_evidence_objects"))
+KNOWN_MODEL_CONTEXT_WINDOWS = {
+    "nvidia/qwen/eccn-qwen-235b": 200_000,
+    "nvidia/qwen/eccn-qwen3-5-397b-a17b": 262_144,
+}
+PROVIDER_TIMING_HEADERS = {
+    "x-litellm-timing-llm-api-ms": "downstream_llm_api_ms",
+    "x-litellm-timing-pre-processing-ms": "proxy_pre_processing_ms",
+    "x-litellm-timing-post-processing-ms": "proxy_post_processing_ms",
+    "x-litellm-timing-message-copy-ms": "proxy_message_copy_ms",
+}
+
+
+@dataclass(frozen=True)
+class LlmConfig:
+    base_url: str = DEFAULT_BASE_URL
+    model: str = DEFAULT_MODEL
+    api_key: str | None = None
+    api_key_file: str | None = None
+    timeout_seconds: float = 120.0
+    max_output_tokens: int = DEFAULT_LLM_MAX_OUTPUT_TOKENS
+    context_window_tokens: int | None = None
+    context_safety_tokens: int = DEFAULT_CONTEXT_SAFETY_TOKENS
+    temperature: float | None = 0.2
+    top_p: float | None = 0.7
+    omit_sampling_params_for_model_regex: str = DEFAULT_OMIT_SAMPLING_PARAMS_MODEL_RE
+    max_tool_rounds: int = 8
+    max_retries: int = DEFAULT_LLM_MAX_RETRIES
+    retry_backoff_seconds: float = DEFAULT_LLM_RETRY_BACKOFF_SECONDS
+    tools_enabled: bool = True
+    advertised_tools: tuple[str, ...] = DEFAULT_ADVERTISED_TOOLS
+    thinking_mode: str = "auto"
+    reasoning_effort: str | None = None
+
+    def __post_init__(self) -> None:
+        unknown = set(self.advertised_tools).difference(IMPLEMENTED_TOOL_NAMES)
+        if unknown:
+            raise ValueError("unknown advertised tools: " + ", ".join(sorted(unknown)))
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        environ: Mapping[str, str] | None = None,
+        base_url: str | None = None,
+        model: str | None = None,
+        api_key_file: str | None = None,
+        timeout_seconds: float | None = None,
+        max_output_tokens: int | None = None,
+        context_window_tokens: int | None = None,
+        max_tool_rounds: int | None = None,
+        tools_enabled: bool | None = None,
+        advertised_tools: Sequence[str] | None = None,
+        thinking_mode: str | None = None,
+        reasoning_effort: str | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+    ) -> "LlmConfig":
+        environment = os.environ if environ is None else environ
+        return cls(
+            base_url=base_url or environment.get("NVRX_LLM_BASE_URL", DEFAULT_BASE_URL),
+            model=model or environment.get("NVRX_LLM_MODEL", DEFAULT_MODEL),
+            api_key=environment.get("LLM_API_KEY") or environment.get("NVIDIA_API_KEY"),
+            api_key_file=api_key_file or environment.get("LLM_API_KEY_FILE"),
+            timeout_seconds=(
+                timeout_seconds
+                if timeout_seconds is not None
+                else _float_env(environment, "NVRX_LLM_TIMEOUT_SECONDS", 120.0)
+            ),
+            max_output_tokens=(
+                max_output_tokens
+                if max_output_tokens is not None
+                else _int_env(
+                    environment,
+                    "NVRX_LLM_MAX_OUTPUT_TOKENS",
+                    DEFAULT_LLM_MAX_OUTPUT_TOKENS,
+                )
+            ),
+            context_window_tokens=(
+                context_window_tokens
+                if context_window_tokens is not None
+                else _optional_int_env(environment, "NVRX_LLM_CONTEXT_WINDOW_TOKENS")
+            ),
+            context_safety_tokens=_int_env(
+                environment,
+                "NVRX_LLM_CONTEXT_SAFETY_TOKENS",
+                DEFAULT_CONTEXT_SAFETY_TOKENS,
+            ),
+            temperature=(
+                temperature
+                if temperature is not None
+                else _optional_float_env(environment, "NVRX_LLM_TEMPERATURE", 0.2)
+            ),
+            top_p=(
+                top_p
+                if top_p is not None
+                else _optional_float_env(environment, "NVRX_LLM_TOP_P", 0.7)
+            ),
+            max_tool_rounds=(
+                max_tool_rounds
+                if max_tool_rounds is not None
+                else _int_env(environment, "NVRX_LLM_MAX_TOOL_ROUNDS", 8)
+            ),
+            max_retries=_int_env(
+                environment,
+                "NVRX_LLM_MAX_RETRIES",
+                DEFAULT_LLM_MAX_RETRIES,
+            ),
+            retry_backoff_seconds=_float_env(
+                environment,
+                "NVRX_LLM_RETRY_BACKOFF_SECONDS",
+                DEFAULT_LLM_RETRY_BACKOFF_SECONDS,
+            ),
+            tools_enabled=(
+                tools_enabled
+                if tools_enabled is not None
+                else _bool_env(environment, "NVRX_LLM_TOOLS_ENABLED", True)
+            ),
+            advertised_tools=(
+                tuple(advertised_tools)
+                if advertised_tools is not None
+                else _tool_names_env(
+                    environment,
+                    "NVRX_LLM_ADVERTISED_TOOLS",
+                    DEFAULT_ADVERTISED_TOOLS,
+                )
+            ),
+            thinking_mode=(thinking_mode or environment.get("NVRX_LLM_THINKING_MODE", "auto")),
+            reasoning_effort=(reasoning_effort or environment.get("NVRX_LLM_REASONING_EFFORT")),
+        )
+
+    def request_temperature(self) -> float | None:
+        if self.omit_sampling_params_for_model_regex and re.search(
+            self.omit_sampling_params_for_model_regex,
+            self.model,
+            re.IGNORECASE,
+        ):
+            return None
+        return self.temperature
+
+    def request_top_p(self) -> float | None:
+        if self.omit_sampling_params_for_model_regex and re.search(
+            self.omit_sampling_params_for_model_regex,
+            self.model,
+            re.IGNORECASE,
+        ):
+            return None
+        return self.top_p
+
+    def disable_thinking(self) -> bool:
+        if self.thinking_mode not in THINKING_MODES:
+            raise ValueError(f"unknown thinking_mode: {self.thinking_mode}")
+        if self.thinking_mode == "disable":
+            return True
+        if self.thinking_mode == "allow":
+            return False
+        return "qwen" in self.model.lower()
+
+    def resolved_context_window_tokens(self) -> int | None:
+        if self.context_window_tokens is not None:
+            return self.context_window_tokens
+        return KNOWN_MODEL_CONTEXT_WINDOWS.get(self.model)
+
+    def resolved_advertised_tools(self) -> tuple[str, ...]:
+        if not self.tools_enabled:
+            return ()
+        return tuple(dict.fromkeys(self.advertised_tools))
+
+    def tools_active(self) -> bool:
+        return bool(self.resolved_advertised_tools())
+
+
+class LlmCallError(RuntimeError):
+    """Provider call failed after a request was attempted."""
+
+    def __init__(
+        self,
+        message: str,
+        call_record: dict[str, Any],
+        *,
+        prior_call_records: Sequence[Mapping[str, Any]] = (),
+        transcript_events: Sequence[Mapping[str, Any]] = (),
+    ):
+        super().__init__(message)
+        self.call_record = call_record
+        self.prior_call_records = tuple(dict(item) for item in prior_call_records)
+        self.transcript_events = tuple(dict(item) for item in transcript_events)
+
+
+class CredentialProvider(Protocol):
+    """Resolve a provider credential at the infrastructure boundary."""
+
+    def load(self, config: LlmConfig) -> str: ...
+
+
+class ConfigCredentialProvider:
+    """Resolve inline or file-backed credentials declared by ``LlmConfig``."""
+
+    def load(self, config: LlmConfig) -> str:
+        return _load_api_key(config)
+
+
+class ToolLoopSession:
+    """Execute one bounded model/tool conversation and contract-repair turn."""
+
+    def __init__(
+        self,
+        config: LlmConfig,
+        call_model_with_retries: Any,
+        *,
+        credential_provider: CredentialProvider,
+        clock: Clock = SYSTEM_CLOCK,
+    ) -> None:
+        self._config = config
+        self._call_model_with_retries = call_model_with_retries
+        self._credential_provider = credential_provider
+        self._clock = clock
+
+    def run(
+        self,
+        context: L1EvidenceContext,
+        *,
+        deadline_monotonic: float | None,
+    ) -> L1EvidenceResult:
+        state = _ToolConversation.start(
+            self._config,
+            context,
+            api_key=self._credential_provider.load(self._config),
+        )
+        loop_outcome = ToolRoundExecutor(
+            self._config,
+            self._call_model_with_retries,
+            clock=self._clock,
+        ).run(
+            state,
+            deadline_monotonic=deadline_monotonic,
+        )
+        if loop_outcome.result is not None:
+            return loop_outcome.result
+        return ContractRepairExecutor(
+            self._config,
+            self._call_model_with_retries,
+            clock=self._clock,
+        ).run(
+            state,
+            previous_error=loop_outcome.final_error,
+            deadline_monotonic=deadline_monotonic,
+        )
+
+
+@dataclass
+class _ToolConversation:
+    api_key: str
+    tools: Any
+    messages: list[dict[str, Any]]
+    transcript_events: list[dict[str, Any]]
+    model_calls: list[dict[str, Any]]
+    tool_calls: list[dict[str, Any]]
+    unsupported_tool_requests: list[dict[str, Any]]
+    raw_output: str | None = None
+    last_message: dict[str, Any] | None = None
+
+    @classmethod
+    def start(
+        cls,
+        config: LlmConfig,
+        context: L1EvidenceContext,
+        *,
+        api_key: str,
+    ) -> "_ToolConversation":
+        model_view = context.model_view
+        payload = model_view.to_payload()
+        initial_user_message = _initial_user_message(model_view)
+        model_visible_payload = json.loads(initial_user_message)
+        return cls(
+            api_key=api_key,
+            tools=context.tools,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": initial_user_message},
+            ],
+            transcript_events=[
+                {"event_type": "tool_loop_profile", **_tool_loop_profile(config)},
+                {
+                    "event_type": "bundle_snapshot",
+                    "schema_version": model_view.schema_version,
+                    "bundle": payload["evidence_bundle"],
+                    "model_view": payload,
+                    "model_visible_payload": model_visible_payload,
+                },
+            ],
+            model_calls=[],
+            tool_calls=[],
+            unsupported_tool_requests=[],
+        )
+
+
+@dataclass(frozen=True)
+class _ToolLoopOutcome:
+    result: L1EvidenceResult | None
+    final_error: str | None = None
+
+
+class ToolRoundExecutor:
+    """Execute bounded model turns and dispatch advertised read-only tools."""
+
+    def __init__(
+        self,
+        config: LlmConfig,
+        call_model_with_retries: Any,
+        *,
+        clock: Clock = SYSTEM_CLOCK,
+    ) -> None:
+        self._config = config
+        self._call_model_with_retries = call_model_with_retries
+        self._clock = clock
+
+    def run(
+        self,
+        state: _ToolConversation,
+        *,
+        deadline_monotonic: float | None,
+    ) -> _ToolLoopOutcome:
+        for model_turn in range(1, max(1, self._config.max_tool_rounds) + 1):
+            provider_failure = self._request_model(
+                state,
+                model_turn=model_turn,
+                deadline_monotonic=deadline_monotonic,
+            )
+            if provider_failure is not None:
+                return _ToolLoopOutcome(provider_failure)
+            call_record = state.model_calls[-1]
+            message = state.last_message or {}
+            parsed_tool_calls = _message_tool_calls(message)
+            if parsed_tool_calls:
+                failure = self._dispatch_tools(
+                    state,
+                    message,
+                    parsed_tool_calls,
+                    model_turn=model_turn,
+                    deadline_monotonic=deadline_monotonic,
+                )
+                if failure is not None:
+                    return _ToolLoopOutcome(failure)
+                continue
+            if call_record.get("finish_reason") == "length":
+                state.messages.append({"role": "assistant", "content": state.raw_output})
+                return _ToolLoopOutcome(
+                    None,
+                    "model output hit max_tokens before final evidence completed",
+                )
+            try:
+                evidence = _parse_model_evidence(state.raw_output or "")
+            except ValueError as exc:
+                state.messages.append({"role": "assistant", "content": state.raw_output})
+                return _ToolLoopOutcome(None, str(exc))
+            return _ToolLoopOutcome(_successful_evidence_result(self._config, state, evidence))
+        return _ToolLoopOutcome(None)
+
+    def _request_model(
+        self,
+        state: _ToolConversation,
+        *,
+        model_turn: int,
+        deadline_monotonic: float | None,
+    ) -> L1EvidenceResult | None:
+        try:
+            response, call_record = self._call_model_with_retries(
+                api_key=state.api_key,
+                messages=state.messages,
+                include_tools=self._config.tools_active(),
+                model_turn=model_turn,
+                model_calls=state.model_calls,
+                transcript_events=state.transcript_events,
+                deadline_monotonic=deadline_monotonic,
+            )
+        except LlmCallError as exc:
+            return _provider_failure_from_state(self._config, state, exc)
+        state.model_calls.append(call_record)
+        message = _response_message(response)
+        state.last_message = message
+        state.raw_output = message.get("content") or ""
+        parsed_tool_calls = _message_tool_calls(message)
+        state.transcript_events.append(
+            {
+                "event_type": "model_response",
+                "model_turn": model_turn,
+                "model": self._config.model,
+                "finish_reason": call_record.get("finish_reason"),
+                "raw_model_output": state.raw_output,
+                "tool_calls": parsed_tool_calls,
+                "usage": call_record.get("usage"),
+            }
+        )
+        return None
+
+    def _dispatch_tools(
+        self,
+        state: _ToolConversation,
+        message: Mapping[str, Any],
+        tool_requests: list[dict[str, Any]],
+        *,
+        model_turn: int,
+        deadline_monotonic: float | None,
+    ) -> L1EvidenceResult | None:
+        state.messages.append(_assistant_tool_call_message(message))
+        for tool_call in tool_requests:
+            if _deadline_expired(deadline_monotonic, clock=self._clock):
+                return _deadline_failure_from_state(
+                    self._config,
+                    state,
+                    model_turn=model_turn,
+                    reason="before_tool_call",
+                    clock=self._clock,
+                )
+            tool_result, tool_record, unsupported_record = _execute_tool_call(
+                state.tools,
+                tool_call,
+                model_turn=model_turn,
+                advertised_tools=self._config.resolved_advertised_tools(),
+                clock=self._clock,
+            )
+            state.tool_calls.append(tool_record)
+            if unsupported_record is not None:
+                state.unsupported_tool_requests.append(unsupported_record)
+            state.transcript_events.append(
+                {
+                    "event_type": "tool_result",
+                    "model_turn": model_turn,
+                    "tool_call_id": tool_call.get("id"),
+                    "name": tool_call.get("name"),
+                    "result": tool_result,
+                    "record": tool_record,
+                }
+            )
+            state.messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.get("id"),
+                    "name": tool_call.get("name"),
+                    "content": json.dumps(tool_result, sort_keys=True),
+                }
+            )
+            if _deadline_expired(deadline_monotonic, clock=self._clock):
+                return _deadline_failure_from_state(
+                    self._config,
+                    state,
+                    model_turn=model_turn,
+                    reason="after_tool_call",
+                    clock=self._clock,
+                )
+        return None
+
+
+class ContractRepairExecutor:
+    """Request one final schema-conforming response without tool advertisement."""
+
+    def __init__(
+        self,
+        config: LlmConfig,
+        call_model_with_retries: Any,
+        *,
+        clock: Clock = SYSTEM_CLOCK,
+    ) -> None:
+        self._config = config
+        self._call_model_with_retries = call_model_with_retries
+        self._clock = clock
+
+    def run(
+        self,
+        state: _ToolConversation,
+        *,
+        previous_error: str | None,
+        deadline_monotonic: float | None,
+    ) -> L1EvidenceResult:
+        contract_repair_requested = bool(previous_error and "max_tokens" not in previous_error)
+        model_turn = len(state.model_calls) + 1
+        if _deadline_expired(deadline_monotonic, clock=self._clock):
+            return _deadline_failure_from_state(
+                self._config,
+                state,
+                model_turn=model_turn,
+                reason="before_final_evidence_call",
+                clock=self._clock,
+            )
+        _append_contract_repair_prompt(
+            state,
+            previous_error=previous_error,
+            contract_repair_requested=contract_repair_requested,
+        )
+        try:
+            try:
+                response, call_record = self._call_model_with_retries(
+                    api_key=state.api_key,
+                    messages=state.messages,
+                    include_tools=False,
+                    model_turn=model_turn,
+                    model_calls=state.model_calls,
+                    transcript_events=state.transcript_events,
+                    deadline_monotonic=deadline_monotonic,
+                )
+            except LlmCallError as exc:
+                return _provider_failure_from_state(self._config, state, exc)
+            state.model_calls.append(call_record)
+            message = _response_message(response)
+            state.raw_output = message.get("content") or ""
+            state.transcript_events.append(
+                {
+                    "event_type": "model_response",
+                    "model_turn": len(state.model_calls),
+                    "model": self._config.model,
+                    "finish_reason": call_record.get("finish_reason"),
+                    "raw_model_output": state.raw_output,
+                    "usage": call_record.get("usage"),
+                }
+            )
+            if call_record.get("finish_reason") == "length":
+                raise ValueError("model output hit max_tokens during final evidence response")
+            evidence = _parse_model_evidence(state.raw_output)
+        except Exception as exc:
+            return _malformed_evidence_result(
+                self._config,
+                state,
+                exc,
+                contract_repair_requested=contract_repair_requested,
+            )
+        return _successful_evidence_result(
+            self._config,
+            state,
+            evidence,
+            forced_final=True,
+            contract_repair_requested=contract_repair_requested,
+        )
+
+
+def _append_contract_repair_prompt(
+    state: _ToolConversation,
+    *,
+    previous_error: str | None,
+    contract_repair_requested: bool,
+) -> None:
+    state.transcript_events.append(
+        {
+            "event_type": "budget_event",
+            "reason": (
+                "contract_repair_call"
+                if contract_repair_requested
+                else "forced_final_evidence_call"
+            ),
+            "previous_error": previous_error,
+        }
+    )
+    repair_context = (
+        f"The previous response could not be accepted: {previous_error}. " if previous_error else ""
+    )
+    state.messages.append(
+        {
+            "role": "user",
+            "content": (
+                f"{repair_context}Return one complete {L1_EVIDENCE_SCHEMA_VERSION} "
+                "JSON object now. Copy schema_version exactly. Include the primary "
+                "failure, root_cause_assessment, model_recovery_assessment, "
+                "related_failures, and grounded evidence. Do not call "
+                "tools. Do not include scores or decisions."
+            ),
+        }
+    )
+
+
+def _successful_evidence_result(
+    config: LlmConfig,
+    state: _ToolConversation,
+    evidence: Mapping[str, Any],
+    *,
+    forced_final: bool = False,
+    contract_repair_requested: bool = False,
+) -> L1EvidenceResult:
+    anomalies: dict[str, Any] = {
+        "unsupported_tool_request_seen": bool(state.unsupported_tool_requests),
+    }
+    if forced_final:
+        anomalies.update(
+            {
+                "forced_final_evidence_call": True,
+                "contract_repair_requested": contract_repair_requested,
+            }
+        )
+    return L1EvidenceResult(
+        evidence=evidence,
+        model=config.model,
+        raw_model_output=state.raw_output,
+        success=True,
+        model_calls=tuple(state.model_calls),
+        tool_calls=tuple(state.tool_calls),
+        unsupported_tool_requests=tuple(state.unsupported_tool_requests),
+        transcript_events=tuple(state.transcript_events),
+        anomalies=anomalies,
+    )
+
+
+def _malformed_evidence_result(
+    config: LlmConfig,
+    state: _ToolConversation,
+    error: Exception,
+    *,
+    contract_repair_requested: bool,
+) -> L1EvidenceResult:
+    return L1EvidenceResult(
+        evidence=None,
+        model=config.model,
+        raw_model_output=state.raw_output,
+        success=False,
+        malformed=True,
+        errors=(str(error),),
+        model_calls=tuple(state.model_calls),
+        tool_calls=tuple(state.tool_calls),
+        unsupported_tool_requests=tuple(state.unsupported_tool_requests),
+        transcript_events=tuple(state.transcript_events),
+        anomalies={
+            "forced_final_evidence_call": True,
+            "contract_repair_requested": contract_repair_requested,
+            "malformed_model_evidence": True,
+            "model_output_truncated": bool(
+                state.model_calls and state.model_calls[-1].get("finish_reason") == "length"
+            ),
+            "unsupported_tool_request_seen": bool(state.unsupported_tool_requests),
+        },
+    )
+
+
+def _provider_failure_from_state(
+    config: LlmConfig,
+    state: _ToolConversation,
+    error: LlmCallError,
+) -> L1EvidenceResult:
+    return _provider_failure_result(
+        config=config,
+        exc=error,
+        raw_output=state.raw_output,
+        model_calls=state.model_calls,
+        tool_calls=state.tool_calls,
+        unsupported_tool_requests=state.unsupported_tool_requests,
+        transcript_events=state.transcript_events,
+    )
+
+
+def _deadline_failure_from_state(
+    config: LlmConfig,
+    state: _ToolConversation,
+    *,
+    model_turn: int,
+    reason: str,
+    clock: Clock = SYSTEM_CLOCK,
+) -> L1EvidenceResult:
+    return _deadline_failure_result(
+        config=config,
+        raw_output=state.raw_output,
+        model_calls=state.model_calls,
+        tool_calls=state.tool_calls,
+        unsupported_tool_requests=state.unsupported_tool_requests,
+        transcript_events=state.transcript_events,
+        model_turn=model_turn,
+        reason=reason,
+        clock=clock,
+    )
+
+
+class RetryingChatTransport:
+    """Apply deadline-aware retry policy around one provider request callable."""
+
+    def __init__(
+        self,
+        config: LlmConfig,
+        request_call: Any,
+        *,
+        clock: Clock = SYSTEM_CLOCK,
+        sleeper: Sleeper = SYSTEM_SLEEPER,
+    ) -> None:
+        self._config = config
+        self._request_call = request_call
+        self._clock = clock
+        self._sleeper = sleeper
+
+    def call(
+        self,
+        *,
+        api_key: str,
+        messages: list[dict[str, Any]],
+        include_tools: bool,
+        model_turn: int,
+        deadline_monotonic: float | None,
+    ) -> "RetryOutcome":
+        max_retries = max(0, self._config.max_retries)
+        max_attempts = max_retries + 1
+        prior_call_records: list[dict[str, Any]] = []
+        transcript_events: list[dict[str, Any]] = []
+        for attempt in range(1, max_attempts + 1):
+            if _deadline_expired(deadline_monotonic, clock=self._clock):
+                deadline_error = _deadline_call_error(
+                    config=self._config,
+                    model_turn=model_turn,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    reason="before_model_request",
+                    clock=self._clock,
+                )
+                deadline_error.prior_call_records = tuple(prior_call_records)
+                deadline_error.transcript_events = tuple(transcript_events)
+                raise deadline_error
+            transcript_events.append(
+                _model_request_event(
+                    config=self._config,
+                    messages=messages,
+                    include_tools=include_tools,
+                    model_turn=model_turn,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    deadline_monotonic=deadline_monotonic,
+                    clock=self._clock,
+                )
+            )
+            try:
+                response, call_record = self._request_call(
+                    api_key=api_key,
+                    messages=messages,
+                    include_tools=include_tools,
+                    model_turn=model_turn,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    deadline_monotonic=deadline_monotonic,
+                )
+                return RetryOutcome(
+                    response=response,
+                    call_record=call_record,
+                    prior_call_records=tuple(prior_call_records),
+                    transcript_events=tuple(transcript_events),
+                )
+            except LlmCallError as exc:
+                retryable = bool(exc.call_record.get("retryable"))
+                if not retryable or attempt >= max_attempts:
+                    exc.prior_call_records = tuple(prior_call_records)
+                    exc.transcript_events = tuple(transcript_events)
+                    raise
+                backoff_s = max(0.0, self._config.retry_backoff_seconds)
+                remaining_s = _remaining_deadline_seconds(
+                    deadline_monotonic,
+                    clock=self._clock,
+                )
+                if remaining_s is not None and remaining_s <= backoff_s:
+                    exc.call_record["retry_scheduled"] = False
+                    exc.call_record["retry_blocked_by_deadline"] = True
+                    prior_call_records.append(exc.call_record)
+                    transcript_events.append(
+                        {
+                            "event_type": "provider_error",
+                            "model_turn": model_turn,
+                            "model": self._config.model,
+                            "attempt": attempt,
+                            "error_type": exc.call_record.get("error_type"),
+                            "http_status": exc.call_record.get("http_status"),
+                            "timeout": exc.call_record.get("timeout"),
+                            "retryable": retryable,
+                            "retry_scheduled": False,
+                            "retry_blocked_by_deadline": True,
+                            "error": exc.call_record.get("error"),
+                            "latency_s": exc.call_record.get("latency_s"),
+                        }
+                    )
+                    deadline_error = _deadline_call_error(
+                        config=self._config,
+                        model_turn=model_turn,
+                        attempt=attempt,
+                        max_retries=max_retries,
+                        reason="before_retry_backoff",
+                        clock=self._clock,
+                    )
+                    deadline_error.prior_call_records = tuple(prior_call_records)
+                    deadline_error.transcript_events = tuple(transcript_events)
+                    raise deadline_error from exc
+                exc.call_record["retry_scheduled"] = True
+                exc.call_record["retry_after_s"] = backoff_s
+                prior_call_records.append(exc.call_record)
+                transcript_events.append(
+                    {
+                        "event_type": "provider_error",
+                        "model_turn": model_turn,
+                        "model": self._config.model,
+                        "attempt": attempt,
+                        "error_type": exc.call_record.get("error_type"),
+                        "http_status": exc.call_record.get("http_status"),
+                        "timeout": exc.call_record.get("timeout"),
+                        "retryable": retryable,
+                        "retry_scheduled": True,
+                        "retry_after_s": backoff_s,
+                        "error": exc.call_record.get("error"),
+                        "latency_s": exc.call_record.get("latency_s"),
+                    }
+                )
+                if backoff_s:
+                    self._sleeper.sleep(backoff_s)
+        raise AssertionError("unreachable retry loop exit")
+
+
+@dataclass(frozen=True)
+class RetryOutcome:
+    """Provider response plus retry attempts and their trace events."""
+
+    response: Mapping[str, Any]
+    call_record: Mapping[str, Any]
+    prior_call_records: tuple[Mapping[str, Any], ...]
+    transcript_events: tuple[Mapping[str, Any], ...]
+
+
+@dataclass(frozen=True)
+class _PreparedProviderRequest:
+    url: str
+    content: bytes
+    headers: Mapping[str, str]
+    model_turn: int
+    include_tools: bool
+    started: float
+    attempt: int
+    max_retries: int | None
+    context_budget: Mapping[str, Any]
+    effective_timeout_seconds: float
+    remaining_before_call_s: float | None
+
+
+def _prepare_provider_request(
+    config: LlmConfig,
+    *,
+    api_key: str,
+    messages: list[dict[str, Any]],
+    include_tools: bool,
+    model_turn: int,
+    attempt: int,
+    max_retries: int | None,
+    deadline_monotonic: float | None,
+    clock: Clock = SYSTEM_CLOCK,
+) -> _PreparedProviderRequest:
+    started = clock.monotonic()
+    remaining_before_call_s = _remaining_deadline_seconds(
+        deadline_monotonic,
+        clock=clock,
+    )
+    if remaining_before_call_s is not None and remaining_before_call_s <= 0:
+        raise _deadline_call_error(
+            config=config,
+            model_turn=model_turn,
+            attempt=attempt,
+            max_retries=config.max_retries if max_retries is None else max_retries,
+            reason="before_http_request",
+            clock=clock,
+        )
+    effective_timeout_seconds = config.timeout_seconds
+    if remaining_before_call_s is not None:
+        effective_timeout_seconds = min(effective_timeout_seconds, remaining_before_call_s)
+    context_budget = _request_context_budget(config, messages, include_tools=include_tools)
+    body = _request_body(config, messages, include_tools=include_tools)
+    return _PreparedProviderRequest(
+        url=config.base_url.rstrip("/") + "/chat/completions",
+        content=_encoded_request_body(body),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        model_turn=model_turn,
+        include_tools=include_tools,
+        started=started,
+        attempt=attempt,
+        max_retries=max_retries,
+        context_budget=context_budget,
+        effective_timeout_seconds=effective_timeout_seconds,
+        remaining_before_call_s=remaining_before_call_s,
+    )
+
+
+class HttpClient(Protocol):
+    """Synchronous HTTP client used by one persistent provider route."""
+
+    def post(
+        self,
+        url: str,
+        *,
+        content: bytes,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> httpx.Response: ...
+
+    def close(self) -> None: ...
+
+
+class OpenAICompatibleTransport:
+    """Issue one OpenAI-compatible HTTP request and classify its outcome."""
+
+    def __init__(
+        self,
+        config: LlmConfig,
+        *,
+        http_client: HttpClient | None = None,
+        clock: Clock = SYSTEM_CLOCK,
+    ) -> None:
+        self._config = config
+        self._http_client = http_client or httpx.Client(follow_redirects=True)
+        self._owns_http_client = http_client is None
+        self._clock = clock
+        self._closed = False
+
+    def close(self) -> None:
+        """Release the route-owned connection pool."""
+
+        if self._closed:
+            return
+        self._closed = True
+        if self._owns_http_client:
+            self._http_client.close()
+
+    def call(
+        self,
+        *,
+        api_key: str,
+        messages: list[dict[str, Any]],
+        include_tools: bool,
+        model_turn: int,
+        attempt: int = 1,
+        max_retries: int | None = None,
+        deadline_monotonic: float | None = None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        prepared = _prepare_provider_request(
+            self._config,
+            api_key=api_key,
+            messages=messages,
+            include_tools=include_tools,
+            model_turn=model_turn,
+            attempt=attempt,
+            max_retries=max_retries,
+            deadline_monotonic=deadline_monotonic,
+            clock=self._clock,
+        )
+        try:
+            response = self._http_client.post(
+                prepared.url,
+                content=prepared.content,
+                headers=prepared.headers,
+                timeout=prepared.effective_timeout_seconds,
+            )
+            provider_reported_timing = _provider_reported_timing(response.headers)
+            if response.status_code >= 400:
+                raise self._classified_http_error(response, prepared)
+            payload = response.json()
+        except LlmCallError:
+            raise
+        except httpx.TimeoutException as exc:
+            raise self._classified_timeout(exc, prepared) from exc
+        except httpx.RequestError as exc:
+            raise self._classified_request_error(exc, prepared) from exc
+        except json.JSONDecodeError as exc:
+            raise self._classified_decode_error(exc, prepared) from exc
+
+        if _deadline_expired(deadline_monotonic, clock=self._clock):
+            raise _deadline_call_error(
+                config=self._config,
+                model_turn=model_turn,
+                attempt=attempt,
+                max_retries=self._config.max_retries if max_retries is None else max_retries,
+                reason="after_http_response",
+                started=prepared.started,
+                effective_timeout_seconds=prepared.effective_timeout_seconds,
+                remaining_before_call_s=prepared.remaining_before_call_s,
+                clock=self._clock,
+            )
+
+        choice = (payload.get("choices") or [{}])[0]
+        call_record = self._call_record(
+            model_turn=model_turn,
+            include_tools=include_tools,
+            started=prepared.started,
+            attempt=attempt,
+            max_retries=max_retries,
+            success=True,
+            finish_reason=choice.get("finish_reason"),
+            usage=payload.get("usage"),
+            provider_reported_timing=provider_reported_timing,
+            context_budget=prepared.context_budget,
+            effective_timeout_seconds=prepared.effective_timeout_seconds,
+            remaining_before_call_s=prepared.remaining_before_call_s,
+        )
+        return payload, call_record
+
+    def _classified_http_error(
+        self,
+        response: httpx.Response,
+        prepared: "_PreparedProviderRequest",
+    ) -> LlmCallError:
+        detail = response.text
+        status = response.status_code
+        context_window_exceeded = _is_context_window_exceeded_error(detail)
+        record = self._failure_record(
+            prepared,
+            error_type=("context_window_exceeded" if context_window_exceeded else "http_error"),
+            error=f"HTTP {status}",
+            http_status=status,
+            response_body=_truncate_error_detail(detail),
+            retryable=_is_retryable_http_status(status),
+            timeout=_is_http_timeout_status(status),
+            provider_reported_timing=_provider_reported_timing(response.headers),
+        )
+        return LlmCallError(f"HTTP {status}: {detail}", record)
+
+    def _classified_request_error(
+        self,
+        error: httpx.RequestError,
+        prepared: "_PreparedProviderRequest",
+    ) -> LlmCallError:
+        error_type, retryable = _httpx_request_error(error)
+        record = self._failure_record(
+            prepared,
+            error_type=error_type,
+            error=str(error),
+            retryable=retryable,
+            timeout=False,
+        )
+        return LlmCallError(f"failed to reach LLM endpoint: {error}", record)
+
+    def _classified_timeout(
+        self,
+        error: Exception,
+        prepared: "_PreparedProviderRequest",
+    ) -> LlmCallError:
+        record = self._failure_record(
+            prepared,
+            error_type="timeout",
+            error=str(error),
+            retryable=True,
+            timeout=True,
+        )
+        return LlmCallError(f"LLM request timed out: {error}", record)
+
+    def _classified_decode_error(
+        self,
+        error: json.JSONDecodeError,
+        prepared: "_PreparedProviderRequest",
+    ) -> LlmCallError:
+        record = self._failure_record(
+            prepared,
+            error_type="provider_response_decode_error",
+            error=str(error),
+            retryable=True,
+        )
+        return LlmCallError(f"LLM response was not JSON: {error}", record)
+
+    def _failure_record(
+        self,
+        prepared: "_PreparedProviderRequest",
+        **failure: Any,
+    ) -> dict[str, Any]:
+        return self._call_record(
+            model_turn=prepared.model_turn,
+            include_tools=prepared.include_tools,
+            started=prepared.started,
+            attempt=prepared.attempt,
+            max_retries=prepared.max_retries,
+            success=False,
+            context_budget=prepared.context_budget,
+            effective_timeout_seconds=prepared.effective_timeout_seconds,
+            remaining_before_call_s=prepared.remaining_before_call_s,
+            **failure,
+        )
+
+    def _call_record(
+        self,
+        *,
+        model_turn: int,
+        include_tools: bool,
+        started: float,
+        attempt: int,
+        max_retries: int | None,
+        success: bool,
+        finish_reason: str | None = None,
+        usage: Mapping[str, Any] | None = None,
+        provider_reported_timing: Mapping[str, Any] | None = None,
+        error_type: str | None = None,
+        error: str | None = None,
+        http_status: int | None = None,
+        response_body: str | None = None,
+        retryable: bool = False,
+        timeout: bool = False,
+        context_budget: Mapping[str, Any] | None = None,
+        effective_timeout_seconds: float | None = None,
+        remaining_before_call_s: float | None = None,
+    ) -> dict[str, Any]:
+        record = {
+            "layer": "L1",
+            "http_transport": "httpx",
+            "model": self._config.model,
+            "model_turn": model_turn,
+            "attempt": attempt,
+            "max_retries": self._config.max_retries if max_retries is None else max_retries,
+            "success": success,
+            "latency_s": round(self._clock.monotonic() - started, 3),
+            "finish_reason": finish_reason,
+            "usage": usage,
+            "tools_advertised": include_tools,
+            "reasoning_mode_requested": self._config.thinking_mode,
+            "reasoning_mode_resolved": (
+                "disabled" if self._config.disable_thinking() else "provider_default"
+            ),
+            "provider_options": (
+                {"enable_thinking": False} if self._config.disable_thinking() else {}
+            ),
+            "context_budget": dict(context_budget or {}),
+            "configured_request_timeout_seconds": self._config.timeout_seconds,
+            "effective_request_timeout_seconds": effective_timeout_seconds,
+            "remaining_analysis_budget_before_call_s": remaining_before_call_s,
+        }
+        if provider_reported_timing:
+            record["provider_reported_timing"] = dict(provider_reported_timing)
+        if not success:
+            record.update(
+                {
+                    "error_type": error_type,
+                    "error": error,
+                    "http_status": http_status,
+                    "response_body": response_body,
+                    "retryable": retryable,
+                    "retry_scheduled": False,
+                    "timeout": timeout,
+                }
+            )
+        return record
+
+
+class ChatTransport(Protocol):
+    """One provider request transport used by the L1 tool loop."""
+
+    def call(self, **kwargs: Any) -> tuple[dict[str, Any], dict[str, Any]]: ...
+
+
+RetryTransportFactory = Callable[[LlmConfig, Any], RetryingChatTransport]
+
+
+class LlmEvidenceExtractor:
+    """Bounded OpenAI-compatible tool-loop client for L1 evidence extraction."""
+
+    def __init__(
+        self,
+        config: LlmConfig | None = None,
+        *,
+        transport: ChatTransport | None = None,
+        retry_transport_factory: RetryTransportFactory | None = None,
+        credential_provider: CredentialProvider | None = None,
+        clock: Clock = SYSTEM_CLOCK,
+        sleeper: Sleeper = SYSTEM_SLEEPER,
+    ):
+        self._config = config or LlmConfig.from_env()
+        self._clock = clock
+        self._sleeper = sleeper
+        self._owns_transport = transport is None
+        self._transport = transport or OpenAICompatibleTransport(
+            self._config,
+            clock=clock,
+        )
+        self._retry_transport_factory = retry_transport_factory
+        self._credential_provider = credential_provider or ConfigCredentialProvider()
+        self._closed = False
+
+    def close(self) -> None:
+        """Release a transport created and owned by this extractor."""
+
+        if self._closed:
+            return
+        self._closed = True
+        if self._owns_transport:
+            close = getattr(self._transport, "close", None)
+            if close is not None:
+                close()
+
+    def extract_evidence(
+        self,
+        context: L1EvidenceContext,
+        *,
+        deadline_monotonic: float | None = None,
+    ) -> L1EvidenceResult:
+        try:
+            return self._extract_evidence(
+                context,
+                deadline_monotonic=deadline_monotonic,
+            )
+        except Exception as exc:  # pragma: no cover - defensive provider boundary
+            return L1EvidenceResult(
+                evidence=None,
+                model=self._config.model,
+                success=False,
+                errors=(str(exc),),
+                anomalies={"provider_error": True},
+            )
+
+    def _extract_evidence(
+        self,
+        context: L1EvidenceContext,
+        *,
+        deadline_monotonic: float | None,
+    ) -> L1EvidenceResult:
+        return ToolLoopSession(
+            self._config,
+            self._call_model_with_retries,
+            credential_provider=self._credential_provider,
+            clock=self._clock,
+        ).run(
+            context,
+            deadline_monotonic=deadline_monotonic,
+        )
+
+    def _call_model_with_retries(
+        self,
+        **kwargs: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        model_calls = kwargs.pop("model_calls")
+        transcript_events = kwargs.pop("transcript_events")
+        try:
+            retry_transport = (
+                self._retry_transport_factory(self._config, self._call_model)
+                if self._retry_transport_factory is not None
+                else RetryingChatTransport(
+                    self._config,
+                    self._call_model,
+                    clock=self._clock,
+                    sleeper=self._sleeper,
+                )
+            )
+            outcome = retry_transport.call(**kwargs)
+        except LlmCallError as exc:
+            model_calls.extend(dict(item) for item in exc.prior_call_records)
+            transcript_events.extend(dict(item) for item in exc.transcript_events)
+            raise
+        model_calls.extend(dict(item) for item in outcome.prior_call_records)
+        transcript_events.extend(dict(item) for item in outcome.transcript_events)
+        return dict(outcome.response), dict(outcome.call_record)
+
+    def _call_model(
+        self,
+        **kwargs: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        return self._transport.call(**kwargs)
+
+
+def _provider_reported_timing(headers: Any) -> dict[str, Any]:
+    """Extract optional proxy timing headers without inferring missing spans."""
+
+    if headers is None:
+        return {}
+    normalized_headers: dict[str, Any] = {}
+    try:
+        normalized_headers = {str(key).lower(): value for key, value in headers.items()}
+    except (AttributeError, TypeError, ValueError):
+        return {}
+
+    components: dict[str, float] = {}
+    for header_name, field_name in PROVIDER_TIMING_HEADERS.items():
+        raw_value = normalized_headers.get(header_name)
+        if raw_value is None:
+            continue
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(value) or value < 0:
+            continue
+        components[field_name] = value
+    if not components:
+        return {}
+    return {"source": "response_headers", **components}
+
+
+def _request_body(
+    config: LlmConfig,
+    messages: list[dict[str, Any]],
+    *,
+    include_tools: bool,
+) -> dict[str, Any]:
+    budget = _request_context_budget(config, messages, include_tools=include_tools)
+    body: dict[str, Any] = {
+        "model": config.model,
+        "messages": messages,
+        "max_tokens": budget["effective_max_output_tokens"],
+    }
+    if config.request_temperature() is not None:
+        body["temperature"] = config.request_temperature()
+    if config.request_top_p() is not None:
+        body["top_p"] = config.request_top_p()
+    if config.reasoning_effort:
+        body["reasoning_effort"] = config.reasoning_effort
+    if config.disable_thinking():
+        body["chat_template_kwargs"] = {"enable_thinking": False}
+    if include_tools and config.advertised_tools:
+        body["tools"] = _tool_schemas(config)
+        body["tool_choice"] = "auto"
+    return body
+
+
+def _request_context_budget(
+    config: LlmConfig,
+    messages: list[dict[str, Any]],
+    *,
+    include_tools: bool,
+) -> dict[str, Any]:
+    context_window = config.resolved_context_window_tokens()
+    estimate_payload: dict[str, Any] = {"messages": messages}
+    if include_tools:
+        estimate_payload["tools"] = _tool_schemas(config)
+    input_chars = len(
+        json.dumps(
+            estimate_payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+    raw_estimated_input_tokens = math.ceil(input_chars / ESTIMATED_CHARS_PER_INPUT_TOKEN)
+    estimated_input_tokens = math.ceil(
+        raw_estimated_input_tokens * CONTEXT_TOKEN_ESTIMATE_MULTIPLIER
+    )
+    effective_max_output_tokens = config.max_output_tokens
+    if context_window is not None:
+        available = max(
+            1,
+            context_window - estimated_input_tokens - max(0, config.context_safety_tokens),
+        )
+        effective_max_output_tokens = min(config.max_output_tokens, available)
+    return {
+        "context_window_tokens": context_window,
+        "raw_estimated_input_tokens": raw_estimated_input_tokens,
+        "estimated_input_tokens": estimated_input_tokens,
+        "estimation_chars_per_token": ESTIMATED_CHARS_PER_INPUT_TOKEN,
+        "estimation_multiplier": CONTEXT_TOKEN_ESTIMATE_MULTIPLIER,
+        "input_chars": input_chars,
+        "configured_max_output_tokens": config.max_output_tokens,
+        "effective_max_output_tokens": effective_max_output_tokens,
+        "safety_tokens": max(0, config.context_safety_tokens),
+        "adjusted": effective_max_output_tokens != config.max_output_tokens,
+    }
+
+
+def _model_request_event(
+    *,
+    config: LlmConfig,
+    messages: list[dict[str, Any]],
+    include_tools: bool,
+    model_turn: int,
+    attempt: int,
+    max_retries: int,
+    deadline_monotonic: float | None = None,
+    clock: Clock = SYSTEM_CLOCK,
+) -> dict[str, Any]:
+    body = _request_body(config, messages, include_tools=include_tools)
+    context_budget = _request_context_budget(config, messages, include_tools=include_tools)
+    encoded = _encoded_request_body(body)
+    request_body = json.loads(encoded.decode("utf-8"))
+    return {
+        "event_type": "model_request",
+        "model_turn": model_turn,
+        "attempt": attempt,
+        "max_retries": max_retries,
+        "model": config.model,
+        "provider_route": config.base_url,
+        "endpoint": config.base_url.rstrip("/") + "/chat/completions",
+        "context_budget": context_budget,
+        "timeout_seconds": config.timeout_seconds,
+        "remaining_analysis_budget_s": _remaining_deadline_seconds(
+            deadline_monotonic,
+            clock=clock,
+        ),
+        "request_body": request_body,
+        "advertised_tool_schemas": request_body.get("tools", []),
+        "payload_sha256": "sha256:" + hashlib.sha256(encoded).hexdigest(),
+        "payload_bytes": len(encoded),
+        "redaction_status": "api_credentials_excluded",
+        "truncated": False,
+        "decision_budget": None,
+    }
+
+
+def _encoded_request_body(body: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        body,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _provider_failure_result(
+    *,
+    config: LlmConfig,
+    exc: LlmCallError,
+    raw_output: str | None,
+    model_calls: list[dict[str, Any]],
+    tool_calls: list[dict[str, Any]],
+    unsupported_tool_requests: list[dict[str, Any]],
+    transcript_events: list[dict[str, Any]],
+) -> L1EvidenceResult:
+    model_calls.append(exc.call_record)
+    transcript_events.append(
+        {
+            "event_type": "provider_error",
+            "model_turn": exc.call_record.get("model_turn"),
+            "model": config.model,
+            "error_type": exc.call_record.get("error_type"),
+            "http_status": exc.call_record.get("http_status"),
+            "timeout": exc.call_record.get("timeout"),
+            "retryable": exc.call_record.get("retryable"),
+            "error": exc.call_record.get("error"),
+            "latency_s": exc.call_record.get("latency_s"),
+        }
+    )
+    error_type = str(exc.call_record.get("error_type") or "provider_error")
+    return L1EvidenceResult(
+        evidence=None,
+        model=config.model,
+        raw_model_output=raw_output,
+        success=False,
+        malformed=False,
+        errors=(str(exc),),
+        model_calls=tuple(model_calls),
+        tool_calls=tuple(tool_calls),
+        unsupported_tool_requests=tuple(unsupported_tool_requests),
+        transcript_events=tuple(transcript_events),
+        anomalies={
+            "provider_error": True,
+            "provider_error_type": error_type,
+            "provider_timeout": bool(exc.call_record.get("timeout")),
+            "deadline_exceeded": error_type == "analysis_deadline_exceeded",
+            "context_window_exceeded": error_type == "context_window_exceeded",
+            "unsupported_tool_request_seen": bool(unsupported_tool_requests),
+        },
+    )
+
+
+def _remaining_deadline_seconds(
+    deadline_monotonic: float | None,
+    *,
+    clock: Clock = SYSTEM_CLOCK,
+) -> float | None:
+    if deadline_monotonic is None:
+        return None
+    return max(0.0, deadline_monotonic - clock.monotonic())
+
+
+def _deadline_expired(
+    deadline_monotonic: float | None,
+    *,
+    clock: Clock = SYSTEM_CLOCK,
+) -> bool:
+    remaining = _remaining_deadline_seconds(deadline_monotonic, clock=clock)
+    return remaining is not None and remaining <= 0
+
+
+def _deadline_call_error(
+    *,
+    config: LlmConfig,
+    model_turn: int,
+    attempt: int,
+    max_retries: int,
+    reason: str,
+    started: float | None = None,
+    effective_timeout_seconds: float | None = None,
+    remaining_before_call_s: float | None = None,
+    clock: Clock = SYSTEM_CLOCK,
+) -> LlmCallError:
+    message = f"analysis deadline exceeded: {reason}"
+    call_record = {
+        "layer": "L1",
+        "model": config.model,
+        "model_turn": model_turn,
+        "attempt": attempt,
+        "max_retries": max_retries,
+        "success": False,
+        "latency_s": round(clock.monotonic() - started, 3) if started is not None else 0.0,
+        "finish_reason": None,
+        "usage": None,
+        "tools_advertised": False,
+        "reasoning_mode_requested": config.thinking_mode,
+        "error_type": "analysis_deadline_exceeded",
+        "error": message,
+        "http_status": None,
+        "response_body": None,
+        "retryable": False,
+        "retry_scheduled": False,
+        "timeout": True,
+        "deadline_exceeded": True,
+        "deadline_reason": reason,
+        "configured_request_timeout_seconds": config.timeout_seconds,
+        "effective_request_timeout_seconds": effective_timeout_seconds,
+        "remaining_analysis_budget_before_call_s": remaining_before_call_s,
+    }
+    return LlmCallError(message, call_record)
+
+
+def _deadline_failure_result(
+    *,
+    config: LlmConfig,
+    raw_output: str | None,
+    model_calls: list[dict[str, Any]],
+    tool_calls: list[dict[str, Any]],
+    unsupported_tool_requests: list[dict[str, Any]],
+    transcript_events: list[dict[str, Any]],
+    model_turn: int,
+    reason: str,
+    clock: Clock = SYSTEM_CLOCK,
+) -> L1EvidenceResult:
+    return _provider_failure_result(
+        config=config,
+        exc=_deadline_call_error(
+            config=config,
+            model_turn=model_turn,
+            attempt=1,
+            max_retries=config.max_retries,
+            reason=reason,
+            clock=clock,
+        ),
+        raw_output=raw_output,
+        model_calls=model_calls,
+        tool_calls=tool_calls,
+        unsupported_tool_requests=unsupported_tool_requests,
+        transcript_events=transcript_events,
+    )
+
+
+def _initial_user_message(model_view: L0ModelFacingView) -> str:
+    payload = {
+        "response_schema": model_response_schema(),
+        **model_view.prompt_payload(),
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _tool_loop_profile(config: LlmConfig) -> dict[str, Any]:
+    advertised_tools = config.resolved_advertised_tools()
+    tools_active = bool(advertised_tools)
+    max_tool_rounds = max(1, config.max_tool_rounds) if tools_active else 0
+    return {
+        "tools_enabled": tools_active,
+        "advertised_tools": list(advertised_tools),
+        "max_tool_rounds": max_tool_rounds,
+        "max_model_turns": max_tool_rounds + 1 if tools_active else 1,
+        "meaning": (
+            "tool-enabled model rounds followed by one tools-disabled final turn"
+            if tools_active
+            else "single tools-disabled model turn"
+        ),
+    }
+
+
+def _tool_schemas(config: LlmConfig) -> list[dict[str, Any]]:
+    schemas = [
+        {
+            "type": "function",
+            "function": {
+                "name": "overview",
+                "description": "Return a compact summary, head/tail preview, and L0 findings.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "grep_log",
+                "description": "Search the bound log with a regular expression.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {"type": "string"},
+                        "ignore_case": {"type": "boolean", "default": True},
+                        "max_matches": {"type": "integer", "default": 50},
+                    },
+                    "required": ["pattern"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "read_window",
+                "description": "Read original log lines around one center line.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "center_line": {"type": "integer"},
+                        "before": {"type": "integer", "default": 20},
+                        "after": {"type": "integer", "default": 80},
+                    },
+                    "required": ["center_line"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_evidence_objects",
+                "description": (
+                    "Resolve stable L0A evidence references from the current attempt "
+                    "without rescanning the log."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "refs": {
+                            "type": "array",
+                            "items": {"type": "string", "maxLength": 128},
+                            "maxItems": 8,
+                        }
+                    },
+                    "required": ["refs"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    ]
+    advertised = set(config.resolved_advertised_tools())
+    return [schema for schema in schemas if schema["function"]["name"] in advertised]
+
+
+def _execute_tool_call(
+    tools: LogTools,
+    tool_call: dict[str, Any],
+    *,
+    model_turn: int,
+    advertised_tools: Sequence[str] = DEFAULT_ADVERTISED_TOOLS,
+    clock: Clock = SYSTEM_CLOCK,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any] | None]:
+    started = clock.monotonic()
+    name = str(tool_call.get("name") or "")
+    args = _tool_args(tool_call)
+    unsupported: dict[str, Any] | None = None
+    try:
+        if name not in advertised_tools:
+            result = {"error": "tool_not_advertised", "requested_tool_name": name}
+            unsupported = {
+                "model_turn": model_turn,
+                "requested_tool_name": name,
+                "args_summary": _compact_args(args),
+                "rejection_reason": "tool_not_advertised",
+            }
+        elif name == "overview":
+            result = tools.overview()
+        elif name == "grep_log":
+            result = tools.grep_log(
+                str(args.get("pattern") or ""),
+                ignore_case=bool(args.get("ignore_case", True)),
+                max_matches=int(args.get("max_matches", 50)),
+            )
+        elif name == "read_window":
+            result = tools.read_window(
+                int(args["center_line"]),
+                before=int(args.get("before", 20)),
+                after=int(args.get("after", 80)),
+            )
+        elif name == "get_evidence_objects":
+            refs = args.get("refs")
+            if not isinstance(refs, list) or not all(isinstance(ref, str) for ref in refs):
+                raise ValueError("refs must be an array of strings")
+            result = tools.get_evidence_objects(refs)
+        else:
+            result = {"error": "tool_not_implemented", "requested_tool_name": name}
+            unsupported = {
+                "model_turn": model_turn,
+                "requested_tool_name": name,
+                "args_summary": _compact_args(args),
+                "rejection_reason": "tool_not_implemented",
+            }
+    except Exception as exc:
+        result = {"error": str(exc), "requested_tool_name": name}
+
+    result_text = json.dumps(result, sort_keys=True)
+    record = {
+        "tool_call_id": tool_call.get("id"),
+        "model_turn": model_turn,
+        "name": name,
+        "args_summary": _compact_args(args),
+        "latency_ms": round((clock.monotonic() - started) * 1000),
+        "result_chars": len(result_text),
+        "result_lines": _result_line_count(result),
+        "total_matches": result.get("total_matches") if isinstance(result, dict) else None,
+        "truncated": bool(result.get("truncated")) if isinstance(result, dict) else False,
+        "error": result.get("error") if isinstance(result, dict) else None,
+    }
+    return result, record, unsupported
+
+
+def _tool_args(tool_call: dict[str, Any]) -> dict[str, Any]:
+    raw = tool_call.get("arguments") or "{}"
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(str(raw))
+    except json.JSONDecodeError:
+        parsed = {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _compact_args(args: dict[str, Any]) -> str:
+    return "|".join(f"{key}={args[key]}" for key in sorted(args))[:300]
+
+
+def _result_line_count(result: dict[str, Any]) -> int:
+    if "matches" in result and isinstance(result["matches"], list):
+        return len(result["matches"])
+    if "lines" in result and isinstance(result["lines"], list):
+        return len(result["lines"])
+    if "objects" in result and isinstance(result["objects"], list):
+        return sum(
+            len(payload["lines"])
+            for item in result["objects"]
+            if isinstance(item, dict)
+            and isinstance((payload := item.get("payload")), dict)
+            and isinstance(payload.get("lines"), list)
+        )
+    return 0
+
+
+def _response_message(response: dict[str, Any]) -> dict[str, Any]:
+    choice = (response.get("choices") or [{}])[0]
+    message = choice.get("message") or {}
+    return message if isinstance(message, dict) else {}
+
+
+def _message_tool_calls(message: dict[str, Any]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for item in message.get("tool_calls") or []:
+        function = item.get("function") or {}
+        result.append(
+            {
+                "id": item.get("id"),
+                "name": function.get("name"),
+                "arguments": function.get("arguments") or "{}",
+            }
+        )
+    return result
+
+
+def _assistant_tool_call_message(message: dict[str, Any]) -> dict[str, Any]:
+    result = {"role": "assistant", "content": message.get("content") or ""}
+    if "tool_calls" in message:
+        result["tool_calls"] = message["tool_calls"]
+    return result
+
+
+def _parse_model_evidence(text: str | None) -> dict[str, Any]:
+    if not text:
+        raise ValueError("empty model output")
+    payload_text = _extract_json_text(text)
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError:
+        try:
+            payload = ast.literal_eval(payload_text)
+        except Exception as exc:
+            raise ValueError(f"model output is not JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("model output JSON must be an object")
+    contract_errors = model_evidence_contract_errors(payload)
+    if contract_errors:
+        raise ValueError("model evidence contract failed: " + "; ".join(contract_errors))
+    return payload
+
+
+def _extract_json_text(text: str) -> str:
+    stripped = text.strip()
+    fenced = re.search(r"```(?:json)?\s*(\{.*\})\s*```", stripped, re.S)
+    if fenced:
+        return fenced.group(1)
+    start = stripped.find("{")
+    if start < 0:
+        return stripped
+    decoder = json.JSONDecoder()
+    try:
+        _, end = decoder.raw_decode(stripped[start:])
+        return stripped[start : start + end]
+    except json.JSONDecodeError:
+        return stripped[start:]
+
+
+def _load_api_key(config: LlmConfig) -> str:
+    if config.api_key:
+        return config.api_key.strip()
+    if not config.api_key_file:
+        raise RuntimeError("no API key configured")
+    key_file = Path(os.path.expanduser(config.api_key_file))
+    key = key_file.read_text(encoding="utf-8", errors="replace").strip()
+    if not key:
+        raise RuntimeError(f"empty API key file: {key_file}")
+    return key
+
+
+def _is_retryable_http_status(status: int) -> bool:
+    return status == 429 or 500 <= status <= 599
+
+
+def _is_http_timeout_status(status: int) -> bool:
+    return status == 504
+
+
+def _httpx_request_error(error: httpx.RequestError) -> tuple[str, bool]:
+    """Return a stable trace category and retryability for transport failures."""
+
+    categories: tuple[tuple[type[httpx.RequestError], str, bool], ...] = (
+        (httpx.ConnectError, "connect_error", True),
+        (httpx.ReadError, "read_error", True),
+        (httpx.WriteError, "write_error", True),
+        (httpx.CloseError, "close_error", True),
+        (httpx.ProxyError, "proxy_error", True),
+        (httpx.RemoteProtocolError, "remote_protocol_error", True),
+        (httpx.LocalProtocolError, "local_protocol_error", False),
+        (httpx.UnsupportedProtocol, "unsupported_protocol", False),
+        (httpx.DecodingError, "response_decoding_error", False),
+    )
+    for error_class, error_type, retryable in categories:
+        if isinstance(error, error_class):
+            return error_type, retryable
+    return "request_error", False
+
+
+def _is_context_window_exceeded_error(detail: str) -> bool:
+    lowered = detail.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "contextwindowexceeded",
+            "context window exceeded",
+            "maximum context length",
+            "max context length",
+        )
+    )
+
+
+def _truncate_error_detail(detail: str) -> str:
+    if len(detail) <= MAX_ERROR_DETAIL_CHARS:
+        return detail
+    return detail[:MAX_ERROR_DETAIL_CHARS] + "...[truncated]"
+
+
+def _float_env(environment: Mapping[str, str], name: str, default: float) -> float:
+    value = environment.get(name)
+    if value is None or value == "":
+        return default
+    return float(value)
+
+
+def _optional_float_env(
+    environment: Mapping[str, str],
+    name: str,
+    default: float | None,
+) -> float | None:
+    value = environment.get(name)
+    if value is None or value == "":
+        return default
+    if value.lower() in {"none", "null", "default"}:
+        return None
+    return float(value)
+
+
+def _int_env(environment: Mapping[str, str], name: str, default: int) -> int:
+    value = environment.get(name)
+    if value is None or value == "":
+        return default
+    return int(value)
+
+
+def _optional_int_env(environment: Mapping[str, str], name: str) -> int | None:
+    value = environment.get(name)
+    if value is None or value == "":
+        return None
+    if value.lower() in {"none", "null", "default"}:
+        return None
+    return int(value)
+
+
+def _bool_env(environment: Mapping[str, str], name: str, default: bool) -> bool:
+    value = environment.get(name)
+    if value is None or value == "":
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _tool_names_env(
+    environment: Mapping[str, str],
+    name: str,
+    default: Sequence[str],
+) -> tuple[str, ...]:
+    value = environment.get(name)
+    if value is None:
+        return tuple(default)
+    return tuple(item.strip() for item in value.split(",") if item.strip())

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prompt constants for L1 model evidence extraction."""
+
+from __future__ import annotations
+
+from .response_contract import L1_RESPONSE_CONTRACT
+
+_SUPPORT_TAGS = ", ".join(sorted(L1_RESPONSE_CONTRACT.evidence_support_tags))
+
+SYSTEM_PROMPT = f"""\
+Analyze one distributed-training log and return the structured current-log evidence
+object defined by the supplied response schema.
+
+Assessment:
+- Separate the observed failure mechanism, root-cause assessment, and operational
+  recovery assessment. Do not turn a hypothesis into an observed fact.
+
+Evidence method:
+- Use only the supplied evidence and advertised read-only tools. Cite only original log
+  lines and quotes supplied by them.
+- Emit each source citation once in evidence and tag it with every supported claim using
+  only {_SUPPORT_TAGS}.
+- Inspect supplied context before calling tools; use a tool only when information needed
+  for the assessment is missing.
+- Original log text is source evidence. decision_evidence is the canonical deterministic
+  selection, while evidence_bundle provides selected supporting objects and raw windows.
+  If a label conflicts with original log text, follow the original text and explain the
+  conflict.
+- selected_evidence_references are provenance references. Do not assume their object IDs
+  can be resolved unless get_evidence_objects is advertised as a tool.
+- Treat precomputed pattern matches, candidate labels, ordering, and frequency as
+  retrieval aids, not causal conclusions.
+- Use chronology and complete traceback context to select the initiating failure.
+  Distinguish it from downstream cascades, wrappers, cleanup, and teardown failures.
+- Repeated rendering or multi-rank fanout within one causal episode is one event, not
+  evidence of cross-attempt persistence.
+- A reporting component, call stack, resource name, or diagnostic suggestion does not
+  by itself establish fault ownership, root cause, transience, or persistence.
+- Require evidence for failure-domain and retry-outlook conclusions. If the current log
+  cannot distinguish them, preserve supported, hypothetical, or unknown semantics and
+  state the missing evidence.
+
+Operational interpretation:
+- Workload domain includes application code, model, data, configuration, and
+  workload-selected framework or library behavior. Infrastructure domain includes
+  hardware, platform, and external services when the current log supports that
+  attribution. Uncertain ownership within the workload stack does not by itself make
+  the domain unknown.
+- Evaluate the next attempt under these product guarantees: the workload is unchanged,
+  process state is recreated, normal restart delay applies, hardware allocation may
+  change, and external-service state may change. A possible transition does not prove
+  recovery, while a fixed request, workload call stack, or missing cleanup message does
+  not prove that mutable failure state survives restart.
+- Treat supplied execution facts as positional evidence. Prior progress proves
+  runnability, not transience. Replay distance and failure position do not establish
+  persistence. Interpret decision_evidence.operation_artifact_facts according to their
+  declared identity strength: success on the exact file, object, or shard is relevant to
+  that physical unit while data-region and observer differences remain material;
+  success on another shard is only partial evidence; and success on a different
+  checkpoint, dataset file, or artifact proves general pipeline runnability, not the
+  health of the failed artifact. Distributed fanout is one operation, not cross-attempt
+  recurrence. Later aggregate progress in an interleaved log does not prove recovery of
+  the same rank or component.
+
+Return exactly these two current-attempt recovery claims. Each claim contains a value,
+an evidence status, and confidence in that claim:
+1. failure_domain: workload, infrastructure, or unknown.
+2. retry_outlook_without_workload_change: cannot_recover, may_recover, or unknown. An
+   unchanged workload still receives the product restart transition, including process
+   recreation, normal delay, possible hardware reallocation, and changed external state.
+
+For each claim, status is established_by_current_log, supported_but_unconfirmed,
+hypothesis_only, or unknown. established_by_current_log requires direct current-log
+support for that specific claim. Confidence is a 1..99 calibration signal for that claim;
+the client does not use it as a policy threshold.
+For either recovery claim, value unknown must use status unknown, and status unknown must
+use value unknown.
+
+Use cannot_recover only when the current log affirmatively establishes that the same
+unchanged workload cannot recover through the product restart transition. Use
+may_recover when normal retry, teardown, delay, reallocation, or mutable external state
+provides a supported recovery mechanism. Otherwise use unknown. Durable remediation and
+best-practice workload changes are outside this assessment: a workload may benefit from a
+later change while the next unchanged retry may still recover. Ground each concept in the
+rationale and cited supporting evidence.
+
+Set each root-cause or recovery-claim status to established_by_current_log only when that
+specific assessment is directly established. Otherwise use supported_but_unconfirmed,
+hypothesis_only, or unknown as defined by the schema. List material alternatives and the
+missing evidence needed to distinguish them.
+
+When no failure is observed, use analysis_status=no_failure_observed, set primary_failure
+to null, root-cause summary to "{L1_RESPONSE_CONTRACT.no_failure_summary}", recovery
+rationale to "{L1_RESPONSE_CONTRACT.no_failure_rationale}", use the response schema's
+canonical unknown recovery claims, and leave plausible causes, missing evidence, related
+failures, and evidence empty. When evidence is insufficient to identify a primary, use
+analysis_status=insufficient_evidence, root-cause summary to
+"{L1_RESPONSE_CONTRACT.insufficient_summary}", recovery rationale to
+"{L1_RESPONSE_CONTRACT.insufficient_rationale}", the same canonical unknown recovery
+claims, and list at least one missing-evidence item. Related failure lines are grounded
+diagnostic references, not additional policy-claim citations.
+
+Return one compact JSON object matching the supplied schema. Include only the strongest
+evidence and at most three related failures. Emit no fingerprint, data-position identity,
+fault outcome, or action; the client derives those fields.
+"""

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/provider_profiles.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/provider_profiles.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Explicit deployment profiles for provider-specific CLI defaults."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProviderProfile:
+    base_url: str
+    model: str
+
+
+NVIDIA_INFERENCE_HUB = ProviderProfile(
+    base_url="https://inference-api.nvidia.com/v1",
+    model="nvidia/qwen/qwen3.5-35b-a3b",
+)

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/response_contract.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/response_contract.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single source of truth for the L1 model response contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..models import (
+    L1_EVIDENCE_SCHEMA_VERSION,
+    AssessmentStatus,
+    CausalRole,
+    FailureDomain,
+    L1AnalysisStatus,
+    RetryOutlookWithoutWorkloadChange,
+)
+
+PRIMARY_FAILURE_SUPPORT_TAG = "primary_failure"
+ROOT_CAUSE_SUPPORT_TAG = "root_cause_assessment"
+FAILURE_DOMAIN_SUPPORT_TAG = "failure_domain"
+RETRY_OUTLOOK_SUPPORT_TAG = "retry_outlook_without_workload_change"
+
+
+@dataclass(frozen=True)
+class L1ResponseContract:
+    """Closed L1 shape, limits, enums, and model-visible description."""
+
+    top_level_fields: frozenset[str] = frozenset(
+        {
+            "schema_version",
+            "analysis_status",
+            "primary_failure",
+            "root_cause_assessment",
+            "model_recovery_assessment",
+            "related_failures",
+            "evidence",
+        }
+    )
+    primary_failure_fields: frozenset[str] = frozenset({"line", "causal_role", "failure_identity"})
+    failure_identity_fields: frozenset[str] = frozenset(
+        {"operation", "mechanism", "component", "artifact_path"}
+    )
+    root_cause_fields: frozenset[str] = frozenset(
+        {"summary", "status", "plausible_causes", "missing_evidence"}
+    )
+    recovery_assessment_fields: frozenset[str] = frozenset(
+        {"failure_domain", "retry_outlook_without_workload_change", "rationale"}
+    )
+    claim_fields: frozenset[str] = frozenset({"value", "status", "confidence"})
+    related_failure_fields: frozenset[str] = frozenset({"line", "causal_role", "rationale"})
+    evidence_fields: frozenset[str] = frozenset({"id", "line", "quote", "supports"})
+    evidence_support_tags: frozenset[str] = frozenset(
+        {
+            PRIMARY_FAILURE_SUPPORT_TAG,
+            ROOT_CAUSE_SUPPORT_TAG,
+            FAILURE_DOMAIN_SUPPORT_TAG,
+            RETRY_OUTLOOK_SUPPORT_TAG,
+        }
+    )
+    max_plausible_causes: int = 3
+    max_missing_evidence: int = 5
+    max_related_failures: int = 3
+    max_evidence_items: int = 12
+    max_evidence_id_chars: int = 64
+    min_confidence: int = 1
+    max_confidence: int = 99
+    non_primary_confidence: int = 1
+    require_unique_evidence_ids: bool = True
+    no_failure_summary: str = "No failure was observed in the supplied evidence."
+    no_failure_rationale: str = "Recovery is not assessed because no failure was observed."
+    insufficient_summary: str = "Insufficient evidence to identify a primary failure."
+    insufficient_rationale: str = "Recovery is not assessed without an identified primary failure."
+
+    @property
+    def analysis_statuses(self) -> frozenset[str]:
+        return frozenset(item.value for item in L1AnalysisStatus)
+
+    @property
+    def causal_roles(self) -> frozenset[str]:
+        return frozenset(item.value for item in CausalRole)
+
+    @property
+    def related_causal_roles(self) -> frozenset[str]:
+        return frozenset(
+            {
+                CausalRole.CASCADE.value,
+                CausalRole.TEARDOWN.value,
+                CausalRole.UNKNOWN.value,
+            }
+        )
+
+    @property
+    def failure_domains(self) -> frozenset[str]:
+        return frozenset(item.value for item in FailureDomain)
+
+    @property
+    def retry_outlooks(self) -> frozenset[str]:
+        return frozenset(item.value for item in RetryOutlookWithoutWorkloadChange)
+
+    @property
+    def assessment_statuses(self) -> frozenset[str]:
+        return frozenset(item.value for item in AssessmentStatus)
+
+    @property
+    def required_primary_support_tags(self) -> frozenset[str]:
+        return self.evidence_support_tags
+
+    def model_schema(self) -> dict[str, Any]:
+        """Return the complete contract advertised in the initial model request."""
+
+        claim_statuses = sorted(self.assessment_statuses)
+
+        def claim(values: frozenset[str]) -> dict[str, Any]:
+            return {
+                "type": "object",
+                "additionalProperties": False,
+                "required": sorted(self.claim_fields),
+                "properties": {
+                    "value": {"type": "string", "enum": sorted(values)},
+                    "status": {"type": "string", "enum": claim_statuses},
+                    "confidence": {
+                        "type": "integer",
+                        "minimum": self.min_confidence,
+                        "maximum": self.max_confidence,
+                        "description": "Calibration-only confidence in this claim.",
+                    },
+                },
+                "semanticConstraint": (
+                    "value=unknown if and only if status=unknown; " "otherwise neither is unknown"
+                ),
+            }
+
+        failure_identity = {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(self.failure_identity_fields),
+            "properties": {
+                name: {"type": ["string", "null"]} for name in sorted(self.failure_identity_fields)
+            },
+        }
+        primary_failure = {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(self.primary_failure_fields),
+            "properties": {
+                "line": {"type": "integer", "minimum": 1},
+                "causal_role": {"type": "string", "enum": sorted(self.causal_roles)},
+                "failure_identity": failure_identity,
+            },
+        }
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(self.top_level_fields),
+            "properties": {
+                "schema_version": {"type": "string", "const": L1_EVIDENCE_SCHEMA_VERSION},
+                "analysis_status": {
+                    "type": "string",
+                    "enum": sorted(self.analysis_statuses),
+                },
+                "primary_failure": {"oneOf": [primary_failure, {"type": "null"}]},
+                "root_cause_assessment": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": sorted(self.root_cause_fields),
+                    "properties": {
+                        "summary": {"type": "string", "minLength": 1},
+                        "status": {"type": "string", "enum": claim_statuses},
+                        "plausible_causes": {
+                            "type": "array",
+                            "maxItems": self.max_plausible_causes,
+                            "items": {"type": "string", "minLength": 1},
+                        },
+                        "missing_evidence": {
+                            "type": "array",
+                            "maxItems": self.max_missing_evidence,
+                            "items": {"type": "string", "minLength": 1},
+                        },
+                    },
+                },
+                "model_recovery_assessment": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": sorted(self.recovery_assessment_fields),
+                    "properties": {
+                        "failure_domain": claim(self.failure_domains),
+                        "retry_outlook_without_workload_change": claim(self.retry_outlooks),
+                        "rationale": {"type": "string", "minLength": 1},
+                    },
+                },
+                "related_failures": {
+                    "type": "array",
+                    "maxItems": self.max_related_failures,
+                    "description": (
+                        "Grounded source-line references for diagnostic relationships; "
+                        "they are not canonical policy-claim citations."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": sorted(self.related_failure_fields),
+                        "properties": {
+                            "line": {"type": "integer", "minimum": 1},
+                            "causal_role": {
+                                "type": "string",
+                                "enum": sorted(self.related_causal_roles),
+                            },
+                            "rationale": {"type": "string", "minLength": 1},
+                        },
+                    },
+                },
+                "evidence": {
+                    "type": "array",
+                    "maxItems": self.max_evidence_items,
+                    "description": "Canonical citations for the four policy-relevant claims.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": sorted(self.evidence_fields),
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": self.max_evidence_id_chars,
+                            },
+                            "line": {"type": "integer", "minimum": 1},
+                            "quote": {"type": "string", "minLength": 1},
+                            "supports": {
+                                "type": "array",
+                                "minItems": 1,
+                                "uniqueItems": True,
+                                "items": {
+                                    "type": "string",
+                                    "enum": sorted(self.evidence_support_tags),
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            "semanticConstraints": {
+                "evidence_ids": "unique non-empty strings",
+                "primary_identified": {
+                    "primary_failure": "required object",
+                    "evidence": ("non-empty and collectively supports every evidence support tag"),
+                },
+                "no_failure_observed": {
+                    "primary_failure": None,
+                    "root_cause_summary": self.no_failure_summary,
+                    "root_cause_status": "unknown",
+                    "plausible_causes": [],
+                    "missing_evidence": [],
+                    "recovery_claims": "unknown value, unknown status, confidence 1",
+                    "recovery_rationale": self.no_failure_rationale,
+                    "related_failures": [],
+                    "evidence": [],
+                },
+                "insufficient_evidence": {
+                    "primary_failure": None,
+                    "root_cause_summary": self.insufficient_summary,
+                    "root_cause_status": "unknown",
+                    "plausible_causes": [],
+                    "missing_evidence": "one or more strings",
+                    "recovery_claims": "unknown value, unknown status, confidence 1",
+                    "recovery_rationale": self.insufficient_rationale,
+                    "related_failures": [],
+                    "evidence": [],
+                },
+            },
+        }
+
+
+L1_RESPONSE_CONTRACT = L1ResponseContract()
+
+
+def model_response_schema() -> dict[str, Any]:
+    """Return the model-visible response schema from the canonical contract."""
+
+    return L1_RESPONSE_CONTRACT.model_schema()

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/tools.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/tools.py
@@ -1,0 +1,574 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only log tools over an L0 evidence bundle."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict
+from typing import Any, Callable, Iterable
+
+from ..infrastructure.log_source import LogSnapshot
+from ..models import CausalRole, L0Bundle, L0ModelFacingView, LogLine
+from .contracts import EvidenceTools, L1EvidenceContext
+
+OVERVIEW_HEAD_LINES = 40
+OVERVIEW_TAIL_LINES = 80
+OVERVIEW_MAX_CHARS = 12_000
+GREP_MAX_MATCHES = 50
+GREP_MAX_MATCHES_HARD_LIMIT = 200
+READ_WINDOW_MAX_LINES = 240
+READ_WINDOW_MAX_CHARS = 50_000
+TOOL_LINE_MAX_CHARS = 2_000
+EVIDENCE_OBJECTS_SCHEMA_VERSION = "restart_agent_evidence_objects.v1"
+EVIDENCE_OBJECTS_MAX_REFS = 8
+EVIDENCE_OBJECTS_MAX_CHARS = 50_000
+EVIDENCE_OBJECT_REF_MAX_CHARS = 128
+EVIDENCE_OBJECTS_METADATA_RESERVE_CHARS = 2_048
+
+
+EvidenceToolsFactory = Callable[[L0Bundle, LogSnapshot], EvidenceTools]
+
+
+def build_l1_evidence_context(
+    bundle: L0Bundle,
+    model_view: L0ModelFacingView,
+    source_log: LogSnapshot,
+    tools_factory: EvidenceToolsFactory | None = None,
+) -> L1EvidenceContext:
+    """Assemble the provider-neutral L1 view and controlled expansion tools."""
+
+    factory = tools_factory or LogTools
+    return L1EvidenceContext(model_view=model_view, tools=factory(bundle, source_log))
+
+
+class LogTools:
+    def __init__(self, bundle: L0Bundle, source_log: LogSnapshot):
+        self._bundle = bundle
+        self._source_log = source_log
+
+    def overview(self) -> dict[str, Any]:
+        return _build_overview(self._bundle, self._source_log)
+
+    def grep_log(
+        self,
+        pattern: str,
+        *,
+        ignore_case: bool = True,
+        max_matches: int = GREP_MAX_MATCHES,
+    ) -> dict[str, Any]:
+        max_matches = min(max(max_matches, 0), GREP_MAX_MATCHES_HARD_LIMIT)
+        flags = re.I if ignore_case else 0
+        regex = re.compile(pattern, flags)
+        matches: list[dict[str, Any]] = []
+        total = 0
+        for item in self._source_log.log_lines():
+            if not regex.search(item.text):
+                continue
+            total += 1
+            if len(matches) < max_matches:
+                matches.append(_line_payload(item))
+        return {
+            "pattern": pattern,
+            "matches": matches,
+            "total_matches": total,
+            "truncated": total > len(matches),
+        }
+
+    def read_window(
+        self,
+        center_line: int,
+        *,
+        before: int = 20,
+        after: int = 80,
+    ) -> dict[str, Any]:
+        before = min(max(before, 0), 120)
+        after = min(max(after, 0), 120)
+        start = max(1, center_line - before)
+        end = min(self._bundle.line_count, center_line + after)
+        if end - start + 1 > READ_WINDOW_MAX_LINES:
+            end = start + READ_WINDOW_MAX_LINES - 1
+
+        selected, chars_truncated = _line_payload_with_char_cap(
+            self._source_log.log_lines(start_line=start, end_line=end),
+            READ_WINDOW_MAX_CHARS,
+        )
+        return {
+            "start_line": start,
+            "end_line": end,
+            "lines": selected,
+            "truncated": end < min(self._bundle.line_count, center_line + after) or chars_truncated,
+        }
+
+    def get_evidence_objects(self, refs: list[str]) -> dict[str, Any]:
+        """Resolve attempt-scoped L0A references without rereading the log."""
+
+        requested_refs: list[str] = []
+        invalid_refs: list[str] = []
+        request_truncated = len(refs) > EVIDENCE_OBJECTS_MAX_REFS
+        for ref in refs[:EVIDENCE_OBJECTS_MAX_REFS]:
+            if len(ref) > EVIDENCE_OBJECT_REF_MAX_CHARS:
+                invalid_refs.append(ref[:EVIDENCE_OBJECT_REF_MAX_CHARS])
+                request_truncated = True
+                continue
+            if ref not in requested_refs:
+                requested_refs.append(ref)
+
+        index = _evidence_object_index(self._bundle)
+        objects: list[dict[str, Any]] = []
+        missing_refs: list[str] = []
+        omitted_refs: list[str] = []
+        object_truncated = False
+        for ref in requested_refs:
+            indexed = index.get(ref)
+            if indexed is None:
+                missing_refs.append(ref)
+                continue
+            object_type, value = indexed
+            response_without_object = {
+                "schema_version": EVIDENCE_OBJECTS_SCHEMA_VERSION,
+                "requested_refs": requested_refs,
+                "objects": objects,
+                "missing_refs": missing_refs,
+                "invalid_refs": invalid_refs,
+                "omitted_refs": omitted_refs,
+                "truncated": True,
+            }
+            remaining = (
+                EVIDENCE_OBJECTS_MAX_CHARS
+                - _json_chars(response_without_object)
+                - EVIDENCE_OBJECTS_METADATA_RESERVE_CHARS
+            )
+            if remaining <= 256:
+                omitted_refs.append(ref)
+                object_truncated = True
+                continue
+            payload, payload_truncated = _bounded_json_payload(
+                _json_compatible(asdict(value)),
+                remaining,
+            )
+            candidate = {
+                "ref": ref,
+                "object_type": object_type,
+                "payload": payload,
+                "truncated": payload_truncated,
+            }
+            if _json_chars({**response_without_object, "objects": [*objects, candidate]}) > (
+                EVIDENCE_OBJECTS_MAX_CHARS
+            ):
+                omitted_refs.append(ref)
+                object_truncated = True
+                continue
+            objects.append(candidate)
+            object_truncated = object_truncated or payload_truncated
+
+        return {
+            "schema_version": EVIDENCE_OBJECTS_SCHEMA_VERSION,
+            "requested_refs": requested_refs,
+            "objects": objects,
+            "missing_refs": missing_refs,
+            "invalid_refs": invalid_refs,
+            "omitted_refs": omitted_refs,
+            "limits": {
+                "max_refs": EVIDENCE_OBJECTS_MAX_REFS,
+                "max_chars": EVIDENCE_OBJECTS_MAX_CHARS,
+            },
+            "truncated": request_truncated or object_truncated or bool(omitted_refs),
+        }
+
+
+def _build_overview(bundle: L0Bundle, source_log: LogSnapshot) -> dict[str, Any]:
+    head = list(source_log.log_lines(end_line=OVERVIEW_HEAD_LINES))
+    tail_start = max(1, source_log.line_count - OVERVIEW_TAIL_LINES + 1)
+    tail = list(source_log.log_lines(start_line=tail_start))
+    head_payload, head_truncated = _line_payload_with_char_cap(head, OVERVIEW_MAX_CHARS // 2)
+    tail_payload, tail_truncated = _line_payload_with_char_cap(tail, OVERVIEW_MAX_CHARS // 2)
+    return {
+        "line_count": bundle.line_count,
+        "byte_size": bundle.byte_size,
+        "head": head_payload,
+        "tail": tail_payload,
+        "deterministic_summary": {
+            "path_access_facts": [dict(item) for item in bundle.path_access_facts],
+            "path_namespace_summary": dict(bundle.path_namespace_summary),
+            "run_progress_summary": _run_progress_summary_payload(bundle.run_progress_summary),
+            "job_metadata": _job_metadata_payload(bundle.job_metadata),
+            "later_progress_after_fault_observations": [
+                {
+                    "failure_class": item.failure_class,
+                    "root_fingerprint": item.root_fingerprint,
+                    "event_count": item.event_count,
+                    "sample_event_lines": list(item.sample_event_lines),
+                    "sample_later_progress_lines": list(item.sample_later_progress_lines),
+                    "matches_terminal_fingerprint": (item.matches_terminal_fingerprint),
+                    "ordering_basis": item.ordering_basis,
+                    "interpretation": item.interpretation,
+                    "component_recovery_proven": item.component_recovery_proven,
+                }
+                for item in bundle.later_progress_after_fault_observations[:10]
+            ],
+            "progress_lines": list(bundle.progress.progress_lines[-20:]),
+            "recent_progress_markers": [
+                _progress_marker_payload(marker)
+                for marker in bundle.progress.progress_markers[-20:]
+            ],
+            "recent_checkpoint_markers": [
+                _progress_marker_payload(marker)
+                for marker in bundle.progress.checkpoint_markers[-10:]
+            ],
+            "recent_setup_markers": [
+                _progress_marker_payload(marker) for marker in bundle.progress.setup_markers[-10:]
+            ],
+            "failure_episodes": [
+                {
+                    "episode_id": episode.episode_id,
+                    "status": episode.status,
+                    "start_line": episode.start_line,
+                    "end_line": episode.end_line,
+                    "first_exception_line": episode.first_exception_line,
+                    "terminal_exception_line": episode.terminal_exception_line,
+                    "terminal_exception_iteration": episode.terminal_exception_iteration,
+                    "terminal_exception_causal_role_hint": (
+                        episode.terminal_exception_causal_role_hint
+                    ),
+                    "exception_chain_lines": list(episode.exception_chain_lines),
+                    "duplicate_rendering_lines": list(episode.duplicate_rendering_lines),
+                    "wrapper_exception_lines": list(episode.wrapper_exception_lines),
+                    "exception_rank": episode.exception_rank,
+                    "exception_node": episode.exception_node,
+                    "exception_gpu": episode.exception_gpu,
+                    "last_progress_before": _progress_marker_payload(episode.last_progress_before),
+                    "first_progress_after": _progress_marker_payload(episode.first_progress_after),
+                    "first_teardown_line": episode.first_teardown_line,
+                    "first_process_termination_line": (episode.first_process_termination_line),
+                    "first_scheduler_cancel_line": episode.first_scheduler_cancel_line,
+                    "cause_confirmations": [
+                        _registry_hint(bundle, confirmation)
+                        for confirmation in episode.cause_confirmations
+                    ],
+                    "context_window_ids": list(episode.context_window_ids),
+                    "reason": episode.reason,
+                }
+                for episode in bundle.failure_episodes[:10]
+            ],
+            "distributed_failure_incidents": [
+                {
+                    "incident_id": incident.incident_id,
+                    "incident_kind": incident.incident_kind,
+                    "incident_type": incident.incident_type,
+                    "status": incident.status,
+                    "first_observed_line": incident.first_observed_line,
+                    "last_observed_line": incident.last_observed_line,
+                    "primary_observed_line": incident.primary_observed_line,
+                    "sample_lines": list(incident.sample_lines),
+                    "event_count": incident.event_count,
+                    "unique_operation_count": incident.unique_operation_count,
+                    "operation_types": list(incident.operation_types),
+                    "operation_signatures": list(incident.operation_signatures),
+                    "observed_rank_count": incident.observed_rank_count,
+                    "rank_spread_sample": list(incident.rank_spread),
+                    "process_group_types": list(incident.process_group_types),
+                    "phase": incident.phase,
+                    "configured_timeout_seconds": (incident.configured_timeout_seconds),
+                    "last_progress_line": incident.last_progress_line,
+                    "last_progress_timestamp": incident.last_progress_timestamp,
+                    "first_detection_timestamp": incident.first_detection_timestamp,
+                    "seconds_since_last_progress": incident.seconds_since_last_progress,
+                    "detection_lag_seconds": incident.detection_lag_seconds,
+                    "current_attempt_incident_fingerprint": incident.history_fingerprint,
+                    "root_cause_status": incident.root_cause_status,
+                    "interpretation": incident.interpretation,
+                }
+                for incident in bundle.distributed_failure_incidents[:10]
+            ],
+            "cause_confirmations": [
+                _registry_hint(bundle, confirmation)
+                for confirmation in bundle.cause_confirmations[:10]
+            ],
+            "registry_candidate_groups": _registry_candidate_groups(bundle),
+            "registry_candidate": _registry_hint(
+                bundle,
+                bundle.deterministic_primary_candidate,
+            ),
+            "candidate_anchors": [
+                {
+                    "anchor_id": anchor.anchor_id,
+                    "line": anchor.line,
+                    "sources": list(anchor.sources),
+                    "high_signal": anchor.high_signal,
+                    "causal_role_hint": anchor.causal_role_hint,
+                    "anchor_rank": anchor.anchor_rank,
+                    "taxonomy_hint": _registry_hint(
+                        bundle,
+                        anchor.taxonomy_match,
+                    ),
+                    "nearby_progress_observations": {
+                        "prior_observed_progress_line": (anchor.prior_observed_progress_line),
+                        "later_observed_progress_line": (anchor.later_observed_progress_line),
+                        "prior_progress_rank": anchor.prior_progress_rank,
+                        "later_progress_rank": anchor.later_progress_rank,
+                        "later_progress_rank_relation": (anchor.later_progress_rank_relation),
+                        "later_observation_proves_recovery": (
+                            anchor.later_observation_proves_recovery
+                        ),
+                    },
+                    "first_downstream_registry_hint": _registry_hint(
+                        bundle,
+                        anchor.first_downstream_registry_match,
+                    ),
+                    "first_downstream_cascade": (
+                        anchor.first_downstream_cascade.to_failure_payload()
+                        if anchor.first_downstream_cascade
+                        else None
+                    ),
+                    "context_window_ids": list(anchor.context_window_ids),
+                }
+                for anchor in bundle.candidate_anchors[:20]
+            ],
+            "cascade_groups": [
+                {
+                    "failure_class": cascade.failure_class,
+                    "cascade_fingerprint": cascade.cascade_fingerprint,
+                    "first_line": cascade.first_line,
+                    "last_line": cascade.last_line,
+                    "count": cascade.count,
+                    "sample_lines": list(cascade.sample_lines),
+                    "rank_spread": list(cascade.rank_spread),
+                    "node_spread": list(cascade.node_spread),
+                    "gpu_spread": list(cascade.gpu_spread),
+                    "reason": cascade.reason,
+                }
+                for cascade in bundle.cascades[:20]
+            ],
+            "termination_candidates": [],
+        },
+        "truncated": (len(bundle.registry_matches) > 20 or head_truncated or tail_truncated),
+    }
+
+
+def _evidence_object_index(bundle: L0Bundle) -> dict[str, tuple[str, Any]]:
+    index: dict[str, tuple[str, Any]] = {}
+    collections = (
+        ("occurrence_group", bundle.occurrence_groups, "occurrence_group_id"),
+        ("context_window", bundle.context_windows, "window_id"),
+        ("candidate_anchor", bundle.candidate_anchors, "anchor_id"),
+        ("failure_episode", bundle.failure_episodes, "episode_id"),
+        ("distributed_incident", bundle.distributed_failure_incidents, "incident_id"),
+        ("progress_marker", bundle.progress.progress_markers, "marker_id"),
+        ("checkpoint_marker", bundle.progress.checkpoint_markers, "marker_id"),
+        ("setup_marker", bundle.progress.setup_markers, "marker_id"),
+    )
+    for object_type, values, id_field in collections:
+        for value in values:
+            ref = str(getattr(value, id_field))
+            index.setdefault(ref, (object_type, value))
+    return index
+
+
+def _bounded_json_payload(value: Any, max_chars: int) -> tuple[Any, bool]:
+    if _json_chars(value) <= max_chars:
+        return value, False
+    if isinstance(value, str):
+        keep = max(0, max_chars - 32)
+        return value[:keep], True
+    if isinstance(value, list):
+        result: list[Any] = []
+        truncated = False
+        for item in value:
+            remaining = max_chars - _json_chars(result) - 2
+            if remaining <= 0:
+                truncated = True
+                break
+            bounded_item, item_truncated = _bounded_json_payload(item, remaining)
+            candidate = [*result, bounded_item]
+            if _json_chars(candidate) > max_chars:
+                truncated = True
+                break
+            result.append(bounded_item)
+            truncated = truncated or item_truncated
+        return result, truncated or len(result) < len(value)
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        truncated = False
+        for key, item in value.items():
+            remaining = max_chars - _json_chars(result) - len(str(key)) - 8
+            if remaining <= 0:
+                truncated = True
+                break
+            bounded_item, item_truncated = _bounded_json_payload(item, remaining)
+            candidate = {**result, key: bounded_item}
+            if _json_chars(candidate) > max_chars:
+                truncated = True
+                break
+            result[key] = bounded_item
+            truncated = truncated or item_truncated
+        return result, truncated or len(result) < len(value)
+    return value, True
+
+
+def _json_compatible(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _json_compatible(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_compatible(item) for item in value]
+    return value
+
+
+def _json_chars(value: Any) -> int:
+    return len(json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+
+
+def _line_payload_with_char_cap(
+    lines: Iterable[LogLine],
+    max_chars: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    payload: list[dict[str, Any]] = []
+    used = 0
+    truncated = False
+    for item in lines:
+        text = item.text
+        next_used = used + len(text)
+        if next_used > max_chars:
+            remaining = max(0, max_chars - used)
+            if remaining > 0:
+                payload.append({"line": item.line, "text": text[:remaining]})
+            truncated = True
+            break
+        payload.append(_line_payload(item))
+        used = next_used
+    return payload, truncated
+
+
+def _line_payload(item: LogLine) -> dict[str, Any]:
+    text = item.text
+    truncated = len(text) > TOOL_LINE_MAX_CHARS
+    payload = {"line": item.line, "text": text[:TOOL_LINE_MAX_CHARS]}
+    if truncated:
+        payload["line_truncated"] = True
+        payload["original_chars"] = len(text)
+    return payload
+
+
+def _progress_marker_payload(marker: Any | None) -> dict[str, Any] | None:
+    if marker is None:
+        return None
+    return {
+        "marker_id": marker.marker_id,
+        "marker_type": marker.marker_type,
+        "value": marker.value,
+        "state": marker.state,
+        "line": marker.line,
+        "timestamp": marker.timestamp,
+        "rank": marker.rank,
+        "node": marker.node,
+        "gpu": marker.gpu,
+        "pattern_id": marker.pattern_id,
+        "secondary_value": dict(marker.secondary_value),
+    }
+
+
+def _run_progress_summary_payload(summary: Any) -> dict[str, Any]:
+    return {
+        "first_iteration": summary.first_iteration,
+        "first_iteration_line": summary.first_iteration_line,
+        "first_iteration_timestamp": summary.first_iteration_timestamp,
+        "last_iteration": summary.last_iteration,
+        "last_iteration_line": summary.last_iteration_line,
+        "last_iteration_timestamp": summary.last_iteration_timestamp,
+        "iteration_delta": summary.iteration_delta,
+        "total_iterations": summary.total_iterations,
+        "first_consumed_samples": summary.first_consumed_samples,
+        "last_consumed_samples": summary.last_consumed_samples,
+        "consumed_samples_delta": summary.consumed_samples_delta,
+        "progress_marker_count": summary.progress_marker_count,
+        "checkpoint_marker_count": summary.checkpoint_marker_count,
+        "setup_marker_count": summary.setup_marker_count,
+        "last_checkpoint_iteration": summary.last_checkpoint_iteration,
+        "last_checkpoint_line": summary.last_checkpoint_line,
+        "checkpoint_load_iteration": summary.checkpoint_load_iteration,
+        "checkpoint_load_line": summary.checkpoint_load_line,
+        "latest_observed_failure_iteration": summary.latest_observed_failure_iteration,
+        "latest_observed_failure_iteration_line": (summary.latest_observed_failure_iteration_line),
+        "observed_iterations_after_checkpoint_load": (
+            summary.observed_iterations_after_checkpoint_load
+        ),
+        "last_setup_marker_type": summary.last_setup_marker_type,
+        "last_setup_line": summary.last_setup_line,
+        "successful_runtime_seconds": summary.successful_runtime_seconds,
+        "iterations_since_checkpoint": summary.iterations_since_checkpoint,
+        "progress_after_failure_episode": summary.progress_after_failure_episode,
+        "first_terminal_incident_line": summary.first_terminal_incident_line,
+        "first_terminal_incident_timestamp": summary.first_terminal_incident_timestamp,
+        "configured_terminal_timeout_seconds": summary.configured_terminal_timeout_seconds,
+        "seconds_from_last_progress_to_terminal_incident": (
+            summary.seconds_from_last_progress_to_terminal_incident
+        ),
+        "terminal_detection_lag_seconds": summary.terminal_detection_lag_seconds,
+    }
+
+
+def _job_metadata_payload(metadata: Any) -> dict[str, Any]:
+    return {
+        "explicit_world_size": metadata.explicit_world_size,
+        "explicit_world_size_line": metadata.explicit_world_size_line,
+        "observed_rank_min": metadata.observed_rank_min,
+        "observed_rank_max": metadata.observed_rank_max,
+        "observed_rank_count": metadata.observed_rank_count,
+        "inferred_world_size_lower_bound": metadata.inferred_world_size_lower_bound,
+        "world_size_source": metadata.world_size_source,
+        "world_size_confidence": metadata.world_size_confidence,
+        "observed_node_count": metadata.observed_node_count,
+        "rank_to_gpu_mapping_available": metadata.rank_to_gpu_mapping_available,
+    }
+
+
+def _registry_candidate_groups(bundle: L0Bundle) -> list[dict[str, Any]]:
+    groups: dict[tuple[str | None, str], dict[str, Any]] = {}
+    for match in bundle.registry_matches:
+        key = (match.registry_id, match.signature)
+        group = groups.get(key)
+        if group is None:
+            group = {
+                "registry_id": match.registry_id,
+                "failure_class_hint": match.failure_class,
+                "signature_hint": match.signature,
+                "first_line": match.line,
+                "count": 0,
+                "sample_lines": [],
+                "causal_role_hint": _causal_role_hint(bundle, match.line),
+                "provisional": True,
+            }
+            groups[key] = group
+        group["count"] += 1
+        if match.line is not None and len(group["sample_lines"]) < 5:
+            group["sample_lines"].append(match.line)
+        if _causal_role_hint(bundle, match.line) == CausalRole.TEARDOWN.value:
+            group["causal_role_hint"] = CausalRole.TEARDOWN.value
+    return list(groups.values())[:20]
+
+
+def _registry_hint(bundle: L0Bundle, match: Any | None) -> dict[str, Any] | None:
+    if match is None:
+        return None
+    return {
+        "failure_class_hint": match.failure_class,
+        "signature_hint": match.signature,
+        "line": match.line,
+        "rank": match.rank,
+        "phase": match.phase,
+        "failure_iteration": match.failure_iteration,
+        "registry_id": match.registry_id,
+        "causal_role_hint": _causal_role_hint(bundle, match.line),
+        "provisional": True,
+    }
+
+
+def _causal_role_hint(bundle: L0Bundle, line: int | None) -> str:
+    if line is None:
+        return CausalRole.UNKNOWN.value
+    for episode in bundle.failure_episodes:
+        if episode.terminal_exception_line == line:
+            return episode.terminal_exception_causal_role_hint
+    return CausalRole.UNKNOWN.value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider-neutral validation for the closed L1 semantic evidence contract."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..models import L1_EVIDENCE_SCHEMA_VERSION, AssessmentStatus, L1AnalysisStatus
+from .response_contract import L1_RESPONSE_CONTRACT
+
+
+def model_evidence_contract_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return structural errors without applying semantic policy judgment."""
+
+    errors = _object_shape_errors(payload, L1_RESPONSE_CONTRACT.top_level_fields, "top-level")
+    if payload.get("schema_version") != L1_EVIDENCE_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {L1_EVIDENCE_SCHEMA_VERSION}")
+
+    analysis_status = payload.get("analysis_status")
+    if analysis_status not in L1_RESPONSE_CONTRACT.analysis_statuses:
+        errors.append("analysis_status is invalid")
+
+    primary = payload.get("primary_failure")
+    if primary is not None and not isinstance(primary, Mapping):
+        errors.append("primary_failure must be an object or null")
+    elif isinstance(primary, Mapping):
+        errors.extend(_primary_failure_errors(primary))
+
+    if analysis_status == L1AnalysisStatus.PRIMARY_IDENTIFIED.value and not isinstance(
+        primary, Mapping
+    ):
+        errors.append(
+            "primary_failure must be an object when analysis_status is primary_identified"
+        )
+    if (
+        analysis_status
+        in {
+            L1AnalysisStatus.NO_FAILURE_OBSERVED.value,
+            L1AnalysisStatus.INSUFFICIENT_EVIDENCE.value,
+        }
+        and primary is not None
+    ):
+        errors.append("primary_failure must be null when no primary was identified")
+
+    errors.extend(_root_cause_errors(payload.get("root_cause_assessment")))
+    errors.extend(_recovery_assessment_errors(payload.get("model_recovery_assessment")))
+    errors.extend(_related_failure_errors(payload.get("related_failures")))
+    evidence_errors, support_tags = _evidence_errors(payload.get("evidence"))
+    errors.extend(evidence_errors)
+
+    if analysis_status == L1AnalysisStatus.PRIMARY_IDENTIFIED.value:
+        for required_support in sorted(L1_RESPONSE_CONTRACT.required_primary_support_tags):
+            if required_support not in support_tags:
+                errors.append(f"evidence must support {required_support}")
+    elif analysis_status in {
+        L1AnalysisStatus.NO_FAILURE_OBSERVED.value,
+        L1AnalysisStatus.INSUFFICIENT_EVIDENCE.value,
+    }:
+        errors.extend(_non_primary_semantic_errors(payload, analysis_status))
+    return errors
+
+
+def _object_shape_errors(
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    field: str,
+) -> list[str]:
+    errors: list[str] = []
+    missing = sorted(expected.difference(value))
+    extra = sorted(set(value).difference(expected))
+    if missing:
+        errors.append(f"{field} missing fields: " + ", ".join(missing))
+    if extra:
+        errors.append(f"{field} has unsupported fields: " + ", ".join(extra))
+    return errors
+
+
+def _primary_failure_errors(primary: Mapping[str, Any]) -> list[str]:
+    errors = _object_shape_errors(
+        primary,
+        L1_RESPONSE_CONTRACT.primary_failure_fields,
+        "primary_failure",
+    )
+    errors.extend(_positive_line_errors(primary.get("line"), "primary_failure.line"))
+    if primary.get("causal_role") not in L1_RESPONSE_CONTRACT.causal_roles:
+        errors.append("primary_failure.causal_role is invalid")
+    identity = primary.get("failure_identity")
+    if not isinstance(identity, Mapping):
+        errors.append("primary_failure.failure_identity must be an object")
+        return errors
+    errors.extend(
+        _object_shape_errors(
+            identity,
+            L1_RESPONSE_CONTRACT.failure_identity_fields,
+            "primary_failure.failure_identity",
+        )
+    )
+    for name in L1_RESPONSE_CONTRACT.failure_identity_fields:
+        value = identity.get(name)
+        if value is not None and not isinstance(value, str):
+            errors.append(f"primary_failure.failure_identity.{name} must be a string or null")
+    return errors
+
+
+def _root_cause_errors(root_cause: Any) -> list[str]:
+    if not isinstance(root_cause, Mapping):
+        return ["root_cause_assessment must be an object"]
+    errors = _object_shape_errors(
+        root_cause,
+        L1_RESPONSE_CONTRACT.root_cause_fields,
+        "root_cause_assessment",
+    )
+    if not _nonempty_string(root_cause.get("summary")):
+        errors.append("root_cause_assessment.summary must be a non-empty string")
+    if root_cause.get("status") not in L1_RESPONSE_CONTRACT.assessment_statuses:
+        errors.append("root_cause_assessment.status is invalid")
+    for field, maximum in (
+        ("plausible_causes", L1_RESPONSE_CONTRACT.max_plausible_causes),
+        ("missing_evidence", L1_RESPONSE_CONTRACT.max_missing_evidence),
+    ):
+        value = root_cause.get(field)
+        if not isinstance(value, list):
+            errors.append(f"root_cause_assessment.{field} must be an array")
+        elif not all(_nonempty_string(item) for item in value):
+            errors.append(f"root_cause_assessment.{field} items must be non-empty strings")
+        elif len(value) > maximum:
+            errors.append(f"root_cause_assessment.{field} must contain at most {maximum} items")
+    return errors
+
+
+def _recovery_assessment_errors(assessment: Any) -> list[str]:
+    if not isinstance(assessment, Mapping):
+        return ["model_recovery_assessment must be an object"]
+    errors = _object_shape_errors(
+        assessment,
+        L1_RESPONSE_CONTRACT.recovery_assessment_fields,
+        "model_recovery_assessment",
+    )
+    errors.extend(
+        _claim_errors(
+            assessment.get("failure_domain"),
+            field="model_recovery_assessment.failure_domain",
+            valid_values=L1_RESPONSE_CONTRACT.failure_domains,
+        )
+    )
+    errors.extend(
+        _claim_errors(
+            assessment.get("retry_outlook_without_workload_change"),
+            field="model_recovery_assessment.retry_outlook_without_workload_change",
+            valid_values=L1_RESPONSE_CONTRACT.retry_outlooks,
+        )
+    )
+    if not _nonempty_string(assessment.get("rationale")):
+        errors.append("model_recovery_assessment.rationale must be a non-empty string")
+    return errors
+
+
+def _claim_errors(value: Any, *, field: str, valid_values: frozenset[str]) -> list[str]:
+    if not isinstance(value, Mapping):
+        return [f"{field} must be an object"]
+    errors = _object_shape_errors(value, L1_RESPONSE_CONTRACT.claim_fields, field)
+    claim_value = value.get("value")
+    claim_status = value.get("status")
+    if claim_value not in valid_values:
+        errors.append(f"{field}.value is invalid")
+    if claim_status not in L1_RESPONSE_CONTRACT.assessment_statuses:
+        errors.append(f"{field}.status is invalid")
+    confidence = value.get("confidence")
+    if (
+        isinstance(confidence, bool)
+        or not isinstance(confidence, int)
+        or not L1_RESPONSE_CONTRACT.min_confidence
+        <= confidence
+        <= L1_RESPONSE_CONTRACT.max_confidence
+    ):
+        errors.append(
+            f"{field}.confidence must be an integer from "
+            f"{L1_RESPONSE_CONTRACT.min_confidence} to "
+            f"{L1_RESPONSE_CONTRACT.max_confidence}"
+        )
+    if (claim_value == "unknown") != (claim_status == AssessmentStatus.UNKNOWN.value):
+        errors.append(f"{field} must use value=unknown and status=unknown together")
+    return errors
+
+
+def _related_failure_errors(related: Any) -> list[str]:
+    if not isinstance(related, list):
+        return ["related_failures must be an array"]
+    errors: list[str] = []
+    if len(related) > L1_RESPONSE_CONTRACT.max_related_failures:
+        errors.append(
+            "related_failures must contain at most "
+            f"{L1_RESPONSE_CONTRACT.max_related_failures} items"
+        )
+    for index, item in enumerate(related):
+        field = f"related_failures[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{field} must be an object")
+            continue
+        errors.extend(
+            _object_shape_errors(item, L1_RESPONSE_CONTRACT.related_failure_fields, field)
+        )
+        errors.extend(_positive_line_errors(item.get("line"), f"{field}.line"))
+        if item.get("causal_role") not in L1_RESPONSE_CONTRACT.related_causal_roles:
+            errors.append(f"{field}.causal_role is invalid")
+        if not _nonempty_string(item.get("rationale")):
+            errors.append(f"{field}.rationale must be a non-empty string")
+    return errors
+
+
+def _evidence_errors(evidence: Any) -> tuple[list[str], set[str]]:
+    if not isinstance(evidence, list):
+        return ["evidence must be an array"], set()
+    errors: list[str] = []
+    support_tags: set[str] = set()
+    evidence_ids: set[str] = set()
+    if len(evidence) > L1_RESPONSE_CONTRACT.max_evidence_items:
+        errors.append(
+            f"evidence must contain at most {L1_RESPONSE_CONTRACT.max_evidence_items} items"
+        )
+    for index, item in enumerate(evidence):
+        field = f"evidence[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"{field} must be an object")
+            continue
+        errors.extend(_object_shape_errors(item, L1_RESPONSE_CONTRACT.evidence_fields, field))
+        evidence_id = item.get("id")
+        if (
+            not _nonempty_string(evidence_id)
+            or len(evidence_id) > L1_RESPONSE_CONTRACT.max_evidence_id_chars
+        ):
+            errors.append(
+                f"{field}.id must be a non-empty string of at most "
+                f"{L1_RESPONSE_CONTRACT.max_evidence_id_chars} characters"
+            )
+        elif L1_RESPONSE_CONTRACT.require_unique_evidence_ids and evidence_id in evidence_ids:
+            errors.append(f"{field}.id must be unique")
+        else:
+            evidence_ids.add(evidence_id)
+        errors.extend(_positive_line_errors(item.get("line"), f"{field}.line"))
+        if not _nonempty_string(item.get("quote")):
+            errors.append(f"{field}.quote must be a non-empty string")
+        supports = item.get("supports")
+        if not isinstance(supports, list) or not supports:
+            errors.append(f"{field}.supports must be a non-empty array")
+        elif not all(
+            isinstance(tag, str) and tag in L1_RESPONSE_CONTRACT.evidence_support_tags
+            for tag in supports
+        ):
+            errors.append(f"{field}.supports contains an invalid support tag")
+        elif len(set(supports)) != len(supports):
+            errors.append(f"{field}.supports must not contain duplicates")
+        else:
+            support_tags.update(supports)
+    return errors, support_tags
+
+
+def _non_primary_semantic_errors(
+    payload: Mapping[str, Any],
+    analysis_status: str,
+) -> list[str]:
+    errors: list[str] = []
+    root_cause = payload.get("root_cause_assessment")
+    assessment = payload.get("model_recovery_assessment")
+    related = payload.get("related_failures")
+    evidence = payload.get("evidence")
+    if analysis_status == L1AnalysisStatus.NO_FAILURE_OBSERVED.value:
+        expected_summary = L1_RESPONSE_CONTRACT.no_failure_summary
+        expected_rationale = L1_RESPONSE_CONTRACT.no_failure_rationale
+    else:
+        expected_summary = L1_RESPONSE_CONTRACT.insufficient_summary
+        expected_rationale = L1_RESPONSE_CONTRACT.insufficient_rationale
+    if isinstance(root_cause, Mapping):
+        if root_cause.get("summary") != expected_summary:
+            errors.append(f"non-primary root_cause_assessment.summary must be {expected_summary!r}")
+        if root_cause.get("status") != AssessmentStatus.UNKNOWN.value:
+            errors.append("non-primary root_cause_assessment.status must be unknown")
+        if root_cause.get("plausible_causes") != []:
+            errors.append("non-primary root_cause_assessment.plausible_causes must be empty")
+        missing = root_cause.get("missing_evidence")
+        if analysis_status == L1AnalysisStatus.NO_FAILURE_OBSERVED.value and missing != []:
+            errors.append("no_failure_observed missing_evidence must be empty")
+        if (
+            analysis_status == L1AnalysisStatus.INSUFFICIENT_EVIDENCE.value
+            and isinstance(missing, list)
+            and not missing
+        ):
+            errors.append("insufficient_evidence missing_evidence must not be empty")
+    if isinstance(assessment, Mapping):
+        if assessment.get("rationale") != expected_rationale:
+            errors.append(
+                f"non-primary model_recovery_assessment.rationale must be "
+                f"{expected_rationale!r}"
+            )
+        for name in ("failure_domain", "retry_outlook_without_workload_change"):
+            claim = assessment.get(name)
+            if not isinstance(claim, Mapping):
+                continue
+            if claim.get("value") != "unknown" or claim.get("status") != "unknown":
+                errors.append(f"non-primary {name} must use value=unknown and status=unknown")
+            if claim.get("confidence") != L1_RESPONSE_CONTRACT.non_primary_confidence:
+                errors.append(
+                    f"non-primary {name}.confidence must be "
+                    f"{L1_RESPONSE_CONTRACT.non_primary_confidence}"
+                )
+    if related != []:
+        errors.append("non-primary related_failures must be empty")
+    if evidence != []:
+        errors.append("non-primary evidence must be empty")
+    return errors
+
+
+def _positive_line_errors(value: Any, field: str) -> list[str]:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return [f"{field} must be a positive integer"]
+    return []
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l2/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l2/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 grounding, failure identity, and advisory audit."""
+
+from .audit import L2GroundingInput, L2Result, ground_and_audit_model_evidence
+from .failure_facts import build_attempt_failure_facts
+
+__all__ = [
+    "L2GroundingInput",
+    "L2Result",
+    "build_attempt_failure_facts",
+    "ground_and_audit_model_evidence",
+]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l2/audit.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l2/audit.py
@@ -1,0 +1,1256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L2 source grounding, history identity, and credibility diagnostics."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from ..identity import (
+    canonical_observed_fingerprint,
+    extract_data_position_fingerprint,
+    extract_failure_iteration,
+    extract_gpu,
+    extract_node,
+    extract_rank,
+    grounded_artifact_path,
+)
+from ..infrastructure.log_source import LogSnapshot
+from ..l0.decision import canonical_identity_anchor_line, distributed_incident_for_line
+from ..l1.contracts import L1EvidenceResult
+from ..l1.response_contract import FAILURE_DOMAIN_SUPPORT_TAG, RETRY_OUTLOOK_SUPPORT_TAG
+from ..models import (
+    AffectedEntity,
+    AssessmentStatus,
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    CausalRole,
+    FailureEvidence,
+    FaultOutcome,
+    L0Bundle,
+    L0ModelFacingView,
+    ModelRecoveryAssessment,
+)
+from .failure_facts import build_attempt_failure_facts, build_grounded_affected_entity
+from .grounding import model_visible_line_numbers, model_visible_line_texts
+
+PROHIBITED_MODEL_FIELDS = {
+    "user_failure",
+    "not_user_failure",
+    "decision",
+    "decision_basis",
+    "evidence_coverage",
+}
+NEARBY_EVIDENCE_LINE_RADIUS = 5
+
+
+@dataclass(frozen=True)
+class L2GroundingInput:
+    """Complete typed input required to ground and audit one L1 result."""
+
+    bundle: L0Bundle
+    model_view: L0ModelFacingView
+    l1_result: L1EvidenceResult
+    source_log: LogSnapshot
+
+
+@dataclass(frozen=True)
+class L2Result:
+    """Grounded L1 semantics plus optional audit diagnostics."""
+
+    primary: FailureEvidence | None
+    enriched_failure_facts: AttemptFailureFacts | None
+    used: bool
+    grounding_status: str
+    audit_status: str
+    root_cause_assessment: Mapping[str, Any] | None = None
+    model_recovery_assessment: ModelRecoveryAssessment | None = None
+    recovery_assessment_used: bool = False
+    recovery_assessment_policy_grounded: bool = False
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, Any]:
+        payload = dict(self.diagnostics)
+        payload.update(
+            {
+                "used": self.used,
+                "grounding_status": self.grounding_status,
+                "audit_status": self.audit_status,
+                "primary_used": self.primary is not None and self.used,
+                "enriched_failure_facts": (
+                    self.enriched_failure_facts.to_payload()
+                    if self.enriched_failure_facts is not None
+                    else None
+                ),
+                "recovery_assessment_used": self.recovery_assessment_used,
+                "recovery_assessment_policy_grounded": (self.recovery_assessment_policy_grounded),
+                "root_cause_assessment": (
+                    dict(self.root_cause_assessment)
+                    if self.root_cause_assessment is not None
+                    else None
+                ),
+                "model_recovery_assessment": (
+                    self.model_recovery_assessment.to_payload()
+                    if self.model_recovery_assessment is not None
+                    else None
+                ),
+            }
+        )
+        return payload
+
+    @classmethod
+    def not_run(cls, reason: str) -> "L2Result":
+        return cls(
+            primary=None,
+            enriched_failure_facts=None,
+            used=False,
+            grounding_status="not_run",
+            audit_status="not_run",
+            recovery_assessment_policy_grounded=False,
+            diagnostics={
+                "not_run_reason": reason,
+                "field_findings": {},
+                "field_finding_codes": {},
+                "findings": [],
+                "ignored_prohibited_fields": [],
+                "citation_audits": [],
+                "grounding_adjustments": [],
+                "recovery_field_audits": [],
+            },
+        )
+
+
+@dataclass(frozen=True)
+class PrimaryGrounding:
+    """Source-grounded primary selection and its citation resolution."""
+
+    model_primary: Mapping[str, Any]
+    line: int
+    log_line: str
+    source_line_available: bool
+    grounding_method: str
+    grounded_evidence: tuple[Mapping[str, Any], ...]
+    resolved_lines: Mapping[int, int]
+    cited_lines: frozenset[int]
+    visible_lines: frozenset[int]
+
+
+@dataclass(frozen=True)
+class RecoveryAudit:
+    """Grounded support and credibility signals for the model recovery assessment."""
+
+    root_cause_assessment: Mapping[str, Any]
+    recovery_assessment: Mapping[str, Any]
+    failure_domain_value: str
+    failure_domain_status: str
+    failure_domain_confidence: int
+    retry_outlook_value: str
+    retry_outlook_status: str
+    retry_outlook_confidence: int
+    root_cause_status: str
+    failure_domain_supporting_lines: frozenset[int]
+    retry_outlook_supporting_lines: frozenset[int]
+    unresolved_supporting_lines: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class RecoverySupport:
+    """Resolved source support attached to the model recovery assessment."""
+
+    failure_domain_lines: frozenset[int]
+    retry_outlook_lines: frozenset[int]
+    unresolved_lines: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class HistoryIdentity:
+    """Source-grounded identity used for current-failure history comparison."""
+
+    anchor_line: int
+    anchor_reason: str
+    log_line: str
+    l0_match: FailureEvidence | None
+    root_fingerprint: str | None
+    root_fingerprint_source: str
+    affected_entity: AffectedEntity | None
+
+
+@dataclass(frozen=True)
+class CitationGrounding:
+    """Pure resolution result for one model citation."""
+
+    original_line: int
+    resolved_line: int | None
+    quote: str | None
+    supports: tuple[str, ...]
+    status: str
+    candidate_lines: tuple[int, ...] = ()
+
+
+def result_from_payload(
+    primary: FailureEvidence | None,
+    payload: Mapping[str, Any],
+    model_view: L0ModelFacingView,
+) -> L2Result:
+    details = dict(payload)
+    root_cause = details.pop("root_cause_assessment", None)
+    assessment = details.pop("model_recovery_assessment", None)
+    used = bool(details.pop("used", False))
+    grounding_status = str(details.pop("grounding_status", "unavailable"))
+    audit_status = str(details.pop("audit_status", "findings"))
+    recovery_assessment_used = bool(details.pop("recovery_assessment_used", False))
+    recovery_assessment_policy_grounded = bool(
+        details.pop("recovery_assessment_policy_grounded", False)
+    )
+    details.pop("primary_used", None)
+    enriched_failure_facts = (
+        build_attempt_failure_facts(
+            primary,
+            model_view.decision_evidence,
+            source=AttemptFailureFactsSource.L2_GROUNDED,
+            identity_anchor_line=_optional_int(details.get("stable_identity_anchor_line")),
+            identity_anchor_reason=_optional_str(details.get("stable_identity_anchor_reason")),
+        )
+        if primary is not None
+        else None
+    )
+    return L2Result(
+        primary=primary,
+        enriched_failure_facts=enriched_failure_facts,
+        used=used,
+        grounding_status=grounding_status,
+        audit_status=audit_status,
+        root_cause_assessment=(dict(root_cause) if isinstance(root_cause, Mapping) else None),
+        model_recovery_assessment=(
+            ModelRecoveryAssessment.from_mapping(assessment)
+            if isinstance(assessment, Mapping)
+            else None
+        ),
+        recovery_assessment_used=recovery_assessment_used,
+        recovery_assessment_policy_grounded=recovery_assessment_policy_grounded,
+        diagnostics=details,
+    )
+
+
+def ground_and_audit_model_evidence(
+    grounding_input: L2GroundingInput,
+) -> L2Result:
+    primary, payload = _audit_model_evidence_payload(
+        grounding_input.bundle,
+        grounding_input.model_view,
+        grounding_input.l1_result,
+        grounding_input.source_log,
+    )
+    return result_from_payload(primary, payload, grounding_input.model_view)
+
+
+def _new_audit(l1_result: L1EvidenceResult) -> dict[str, Any]:
+    return {
+        "used": False,
+        "audit_status": "findings",
+        "primary_used": False,
+        "recovery_assessment_used": False,
+        "recovery_assessment_policy_grounded": False,
+        "field_findings": {},
+        "field_finding_codes": {},
+        "findings": [],
+        "ignored_prohibited_fields": [],
+        "citation_audits": [],
+        "grounding_adjustments": [],
+        "recovery_field_audits": [],
+        "model": l1_result.model or None,
+    }
+
+
+def _normalized_l1_evidence(
+    l1_result: L1EvidenceResult,
+    audit: dict[str, Any],
+) -> dict[str, Any]:
+    if not l1_result.success or l1_result.evidence is None:
+        raise ValueError("L2 grounding requires a structurally usable L1 response")
+
+    evidence = dict(l1_result.evidence)
+    prohibited = sorted(PROHIBITED_MODEL_FIELDS.intersection(evidence))
+    if not prohibited:
+        return evidence
+
+    audit["ignored_prohibited_fields"] = prohibited
+    _record_field_finding(
+        audit,
+        "top_level",
+        "ignored prohibited model fields: " + ", ".join(prohibited),
+        code="prohibited_fields_ignored",
+    )
+    return {key: value for key, value in evidence.items() if key not in prohibited}
+
+
+def _ground_primary_selection(
+    *,
+    bundle: L0Bundle,
+    model_view: L0ModelFacingView,
+    l1_result: L1EvidenceResult,
+    source_log: LogSnapshot,
+    evidence: Mapping[str, Any],
+    audit: dict[str, Any],
+) -> PrimaryGrounding | None:
+    primary = evidence.get("primary_failure")
+    if primary is None:
+        return None
+    assert isinstance(primary, Mapping)
+
+    causal_role = str(primary.get("causal_role") or "")
+    if causal_role not in {CausalRole.INITIATING.value, CausalRole.UNKNOWN.value}:
+        _record_field_finding(
+            audit,
+            "primary_failure",
+            "primary_failure causal_role is not initiating or unknown",
+            code="primary_causal_role_suspect",
+        )
+
+    line = _optional_int(primary.get("line"))
+    assert line is not None
+    log_line = _line_text(source_log, line)
+    source_line_available = log_line is not None
+    if log_line is None:
+        _record_field_finding(
+            audit,
+            "primary_failure",
+            f"primary_failure line {line} is outside the source log",
+            code="primary_line_outside_log",
+        )
+        log_line = "unverified model-selected failure"
+
+    visible_lines = model_visible_line_numbers(model_view, l1_result)
+    grounded_evidence, resolved_lines = _audited_model_evidence(
+        bundle,
+        evidence,
+        audit,
+        source_log=source_log,
+        model_visible_texts=model_visible_line_texts(model_view, l1_result),
+    )
+    resolved_primary_line = resolved_lines.get(line, line)
+    grounding_method = "exact_source_line" if source_line_available else "unavailable"
+    if resolved_primary_line != line:
+        audit.setdefault("grounding_adjustments", []).append(
+            {
+                "field": "primary_failure.line",
+                "from": line,
+                "to": resolved_primary_line,
+                "reason": "nearby_unique_quote_match",
+            }
+        )
+        line = resolved_primary_line
+        log_line = _line_text(source_log, line)
+        if log_line is None:
+            raise AssertionError("resolved evidence line must exist in source log")
+        source_line_available = True
+        grounding_method = "nearby_unique_quote_match"
+
+    audit["grounding_status"] = "grounded" if source_line_available else "unavailable"
+    audit["grounding_method"] = grounding_method
+    return PrimaryGrounding(
+        model_primary=primary,
+        line=line,
+        log_line=log_line,
+        source_line_available=source_line_available,
+        grounding_method=grounding_method,
+        grounded_evidence=grounded_evidence,
+        resolved_lines=resolved_lines,
+        cited_lines=frozenset(int(item["line"]) for item in grounded_evidence),
+        visible_lines=frozenset(visible_lines),
+    )
+
+
+def _audit_recovery_assessment(
+    *,
+    bundle: L0Bundle,
+    grounding: PrimaryGrounding,
+    root_cause_assessment: Mapping[str, Any],
+    recovery_assessment: Mapping[str, Any],
+    audit: dict[str, Any],
+) -> RecoveryAudit:
+    failure_domain = recovery_assessment.get("failure_domain")
+    retry_outlook = recovery_assessment.get("retry_outlook_without_workload_change")
+    assert isinstance(failure_domain, Mapping)
+    assert isinstance(retry_outlook, Mapping)
+    failure_domain_value = str(failure_domain.get("value") or "")
+    failure_domain_status = str(failure_domain.get("status") or "")
+    retry_outlook_value = str(retry_outlook.get("value") or "")
+    retry_outlook_status = str(retry_outlook.get("status") or "")
+    root_cause_status = str(root_cause_assessment.get("status") or "")
+    audit.update(
+        {
+            "model_failure_domain": failure_domain_value,
+            "model_failure_domain_status": failure_domain_status,
+            "model_failure_domain_confidence": int(failure_domain.get("confidence") or 0),
+            "model_retry_outlook_without_workload_change": retry_outlook_value,
+            "model_retry_outlook_status": retry_outlook_status,
+            "model_retry_outlook_confidence": int(retry_outlook.get("confidence") or 0),
+            "model_root_cause_status": root_cause_status,
+            "root_cause_assessment": dict(root_cause_assessment),
+            "model_recovery_assessment": dict(recovery_assessment),
+            "path_namespace_summary": dict(bundle.path_namespace_summary),
+        }
+    )
+    _audit_unverified_path_identity_claims(
+        bundle,
+        root_cause_assessment,
+        recovery_assessment,
+        audit,
+    )
+    support = _ground_recovery_support(grounding=grounding, audit=audit)
+    _audit_progress_claim(
+        bundle,
+        root_cause_assessment,
+        recovery_assessment,
+        audit,
+    )
+
+    return RecoveryAudit(
+        root_cause_assessment=root_cause_assessment,
+        recovery_assessment=recovery_assessment,
+        failure_domain_value=failure_domain_value,
+        failure_domain_status=failure_domain_status,
+        failure_domain_confidence=int(failure_domain.get("confidence") or 0),
+        retry_outlook_value=retry_outlook_value,
+        retry_outlook_status=retry_outlook_status,
+        retry_outlook_confidence=int(retry_outlook.get("confidence") or 0),
+        root_cause_status=root_cause_status,
+        failure_domain_supporting_lines=support.failure_domain_lines,
+        retry_outlook_supporting_lines=support.retry_outlook_lines,
+        unresolved_supporting_lines=support.unresolved_lines,
+    )
+
+
+def _ground_recovery_support(
+    *, grounding: PrimaryGrounding, audit: dict[str, Any]
+) -> RecoverySupport:
+    domain_lines = frozenset(
+        int(item["line"])
+        for item in grounding.grounded_evidence
+        if FAILURE_DOMAIN_SUPPORT_TAG in item.get("supports", [])
+    )
+    retry_lines = frozenset(
+        int(item["line"])
+        for item in grounding.grounded_evidence
+        if RETRY_OUTLOOK_SUPPORT_TAG in item.get("supports", [])
+    )
+    unresolved = tuple(
+        sorted(
+            int(item["original_line"])
+            for item in audit.get("citation_audits") or []
+            if item.get("resolved_line") is None
+            and set(item.get("supports") or []).intersection(
+                {FAILURE_DOMAIN_SUPPORT_TAG, RETRY_OUTLOOK_SUPPORT_TAG}
+            )
+            and isinstance(item.get("original_line"), int)
+        )
+    )
+    audit.update(
+        {
+            "failure_domain_supporting_lines": sorted(domain_lines),
+            "retry_outlook_supporting_lines": sorted(retry_lines),
+            "recovery_unresolved_supporting_lines": list(unresolved),
+        }
+    )
+    if not domain_lines:
+        _record_field_finding(
+            audit,
+            "model_recovery_assessment",
+            "failure_domain has no grounded evidence",
+            code="failure_domain_support_missing",
+        )
+    if not retry_lines:
+        _record_field_finding(
+            audit,
+            "model_recovery_assessment",
+            "retry_outlook has no grounded evidence",
+            code="retry_outlook_support_missing",
+        )
+    if unresolved:
+        _record_field_finding(
+            audit,
+            "model_recovery_assessment",
+            "recovery evidence could not be grounded at lines: "
+            + ", ".join(str(value) for value in unresolved),
+            code="recovery_support_ungrounded",
+        )
+    return RecoverySupport(domain_lines, retry_lines, unresolved)
+
+
+def _audit_progress_claim(
+    bundle: L0Bundle,
+    root_cause_assessment: Mapping[str, Any],
+    recovery_assessment: Mapping[str, Any],
+    audit: dict[str, Any],
+) -> None:
+    if not _observed_failure_position_overclaimed_as_completed_progress(
+        bundle,
+        root_cause_assessment,
+        recovery_assessment,
+    ):
+        return
+    _record_field_finding(
+        audit,
+        "model_recovery_assessment",
+        "the model describes the observed checkpoint-to-failure position as "
+        "completed progress, but L0 observed no completed progress marker for "
+        "that interval",
+        code="observed_failure_position_treated_as_completed_progress",
+        severity="credibility",
+        policy_material=False,
+    )
+
+
+def _audit_model_evidence_payload(
+    bundle: L0Bundle,
+    model_view: L0ModelFacingView,
+    l1_result: L1EvidenceResult,
+    source_log: LogSnapshot,
+) -> tuple[FailureEvidence | None, dict[str, Any]]:
+    audit = _new_audit(l1_result)
+    evidence = _normalized_l1_evidence(l1_result, audit)
+    grounding = _ground_primary_selection(
+        bundle=bundle,
+        model_view=model_view,
+        l1_result=l1_result,
+        source_log=source_log,
+        evidence=evidence,
+        audit=audit,
+    )
+    if grounding is None:
+        return None, audit
+
+    primary = grounding.model_primary
+    root_cause_assessment = evidence.get("root_cause_assessment")
+    recovery_assessment = evidence.get("model_recovery_assessment")
+    assert isinstance(root_cause_assessment, Mapping)
+    assert isinstance(recovery_assessment, Mapping)
+    recovery = _audit_recovery_assessment(
+        bundle=bundle,
+        grounding=grounding,
+        root_cause_assessment=dict(root_cause_assessment),
+        recovery_assessment=dict(recovery_assessment),
+        audit=audit,
+    )
+    quote = _model_quote_for_line(grounding.grounded_evidence, grounding.line)
+    if quote is None:
+        _record_field_finding(
+            audit,
+            "primary_failure",
+            "primary_failure line lacks grounded model evidence",
+            code="primary_evidence_ungrounded",
+        )
+        quote = grounding.log_line
+    audit["grounded_evidence"] = grounding.grounded_evidence
+    related_failures = _audited_related_failures(
+        bundle,
+        evidence,
+        audit,
+        source_log=source_log,
+        visible_lines=grounding.visible_lines,
+    )
+    audit["audited_related_failures"] = related_failures
+
+    l0_match = _l0_match_for_line(bundle, grounding.line)
+    model_identity = primary.get("failure_identity")
+    model_mechanism = (
+        _optional_str(model_identity.get("mechanism"))
+        if isinstance(model_identity, Mapping)
+        else None
+    )
+    failure_class = (
+        l0_match.failure_class if l0_match else model_mechanism or "model_selected_failure"
+    )
+    signature = l0_match.signature if l0_match else quote[:120]
+    if l0_match is not None:
+        audit["same_line_l0_registry_id"] = l0_match.registry_id
+
+    fault_outcome = (
+        l0_match.fault_outcome
+        if l0_match is not None
+        else _client_fault_outcome(bundle, grounding.line)
+    )
+
+    history_identity = _build_history_identity(
+        bundle=bundle,
+        source_log=source_log,
+        grounding=grounding,
+        model_primary=primary,
+        audit=audit,
+    )
+    _finalize_model_audit(grounding, recovery, audit)
+    return (
+        _build_grounded_failure_evidence(
+            model_primary=primary,
+            grounding=grounding,
+            l0_match=l0_match,
+            history_identity=history_identity,
+            failure_class=failure_class,
+            signature=signature,
+            fault_outcome=fault_outcome,
+            quote=quote,
+        ),
+        audit,
+    )
+
+
+def _build_history_identity(
+    *,
+    bundle: L0Bundle,
+    source_log: LogSnapshot,
+    grounding: PrimaryGrounding,
+    model_primary: Mapping[str, Any],
+    audit: dict[str, Any],
+) -> HistoryIdentity:
+    anchor_line, anchor_reason = canonical_identity_anchor_line(
+        bundle,
+        grounding.line,
+        selection_label="model_primary",
+    )
+    log_line = _line_text(source_log, anchor_line) or grounding.log_line
+    l0_match = _l0_match_for_line(bundle, anchor_line)
+    source_context = _identity_source_context(source_log, anchor_line)
+    root_fingerprint_source = "unavailable"
+    root_fingerprint = None
+    distributed_incident = distributed_incident_for_line(bundle, anchor_line)
+    if grounding.source_line_available and distributed_incident is not None:
+        root_fingerprint = distributed_incident.history_fingerprint
+        root_fingerprint_source = distributed_incident.history_fingerprint_source
+        audit.update(
+            {
+                "distributed_incident_id": distributed_incident.incident_id,
+                "distributed_incident_kind": distributed_incident.incident_kind,
+                "distributed_incident_type": distributed_incident.incident_type,
+            }
+        )
+    elif grounding.source_line_available and l0_match is not None:
+        root_fingerprint = l0_match.root_fingerprint
+        root_fingerprint_source = l0_match.root_fingerprint_source
+    if grounding.source_line_available and not root_fingerprint:
+        root_fingerprint_source = "observed_exception"
+        root_fingerprint = canonical_observed_fingerprint(log_line, source_context)
+
+    model_identity = model_primary.get("failure_identity")
+    artifact_path = grounded_artifact_path(
+        model_identity.get("artifact_path") if isinstance(model_identity, Mapping) else None,
+        texts=(
+            log_line,
+            *source_context,
+            *tuple(
+                str(item.get("quote")) for item in grounding.grounded_evidence if item.get("quote")
+            ),
+        ),
+    )
+    affected_entity = build_grounded_affected_entity(
+        quote=log_line,
+        signature=log_line,
+        data_position_fingerprint=extract_data_position_fingerprint(log_line),
+        artifact_path=artifact_path,
+        evidence_line=anchor_line,
+    )
+    audit.update(
+        {
+            "stable_identity_anchor_line": anchor_line,
+            "stable_identity_anchor_reason": anchor_reason,
+            "stable_root_fingerprint": root_fingerprint,
+            "root_fingerprint_source": root_fingerprint_source,
+            "history_identity_ready": bool(root_fingerprint),
+            "affected_entity": (
+                affected_entity.to_payload() if affected_entity is not None else None
+            ),
+        }
+    )
+    return HistoryIdentity(
+        anchor_line=anchor_line,
+        anchor_reason=anchor_reason,
+        log_line=log_line,
+        l0_match=l0_match,
+        root_fingerprint=root_fingerprint,
+        root_fingerprint_source=root_fingerprint_source,
+        affected_entity=affected_entity,
+    )
+
+
+def _finalize_model_audit(
+    grounding: PrimaryGrounding,
+    recovery: RecoveryAudit,
+    audit: dict[str, Any],
+) -> None:
+    audit["recovery_assessment_used"] = True
+    audit["recovery_assessment_policy_grounded"] = bool(
+        grounding.source_line_available
+        and recovery.root_cause_status
+        in {
+            AssessmentStatus.ESTABLISHED_BY_CURRENT_LOG.value,
+            AssessmentStatus.SUPPORTED_BUT_UNCONFIRMED.value,
+        }
+        and recovery.failure_domain_supporting_lines
+        and recovery.retry_outlook_supporting_lines
+        and not recovery.unresolved_supporting_lines
+    )
+    audit["used"] = True
+    audit["primary_used"] = True
+    if audit["field_findings"]:
+        audit["audit_status"] = "findings"
+    elif any(item.get("status") != "exact" for item in audit["citation_audits"]):
+        audit["audit_status"] = "resolved"
+    else:
+        audit["audit_status"] = "clean"
+
+
+def _build_grounded_failure_evidence(
+    *,
+    model_primary: Mapping[str, Any],
+    grounding: PrimaryGrounding,
+    l0_match: FailureEvidence | None,
+    history_identity: HistoryIdentity,
+    failure_class: str,
+    signature: str,
+    fault_outcome: str | None,
+    quote: str,
+) -> FailureEvidence:
+    identity_l0_match = history_identity.l0_match
+    log_line = grounding.log_line
+    return FailureEvidence(
+        failure_class=failure_class,
+        signature=signature,
+        root_fingerprint=history_identity.root_fingerprint,
+        fault_outcome=fault_outcome,
+        causal_role=str(model_primary.get("causal_role") or ""),
+        failure_iteration=(
+            identity_l0_match.failure_iteration
+            if identity_l0_match
+            else extract_failure_iteration(history_identity.log_line)
+        ),
+        data_position_fingerprint=(
+            l0_match.data_position_fingerprint
+            if l0_match
+            else (
+                extract_data_position_fingerprint(log_line)
+                if grounding.source_line_available
+                else None
+            )
+        ),
+        line=grounding.line,
+        quote=quote,
+        rank=(
+            l0_match.rank
+            if l0_match
+            else (extract_rank(log_line) if grounding.source_line_available else None)
+        ),
+        phase=l0_match.phase if l0_match else None,
+        node=(
+            l0_match.node
+            if l0_match
+            else (extract_node(log_line) if grounding.source_line_available else None)
+        ),
+        gpu=(
+            l0_match.gpu
+            if l0_match
+            else (extract_gpu(log_line) if grounding.source_line_available else None)
+        ),
+        registry_id=l0_match.registry_id if l0_match else "model_selected",
+        role=l0_match.role if l0_match else None,
+        recovery_behavior=l0_match.recovery_behavior if l0_match else "none",
+        root_fingerprint_source=history_identity.root_fingerprint_source,
+        affected_entity=history_identity.affected_entity,
+    )
+
+
+def _client_fault_outcome(bundle: L0Bundle, line: int) -> str:
+    for episode in bundle.failure_episodes:
+        episode_lines = {
+            episode.first_exception_line,
+            episode.terminal_exception_line,
+            episode.identity_anchor_line,
+            *episode.precursor_lines,
+            *episode.exception_chain_lines,
+        }
+        if line in episode_lines or episode.start_line <= line <= episode.end_line:
+            return episode.status
+    return FaultOutcome.UNRESOLVED.value
+
+
+def _l0_match_for_line(bundle: L0Bundle, line: int) -> FailureEvidence | None:
+    primary = bundle.deterministic_primary_candidate
+    if primary is not None and primary.line == line:
+        return primary
+    for match in bundle.registry_matches:
+        if match.line == line and match.causal_role not in {
+            CausalRole.CASCADE.value,
+            CausalRole.TEARDOWN.value,
+        }:
+            return match
+    return None
+
+
+def _model_quote_for_line(evidence: tuple[Mapping[str, Any], ...], line: int) -> str | None:
+    for item in evidence:
+        if _optional_int(item.get("line")) == line:
+            return _optional_str(item.get("quote"))
+    return None
+
+
+def _audited_model_evidence(
+    bundle: L0Bundle,
+    evidence: Mapping[str, Any],
+    audit: dict[str, Any],
+    *,
+    source_log: LogSnapshot,
+    model_visible_texts: Mapping[int, set[str]],
+) -> tuple[tuple[Mapping[str, Any], ...], dict[int, int]]:
+    result: list[Mapping[str, Any]] = []
+    resolved_lines: dict[int, int] = {}
+    for index, item in enumerate(evidence.get("evidence") or []):
+        if not isinstance(item, Mapping):
+            _record_field_finding(
+                audit,
+                "evidence",
+                f"evidence[{index}] is not an object",
+                code="evidence_not_object",
+            )
+            continue
+        line = _optional_int(item.get("line"))
+        quote = _optional_str(item.get("quote"))
+        supports = tuple(str(value) for value in item.get("supports") or [])
+        log_line = _line_text(source_log, line) if line is not None else None
+        if line is None or log_line is None:
+            _record_field_finding(
+                audit,
+                "evidence",
+                f"evidence[{index}] line is outside the log",
+                code="evidence_line_outside_log",
+            )
+            audit["citation_audits"].append(
+                {
+                    "index": index,
+                    "original_line": line,
+                    "resolved_line": None,
+                    "supports": list(supports),
+                    "status": "ungrounded",
+                }
+            )
+            continue
+        if not supports:
+            _record_field_finding(
+                audit,
+                "evidence",
+                f"evidence[{index}] supports is missing",
+                code="evidence_supports_missing",
+            )
+            supports = ("unspecified",)
+        resolution = _resolve_citation(
+            source_log=source_log,
+            line=line,
+            log_line=log_line,
+            quote=quote,
+            supports=supports,
+            model_visible_texts=model_visible_texts,
+        )
+        citation_audit = {
+            "index": index,
+            "original_line": line,
+            "resolved_line": resolution.resolved_line,
+            "supports": list(resolution.supports),
+            "status": resolution.status,
+        }
+        if resolution.status in {
+            "ambiguous_nearby_match",
+            "not_model_visible",
+            "ungrounded",
+        }:
+            citation_audit["candidate_lines"] = list(resolution.candidate_lines)
+        audit["citation_audits"].append(citation_audit)
+        if resolution.resolved_line is not None:
+            result.append(
+                {
+                    "id": item.get("id"),
+                    "line": resolution.resolved_line,
+                    "quote": resolution.quote,
+                    "supports": list(resolution.supports),
+                }
+            )
+        if resolution.status == "nearby_resolved":
+            resolved_lines[line] = resolution.resolved_line
+            audit.setdefault("grounding_adjustments", []).append(
+                {
+                    "field": f"evidence[{index}].line",
+                    "from": line,
+                    "to": resolution.resolved_line,
+                    "reason": "nearby_unique_quote_match",
+                }
+            )
+            continue
+        if resolution.resolved_line is not None:
+            continue
+        message = (
+            f"evidence[{index}] line and quote were not visible to the model"
+            if resolution.status == "not_model_visible"
+            else f"evidence[{index}] quote could not be uniquely grounded near line {line}"
+        )
+        _record_field_finding(
+            audit,
+            "evidence",
+            message,
+            code=f"evidence_{resolution.status}",
+        )
+    return tuple(result), resolved_lines
+
+
+def _resolve_citation(
+    *,
+    source_log: LogSnapshot,
+    line: int,
+    log_line: str,
+    quote: str | None,
+    supports: tuple[str, ...],
+    model_visible_texts: Mapping[int, set[str]],
+) -> CitationGrounding:
+    visible_matches = _visible_quote_matches(model_visible_texts, line, quote)
+    if line not in visible_matches:
+        if len(visible_matches) == 1:
+            resolved_line = visible_matches[0]
+            resolved_text = _line_text(source_log, resolved_line)
+            if resolved_text is not None and quote and _quote_matches(resolved_text, quote):
+                return CitationGrounding(
+                    line,
+                    resolved_line,
+                    quote,
+                    supports,
+                    "nearby_resolved",
+                )
+        return CitationGrounding(
+            line,
+            None,
+            quote,
+            supports,
+            "ambiguous_nearby_match" if visible_matches else "not_model_visible",
+            visible_matches,
+        )
+    visible_texts = model_visible_texts[line]
+    if quote and quote in log_line and any(quote in text for text in visible_texts):
+        return CitationGrounding(line, line, quote, supports, "exact")
+    if quote and any(quote in visible_text for visible_text in visible_texts):
+        return CitationGrounding(line, line, quote, supports, "rendered_exact")
+    if quote and (
+        _quote_matches(log_line, quote)
+        or any(_quote_matches(visible_text, quote) for visible_text in visible_texts)
+    ):
+        return CitationGrounding(line, line, quote, supports, "abbreviated_exact")
+    nearby = tuple(
+        candidate
+        for candidate in _nearby_quote_matches(source_log, line, quote)
+        if candidate in visible_matches
+    )
+    if len(nearby) == 1:
+        return CitationGrounding(line, nearby[0], quote, supports, "nearby_resolved")
+    return CitationGrounding(
+        line,
+        None,
+        quote,
+        supports,
+        "ambiguous_nearby_match" if nearby else "ungrounded",
+        nearby,
+    )
+
+
+def _visible_quote_matches(
+    model_visible_texts: Mapping[int, set[str]],
+    line: int,
+    quote: str | None,
+) -> tuple[int, ...]:
+    if not quote:
+        return ()
+    start = max(1, line - NEARBY_EVIDENCE_LINE_RADIUS)
+    stop = line + NEARBY_EVIDENCE_LINE_RADIUS
+    return tuple(
+        candidate
+        for candidate, texts in model_visible_texts.items()
+        if start <= candidate <= stop
+        and any(quote in text or _quote_matches(text, quote) for text in texts)
+    )
+
+
+def _nearby_quote_matches(
+    source_log: LogSnapshot,
+    line: int,
+    quote: str | None,
+) -> list[int]:
+    if not quote:
+        return []
+    matches: list[int] = []
+    start = max(1, line - NEARBY_EVIDENCE_LINE_RADIUS)
+    for candidate in range(start, line + NEARBY_EVIDENCE_LINE_RADIUS + 1):
+        if candidate == line:
+            continue
+        text = _line_text(source_log, candidate)
+        if text is not None and _quote_matches(text, quote):
+            matches.append(candidate)
+    return matches
+
+
+def _quote_matches(source: str, quote: str) -> bool:
+    if quote in source:
+        return True
+    fragments = [
+        fragment.strip()
+        for fragment in re.split(r"(?:\.\.\.\[truncated\]|\.\.\.|…)", quote)
+        if fragment.strip()
+    ]
+    if len(fragments) == 1 and not ("..." in quote or "…" in quote):
+        return False
+    offset = 0
+    for fragment in fragments:
+        index = source.find(fragment, offset)
+        if index < 0:
+            return False
+        offset = index + len(fragment)
+    return bool(fragments)
+
+
+def _audit_unverified_path_identity_claims(
+    bundle: L0Bundle,
+    root_cause_assessment: Mapping[str, Any],
+    recovery_assessment: Mapping[str, Any],
+    audit: dict[str, Any],
+) -> None:
+    summary = bundle.path_namespace_summary
+    if not summary.get("cross_namespace_paths_observed") or summary.get("ownership_verified"):
+        return
+    assessment_text = " ".join(
+        str(value)
+        for value in (
+            root_cause_assessment.get("summary"),
+            root_cause_assessment.get("plausible_causes"),
+            recovery_assessment.get("rationale"),
+        )
+        if value is not None
+    )
+    if not re.search(
+        r"\b(?:owned by|belongs to|different user|another user|effective user|running as)\b",
+        assessment_text,
+        re.I,
+    ):
+        return
+    _record_field_finding(
+        audit,
+        "root_cause_assessment",
+        "path namespaces do not prove the effective process user, file owner, mode, or ACL",
+        code="path_namespace_identity_unverified",
+    )
+
+
+def _audited_related_failures(
+    bundle: L0Bundle,
+    evidence: Mapping[str, Any],
+    audit: dict[str, Any],
+    *,
+    source_log: LogSnapshot,
+    visible_lines: frozenset[int],
+) -> tuple[Mapping[str, Any], ...]:
+    primary = evidence.get("primary_failure")
+    primary_line = _optional_int(primary.get("line")) if isinstance(primary, Mapping) else None
+    result: list[Mapping[str, Any]] = []
+    audited_roles: list[dict[str, Any]] = []
+    for index, item in enumerate(evidence.get("related_failures") or []):
+        if not isinstance(item, Mapping):
+            _record_field_finding(
+                audit,
+                "related_failures",
+                f"related_failures[{index}] must be an object",
+                code="related_failure_not_object",
+            )
+            continue
+        line = _optional_int(item.get("line"))
+        role = _optional_str(item.get("causal_role"))
+        rationale = _optional_str(item.get("rationale"))
+        log_line = _line_text(source_log, line) if line is not None else None
+        if line is None or log_line is None or role is None or rationale is None:
+            _record_field_finding(
+                audit,
+                "related_failures",
+                f"related_failures[{index}] must cite a valid line, role, and rationale",
+                code="related_failure_invalid_reference",
+            )
+            continue
+        if line not in visible_lines:
+            _record_field_finding(
+                audit,
+                "related_failures",
+                f"related_failures[{index}] line {line} was not visible to the model",
+                code="related_failure_line_not_model_visible",
+            )
+            continue
+        if role not in {
+            CausalRole.CASCADE.value,
+            CausalRole.TEARDOWN.value,
+            CausalRole.UNKNOWN.value,
+        }:
+            _record_field_finding(
+                audit,
+                "related_failures",
+                f"related_failures[{index}] has invalid related causal role {role}",
+                code="related_failure_causal_role_invalid",
+            )
+            continue
+        if line == primary_line:
+            _record_field_finding(
+                audit,
+                "related_failures",
+                f"related_failures[{index}] duplicates primary_failure.line",
+                code="related_failure_duplicates_primary",
+            )
+            continue
+        if role in {CausalRole.CASCADE.value, CausalRole.TEARDOWN.value} and (
+            primary_line is not None and line < primary_line
+        ):
+            _record_field_finding(
+                audit,
+                "related_failures",
+                f"related_failures[{index}] cannot precede the primary with role {role}",
+                code="related_failure_impossible_chronology",
+            )
+            continue
+        audited_roles.append({"line": line, "causal_role": role, "rationale": rationale})
+        l0_match = _l0_match_for_line(bundle, line)
+        failure_class = l0_match.failure_class if l0_match else "related_failure"
+        signature = l0_match.signature if l0_match else log_line[:120]
+        root_fingerprint = (
+            l0_match.root_fingerprint
+            if l0_match and l0_match.root_fingerprint
+            else canonical_observed_fingerprint(
+                log_line,
+                _context_before_line(bundle, line),
+            )
+        )
+        payload = FailureEvidence(
+            failure_class=failure_class,
+            signature=signature,
+            root_fingerprint=root_fingerprint,
+            fault_outcome=l0_match.fault_outcome if l0_match else "unresolved",
+            causal_role=role,
+            line=line,
+            quote=log_line,
+            rank=l0_match.rank if l0_match else extract_rank(log_line),
+            phase=l0_match.phase if l0_match else None,
+            node=l0_match.node if l0_match else extract_node(log_line),
+            gpu=l0_match.gpu if l0_match else extract_gpu(log_line),
+            root_fingerprint_source=(
+                l0_match.root_fingerprint_source
+                if l0_match and l0_match.root_fingerprint
+                else "observed_exception"
+            ),
+        ).to_failure_payload()
+        payload["relationship_rationale"] = rationale
+        result.append(payload)
+    audit["audited_related_failure_roles"] = audited_roles
+    return tuple(result)
+
+
+def _record_field_finding(
+    audit: dict[str, Any],
+    field: str,
+    message: str,
+    *,
+    code: str,
+    severity: str = "credibility",
+    policy_material: bool = True,
+) -> None:
+    field_findings = audit.setdefault("field_findings", {})
+    field_findings.setdefault(field, []).append(message)
+    field_finding_codes = audit.setdefault("field_finding_codes", {})
+    field_finding_codes.setdefault(field, []).append(code)
+    audit.setdefault("findings", []).append(
+        {
+            "field": field,
+            "code": code,
+            "message": message,
+            "severity": severity,
+            "policy_material": policy_material,
+        }
+    )
+
+
+def _observed_failure_position_overclaimed_as_completed_progress(
+    bundle: L0Bundle,
+    root_cause_assessment: Mapping[str, Any],
+    recovery_assessment: Mapping[str, Any],
+) -> bool:
+    summary = bundle.run_progress_summary
+    distance = summary.observed_iterations_after_checkpoint_load
+    failure_iteration = summary.latest_observed_failure_iteration
+    if not distance or failure_iteration is None:
+        return False
+    if summary.last_iteration is not None and summary.last_iteration >= failure_iteration:
+        return False
+
+    text = " ".join(
+        str(value)
+        for value in (
+            root_cause_assessment.get("summary"),
+            root_cause_assessment.get("plausible_causes"),
+            root_cause_assessment.get("missing_evidence"),
+            recovery_assessment.get("rationale"),
+        )
+        if value is not None
+    )
+    distance_pattern = re.escape(str(distance))
+    claims_completion = any(
+        re.search(pattern, text, re.I)
+        for pattern in (
+            rf"\b(?:progressed|advanced)\s+(?:by\s+)?{distance_pattern}\s+"
+            r"(?:iterations?|steps?)\b",
+            rf"\b{distance_pattern}\s+(?:successful\s+)?(?:iterations?|steps?)\s+"
+            r"(?:of\s+)?successful\s+(?:execution|progress)\b",
+            rf"\b{distance_pattern}\s+successful\s+(?:iterations?|steps?)\b",
+            r"\bmodel state (?:has )?evolved deterministically\b",
+        )
+    )
+    explicitly_limits_claim = bool(
+        re.search(
+            r"\b(?:does not|doesn't|cannot|can't)\s+(?:itself\s+)?"
+            r"(?:establish|prove|confirm).{0,80}\b(?:recovery|persistence|success)",
+            text,
+            re.I,
+        )
+    )
+    return claims_completion and not explicitly_limits_claim
+
+
+def _context_before_line(bundle: L0Bundle, line: int) -> tuple[str, ...]:
+    by_line: dict[int, str] = {}
+    for window in bundle.context_windows:
+        for item in window.lines:
+            if item.line < line:
+                by_line[item.line] = item.text
+    return tuple(by_line[key] for key in sorted(by_line)[-80:])
+
+
+def _identity_source_context(source_log: LogSnapshot, line: int) -> tuple[str, ...]:
+    return source_log.context_before(line, limit=80)
+
+
+def _line_text(source_log: LogSnapshot, line: int) -> str | None:
+    return source_log.line(line)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l2/failure_facts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l2/failure_facts.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build typed branch-specific failure facts for L3 history comparison."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..identity import build_affected_entity, extract_data_position_identity
+from ..models import (
+    AffectedEntity,
+    AffectedEntityKind,
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    DecisionEvidence,
+    FailureEvidence,
+)
+
+
+def build_attempt_failure_facts(
+    primary: FailureEvidence | None,
+    decision_evidence: DecisionEvidence,
+    *,
+    source: AttemptFailureFactsSource,
+    identity_anchor_line: int | None = None,
+    identity_anchor_reason: str | None = None,
+) -> AttemptFailureFacts:
+    """Build the shared branch-specific failure-facts contract."""
+
+    canonical_identity = decision_evidence.canonical_observed_identity
+    if source == AttemptFailureFactsSource.L0_DETERMINISTIC:
+        root_fingerprint = _optional_str(canonical_identity.get("root_fingerprint"))
+        root_fingerprint_source = _optional_str(canonical_identity.get("root_fingerprint_source"))
+        identity_anchor_line = _optional_int(canonical_identity.get("identity_anchor_line"))
+        identity_anchor_reason = _optional_str(canonical_identity.get("identity_anchor_reason"))
+    else:
+        root_fingerprint = primary.root_fingerprint if primary is not None else None
+        root_fingerprint_source = primary.root_fingerprint_source if primary is not None else None
+
+    return AttemptFailureFacts(
+        source=source,
+        root_fingerprint=root_fingerprint,
+        root_fingerprint_source=root_fingerprint_source,
+        fault_outcome=primary.fault_outcome if primary is not None else None,
+        primary_line=primary.line if primary is not None else None,
+        identity_anchor_line=identity_anchor_line,
+        identity_anchor_reason=identity_anchor_reason,
+        failure_iteration=primary.failure_iteration if primary is not None else None,
+        affected_entity=_affected_entity(primary),
+        faulting_rank=primary.rank if primary is not None else None,
+        faulting_node=primary.node if primary is not None else None,
+        faulting_gpu=primary.gpu if primary is not None else None,
+    )
+
+
+def _affected_entity(primary: FailureEvidence | None) -> AffectedEntity | None:
+    if primary is None:
+        return None
+    if primary.affected_entity is not None:
+        return primary.affected_entity
+    data_position = _data_position_identity(primary)
+    if data_position is not None:
+        return build_affected_entity(
+            AffectedEntityKind.DATA_POSITION,
+            data_position,
+            evidence_line=primary.line,
+        )
+    return None
+
+
+def build_grounded_affected_entity(
+    *,
+    quote: str | None,
+    signature: str | None,
+    data_position_fingerprint: str | None,
+    artifact_path: str | None,
+    evidence_line: int | None,
+) -> AffectedEntity | None:
+    """Build an exact entity from source-grounded current-failure evidence."""
+
+    data_position = None
+    for text in (quote, signature):
+        if text:
+            data_position = extract_data_position_identity(text)
+            if data_position is not None:
+                break
+    if data_position is None:
+        data_position = data_position_fingerprint
+    if data_position is not None:
+        return build_affected_entity(
+            AffectedEntityKind.DATA_POSITION,
+            data_position,
+            evidence_line=evidence_line,
+        )
+    if artifact_path is None:
+        return None
+    normalized_path = artifact_path.rstrip("/") or "/"
+    return build_affected_entity(
+        AffectedEntityKind.ARTIFACT,
+        normalized_path,
+        evidence_line=evidence_line,
+    )
+
+
+def _data_position_identity(primary: FailureEvidence) -> str | None:
+    for text in (primary.quote, primary.signature):
+        if text:
+            identity = extract_data_position_identity(text)
+            if identity is not None:
+                return identity
+    return primary.data_position_fingerprint
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l2/grounding.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l2/grounding.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure helpers for determining which source evidence was visible to L1."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..l1.contracts import L1EvidenceResult
+from ..models import L0ModelFacingView
+
+
+def model_visible_line_numbers(
+    model_view: L0ModelFacingView,
+    result: L1EvidenceResult,
+) -> set[int]:
+    """Return log-line references actually exposed to the model."""
+
+    visible: set[int] = set()
+    saw_model_payload = False
+    for event in result.transcript_events:
+        event_type = event.get("event_type")
+        if event_type == "bundle_snapshot":
+            model_payload = event.get("model_visible_payload")
+            if isinstance(model_payload, Mapping):
+                saw_model_payload = True
+                visible.update(_line_references(model_payload))
+        elif event_type == "tool_result":
+            visible.update(_line_references(event.get("result")))
+    if not saw_model_payload:
+        visible.update(_line_references(model_view.prompt_payload()))
+    return visible
+
+
+def model_visible_line_texts(
+    model_view: L0ModelFacingView,
+    result: L1EvidenceResult,
+) -> dict[int, set[str]]:
+    """Return log-line text exactly as rendered to the model."""
+
+    visible: dict[int, set[str]] = {}
+    saw_model_payload = False
+    for event in result.transcript_events:
+        event_type = event.get("event_type")
+        if event_type == "bundle_snapshot":
+            model_payload = event.get("model_visible_payload")
+            if isinstance(model_payload, Mapping):
+                saw_model_payload = True
+                _collect_line_texts(model_payload, visible)
+        elif event_type == "tool_result":
+            _collect_line_texts(event.get("result"), visible)
+    if not saw_model_payload:
+        _collect_line_texts(model_view.prompt_payload(), visible)
+    return visible
+
+
+def _collect_line_texts(value: Any, result: dict[int, set[str]]) -> None:
+    if isinstance(value, Mapping):
+        for line_field, line in value.items():
+            if not _is_line_field(line_field, line):
+                continue
+            for text_field in _paired_text_fields(str(line_field)):
+                text = value.get(text_field)
+                if isinstance(text, str) and text:
+                    result.setdefault(line, set()).add(text)
+        for item in value.values():
+            _collect_line_texts(item, result)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _collect_line_texts(item, result)
+
+
+def _is_line_field(field: Any, value: Any) -> bool:
+    return (
+        isinstance(field, str)
+        and (field == "line" or field.endswith("_line"))
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+        and value > 0
+    )
+
+
+def _paired_text_fields(line_field: str) -> tuple[str, ...]:
+    if line_field == "line":
+        return ("text", "quote")
+    stem = line_field[: -len("_line")]
+    fields = (f"{stem}_text", f"{stem}_quote")
+    if line_field == "first_line":
+        return (*fields, "representative_quote")
+    return fields
+
+
+def _line_references(value: Any, *, field_name: str | None = None) -> set[int]:
+    result: set[int] = set()
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            result.update(_line_references(item, field_name=str(key)))
+        return result
+    if isinstance(value, (list, tuple)):
+        if field_name and field_name.endswith("lines"):
+            result.update(
+                int(item)
+                for item in value
+                if isinstance(item, int) and not isinstance(item, bool) and item > 0
+            )
+        for item in value:
+            result.update(_line_references(item))
+        return result
+    if (
+        field_name
+        and (field_name == "line" or field_name.endswith("_line"))
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+        and value > 0
+    ):
+        result.add(value)
+    return result

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l3/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l3/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L3 deterministic cross-attempt history comparison."""
+
+from .history import DETERMINISTIC_FACT_SELECTOR, HistoryEvaluationInput, evaluate_history
+
+__all__ = ["DETERMINISTIC_FACT_SELECTOR", "HistoryEvaluationInput", "evaluate_history"]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l3/history.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l3/history.py
@@ -1,0 +1,419 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic L3 comparison over immutable attempt records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from ..models import (
+    AffectedEntityRelation,
+    AttemptFailureFacts,
+    AttemptProgressSummary,
+    AttemptRecord,
+    FaultOutcome,
+    HistoryDimensionComparison,
+    HistoryProgressComparison,
+    HistoryProgressRelation,
+    HistorySummary,
+    PriorAttemptView,
+)
+
+DETERMINISTIC_FACT_SELECTOR = "deterministic"
+
+
+@dataclass(frozen=True)
+class HistoryEvaluationInput:
+    """Current record, selected facts, and immutable earlier-attempt view."""
+
+    current_record: AttemptRecord
+    fact_selector: str
+    prior_attempts: PriorAttemptView
+
+
+def evaluate_history(history_input: HistoryEvaluationInput) -> HistorySummary:
+    prior_view = history_input.prior_attempts
+    current_facts = _selected_current_facts(
+        history_input.current_record,
+        history_input.fact_selector,
+    )
+    if not prior_view.available:
+        return HistorySummary(
+            available=False,
+            availability_reason=prior_view.availability_reason,
+        )
+    if current_facts is None or not current_facts.root_fingerprint:
+        return HistorySummary(
+            available=False,
+            availability_reason="missing_root_fingerprint",
+            same_job_attempts=len(prior_view.records),
+        )
+
+    ordered = tuple(sorted(prior_view.records, key=lambda record: record.cycle_id))
+    matching = tuple(
+        record
+        for record in ordered
+        if record.deterministic.root_fingerprint == current_facts.root_fingerprint
+    )
+    comparisons = tuple(
+        _compare_progress(history_input.current_record, current_facts, record)
+        for record in matching
+    )
+    qualifying_pairs = tuple(
+        (record, comparison)
+        for record, comparison in zip(matching, comparisons)
+        if comparison.prior_fault_outcome
+        in {FaultOutcome.TERMINAL.value, FaultOutcome.UNRESOLVED.value}
+    )
+    qualifying = tuple(comparison for _record, comparison in qualifying_pairs)
+    qualifying_records = tuple(record for record, _comparison in qualifying_pairs)
+
+    observed_advance = _relation_count(qualifying, HistoryProgressRelation.ADVANCED)
+    same_progress = _relation_count(qualifying, HistoryProgressRelation.SAME)
+    regressed = _relation_count(qualifying, HistoryProgressRelation.REGRESSED)
+    unknown = _relation_count(qualifying, HistoryProgressRelation.UNKNOWN)
+    no_observed_advance = same_progress + regressed
+    exact_failure_position = sum(
+        item.same_failure_iteration
+        and item.relation
+        in {HistoryProgressRelation.SAME.value, HistoryProgressRelation.REGRESSED.value}
+        for item in qualifying
+    )
+    same_rank_iteration = sum(
+        item.same_failure_iteration
+        and item.same_rank
+        and item.relation
+        in {HistoryProgressRelation.SAME.value, HistoryProgressRelation.REGRESSED.value}
+        for item in qualifying
+    )
+    comparable = tuple(
+        item for item in qualifying if item.relation != HistoryProgressRelation.UNKNOWN.value
+    )
+    same_entity = tuple(
+        item
+        for item in qualifying
+        if item.affected_entity_relation == AffectedEntityRelation.SAME.value
+    )
+    same_entity_comparable = tuple(
+        item for item in same_entity if item.relation != HistoryProgressRelation.UNKNOWN.value
+    )
+
+    rank_matches = current_facts.faulting_rank is not None and any(
+        record.deterministic.faulting_rank == current_facts.faulting_rank
+        for record in qualifying_records
+    )
+    node_matches = current_facts.faulting_node is not None and any(
+        record.deterministic.faulting_node == current_facts.faulting_node
+        for record in qualifying_records
+    )
+    cross_node = current_facts.faulting_node is not None and any(
+        record.deterministic.faulting_node is not None
+        and record.deterministic.faulting_node != current_facts.faulting_node
+        for record in qualifying_records
+    )
+    gpu_matches = current_facts.faulting_gpu is not None and any(
+        record.deterministic.faulting_gpu == current_facts.faulting_gpu
+        for record in qualifying_records
+    )
+
+    return HistorySummary(
+        available=True,
+        availability_reason="ready",
+        same_job_attempts=len(ordered),
+        matching_root_attempts=len(matching),
+        comparisons=comparisons,
+        observed_advance_attempts=observed_advance,
+        same_progress_attempts=same_progress,
+        regressed_progress_attempts=regressed,
+        unknown_progress_attempts=unknown,
+        no_observed_advance_attempts=no_observed_advance,
+        matching_root_attempts_with_observed_training_progress=sum(
+            record.progress.training_progress == "observed" for record in matching
+        ),
+        matching_root_attempts_before_observed_training_progress=sum(
+            record.progress.failure_position == "before_observed_training_progress"
+            for record in matching
+        ),
+        matching_root_attempts_with_unknown_training_progress=sum(
+            record.progress.training_progress == "unknown" for record in matching
+        ),
+        exact_failure_position_attempts=exact_failure_position,
+        same_rank_iteration_attempts=same_rank_iteration,
+        same_entity_attempts=len(same_entity),
+        different_entity_attempts=sum(
+            item.affected_entity_relation == AffectedEntityRelation.DIFFERENT.value
+            for item in qualifying
+        ),
+        unknown_entity_attempts=sum(
+            item.affected_entity_relation == AffectedEntityRelation.UNKNOWN.value
+            for item in qualifying
+        ),
+        consecutive_same_root_no_advance_attempts=_consecutive_same_root_no_advance(
+            history_input.current_record,
+            current_facts,
+            ordered,
+        ),
+        consecutive_same_root_and_entity_no_advance_attempts=(
+            _consecutive_same_root_no_advance(
+                history_input.current_record,
+                current_facts,
+                ordered,
+                require_same_entity=True,
+            )
+        ),
+        advanced_beyond_all_comparable_attempts=bool(comparable)
+        and all(item.relation == HistoryProgressRelation.ADVANCED.value for item in comparable),
+        advanced_beyond_all_same_entity_comparable_attempts=bool(same_entity_comparable)
+        and all(
+            item.relation == HistoryProgressRelation.ADVANCED.value
+            for item in same_entity_comparable
+        ),
+        cross_node_recurrence=cross_node,
+        same_node_recurrence=node_matches,
+        same_gpu_recurrence=gpu_matches,
+        same_rank_only_recurrence=rank_matches and not node_matches and not gpu_matches,
+        rank_to_gpu_mapping_available=any(
+            record.deterministic.rank_to_gpu_map for record in qualifying_records
+        ),
+    )
+
+
+def _selected_current_facts(
+    record: AttemptRecord,
+    selector: str,
+) -> AttemptFailureFacts | None:
+    if selector == DETERMINISTIC_FACT_SELECTOR:
+        return record.deterministic
+    for entry in record.enriched:
+        if entry.route_id == selector:
+            return entry.facts
+    return None
+
+
+def _compare_progress(
+    current_record: AttemptRecord,
+    current_facts: AttemptFailureFacts,
+    prior_record: AttemptRecord,
+) -> HistoryProgressComparison:
+    prior_facts = prior_record.deterministic
+    dimensions = _positive_progress_dimensions(current_record.progress, prior_record.progress)
+    selected_basis = _selected_basis(dimensions)
+    relation, conflict = _combine_positive_dimensions(dimensions)
+    if not dimensions or all(
+        item.relation == HistoryProgressRelation.UNKNOWN.value for item in dimensions
+    ):
+        fallback = _failure_iteration_dimension(
+            current_facts.failure_iteration,
+            prior_facts.failure_iteration,
+        )
+        dimensions = (*dimensions, fallback)
+        selected_basis = "failure_iteration"
+        relation = fallback.relation
+        conflict = False
+
+    return HistoryProgressComparison(
+        prior_cycle_id=prior_record.cycle_id,
+        selected_basis=selected_basis,
+        dimension_comparisons=dimensions,
+        positive_progress_conflict=conflict,
+        relation=relation,
+        prior_attempt_progress=prior_record.progress.to_payload(),
+        prior_fault_outcome=prior_facts.fault_outcome,
+        same_failure_iteration=(
+            current_facts.failure_iteration is not None
+            and prior_facts.failure_iteration == current_facts.failure_iteration
+        ),
+        same_rank=(
+            current_facts.faulting_rank is not None
+            and prior_facts.faulting_rank == current_facts.faulting_rank
+        ),
+        affected_entity_relation=_affected_entity_relation(current_facts, prior_facts),
+    )
+
+
+def _positive_progress_dimensions(
+    current: AttemptProgressSummary,
+    prior: AttemptProgressSummary,
+) -> tuple[HistoryDimensionComparison, ...]:
+    candidates = (
+        (
+            "completed_step",
+            prior.training_progress,
+            current.training_progress,
+            prior.last_completed_step,
+            current.last_completed_step,
+        ),
+        (
+            "checkpoint_step",
+            prior.checkpoint_progress,
+            current.checkpoint_progress,
+            prior.last_checkpoint_step,
+            current.last_checkpoint_step,
+        ),
+    )
+    return tuple(
+        _dimension_comparison(
+            dimension,
+            prior_status,
+            current_status,
+            prior_value,
+            current_value,
+        )
+        for dimension, prior_status, current_status, prior_value, current_value in candidates
+        if prior_status != "unknown" or current_status != "unknown"
+    )
+
+
+def _dimension_comparison(
+    dimension: str,
+    prior_status: str,
+    current_status: str,
+    prior_value: int | None,
+    current_value: int | None,
+) -> HistoryDimensionComparison:
+    delta = None
+    if prior_status == "unknown" or current_status == "unknown":
+        relation = HistoryProgressRelation.UNKNOWN.value
+    elif current_status == "observed" and prior_status == "not_observed":
+        relation = HistoryProgressRelation.ADVANCED.value
+    elif current_status == "not_observed" and prior_status == "observed":
+        relation = HistoryProgressRelation.REGRESSED.value
+    elif current_status == prior_status == "not_observed":
+        relation = HistoryProgressRelation.SAME.value
+    elif prior_value is None or current_value is None:
+        relation = HistoryProgressRelation.UNKNOWN.value
+    else:
+        delta = current_value - prior_value
+        relation = _relation_from_delta(delta)
+    return HistoryDimensionComparison(
+        dimension=dimension,
+        prior_observation_status=prior_status,
+        current_observation_status=current_status,
+        prior_value=prior_value,
+        current_value=current_value,
+        delta=delta,
+        relation=relation,
+    )
+
+
+def _failure_iteration_dimension(
+    current_value: int | None,
+    prior_value: int | None,
+) -> HistoryDimensionComparison:
+    delta = (
+        current_value - prior_value
+        if current_value is not None and prior_value is not None
+        else None
+    )
+    return HistoryDimensionComparison(
+        dimension="failure_iteration",
+        prior_observation_status="observed" if prior_value is not None else "unknown",
+        current_observation_status="observed" if current_value is not None else "unknown",
+        prior_value=prior_value,
+        current_value=current_value,
+        delta=delta,
+        relation=(
+            _relation_from_delta(delta)
+            if delta is not None
+            else HistoryProgressRelation.UNKNOWN.value
+        ),
+    )
+
+
+def _combine_positive_dimensions(
+    dimensions: Sequence[HistoryDimensionComparison],
+) -> tuple[str, bool]:
+    relations = {item.relation for item in dimensions}
+    advanced = HistoryProgressRelation.ADVANCED.value in relations
+    regressed = HistoryProgressRelation.REGRESSED.value in relations
+    if advanced and regressed:
+        return HistoryProgressRelation.UNKNOWN.value, True
+    if advanced:
+        return HistoryProgressRelation.ADVANCED.value, False
+    if regressed:
+        return HistoryProgressRelation.REGRESSED.value, False
+    if (
+        relations
+        and relations.issubset(
+            {HistoryProgressRelation.SAME.value, HistoryProgressRelation.UNKNOWN.value}
+        )
+        and HistoryProgressRelation.SAME.value in relations
+    ):
+        return HistoryProgressRelation.SAME.value, False
+    return HistoryProgressRelation.UNKNOWN.value, False
+
+
+def _selected_basis(dimensions: Sequence[HistoryDimensionComparison]) -> str:
+    names = {
+        item.dimension
+        for item in dimensions
+        if item.relation != HistoryProgressRelation.UNKNOWN.value
+    }
+    if names == {"completed_step", "checkpoint_step"}:
+        return "completed_step_and_checkpoint_step"
+    if names == {"completed_step"}:
+        return "completed_step"
+    if names == {"checkpoint_step"}:
+        return "checkpoint_step"
+    return "none"
+
+
+def _relation_from_delta(delta: int) -> str:
+    if delta > 0:
+        return HistoryProgressRelation.ADVANCED.value
+    if delta < 0:
+        return HistoryProgressRelation.REGRESSED.value
+    return HistoryProgressRelation.SAME.value
+
+
+def _relation_count(
+    comparisons: Sequence[HistoryProgressComparison],
+    relation: HistoryProgressRelation,
+) -> int:
+    return sum(item.relation == relation.value for item in comparisons)
+
+
+def _consecutive_same_root_no_advance(
+    current_record: AttemptRecord,
+    current_facts: AttemptFailureFacts,
+    ordered: Sequence[AttemptRecord],
+    *,
+    require_same_entity: bool = False,
+) -> int:
+    count = 0
+    for prior_record in reversed(ordered):
+        if prior_record.deterministic.root_fingerprint != current_facts.root_fingerprint:
+            break
+        comparison = _compare_progress(current_record, current_facts, prior_record)
+        if (
+            require_same_entity
+            and comparison.affected_entity_relation != AffectedEntityRelation.SAME.value
+        ):
+            break
+        if comparison.prior_fault_outcome not in {
+            FaultOutcome.TERMINAL.value,
+            FaultOutcome.UNRESOLVED.value,
+        }:
+            break
+        if comparison.relation not in {
+            HistoryProgressRelation.SAME.value,
+            HistoryProgressRelation.REGRESSED.value,
+        }:
+            break
+        count += 1
+    return count
+
+
+def _affected_entity_relation(
+    current_facts: AttemptFailureFacts,
+    prior_facts: AttemptFailureFacts,
+) -> str:
+    current = current_facts.affected_entity
+    prior = prior_facts.affected_entity
+    if current is None or prior is None:
+        return AffectedEntityRelation.UNKNOWN.value
+    if current.kind == prior.kind and current.fingerprint == prior.fingerprint:
+        return AffectedEntityRelation.SAME.value
+    return AffectedEntityRelation.DIFFERENT.value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l4/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l4/__init__.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L4 deterministic retry-budget policy."""
+
+from .policy import (
+    L4PolicyInput,
+    L4PolicyOutcome,
+    RetryLedgerEvaluation,
+    RetryPolicyEvaluation,
+    evaluate_policy,
+)
+
+__all__ = [
+    "L4PolicyInput",
+    "L4PolicyOutcome",
+    "RetryLedgerEvaluation",
+    "RetryPolicyEvaluation",
+    "evaluate_policy",
+]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
@@ -1,0 +1,512 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic retry-rule and concurrent retry-ledger policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from ..models import (
+    AffectedEntity,
+    AssessmentStatus,
+    Decision,
+    DecisionBasis,
+    DeclaredRecoveryCapability,
+    FailureDomain,
+    FailureEvidence,
+    HistoryMatchScope,
+    HistorySummary,
+    ModelRecoveryAssessment,
+    RetryOutlookWithoutWorkloadChange,
+    RetryPolicyConfig,
+    RetryPolicyRule,
+)
+
+GENERAL_ROOT_CEILING_ID = "general_root_ceiling"
+SELECTED_RULE_BUDGET_ID = "selected_rule_budget"
+
+
+@dataclass(frozen=True)
+class L4PolicyInput:
+    primary: FailureEvidence | None
+    history: HistorySummary
+    current_affected_entity: AffectedEntity | None = None
+    model_recovery_assessment: ModelRecoveryAssessment | None = None
+    assessment_grounded: bool = False
+    retry_policy: RetryPolicyConfig = RetryPolicyConfig()
+    declared_recovery_capabilities: tuple[DeclaredRecoveryCapability, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.model_recovery_assessment is not None and not isinstance(
+            self.model_recovery_assessment,
+            ModelRecoveryAssessment,
+        ):
+            raise TypeError("L4 model_recovery_assessment must be typed")
+        if self.current_affected_entity is not None and not isinstance(
+            self.current_affected_entity,
+            AffectedEntity,
+        ):
+            raise TypeError("L4 current_affected_entity must be typed")
+        if not isinstance(self.retry_policy, RetryPolicyConfig):
+            raise TypeError("L4 retry_policy must be typed")
+        if any(
+            not isinstance(capability, DeclaredRecoveryCapability)
+            for capability in self.declared_recovery_capabilities
+        ):
+            raise TypeError("L4 declared_recovery_capabilities must be typed")
+
+
+@dataclass(frozen=True)
+class RetryLedgerEvaluation:
+    ledger_id: str
+    applicable: bool
+    rule: str
+    history_match_scope: str
+    allowed_retries: int | None
+    matching_prior_failures: int = 0
+    observed_advance: bool = False
+    exhausted: bool = False
+    inapplicable_reason: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "ledger_id": self.ledger_id,
+            "applicable": self.applicable,
+            "rule": self.rule,
+            "history_match_scope": self.history_match_scope,
+            "allowed_retries": self.allowed_retries,
+            "matching_prior_failures": self.matching_prior_failures,
+            "observed_advance": self.observed_advance,
+            "exhausted": self.exhausted,
+            "inapplicable_reason": self.inapplicable_reason,
+        }
+
+
+@dataclass(frozen=True)
+class RetryPolicyEvaluation:
+    policy_version: str
+    rule: str | None
+    retry_budget_exhausted: bool
+    exhausted_by: tuple[str, ...]
+    general_root_ceiling: RetryLedgerEvaluation
+    selected_rule_budget: RetryLedgerEvaluation | None
+    decision: str
+    decision_basis: str
+    failure_domain: str | None = None
+    failure_domain_status: str | None = None
+    failure_domain_confidence: int | None = None
+    retry_outlook_without_workload_change: str | None = None
+    retry_outlook_status: str | None = None
+    retry_outlook_confidence: int | None = None
+    recovery_assessment_policy_grounded: bool = False
+    current_evidence_qualified: bool = False
+    current_affected_entity: Mapping[str, Any] | None = None
+    match_requirements: Mapping[str, str] | None = None
+    declared_recovery_capability_ids: tuple[str, ...] = ()
+    applied_recovery_capability: Mapping[str, Any] | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "policy_version": self.policy_version,
+            "rule": self.rule,
+            "decision": self.decision,
+            "decision_basis": self.decision_basis,
+            "retry_budget_exhausted": self.retry_budget_exhausted,
+            "exhausted_by": list(self.exhausted_by),
+            "general_root_ceiling": self.general_root_ceiling.to_payload(),
+            "selected_rule_budget": (
+                self.selected_rule_budget.to_payload()
+                if self.selected_rule_budget is not None
+                else None
+            ),
+            "failure_domain": self.failure_domain,
+            "failure_domain_status": self.failure_domain_status,
+            "failure_domain_confidence": self.failure_domain_confidence,
+            "retry_outlook_without_workload_change": (self.retry_outlook_without_workload_change),
+            "retry_outlook_status": self.retry_outlook_status,
+            "retry_outlook_confidence": self.retry_outlook_confidence,
+            "recovery_assessment_policy_grounded": (self.recovery_assessment_policy_grounded),
+            "current_evidence_qualified": self.current_evidence_qualified,
+            "current_affected_entity": (
+                dict(self.current_affected_entity)
+                if self.current_affected_entity is not None
+                else None
+            ),
+            "match_requirements": dict(self.match_requirements or {}),
+            "declared_recovery_capability_ids": list(self.declared_recovery_capability_ids),
+            "applied_recovery_capability": (
+                dict(self.applied_recovery_capability)
+                if self.applied_recovery_capability is not None
+                else None
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class L4PolicyOutcome:
+    primary: FailureEvidence | None
+    retry_policy: RetryPolicyEvaluation
+
+
+def evaluate_policy(policy_input: L4PolicyInput) -> L4PolicyOutcome:
+    configured = policy_input.retry_policy
+    assessment = policy_input.model_recovery_assessment
+    domain = assessment.failure_domain.value.value if assessment is not None else None
+    domain_status = assessment.failure_domain.status.value if assessment is not None else None
+    domain_confidence = assessment.failure_domain.confidence if assessment is not None else None
+    outlook = (
+        assessment.retry_outlook_without_workload_change.value.value
+        if assessment is not None
+        else None
+    )
+    outlook_status = (
+        assessment.retry_outlook_without_workload_change.status.value
+        if assessment is not None
+        else None
+    )
+    outlook_confidence = (
+        assessment.retry_outlook_without_workload_change.confidence
+        if assessment is not None
+        else None
+    )
+    current_evidence_qualified = _current_evidence_qualifies_for_immediate_stop(
+        primary=policy_input.primary,
+        assessment_grounded=policy_input.assessment_grounded,
+        domain=domain,
+        domain_status=domain_status,
+        outlook=outlook,
+        outlook_status=outlook_status,
+    )
+    matching_capability = _matching_recovery_capability(
+        policy_input.primary,
+        policy_input.declared_recovery_capabilities,
+    )
+    applied_capability = (
+        matching_capability
+        if _capability_entity_matches(
+            matching_capability,
+            policy_input.current_affected_entity,
+        )
+        else None
+    )
+    rule = _select_rule(
+        primary=policy_input.primary,
+        current_affected_entity=policy_input.current_affected_entity,
+        matching_capability=matching_capability,
+        applied_capability=applied_capability,
+        assessment_grounded=policy_input.assessment_grounded,
+        outlook=outlook,
+        outlook_status=outlook_status,
+        current_evidence_qualified=current_evidence_qualified,
+    )
+
+    general_root_ceiling = _general_root_ceiling(
+        primary=policy_input.primary,
+        rule=rule,
+        history=policy_input.history,
+        allowed_retries=configured.general_retry_allowed_retries,
+    )
+    selected_rule_budget = _selected_rule_budget(
+        rule=rule,
+        applied_capability=applied_capability,
+        history=policy_input.history,
+        confirmation_retries=configured.confirmation_retry_allowed_retries,
+        bounded_retries=configured.bounded_retry_allowed_retries,
+        general_retries=configured.general_retry_allowed_retries,
+    )
+    exhausted_by = tuple(
+        ledger.ledger_id
+        for ledger in (general_root_ceiling, selected_rule_budget)
+        if ledger is not None and ledger.exhausted
+    )
+    retry_budget_exhausted = bool(exhausted_by)
+    observed_advance = any(
+        ledger is not None and ledger.applicable and ledger.observed_advance
+        for ledger in (general_root_ceiling, selected_rule_budget)
+    )
+    decision, basis = _decision(
+        primary=policy_input.primary,
+        rule=rule,
+        retry_budget_exhausted=retry_budget_exhausted,
+        observed_advance=observed_advance,
+    )
+    selected_scope = (
+        selected_rule_budget.history_match_scope
+        if selected_rule_budget is not None
+        else HistoryMatchScope.ROOT_ONLY.value
+    )
+    return L4PolicyOutcome(
+        primary=policy_input.primary,
+        retry_policy=RetryPolicyEvaluation(
+            policy_version=configured.policy_version,
+            rule=rule,
+            retry_budget_exhausted=retry_budget_exhausted,
+            exhausted_by=exhausted_by,
+            general_root_ceiling=general_root_ceiling,
+            selected_rule_budget=selected_rule_budget,
+            decision=decision,
+            decision_basis=basis,
+            failure_domain=domain,
+            failure_domain_status=domain_status,
+            failure_domain_confidence=domain_confidence,
+            retry_outlook_without_workload_change=outlook,
+            retry_outlook_status=outlook_status,
+            retry_outlook_confidence=outlook_confidence,
+            recovery_assessment_policy_grounded=policy_input.assessment_grounded,
+            current_evidence_qualified=current_evidence_qualified,
+            current_affected_entity=(
+                policy_input.current_affected_entity.to_payload()
+                if policy_input.current_affected_entity is not None
+                else None
+            ),
+            match_requirements={
+                "job_id": "exact",
+                "root_fingerprint": ("exact" if policy_input.primary is not None else "missing"),
+                "affected_entity": (
+                    "exact"
+                    if selected_scope == HistoryMatchScope.ROOT_AND_ENTITY.value
+                    else "not_required"
+                ),
+                "progress": "no_observed_advance",
+            },
+            declared_recovery_capability_ids=tuple(
+                capability.capability_id.value
+                for capability in policy_input.declared_recovery_capabilities
+            ),
+            applied_recovery_capability=(
+                applied_capability.to_payload() if applied_capability is not None else None
+            ),
+        ),
+    )
+
+
+def _current_evidence_qualifies_for_immediate_stop(
+    *,
+    primary: FailureEvidence | None,
+    assessment_grounded: bool,
+    domain: str | None,
+    domain_status: str | None,
+    outlook: str | None,
+    outlook_status: str | None,
+) -> bool:
+    return bool(
+        primary is not None
+        and assessment_grounded
+        and domain == FailureDomain.WORKLOAD.value
+        and domain_status == AssessmentStatus.ESTABLISHED_BY_CURRENT_LOG.value
+        and outlook == RetryOutlookWithoutWorkloadChange.CANNOT_RECOVER.value
+        and outlook_status == AssessmentStatus.ESTABLISHED_BY_CURRENT_LOG.value
+    )
+
+
+def _select_rule(
+    *,
+    primary: FailureEvidence | None,
+    current_affected_entity: AffectedEntity | None,
+    matching_capability: DeclaredRecoveryCapability | None,
+    applied_capability: DeclaredRecoveryCapability | None,
+    assessment_grounded: bool,
+    outlook: str | None,
+    outlook_status: str | None,
+    current_evidence_qualified: bool,
+) -> str | None:
+    if primary is None:
+        return None
+    if applied_capability is not None:
+        return RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value
+    if matching_capability is not None:
+        return RetryPolicyRule.GENERAL_RETRY.value
+    if current_evidence_qualified:
+        return RetryPolicyRule.WORKLOAD_UNRECOVERABLE.value
+    if current_affected_entity is not None:
+        return RetryPolicyRule.CONFIRMATION_RETRY.value
+    if (
+        assessment_grounded
+        and outlook == RetryOutlookWithoutWorkloadChange.MAY_RECOVER.value
+        and outlook_status
+        in {
+            AssessmentStatus.ESTABLISHED_BY_CURRENT_LOG.value,
+            AssessmentStatus.SUPPORTED_BUT_UNCONFIRMED.value,
+        }
+    ):
+        return RetryPolicyRule.BOUNDED_RETRY.value
+    return RetryPolicyRule.GENERAL_RETRY.value
+
+
+def _general_root_ceiling(
+    *,
+    primary: FailureEvidence | None,
+    rule: str | None,
+    history: HistorySummary,
+    allowed_retries: int,
+) -> RetryLedgerEvaluation:
+    if primary is None:
+        return _inapplicable_ledger(
+            ledger_id=GENERAL_ROOT_CEILING_ID,
+            rule=RetryPolicyRule.GENERAL_RETRY.value,
+            scope=HistoryMatchScope.ROOT_ONLY,
+            reason="missing_primary",
+        )
+    if rule == RetryPolicyRule.WORKLOAD_UNRECOVERABLE.value:
+        return _inapplicable_ledger(
+            ledger_id=GENERAL_ROOT_CEILING_ID,
+            rule=RetryPolicyRule.GENERAL_RETRY.value,
+            scope=HistoryMatchScope.ROOT_ONLY,
+            reason="immediate_unrecoverable",
+        )
+    return _evaluate_ledger(
+        ledger_id=GENERAL_ROOT_CEILING_ID,
+        rule=RetryPolicyRule.GENERAL_RETRY.value,
+        scope=HistoryMatchScope.ROOT_ONLY,
+        allowed_retries=allowed_retries,
+        history=history,
+    )
+
+
+def _selected_rule_budget(
+    *,
+    rule: str | None,
+    applied_capability: DeclaredRecoveryCapability | None,
+    history: HistorySummary,
+    confirmation_retries: int,
+    bounded_retries: int,
+    general_retries: int,
+) -> RetryLedgerEvaluation | None:
+    if rule == RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value:
+        assert applied_capability is not None
+        allowed_retries = applied_capability.allowed_retries
+        scope = applied_capability.history_match_scope
+    elif rule == RetryPolicyRule.CONFIRMATION_RETRY.value:
+        allowed_retries = confirmation_retries
+        scope = HistoryMatchScope.ROOT_AND_ENTITY
+    elif rule == RetryPolicyRule.BOUNDED_RETRY.value:
+        allowed_retries = bounded_retries
+        scope = HistoryMatchScope.ROOT_ONLY
+    else:
+        return None
+    if allowed_retries >= general_retries:
+        return None
+    return _evaluate_ledger(
+        ledger_id=SELECTED_RULE_BUDGET_ID,
+        rule=rule,
+        scope=scope,
+        allowed_retries=allowed_retries,
+        history=history,
+    )
+
+
+def _evaluate_ledger(
+    *,
+    ledger_id: str,
+    rule: str,
+    scope: HistoryMatchScope,
+    allowed_retries: int,
+    history: HistorySummary,
+) -> RetryLedgerEvaluation:
+    if not history.available:
+        return _inapplicable_ledger(
+            ledger_id=ledger_id,
+            rule=rule,
+            scope=scope,
+            reason="history_unavailable",
+            allowed_retries=allowed_retries,
+        )
+    matching_prior_failures, observed_advance = _history_measurements(history, scope)
+    return RetryLedgerEvaluation(
+        ledger_id=ledger_id,
+        applicable=True,
+        rule=rule,
+        history_match_scope=scope.value,
+        allowed_retries=allowed_retries,
+        matching_prior_failures=matching_prior_failures,
+        observed_advance=observed_advance,
+        exhausted=(not observed_advance and matching_prior_failures >= allowed_retries),
+    )
+
+
+def _inapplicable_ledger(
+    *,
+    ledger_id: str,
+    rule: str,
+    scope: HistoryMatchScope,
+    reason: str,
+    allowed_retries: int | None = None,
+) -> RetryLedgerEvaluation:
+    return RetryLedgerEvaluation(
+        ledger_id=ledger_id,
+        applicable=False,
+        rule=rule,
+        history_match_scope=scope.value,
+        allowed_retries=allowed_retries,
+        inapplicable_reason=reason,
+    )
+
+
+def _matching_recovery_capability(
+    primary: FailureEvidence | None,
+    capabilities: tuple[DeclaredRecoveryCapability, ...],
+) -> DeclaredRecoveryCapability | None:
+    if primary is None:
+        return None
+    primary_classifiers = {primary.registry_id, primary.failure_class}
+    for capability in capabilities:
+        if primary.recovery_behavior != capability.behavior.value:
+            continue
+        if primary_classifiers.intersection(capability.applies_to):
+            return capability
+    return None
+
+
+def _capability_entity_matches(
+    capability: DeclaredRecoveryCapability | None,
+    affected_entity: AffectedEntity | None,
+) -> bool:
+    return bool(
+        capability is not None
+        and affected_entity is not None
+        and affected_entity.kind == capability.required_entity_kind
+    )
+
+
+def _history_measurements(
+    history: HistorySummary,
+    scope: HistoryMatchScope,
+) -> tuple[int, bool]:
+    if scope == HistoryMatchScope.ROOT_AND_ENTITY:
+        return (
+            history.consecutive_same_root_and_entity_no_advance_attempts,
+            history.advanced_beyond_all_same_entity_comparable_attempts,
+        )
+    return (
+        history.consecutive_same_root_no_advance_attempts,
+        history.advanced_beyond_all_comparable_attempts,
+    )
+
+
+def _decision(
+    *,
+    primary: FailureEvidence | None,
+    rule: str | None,
+    retry_budget_exhausted: bool,
+    observed_advance: bool,
+) -> tuple[str, str]:
+    if primary is None:
+        return Decision.RESTART.value, DecisionBasis.NO_PRIMARY_FAILURE.value
+    if rule == RetryPolicyRule.WORKLOAD_UNRECOVERABLE.value:
+        return Decision.STOP.value, DecisionBasis.WORKLOAD_UNRECOVERABLE.value
+    if retry_budget_exhausted:
+        return Decision.STOP.value, DecisionBasis.RETRY_BUDGET_EXHAUSTED.value
+    if observed_advance:
+        return Decision.RESTART.value, DecisionBasis.OBSERVED_ADVANCE.value
+    if rule == RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value:
+        return (
+            Decision.RESTART.value,
+            DecisionBasis.WORKLOAD_MANAGED_RECOVERY_AVAILABLE.value,
+        )
+    if rule == RetryPolicyRule.BOUNDED_RETRY.value:
+        return Decision.RESTART.value, DecisionBasis.RETRY_RECOVERY_AVAILABLE.value
+    if rule == RetryPolicyRule.CONFIRMATION_RETRY.value:
+        return Decision.RESTART.value, DecisionBasis.CONFIRMATION_RETRY_AVAILABLE.value
+    return Decision.RESTART.value, DecisionBasis.GENERAL_RETRY_AVAILABLE.value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/models.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/models.py
@@ -1,0 +1,1645 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared dataclasses for the restart agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields, is_dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from .immutable import freeze_json_value
+
+RESTART_AGENT_REQUEST_SCHEMA_VERSION = "restart_agent_request.v1"
+RESTART_AGENT_RESPONSE_SCHEMA_VERSION = "restart_agent_response.v1"
+L1_EVIDENCE_SCHEMA_VERSION = "restart_agent_evidence.v1"
+DECISION_EVIDENCE_SCHEMA_VERSION = "restart_agent_decision_evidence.v1"
+L0_MODEL_VIEW_SCHEMA_VERSION = "restart_agent_l0_model_view.v1"
+COLLECT_ALL_SCHEMA_VERSION = "restart_agent_collect_all.v1"
+RETRY_POLICY_VERSION = "retry_budget.v1"
+DEFAULT_RETRY_POLICY: Mapping[str, Any] = MappingProxyType(
+    {
+        "confirmation_retry_allowed_retries": 1,
+        "bounded_retry_allowed_retries": 1,
+        "general_retry_allowed_retries": 3,
+    }
+)
+
+
+class Decision(str, Enum):
+    STOP = "STOP"
+    RESTART = "RESTART"
+
+
+class DecisionBasis(str, Enum):
+    LOG_UNAVAILABLE = "log_unavailable"
+    WORKLOAD_UNRECOVERABLE = "workload_unrecoverable"
+    RETRY_BUDGET_EXHAUSTED = "retry_budget_exhausted"
+    RETRY_RECOVERY_AVAILABLE = "retry_recovery_available"
+    CONFIRMATION_RETRY_AVAILABLE = "confirmation_retry_available"
+    WORKLOAD_MANAGED_RECOVERY_AVAILABLE = "workload_managed_recovery_available"
+    GENERAL_RETRY_AVAILABLE = "general_retry_available"
+    OBSERVED_ADVANCE = "observed_advance"
+    NO_PRIMARY_FAILURE = "no_primary_failure"
+    MALFORMED_MODEL_OUTPUT = "malformed_model_output"
+
+
+class FailureDomain(str, Enum):
+    WORKLOAD = "workload"
+    INFRASTRUCTURE = "infrastructure"
+    UNKNOWN = "unknown"
+
+
+class RetryOutlookWithoutWorkloadChange(str, Enum):
+    CANNOT_RECOVER = "cannot_recover"
+    MAY_RECOVER = "may_recover"
+    UNKNOWN = "unknown"
+
+
+class AssessmentStatus(str, Enum):
+    ESTABLISHED_BY_CURRENT_LOG = "established_by_current_log"
+    SUPPORTED_BUT_UNCONFIRMED = "supported_but_unconfirmed"
+    HYPOTHESIS_ONLY = "hypothesis_only"
+    UNKNOWN = "unknown"
+
+
+class L1AnalysisStatus(str, Enum):
+    PRIMARY_IDENTIFIED = "primary_identified"
+    NO_FAILURE_OBSERVED = "no_failure_observed"
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+
+
+class FaultOutcome(str, Enum):
+    TERMINAL = "terminal"
+    RECOVERED = "recovered"
+    PROGRESSED_AFTER = "progressed_after"
+    UNRESOLVED = "unresolved"
+
+
+class CausalRole(str, Enum):
+    INITIATING = "initiating"
+    CASCADE = "cascade"
+    TEARDOWN = "teardown"
+    UNKNOWN = "unknown"
+
+
+class DistributedIncidentKind(str, Enum):
+    DISTRIBUTED_MECHANISM = "distributed_mechanism"
+    DISTRIBUTED_FANOUT = "distributed_fanout"
+
+
+class AnalysisMode(str, Enum):
+    TERMINAL = "terminal"
+    PROGRESSIVE_START = "progressive_start"
+    PROGRESSIVE_END = "progressive_end"
+
+
+class DecisionCandidateKind(str, Enum):
+    DETERMINISTIC = "deterministic"
+    L1_ENRICHED = "l1_enriched"
+
+
+class ArtifactComparisonLevel(str, Enum):
+    EXACT_PHYSICAL_UNIT = "exact_physical_unit"
+    SAME_LOGICAL_ARTIFACT_OTHER_OR_UNKNOWN_UNIT = "same_logical_artifact_other_or_unknown_unit"
+    SAME_OPERATION_DIFFERENT_ARTIFACT = "same_operation_different_artifact"
+    UNKNOWN_COMPARABILITY = "unknown_comparability"
+
+
+class ArtifactObservationKind(str, Enum):
+    CURRENT_LOG_COMPARISON = "current_log_comparison"
+    DISTRIBUTED_FANOUT = "distributed_fanout"
+
+
+class CoverageStatus(str, Enum):
+    CHECKED = "checked"
+    FOUND = "found"
+    NOT_FOUND = "not_found"
+    NOT_AVAILABLE = "not_available"
+    NOT_CHECKED = "not_checked"
+
+
+class RegistryRole(str, Enum):
+    ROOT_CANDIDATE = "root_candidate"
+    CASCADE_CANDIDATE = "cascade_candidate"
+    CAUSE_CONFIRMATION = "cause_confirmation"
+    EITHER = "either"
+
+
+class RecoveryBehavior(str, Enum):
+    NONE = "none"
+    RETRY_THEN_SKIP = "retry_then_skip"
+
+
+class RecoveryCapabilityId(str, Enum):
+    BAD_TOKEN_RETRY_THEN_SKIP = "bad_token_retry_then_skip"
+
+
+class HistoryProgressRelation(str, Enum):
+    ADVANCED = "advanced"
+    SAME = "same"
+    REGRESSED = "regressed"
+    UNKNOWN = "unknown"
+
+
+class AffectedEntityKind(str, Enum):
+    DATA_POSITION = "data_position"
+    ARTIFACT = "artifact"
+
+
+class AffectedEntityRelation(str, Enum):
+    SAME = "same"
+    DIFFERENT = "different"
+    UNKNOWN = "unknown"
+
+
+class HistoryMatchScope(str, Enum):
+    ROOT_ONLY = "root_only"
+    ROOT_AND_ENTITY = "root_and_entity"
+
+
+class RetryPolicyRule(str, Enum):
+    WORKLOAD_MANAGED_RECOVERY = "workload_managed_recovery"
+    WORKLOAD_UNRECOVERABLE = "workload_unrecoverable"
+    CONFIRMATION_RETRY = "confirmation_retry"
+    BOUNDED_RETRY = "bounded_retry"
+    GENERAL_RETRY = "general_retry"
+
+
+class AttemptFailureFactsSource(str, Enum):
+    L0_DETERMINISTIC = "l0_deterministic"
+    L2_GROUNDED = "l2_grounded"
+
+
+@dataclass(frozen=True)
+class AffectedEntity:
+    """Exact object involved in a failure, independent of failure mechanism."""
+
+    kind: AffectedEntityKind
+    identity: str
+    fingerprint: str
+    evidence_line: int | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, AffectedEntityKind):
+            raise TypeError("affected entity kind must be typed")
+        if not isinstance(self.identity, str) or not self.identity:
+            raise TypeError("affected entity identity must be a non-empty string")
+        if not isinstance(self.fingerprint, str) or not self.fingerprint:
+            raise TypeError("affected entity fingerprint must be a non-empty string")
+        if self.evidence_line is not None and (
+            isinstance(self.evidence_line, bool)
+            or not isinstance(self.evidence_line, int)
+            or self.evidence_line < 1
+        ):
+            raise TypeError("affected entity evidence_line must be a positive integer")
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class AttemptProgressSummary:
+    """Route-independent progress facts derived once from the current log."""
+
+    training_progress: str = "unknown"
+    first_completed_step: int | None = None
+    last_completed_step: int | None = None
+    completed_step_delta: int | None = None
+    progress_marker_count: int = 0
+    checkpoint_progress: str = "unknown"
+    checkpoint_load_step: int | None = None
+    first_checkpoint_step: int | None = None
+    last_checkpoint_step: int | None = None
+    checkpoint_step_delta: int | None = None
+    checkpoint_marker_count: int = 0
+    failure_position: str = "unknown"
+    progress_after_failure: str = "unknown"
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class AttemptFailureFacts:
+    """Compact branch-specific failure observations used by L3."""
+
+    source: AttemptFailureFactsSource
+    root_fingerprint: str | None
+    root_fingerprint_source: str | None
+    fault_outcome: str | None
+    primary_line: int | None = None
+    identity_anchor_line: int | None = None
+    identity_anchor_reason: str | None = None
+    failure_iteration: int | None = None
+    affected_entity: AffectedEntity | None = None
+    faulting_rank: str | None = None
+    faulting_node: str | None = None
+    faulting_gpu: str | None = None
+    rank_to_gpu_map: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "rank_to_gpu_map", freeze_json_value(self.rank_to_gpu_map))
+
+    @property
+    def history_identity_ready(self) -> bool:
+        return bool(self.root_fingerprint)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            **_to_payload(self),
+            "history_identity_ready": self.history_identity_ready,
+        }
+
+
+@dataclass(frozen=True)
+class EnrichedAttemptFacts:
+    """One route-keyed L2-grounded fact block."""
+
+    route_id: str
+    facts: AttemptFailureFacts
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class AttemptRecord:
+    """Neutral immutable record for a current or prior workload attempt."""
+
+    job_id: str
+    cycle_id: int
+    progress: AttemptProgressSummary
+    deterministic: AttemptFailureFacts
+    enriched: Sequence[EnrichedAttemptFacts] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        entries = tuple(self.enriched)
+        route_ids = [entry.route_id for entry in entries]
+        if len(route_ids) != len(set(route_ids)):
+            raise ValueError("AttemptRecord enriched route_id values must be unique")
+        object.__setattr__(self, "enriched", entries)
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class PriorAttemptView:
+    """Immutable runtime-selected earlier records for one invocation."""
+
+    records: Sequence[AttemptRecord] = field(default_factory=tuple)
+    available: bool = False
+    availability_reason: str = "history_disabled"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "records", tuple(self.records))
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class DeclaredRecoveryCapability:
+    """Trusted L4 policy input describing workload-owned recovery behavior."""
+
+    capability_id: RecoveryCapabilityId
+    behavior: RecoveryBehavior
+    applies_to: tuple[str, ...]
+    required_entity_kind: AffectedEntityKind
+    history_match_scope: HistoryMatchScope
+    allowed_retries: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.capability_id, RecoveryCapabilityId):
+            raise TypeError("declared recovery capability id must be typed")
+        if not isinstance(self.behavior, RecoveryBehavior):
+            raise TypeError("declared recovery capability behavior must be typed")
+        if not isinstance(self.required_entity_kind, AffectedEntityKind):
+            raise TypeError("declared recovery capability required_entity_kind must be typed")
+        if not isinstance(self.history_match_scope, HistoryMatchScope):
+            raise TypeError("declared recovery capability history_match_scope must be typed")
+        if not isinstance(self.applies_to, (list, tuple)) or not self.applies_to:
+            raise TypeError("declared recovery capability applies_to must be non-empty")
+        if any(
+            not isinstance(classifier, str) or not classifier.strip()
+            for classifier in self.applies_to
+        ):
+            raise TypeError(
+                "declared recovery capability applies_to items must be non-empty strings"
+            )
+        if isinstance(self.allowed_retries, bool) or not isinstance(self.allowed_retries, int):
+            raise TypeError("declared recovery capability allowed_retries must be an integer")
+        if self.allowed_retries < 1:
+            raise ValueError(
+                "declared recovery capability allowed_retries must be greater than zero"
+            )
+        object.__setattr__(self, "applies_to", tuple(self.applies_to))
+        if self.capability_id == RecoveryCapabilityId.BAD_TOKEN_RETRY_THEN_SKIP:
+            if self.behavior != RecoveryBehavior.RETRY_THEN_SKIP:
+                raise ValueError("bad_token_retry_then_skip behavior must be retry_then_skip")
+            if self.applies_to != ("bad_token_or_window",):
+                raise ValueError(
+                    "bad_token_retry_then_skip applies_to must be " "['bad_token_or_window']"
+                )
+            if self.required_entity_kind != AffectedEntityKind.DATA_POSITION:
+                raise ValueError(
+                    "bad_token_retry_then_skip required_entity_kind must be data_position"
+                )
+            if self.history_match_scope != HistoryMatchScope.ROOT_AND_ENTITY:
+                raise ValueError(
+                    "bad_token_retry_then_skip history_match_scope must be root_and_entity"
+                )
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class RestartAgentRequest:
+    """Validated caller-owned input to one restart-agent invocation."""
+
+    log_path: str
+    job_id: str | None = None
+    cycle_id: int | None = None
+    analysis_mode: str = AnalysisMode.TERMINAL.value
+    schema_version: str = RESTART_AGENT_REQUEST_SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class AnalysisExecutionContext:
+    """Internal context assembled from a request, history, and product config."""
+
+    request: RestartAgentRequest
+    prior_attempts: PriorAttemptView = field(default_factory=PriorAttemptView)
+    retry_policy: Mapping[str, Any] = field(default_factory=lambda: dict(DEFAULT_RETRY_POLICY))
+    declared_recovery_capabilities: tuple[DeclaredRecoveryCapability, ...] = field(
+        default_factory=tuple
+    )
+
+    @property
+    def log_path(self) -> str:
+        return self.request.log_path
+
+    @property
+    def job_id(self) -> str | None:
+        return self.request.job_id
+
+    @property
+    def cycle_id(self) -> int | None:
+        return self.request.cycle_id
+
+    @property
+    def analysis_mode(self) -> str:
+        return self.request.analysis_mode
+
+
+@dataclass(frozen=True)
+class FailureDomainAssessment:
+    """Typed L1 claim about which domain owns the observed failure."""
+
+    value: FailureDomain
+    status: AssessmentStatus
+    confidence: int
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "FailureDomainAssessment":
+        return cls(
+            value=FailureDomain(value.get("value")),
+            status=AssessmentStatus(value.get("status")),
+            confidence=_assessment_confidence(value, "failure domain"),
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class RetryOutlookAssessment:
+    """Typed L1 claim about recovery after the declared restart transition."""
+
+    value: RetryOutlookWithoutWorkloadChange
+    status: AssessmentStatus
+    confidence: int
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "RetryOutlookAssessment":
+        return cls(
+            value=RetryOutlookWithoutWorkloadChange(value.get("value")),
+            status=AssessmentStatus(value.get("status")),
+            confidence=_assessment_confidence(value, "retry outlook"),
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+def _assessment_confidence(value: Mapping[str, Any], label: str) -> int:
+    confidence = value.get("confidence")
+    if isinstance(confidence, bool) or not isinstance(confidence, int):
+        raise TypeError(f"model {label} confidence must be an integer")
+    if not 1 <= confidence <= 99:
+        raise ValueError(f"model {label} confidence must be from 1 to 99")
+    return confidence
+
+
+@dataclass(frozen=True)
+class ModelRecoveryAssessment:
+    """Typed L1 recovery semantics grounded by L2 and consumed by L4."""
+
+    failure_domain: FailureDomainAssessment
+    retry_outlook_without_workload_change: RetryOutlookAssessment
+    rationale: str
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "ModelRecoveryAssessment":
+        rationale = value.get("rationale")
+        if not isinstance(rationale, str) or not rationale.strip():
+            raise ValueError("model recovery rationale must not be empty")
+        failure_domain = value.get("failure_domain")
+        retry_outlook = value.get("retry_outlook_without_workload_change")
+        if not isinstance(failure_domain, Mapping):
+            raise TypeError("model failure_domain must be an object")
+        if not isinstance(retry_outlook, Mapping):
+            raise TypeError("model retry_outlook_without_workload_change must be an object")
+        return cls(
+            failure_domain=FailureDomainAssessment.from_mapping(failure_domain),
+            retry_outlook_without_workload_change=RetryOutlookAssessment.from_mapping(
+                retry_outlook
+            ),
+            rationale=rationale,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class RetryPolicyConfig:
+    """Validated L4 retry-budget configuration."""
+
+    policy_version: str = RETRY_POLICY_VERSION
+    confirmation_retry_allowed_retries: int = 1
+    bounded_retry_allowed_retries: int = 1
+    general_retry_allowed_retries: int = 3
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "confirmation_retry_allowed_retries",
+            "bounded_retry_allowed_retries",
+            "general_retry_allowed_retries",
+        ):
+            value = getattr(self, field_name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{field_name} must be an integer")
+            if value < 0:
+                raise ValueError(f"{field_name} must not be negative")
+        for field_name in (
+            "confirmation_retry_allowed_retries",
+            "bounded_retry_allowed_retries",
+        ):
+            if getattr(self, field_name) > self.general_retry_allowed_retries:
+                raise ValueError(f"{field_name} must not exceed general_retry_allowed_retries")
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any] | None) -> "RetryPolicyConfig":
+        configured = normalize_retry_policy(value or {})
+        return cls(
+            confirmation_retry_allowed_retries=int(
+                configured["confirmation_retry_allowed_retries"]
+            ),
+            bounded_retry_allowed_retries=int(configured["bounded_retry_allowed_retries"]),
+            general_retry_allowed_retries=int(configured["general_retry_allowed_retries"]),
+        )
+
+
+@dataclass(frozen=True)
+class LogLine:
+    line: int
+    text: str
+
+
+@dataclass(frozen=True)
+class FailureEvidence:
+    failure_class: str
+    signature: str
+    root_fingerprint: str | None
+    fault_outcome: str | None
+    causal_role: str = CausalRole.UNKNOWN.value
+    line: int | None = None
+    quote: str | None = None
+    rank: str | None = None
+    phase: str | None = None
+    node: str | None = None
+    gpu: str | None = None
+    failure_iteration: int | None = None
+    data_position_fingerprint: str | None = None
+    registry_id: str | None = None
+    role: str | None = None
+    recovery_behavior: str = RecoveryBehavior.NONE.value
+    root_fingerprint_source: str = "l0_registry"
+    affected_entity: AffectedEntity | None = None
+
+    def to_failure_payload(self) -> dict[str, Any]:
+        return {
+            "failure_class": self.failure_class,
+            "signature": self.signature,
+            "root_fingerprint": self.root_fingerprint,
+            "root_fingerprint_source": self.root_fingerprint_source,
+            "fault_outcome": self.fault_outcome,
+            "causal_role": self.causal_role,
+            "failure_iteration": self.failure_iteration,
+            "data_position_fingerprint": self.data_position_fingerprint,
+            "line": self.line,
+            "rank": self.rank,
+            "phase": self.phase,
+            "node": self.node,
+            "gpu": self.gpu,
+            "affected_entity": (
+                self.affected_entity.to_payload() if self.affected_entity is not None else None
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class CascadeEvidence:
+    failure_class: str
+    cascade_fingerprint: str | None
+    causal_role: str
+    first_line: int
+    last_line: int
+    count: int
+    sample_lines: Sequence[int] = field(default_factory=tuple)
+    rank_spread: Sequence[str] = field(default_factory=tuple)
+    node_spread: Sequence[str] = field(default_factory=tuple)
+    gpu_spread: Sequence[str] = field(default_factory=tuple)
+    reason: str = ""
+    relationship_rationales: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class NormalizedOccurrenceGroup:
+    occurrence_group_id: str
+    normalized_shape: str
+    first_line: int
+    count: int
+    sample_lines: Sequence[int] = field(default_factory=tuple)
+    rank_spread: Sequence[str] = field(default_factory=tuple)
+    node_spread: Sequence[str] = field(default_factory=tuple)
+    gpu_spread: Sequence[str] = field(default_factory=tuple)
+    registry_id: str | None = None
+    classification: str = "unknown"
+    classification_source: str = "deterministic"
+
+
+@dataclass(frozen=True)
+class ContextWindow:
+    window_id: str
+    selected_by: str
+    start_line: int
+    end_line: int
+    seed_lines: Sequence[int] = field(default_factory=tuple)
+    occurrence_group_ids: Sequence[str] = field(default_factory=tuple)
+    lines: Sequence[LogLine] = field(default_factory=tuple)
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class CandidateAnchor:
+    anchor_id: str
+    line: int
+    quote: str
+    sources: Sequence[str] = field(default_factory=tuple)
+    high_signal: bool = False
+    causal_role_hint: str = CausalRole.UNKNOWN.value
+    anchor_rank: str | None = None
+    taxonomy_match: FailureEvidence | None = None
+    prior_observed_progress_line: int | None = None
+    later_observed_progress_line: int | None = None
+    prior_progress_rank: str | None = None
+    later_progress_rank: str | None = None
+    later_progress_rank_relation: str | None = None
+    later_observation_proves_recovery: bool = False
+    first_downstream_registry_match: FailureEvidence | None = None
+    first_downstream_cascade: FailureEvidence | None = None
+    context_window_ids: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ProgressMarker:
+    marker_id: str
+    marker_type: str
+    value: int | str | None
+    state: str
+    line: int
+    quote: str | None = None
+    timestamp: str | None = None
+    rank: str | None = None
+    node: str | None = None
+    gpu: str | None = None
+    pattern_id: str | None = None
+    secondary_value: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "secondary_value", freeze_json_value(self.secondary_value))
+
+
+@dataclass(frozen=True)
+class FailureEpisode:
+    episode_id: str
+    status: str
+    start_line: int
+    end_line: int
+    first_exception_line: int
+    terminal_exception_line: int | None = None
+    terminal_exception_quote: str | None = None
+    terminal_exception_iteration: int | None = None
+    terminal_exception_causal_role_hint: str = CausalRole.UNKNOWN.value
+    precursor_lines: Sequence[int] = field(default_factory=tuple)
+    identity_anchor_line: int | None = None
+    identity_anchor_reason: str | None = None
+    exception_chain_lines: Sequence[int] = field(default_factory=tuple)
+    duplicate_rendering_lines: Sequence[int] = field(default_factory=tuple)
+    wrapper_exception_lines: Sequence[int] = field(default_factory=tuple)
+    exception_rank: str | None = None
+    exception_node: str | None = None
+    exception_gpu: str | None = None
+    last_progress_before: ProgressMarker | None = None
+    first_progress_after: ProgressMarker | None = None
+    first_teardown_line: int | None = None
+    first_process_termination_line: int | None = None
+    first_scheduler_cancel_line: int | None = None
+    first_downstream_cascade: FailureEvidence | None = None
+    cause_confirmations: Sequence[FailureEvidence] = field(default_factory=tuple)
+    context_window_ids: Sequence[str] = field(default_factory=tuple)
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class DistributedFailureIncident:
+    incident_id: str
+    incident_kind: str
+    incident_type: str
+    status: str
+    first_observed_line: int
+    last_observed_line: int
+    primary_observed_line: int
+    primary_observed_quote: str
+    member_event_lines: Sequence[int] = field(default_factory=tuple)
+    sample_lines: Sequence[int] = field(default_factory=tuple)
+    event_count: int = 0
+    unique_operation_count: int = 0
+    operation_types: Sequence[str] = field(default_factory=tuple)
+    operation_signatures: Sequence[str] = field(default_factory=tuple)
+    observed_rank_count: int = 0
+    rank_spread: Sequence[str] = field(default_factory=tuple)
+    process_group_types: Sequence[str] = field(default_factory=tuple)
+    phase: str | None = None
+    configured_timeout_seconds: float | None = None
+    last_progress_line: int | None = None
+    last_progress_timestamp: str | None = None
+    first_detection_timestamp: str | None = None
+    seconds_since_last_progress: float | None = None
+    detection_lag_seconds: float | None = None
+    history_fingerprint: str | None = None
+    history_fingerprint_source: str = "l0_distributed_incident"
+    root_cause_status: str = "unknown"
+    interpretation: str = "observed_terminal_mechanism_not_root_cause"
+
+    def __post_init__(self) -> None:
+        valid_kinds = {item.value for item in DistributedIncidentKind}
+        if self.incident_kind not in valid_kinds:
+            raise ValueError(f"invalid distributed incident kind: {self.incident_kind}")
+        if self.event_count < 1:
+            raise ValueError("distributed incident must have at least one observed event")
+        if (
+            self.incident_kind == DistributedIncidentKind.DISTRIBUTED_FANOUT.value
+            and self.observed_rank_count < 2
+        ):
+            raise ValueError("distributed fanout incident requires at least two distinct ranks")
+
+
+@dataclass(frozen=True)
+class PostFaultSummary:
+    episode_id: str
+    anchor_line: int
+    lines_after_anchor: int
+    progress_after_observed: bool
+    first_progress_after_line: int | None = None
+    later_matching_exception_count: int = 0
+    later_matching_exception_lines: Sequence[int] = field(default_factory=tuple)
+    later_high_signal_count: int = 0
+    last_high_signal_line: int | None = None
+    last_high_signal_quote: str | None = None
+    first_teardown_line: int | None = None
+    first_process_termination_line: int | None = None
+    first_scheduler_cancel_line: int | None = None
+    first_cascade_line: int | None = None
+
+
+@dataclass(frozen=True)
+class ProgressFacts:
+    highest_completed_step: int | None = None
+    last_progress_line: int | None = None
+    last_checkpoint_step: int | None = None
+    last_checkpoint_line: int | None = None
+    latest_observed_failure_iteration: int | None = None
+    latest_observed_failure_iteration_line: int | None = None
+    progress_lines: Sequence[int] = field(default_factory=tuple)
+    checkpoint_lines: Sequence[int] = field(default_factory=tuple)
+    setup_lines: Sequence[int] = field(default_factory=tuple)
+    recovery_lines: Sequence[int] = field(default_factory=tuple)
+    progress_markers: Sequence[ProgressMarker] = field(default_factory=tuple)
+    checkpoint_markers: Sequence[ProgressMarker] = field(default_factory=tuple)
+    setup_markers: Sequence[ProgressMarker] = field(default_factory=tuple)
+    training_progress_dialect_recognized: bool = False
+    checkpoint_progress_dialect_recognized: bool = False
+
+
+@dataclass(frozen=True)
+class RunProgressSummary:
+    first_iteration: int | None = None
+    first_iteration_line: int | None = None
+    first_iteration_timestamp: str | None = None
+    last_iteration: int | None = None
+    last_iteration_line: int | None = None
+    last_iteration_timestamp: str | None = None
+    iteration_delta: int | None = None
+    total_iterations: int | None = None
+    first_consumed_samples: int | None = None
+    last_consumed_samples: int | None = None
+    consumed_samples_delta: int | None = None
+    progress_marker_count: int = 0
+    checkpoint_marker_count: int = 0
+    setup_marker_count: int = 0
+    last_checkpoint_iteration: int | None = None
+    last_checkpoint_line: int | None = None
+    checkpoint_load_iteration: int | None = None
+    checkpoint_load_line: int | None = None
+    latest_observed_failure_iteration: int | None = None
+    latest_observed_failure_iteration_line: int | None = None
+    observed_iterations_after_checkpoint_load: int | None = None
+    last_setup_marker_type: str | None = None
+    last_setup_line: int | None = None
+    successful_runtime_seconds: float | None = None
+    iterations_since_checkpoint: int | None = None
+    progress_after_failure_episode: bool | None = None
+    first_terminal_incident_line: int | None = None
+    first_terminal_incident_timestamp: str | None = None
+    configured_terminal_timeout_seconds: float | None = None
+    seconds_from_last_progress_to_terminal_incident: float | None = None
+    terminal_detection_lag_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class OperationArtifactComparisonEvidence:
+    operation: str
+    artifact_path: str | None = None
+    logical_artifact_id: str | None = None
+    physical_unit_id: str | None = None
+    data_region: str | None = None
+    integrity_marker: str | None = None
+    observation_kind: str = ArtifactObservationKind.CURRENT_LOG_COMPARISON.value
+    comparison_level: str = ArtifactComparisonLevel.UNKNOWN_COMPARABILITY.value
+    comparison_counts: Mapping[str, int] = field(default_factory=dict)
+    success_count: int = 0
+    success_logical_artifact_ids: Sequence[str] = field(default_factory=tuple)
+    success_physical_unit_ids: Sequence[str] = field(default_factory=tuple)
+    success_data_regions: Sequence[str] = field(default_factory=tuple)
+    success_integrity_markers: Sequence[str] = field(default_factory=tuple)
+    success_lines: Sequence[int] = field(default_factory=tuple)
+    successful_observer_ranks: Sequence[str] = field(default_factory=tuple)
+    failed_observer_ranks: Sequence[str] = field(default_factory=tuple)
+    current_start_line: int | None = None
+    current_completion_line: int | None = None
+    current_outcome: str = "unknown"
+    failure_line: int | None = None
+    evidence_scope: str = "current_log"
+    interpretation: str = "comparison_strength_is_identity_scoped"
+
+
+@dataclass(frozen=True)
+class LaterProgressAfterFaultObservation:
+    failure_class: str
+    root_fingerprint: str | None
+    event_count: int
+    sample_event_lines: Sequence[int] = field(default_factory=tuple)
+    sample_later_progress_lines: Sequence[int] = field(default_factory=tuple)
+    matches_terminal_fingerprint: bool = False
+    ordering_basis: str = "log_order"
+    interpretation: str = "job_progress_observed_after_event"
+    component_recovery_proven: bool = False
+
+
+@dataclass(frozen=True)
+class JobMetadata:
+    explicit_world_size: int | None = None
+    explicit_world_size_line: int | None = None
+    observed_rank_min: int | None = None
+    observed_rank_max: int | None = None
+    observed_rank_count: int = 0
+    inferred_world_size_lower_bound: int | None = None
+    world_size_source: str = "not_found"
+    world_size_confidence: str = "not_found"
+    observed_node_count: int = 0
+    rank_to_gpu_mapping_available: bool = False
+
+
+@dataclass(frozen=True)
+class L0Bundle:
+    log_path: str
+    byte_size: int
+    line_count: int
+    path_hints: Sequence[str] = field(default_factory=tuple)
+    path_access_facts: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    path_namespace_summary: Mapping[str, Any] = field(default_factory=dict)
+    occurrence_groups: Sequence[NormalizedOccurrenceGroup] = field(default_factory=tuple)
+    context_windows: Sequence[ContextWindow] = field(default_factory=tuple)
+    candidate_anchors: Sequence[CandidateAnchor] = field(default_factory=tuple)
+    registry_matches: Sequence[FailureEvidence] = field(default_factory=tuple)
+    deterministic_primary_candidate: FailureEvidence | None = None
+    cascades: Sequence[CascadeEvidence] = field(default_factory=tuple)
+    cause_confirmations: Sequence[FailureEvidence] = field(default_factory=tuple)
+    failure_episodes: Sequence[FailureEpisode] = field(default_factory=tuple)
+    distributed_failure_incidents: Sequence[DistributedFailureIncident] = field(
+        default_factory=tuple
+    )
+    post_fault_summaries: Sequence[PostFaultSummary] = field(default_factory=tuple)
+    progress: ProgressFacts = field(default_factory=ProgressFacts)
+    run_progress_summary: RunProgressSummary = field(default_factory=RunProgressSummary)
+    operation_artifact_comparisons: Sequence[OperationArtifactComparisonEvidence] = field(
+        default_factory=tuple
+    )
+    later_progress_after_fault_observations: Sequence[LaterProgressAfterFaultObservation] = field(
+        default_factory=tuple
+    )
+    job_metadata: JobMetadata = field(default_factory=JobMetadata)
+    evidence_coverage: Mapping[str, str] = field(default_factory=dict)
+    selection_summary: Mapping[str, Any] = field(default_factory=dict)
+    anomalies: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DecisionEvidence:
+    """Canonical deterministic decision facts selected from L0A."""
+
+    deterministic_primary_candidate: FailureEvidence | None
+    canonical_observed_identity: Mapping[str, Any]
+    selected_evidence_references: Mapping[str, Any]
+    failure_position: Mapping[str, Any]
+    progress_checkpoint_state: Mapping[str, Any]
+    operation_artifact_facts: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    later_progress_recovery: Mapping[str, Any] = field(default_factory=dict)
+    locality: Mapping[str, Any] = field(default_factory=dict)
+    coverage_lossiness: Mapping[str, Any] = field(default_factory=dict)
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: str = DECISION_EVIDENCE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        for name in (
+            "canonical_observed_identity",
+            "selected_evidence_references",
+            "failure_position",
+            "progress_checkpoint_state",
+            "operation_artifact_facts",
+            "later_progress_recovery",
+            "locality",
+            "coverage_lossiness",
+            "provenance",
+        ):
+            object.__setattr__(self, name, freeze_json_value(getattr(self, name)))
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class L0ModelFacingView:
+    """Deterministic L0B projection consumed by L1."""
+
+    decision_evidence: DecisionEvidence
+    evidence_bundle: Mapping[str, Any]
+    attempt_execution_context: Mapping[str, Any]
+    projection_metrics: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: str = L0_MODEL_VIEW_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        for name in (
+            "evidence_bundle",
+            "attempt_execution_context",
+            "projection_metrics",
+        ):
+            object.__setattr__(self, name, freeze_json_value(getattr(self, name)))
+
+    def prompt_payload(self) -> dict[str, Any]:
+        return {
+            "decision_evidence": self.decision_evidence.to_payload(),
+            "attempt_execution_context": _to_payload(self.attempt_execution_context),
+            "evidence_bundle": _to_payload(self.evidence_bundle),
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            **self.prompt_payload(),
+            "projection_metrics": _to_payload(self.projection_metrics),
+        }
+
+
+@dataclass(frozen=True)
+class HistoryDimensionComparison:
+    dimension: str
+    prior_observation_status: str
+    current_observation_status: str
+    prior_value: int | None = None
+    current_value: int | None = None
+    delta: int | None = None
+    relation: str = HistoryProgressRelation.UNKNOWN.value
+
+
+@dataclass(frozen=True)
+class HistoryProgressComparison:
+    prior_cycle_id: int
+    selected_basis: str = "none"
+    dimension_comparisons: Sequence[HistoryDimensionComparison] = field(default_factory=tuple)
+    positive_progress_conflict: bool = False
+    relation: str = HistoryProgressRelation.UNKNOWN.value
+    prior_attempt_progress: Mapping[str, Any] = field(default_factory=dict)
+    prior_fault_outcome: str | None = None
+    same_failure_iteration: bool = False
+    same_rank: bool = False
+    affected_entity_relation: str = AffectedEntityRelation.UNKNOWN.value
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "dimension_comparisons", tuple(self.dimension_comparisons))
+        object.__setattr__(
+            self,
+            "prior_attempt_progress",
+            freeze_json_value(self.prior_attempt_progress),
+        )
+
+
+@dataclass(frozen=True)
+class HistorySummary:
+    available: bool = False
+    availability_reason: str = "history_disabled"
+    same_job_attempts: int = 0
+    matching_root_attempts: int = 0
+    comparisons: Sequence[HistoryProgressComparison] = field(default_factory=tuple)
+    observed_advance_attempts: int = 0
+    same_progress_attempts: int = 0
+    regressed_progress_attempts: int = 0
+    unknown_progress_attempts: int = 0
+    no_observed_advance_attempts: int = 0
+    matching_root_attempts_with_observed_training_progress: int = 0
+    matching_root_attempts_before_observed_training_progress: int = 0
+    matching_root_attempts_with_unknown_training_progress: int = 0
+    exact_failure_position_attempts: int = 0
+    same_rank_iteration_attempts: int = 0
+    same_entity_attempts: int = 0
+    different_entity_attempts: int = 0
+    unknown_entity_attempts: int = 0
+    consecutive_same_root_no_advance_attempts: int = 0
+    consecutive_same_root_and_entity_no_advance_attempts: int = 0
+    advanced_beyond_all_comparable_attempts: bool = False
+    advanced_beyond_all_same_entity_comparable_attempts: bool = False
+    cross_node_recurrence: bool = False
+    same_node_recurrence: bool = False
+    same_gpu_recurrence: bool = False
+    same_rank_only_recurrence: bool = False
+    rank_to_gpu_mapping_available: bool = False
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    decision: str
+    decision_basis: str
+    retry_policy: Mapping[str, Any] = field(default_factory=dict)
+    failure_domain: str | None = None
+    result_provenance: Mapping[str, Any] = field(default_factory=dict)
+    primary_failure: Mapping[str, Any] | None = None
+    root_cause_assessment: Mapping[str, Any] | None = None
+    model_recovery_assessment: Mapping[str, Any] | None = None
+    secondary_failures: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    cascades: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    evidence_coverage: Mapping[str, str] = field(default_factory=dict)
+    evidence: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+    justification: str = ""
+    schema_version: str = RESTART_AGENT_RESPONSE_SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class DecisionCandidate:
+    """A deadline-usable decision candidate produced during analysis."""
+
+    candidate_kind: str
+    result: AnalysisResult
+    ready_wall_clock_s: float
+    l1_execution_status: str
+    history_summary: Mapping[str, Any] = field(default_factory=dict)
+    stage_timings: Mapping[str, float] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class ModelAnalysisResult:
+    """One independently completed model route in collect-all mode."""
+
+    route_id: str
+    model: str | None
+    endpoint: str | None
+    credential_ref: str | None
+    execution_status: str
+    l1_usable: bool
+    analysis_result: AnalysisResult
+    error: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
+class CollectAllAnalysisResult:
+    """Shared-L0 result containing every model route without arbitration."""
+
+    deterministic_result: AnalysisResult
+    model_results: Sequence[ModelAnalysisResult]
+    shared_analysis: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: str = COLLECT_ALL_SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+def normalize_restart_agent_request(
+    value: RestartAgentRequest | Mapping[str, Any],
+) -> RestartAgentRequest:
+    if isinstance(value, RestartAgentRequest):
+        log_path = value.log_path
+        job_id = value.job_id
+        cycle_id = value.cycle_id
+        analysis_mode = value.analysis_mode
+        schema_version = value.schema_version
+    elif isinstance(value, Mapping):
+        allowed_fields = {
+            "schema_version",
+            "log_path",
+            "job_id",
+            "cycle_id",
+            "analysis_mode",
+        }
+        unknown = sorted(set(value).difference(allowed_fields))
+        if unknown:
+            raise ValueError("unsupported restart-agent request fields: " + ", ".join(unknown))
+        log_path = value.get("log_path")
+        job_id = _optional_request_str(value.get("job_id"), "job_id")
+        cycle_id = value.get("cycle_id")
+        analysis_mode = str(value.get("analysis_mode") or AnalysisMode.TERMINAL.value)
+        schema_version = value.get("schema_version")
+    else:
+        raise TypeError("restart-agent request must be RestartAgentRequest or mapping")
+
+    if schema_version != RESTART_AGENT_REQUEST_SCHEMA_VERSION:
+        raise ValueError(
+            "restart-agent request schema_version must be "
+            f"{RESTART_AGENT_REQUEST_SCHEMA_VERSION!r}"
+        )
+
+    if not log_path:
+        raise TypeError("log_path is required")
+    normalized_log_path = str(log_path)
+    if not Path(normalized_log_path).is_absolute():
+        raise ValueError("log_path must be absolute")
+
+    try:
+        normalized_analysis_mode = AnalysisMode(str(analysis_mode)).value
+    except ValueError as exc:
+        raise ValueError(f"unsupported analysis_mode: {analysis_mode!r}") from exc
+
+    return RestartAgentRequest(
+        log_path=normalized_log_path,
+        job_id=_optional_request_str(job_id, "job_id"),
+        cycle_id=_cycle_id(cycle_id),
+        analysis_mode=normalized_analysis_mode,
+        schema_version=RESTART_AGENT_REQUEST_SCHEMA_VERSION,
+    )
+
+
+def build_analysis_execution_context(
+    request: RestartAgentRequest,
+    *,
+    prior_attempts: PriorAttemptView | None = None,
+    retry_policy: Mapping[str, Any] | None = None,
+    declared_recovery_capabilities: (
+        Sequence[DeclaredRecoveryCapability | Mapping[str, Any]] | None
+    ) = None,
+) -> AnalysisExecutionContext:
+    """Assemble validated agent-owned state around a public request."""
+
+    normalized_retry_policy = normalize_retry_policy(retry_policy or {})
+    normalized_capabilities = normalize_declared_recovery_capabilities(
+        declared_recovery_capabilities or ()
+    )
+    validate_recovery_capability_budgets(
+        normalized_capabilities,
+        normalized_retry_policy,
+    )
+    return AnalysisExecutionContext(
+        request=request,
+        prior_attempts=prior_attempts or PriorAttemptView(),
+        retry_policy=normalized_retry_policy,
+        declared_recovery_capabilities=normalized_capabilities,
+    )
+
+
+def log_unavailable_result(reason: str) -> AnalysisResult:
+    coverage = {
+        "path_hints": CoverageStatus.NOT_AVAILABLE.value,
+        "occurrence_groups": CoverageStatus.NOT_AVAILABLE.value,
+        "context_windows": CoverageStatus.NOT_AVAILABLE.value,
+        "candidate_anchors": CoverageStatus.NOT_AVAILABLE.value,
+        "application_progress": CoverageStatus.NOT_AVAILABLE.value,
+        "checkpoint_progress": CoverageStatus.NOT_AVAILABLE.value,
+        "setup_progress": CoverageStatus.NOT_AVAILABLE.value,
+        "progress_segments": CoverageStatus.NOT_AVAILABLE.value,
+        "job_metadata": CoverageStatus.NOT_AVAILABLE.value,
+        "first_failure_candidate": CoverageStatus.NOT_AVAILABLE.value,
+        "deterministic_taxonomy_primary": CoverageStatus.NOT_AVAILABLE.value,
+        "cascade": CoverageStatus.NOT_AVAILABLE.value,
+        "history": CoverageStatus.NOT_AVAILABLE.value,
+    }
+    return AnalysisResult(
+        decision=Decision.RESTART.value,
+        decision_basis=DecisionBasis.LOG_UNAVAILABLE.value,
+        retry_policy={
+            "policy_version": RETRY_POLICY_VERSION,
+            "rule": None,
+            "decision": Decision.RESTART.value,
+            "decision_basis": DecisionBasis.LOG_UNAVAILABLE.value,
+            "retry_budget_exhausted": False,
+            "exhausted_by": [],
+            "general_root_ceiling": {
+                "ledger_id": "general_root_ceiling",
+                "applicable": False,
+                "rule": RetryPolicyRule.GENERAL_RETRY.value,
+                "history_match_scope": HistoryMatchScope.ROOT_ONLY.value,
+                "allowed_retries": None,
+                "matching_prior_failures": 0,
+                "observed_advance": False,
+                "exhausted": False,
+                "inapplicable_reason": "missing_primary",
+            },
+            "selected_rule_budget": None,
+        },
+        result_provenance={
+            "candidate_kind": DecisionCandidateKind.DETERMINISTIC.value,
+            "evidence_source": "log_unavailable",
+            "model_contribution": "not_enabled",
+            "history_contribution": "not_available",
+            "result_quality": "unusable",
+            "nvrx_use": "fallback_to_nvrx_default",
+            "l1_execution_status": "not_run",
+            "l1_execution_issues": [],
+            "notes": ["log_unavailable"],
+        },
+        primary_failure=None,
+        secondary_failures=(),
+        cascades=(),
+        evidence_coverage=coverage,
+        evidence=(),
+        justification=reason,
+    )
+
+
+def normalize_retry_policy(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError("retry_policy must be a mapping")
+    unknown = sorted(set(value).difference(DEFAULT_RETRY_POLICY))
+    if unknown:
+        raise ValueError("unknown retry_policy fields: " + ", ".join(unknown))
+    result = dict(DEFAULT_RETRY_POLICY)
+    result.update(value)
+    for key in (
+        "confirmation_retry_allowed_retries",
+        "bounded_retry_allowed_retries",
+        "general_retry_allowed_retries",
+    ):
+        configured = result[key]
+        if isinstance(configured, bool) or not isinstance(configured, int):
+            raise TypeError(f"retry_policy.{key} must be an integer")
+        if configured < 0:
+            raise ValueError(f"retry_policy.{key} must not be negative")
+    for key in (
+        "confirmation_retry_allowed_retries",
+        "bounded_retry_allowed_retries",
+    ):
+        if result[key] > result["general_retry_allowed_retries"]:
+            raise ValueError(
+                f"retry_policy.{key} must not exceed " "retry_policy.general_retry_allowed_retries"
+            )
+    return result
+
+
+def validate_recovery_capability_budgets(
+    capabilities: Sequence[DeclaredRecoveryCapability],
+    retry_policy: Mapping[str, Any],
+) -> None:
+    """Ensure specialized recovery never extends the general root ceiling."""
+
+    general_retries = int(retry_policy["general_retry_allowed_retries"])
+    for capability in capabilities:
+        if capability.allowed_retries > general_retries:
+            raise ValueError(
+                "declared recovery capability allowed_retries must not exceed "
+                "retry_policy.general_retry_allowed_retries"
+            )
+
+
+def normalize_declared_recovery_capabilities(
+    value: Any,
+) -> tuple[DeclaredRecoveryCapability, ...]:
+    """Validate the closed MVP set of trusted workload recovery declarations."""
+
+    if not isinstance(value, (list, tuple)):
+        raise TypeError("declared_recovery_capabilities must be an array")
+    normalized: list[DeclaredRecoveryCapability] = []
+    seen_ids: set[RecoveryCapabilityId] = set()
+    expected_fields = {
+        "capability_id",
+        "behavior",
+        "applies_to",
+        "required_entity_kind",
+        "history_match_scope",
+        "allowed_retries",
+    }
+    for index, item in enumerate(value):
+        if isinstance(item, DeclaredRecoveryCapability):
+            capability = item
+        else:
+            if not isinstance(item, Mapping):
+                raise TypeError(f"declared_recovery_capabilities[{index}] must be an object")
+            unknown = sorted(set(item).difference(expected_fields))
+            missing = sorted(expected_fields.difference(item))
+            if unknown:
+                raise ValueError(
+                    f"declared_recovery_capabilities[{index}] has unsupported fields: "
+                    + ", ".join(unknown)
+                )
+            if missing:
+                raise ValueError(
+                    f"declared_recovery_capabilities[{index}] is missing fields: "
+                    + ", ".join(missing)
+                )
+            try:
+                capability_id = RecoveryCapabilityId(str(item["capability_id"]))
+            except ValueError as exc:
+                raise ValueError(
+                    f"declared_recovery_capabilities[{index}].capability_id is unsupported"
+                ) from exc
+            try:
+                behavior = RecoveryBehavior(str(item["behavior"]))
+            except ValueError as exc:
+                raise ValueError(
+                    f"declared_recovery_capabilities[{index}].behavior is unsupported"
+                ) from exc
+            try:
+                required_entity_kind = AffectedEntityKind(str(item["required_entity_kind"]))
+            except ValueError as exc:
+                raise ValueError(
+                    f"declared_recovery_capabilities[{index}].required_entity_kind "
+                    "is unsupported"
+                ) from exc
+            try:
+                history_match_scope = HistoryMatchScope(str(item["history_match_scope"]))
+            except ValueError as exc:
+                raise ValueError(
+                    f"declared_recovery_capabilities[{index}].history_match_scope " "is unsupported"
+                ) from exc
+            applies_to = item["applies_to"]
+            if not isinstance(applies_to, (list, tuple)) or not applies_to:
+                raise TypeError(
+                    f"declared_recovery_capabilities[{index}].applies_to "
+                    "must be a non-empty array"
+                )
+            if any(not isinstance(entry, str) or not entry.strip() for entry in applies_to):
+                raise TypeError(
+                    f"declared_recovery_capabilities[{index}].applies_to "
+                    "items must be non-empty strings"
+                )
+            allowed_retries = item["allowed_retries"]
+            if isinstance(allowed_retries, bool) or not isinstance(allowed_retries, int):
+                raise TypeError(
+                    f"declared_recovery_capabilities[{index}].allowed_retries " "must be an integer"
+                )
+            if allowed_retries < 1:
+                raise ValueError(
+                    f"declared_recovery_capabilities[{index}].allowed_retries "
+                    "must be greater than zero"
+                )
+            capability = DeclaredRecoveryCapability(
+                capability_id=capability_id,
+                behavior=behavior,
+                applies_to=tuple(applies_to),
+                required_entity_kind=required_entity_kind,
+                history_match_scope=history_match_scope,
+                allowed_retries=allowed_retries,
+            )
+
+        if capability.capability_id in seen_ids:
+            raise ValueError(
+                f"duplicate declared recovery capability: {capability.capability_id.value!r}"
+            )
+        seen_ids.add(capability.capability_id)
+        normalized.append(capability)
+    return tuple(normalized)
+
+
+def normalize_attempt_records(value: Sequence[Any]) -> tuple[AttemptRecord, ...]:
+    """Validate a manual attempt-record fixture into deterministic key order."""
+
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError("attempt records must be a sequence")
+    records: list[AttemptRecord] = []
+    seen_cycles: set[tuple[str, int]] = set()
+    for index, item in enumerate(value):
+        record = _attempt_record(
+            item.to_payload() if isinstance(item, AttemptRecord) else item, index
+        )
+        identity = (record.job_id, record.cycle_id)
+        if identity in seen_cycles:
+            raise ValueError(
+                "attempt records contain duplicate job_id/cycle_id record: "
+                f"{record.job_id}/{record.cycle_id}"
+            )
+        seen_cycles.add(identity)
+        records.append(record)
+    return tuple(sorted(records, key=lambda record: (record.job_id, record.cycle_id)))
+
+
+def _attempt_record(value: Any, index: int) -> AttemptRecord:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"attempt records[{index}] must be a mapping")
+    allowed = {"job_id", "cycle_id", "progress", "deterministic", "enriched"}
+    unknown = sorted(set(value).difference(allowed))
+    if unknown:
+        raise ValueError(f"attempt records[{index}] has unsupported fields: {', '.join(unknown)}")
+    job_id = _required_record_string(value.get("job_id"), index, "job_id")
+    cycle_id = _required_record_int(value.get("cycle_id"), index, "cycle_id")
+    progress = _attempt_progress_summary(value.get("progress"), index)
+    deterministic = _attempt_failure_facts(
+        value.get("deterministic"),
+        index,
+        "deterministic",
+        required_identity=True,
+    )
+    enriched_value = value.get("enriched") or []
+    if not isinstance(enriched_value, Sequence) or isinstance(enriched_value, (str, bytes)):
+        raise TypeError(f"attempt records[{index}].enriched must be an array")
+    enriched: list[EnrichedAttemptFacts] = []
+    for entry_index, entry in enumerate(enriched_value):
+        if not isinstance(entry, Mapping):
+            raise TypeError(f"attempt records[{index}].enriched[{entry_index}] must be an object")
+        route_id = _required_record_string(
+            entry.get("route_id"), index, f"enriched[{entry_index}].route_id"
+        )
+        enriched.append(
+            EnrichedAttemptFacts(
+                route_id=route_id,
+                facts=_attempt_failure_facts(
+                    entry.get("facts"),
+                    index,
+                    f"enriched[{entry_index}].facts",
+                    required_identity=False,
+                ),
+            )
+        )
+    return AttemptRecord(
+        job_id=job_id,
+        cycle_id=cycle_id,
+        progress=progress,
+        deterministic=deterministic,
+        enriched=tuple(enriched),
+    )
+
+
+def _attempt_progress_summary(value: Any, index: int) -> AttemptProgressSummary:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"attempt records[{index}].progress must be an object")
+    allowed = {item.name for item in fields(AttemptProgressSummary)}
+    unknown = sorted(set(value).difference(allowed))
+    if unknown:
+        raise ValueError(
+            f"attempt records[{index}].progress has unsupported fields: {', '.join(unknown)}"
+        )
+    statuses = {"observed", "not_observed", "unknown"}
+    for field_name in ("training_progress", "checkpoint_progress", "progress_after_failure"):
+        if value.get(field_name, "unknown") not in statuses:
+            raise ValueError(f"attempt records[{index}].progress.{field_name} is invalid")
+    failure_position = value.get("failure_position", "unknown")
+    if failure_position not in {
+        "before_observed_training_progress",
+        "after_observed_training_progress",
+        "unknown",
+    }:
+        raise ValueError(f"attempt records[{index}].progress.failure_position is invalid")
+    kwargs: dict[str, Any] = {
+        "training_progress": value.get("training_progress", "unknown"),
+        "checkpoint_progress": value.get("checkpoint_progress", "unknown"),
+        "failure_position": failure_position,
+        "progress_after_failure": value.get("progress_after_failure", "unknown"),
+    }
+    for field_name in allowed.difference(kwargs):
+        number = value.get(field_name, 0 if field_name.endswith("_count") else None)
+        if number is not None and (isinstance(number, bool) or not isinstance(number, int)):
+            raise TypeError(f"attempt records[{index}].progress.{field_name} must be an integer")
+        if field_name.endswith("_count") and number is not None and number < 0:
+            raise ValueError(f"attempt records[{index}].progress.{field_name} must be non-negative")
+        kwargs[field_name] = number
+    return AttemptProgressSummary(**kwargs)
+
+
+def _attempt_failure_facts(
+    value: Any,
+    index: int,
+    field_prefix: str,
+    *,
+    required_identity: bool,
+) -> AttemptFailureFacts:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"attempt records[{index}].{field_prefix} must be an object")
+    allowed = {item.name for item in fields(AttemptFailureFacts)}
+    unknown = sorted(set(value).difference(allowed).difference({"history_identity_ready"}))
+    if unknown:
+        raise ValueError(
+            f"attempt records[{index}].{field_prefix} has unsupported fields: " + ", ".join(unknown)
+        )
+    try:
+        source = AttemptFailureFactsSource(value.get("source"))
+    except ValueError as exc:
+        raise ValueError(f"attempt records[{index}].{field_prefix}.source is invalid") from exc
+    root_fingerprint = _optional_str(value.get("root_fingerprint"))
+    root_source = _optional_str(value.get("root_fingerprint_source"))
+    if required_identity and (not root_fingerprint or not root_source):
+        raise ValueError(
+            f"attempt records[{index}].{field_prefix} requires root fingerprint and source"
+        )
+    fault_outcome = _optional_str(value.get("fault_outcome"))
+    if not fault_outcome:
+        raise ValueError(f"attempt records[{index}].{field_prefix}.fault_outcome is required")
+    if fault_outcome is not None and fault_outcome not in {item.value for item in FaultOutcome}:
+        raise ValueError(f"attempt records[{index}].{field_prefix}.fault_outcome is invalid")
+    rank_to_gpu_map = value.get("rank_to_gpu_map") or {}
+    if not isinstance(rank_to_gpu_map, Mapping):
+        raise TypeError(
+            f"attempt records[{index}].{field_prefix}.rank_to_gpu_map must be an object"
+        )
+    int_fields = ("primary_line", "identity_anchor_line", "failure_iteration")
+    numbers = {
+        field_name: _optional_record_int(
+            value.get(field_name), index, f"{field_prefix}.{field_name}"
+        )
+        for field_name in int_fields
+    }
+    affected_entity = _affected_entity(
+        value.get("affected_entity"),
+        index,
+        field_prefix,
+    )
+    return AttemptFailureFacts(
+        source=source,
+        root_fingerprint=root_fingerprint,
+        root_fingerprint_source=root_source,
+        fault_outcome=fault_outcome,
+        primary_line=numbers["primary_line"],
+        identity_anchor_line=numbers["identity_anchor_line"],
+        identity_anchor_reason=_optional_str(value.get("identity_anchor_reason")),
+        failure_iteration=numbers["failure_iteration"],
+        affected_entity=affected_entity,
+        faulting_rank=_optional_str(value.get("faulting_rank")),
+        faulting_node=_optional_str(value.get("faulting_node")),
+        faulting_gpu=_optional_str(value.get("faulting_gpu")),
+        rank_to_gpu_map={str(key): str(item) for key, item in rank_to_gpu_map.items()},
+    )
+
+
+def _affected_entity(
+    value: Any,
+    index: int,
+    field_prefix: str,
+) -> AffectedEntity | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise TypeError(
+            f"attempt records[{index}].{field_prefix}.affected_entity must be an object"
+        )
+    expected = {"kind", "identity", "fingerprint", "evidence_line"}
+    unknown = sorted(set(value).difference(expected))
+    missing = sorted({"kind", "identity", "fingerprint"}.difference(value))
+    if unknown:
+        raise ValueError(
+            f"attempt records[{index}].{field_prefix}.affected_entity "
+            "has unsupported fields: " + ", ".join(unknown)
+        )
+    if missing:
+        raise ValueError(
+            f"attempt records[{index}].{field_prefix}.affected_entity is missing fields: "
+            + ", ".join(missing)
+        )
+    try:
+        kind = AffectedEntityKind(str(value["kind"]))
+    except ValueError as exc:
+        raise ValueError(
+            f"attempt records[{index}].{field_prefix}.affected_entity.kind is invalid"
+        ) from exc
+    return AffectedEntity(
+        kind=kind,
+        identity=_required_record_string(
+            value["identity"],
+            index,
+            f"{field_prefix}.affected_entity.identity",
+        ),
+        fingerprint=_required_record_string(
+            value["fingerprint"],
+            index,
+            f"{field_prefix}.affected_entity.fingerprint",
+        ),
+        evidence_line=_optional_record_int(
+            value.get("evidence_line"),
+            index,
+            f"{field_prefix}.affected_entity.evidence_line",
+        ),
+    )
+
+
+def _required_record_string(value: Any, index: int, field_name: str) -> str:
+    result = _optional_str(value)
+    if result is None:
+        raise ValueError(f"attempt records[{index}].{field_name} is required")
+    return result
+
+
+def _required_record_int(value: Any, index: int, field_name: str) -> int:
+    result = _optional_record_int(value, index, field_name)
+    if result is None:
+        raise ValueError(f"attempt records[{index}].{field_name} is required")
+    return result
+
+
+def _optional_record_int(value: Any, index: int, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"attempt records[{index}].{field_name} must be an integer")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _optional_request_str(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    return value or None
+
+
+def _cycle_id(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("cycle_id must be an integer")
+    return value
+
+
+def _to_payload(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value):
+        result: dict[str, Any] = {}
+        for name in value.__dataclass_fields__:
+            result[name] = _to_payload(getattr(value, name))
+        return result
+    if isinstance(value, Mapping):
+        return {str(k): _to_payload(v) for k, v in value.items()}
+    if isinstance(value, tuple):
+        return [_to_payload(item) for item in value]
+    if isinstance(value, list):
+        return [_to_payload(item) for item in value]
+    return value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/multi_route.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/multi_route.py
@@ -1,0 +1,790 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parallel model-route coordination over one prepared analysis."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from concurrent.futures import FIRST_COMPLETED, Future, wait
+from copy import deepcopy
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+from .decision_pipeline import DecisionOutcome, build_decision_outcome
+from .execution import CollectAllAnalysisRun, L0Artifacts
+from .infrastructure.log_source import LocalLogSource, LogSource
+from .l1 import (
+    DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+    EvidenceExtractor,
+    EvidenceToolsFactory,
+    L1EvidenceResult,
+    ModelRoute,
+)
+from .l2 import L2Result
+from .models import (
+    AnalysisExecutionContext,
+    AnalysisResult,
+    AttemptRecord,
+    CollectAllAnalysisResult,
+    DecisionCandidate,
+    DecisionCandidateKind,
+    DecisionEvidence,
+    L0Bundle,
+    ModelAnalysisResult,
+    log_unavailable_result,
+)
+from .observability import (
+    DecisionTraceInputs,
+    build_decision_trace,
+    build_log_unavailable_trace,
+    history_trace,
+)
+from .preparation import (
+    PreparedAnalysis,
+    l0_artifacts,
+    notify_l0_ready,
+    notify_ready,
+    prepare_analysis,
+    remaining_deadline_seconds,
+    validate_timeout_seconds,
+)
+from .runtime import SYSTEM_CLOCK, THREAD_EXECUTOR_FACTORY, Clock, ExecutorFactory
+from .single_run import SingleRunCoordinator
+
+
+class PreparedRouteRunner(Protocol):
+    def run_prepared(
+        self,
+        prepared: PreparedAnalysis,
+        *,
+        deadline_monotonic: float,
+        route_id: str = "single",
+    ) -> Any: ...
+
+
+RouteRunnerFactory = Callable[[EvidenceExtractor], PreparedRouteRunner]
+LogSourceFactory = Callable[[str], LogSource]
+FutureWaiter = Callable[..., Any]
+
+
+class MultiRouteCoordinator:
+    """Coordinate independent model routes over one prepared L0 analysis."""
+
+    def __init__(
+        self,
+        *,
+        route_runner_factory: RouteRunnerFactory | None = None,
+        log_source_factory: LogSourceFactory = LocalLogSource,
+        evidence_tools_factory: EvidenceToolsFactory | None = None,
+        clock: Clock = SYSTEM_CLOCK,
+        executor_factory: ExecutorFactory = THREAD_EXECUTOR_FACTORY,
+        future_waiter: FutureWaiter | None = None,
+    ) -> None:
+        self._route_runner_factory = route_runner_factory or (
+            lambda extractor: SingleRunCoordinator(
+                evidence_extractor=extractor,
+                log_source_factory=log_source_factory,
+                evidence_tools_factory=evidence_tools_factory,
+                clock=clock,
+                executor_factory=executor_factory,
+            )
+        )
+        self._log_source_factory = log_source_factory
+        self._clock = clock
+        self._executor_factory = executor_factory
+        self._future_waiter = future_waiter or wait
+
+    def run_many(
+        self,
+        execution_context: AnalysisExecutionContext,
+        model_routes: Sequence[ModelRoute],
+        *,
+        l0_bundle: L0Bundle | None = None,
+        max_parallel_models: int | None = None,
+        config_metadata: Mapping[str, Any] | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None = None,
+        on_attempt_record_ready: Callable[[str, AttemptRecord], None] | None = None,
+        timeout_seconds: float = DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+        retain_detailed_artifacts: bool = True,
+    ) -> CollectAllAnalysisRun:
+        """Run independent model routes concurrently over one prepared L0 view."""
+
+        timeout_seconds = validate_timeout_seconds(timeout_seconds)
+        routes = tuple(model_routes)
+        if not routes:
+            raise ValueError("collect-all analysis requires at least one model route")
+        route_ids = [route.route_id for route in routes]
+        if len(set(route_ids)) != len(route_ids):
+            raise ValueError("collect-all model route_id values must be unique")
+        worker_count = max_parallel_models or len(routes)
+        if worker_count < 1:
+            raise ValueError("max_parallel_models must be at least 1")
+        worker_count = min(worker_count, len(routes))
+
+        prepared = prepare_analysis(
+            execution_context,
+            l0_bundle=l0_bundle,
+            include_model_view=True,
+            log_source_factory=self._log_source_factory,
+            clock=self._clock,
+        )
+        return self.run_many_prepared(
+            prepared,
+            routes,
+            max_parallel_models=max_parallel_models,
+            config_metadata=config_metadata,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            on_route_complete=on_route_complete,
+            on_attempt_record_ready=on_attempt_record_ready,
+            timeout_seconds=timeout_seconds,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+
+    def run_many_prepared(
+        self,
+        prepared: PreparedAnalysis,
+        model_routes: Sequence[ModelRoute],
+        *,
+        max_parallel_models: int | None = None,
+        config_metadata: Mapping[str, Any] | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None = None,
+        on_attempt_record_ready: Callable[[str, AttemptRecord], None] | None = None,
+        timeout_seconds: float = DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+        retain_detailed_artifacts: bool = True,
+    ) -> CollectAllAnalysisRun:
+        """Run routes over a caller-finalized immutable L0A boundary."""
+
+        timeout_seconds = validate_timeout_seconds(timeout_seconds)
+        routes = tuple(model_routes)
+        if not routes:
+            raise ValueError("collect-all analysis requires at least one model route")
+        route_ids = [route.route_id for route in routes]
+        if len(set(route_ids)) != len(route_ids):
+            raise ValueError("collect-all model route_id values must be unique")
+        worker_count = max_parallel_models or len(routes)
+        if worker_count < 1:
+            raise ValueError("max_parallel_models must be at least 1")
+        worker_count = min(worker_count, len(routes))
+        deadline_monotonic = prepared.analysis_started + timeout_seconds
+        if prepared.unavailable_reason is not None:
+            return _log_unavailable_collect_all_run(
+                prepared=prepared,
+                routes=routes,
+                worker_count=worker_count,
+                config_metadata=config_metadata,
+                timeout_seconds=timeout_seconds,
+                on_route_complete=on_route_complete,
+            )
+
+        bundle, decision_evidence = _prepared_evidence(prepared)
+        l0_callback_error, l0_callback_wall_clock_s = notify_l0_ready(
+            on_l0_ready,
+            l0_artifacts(prepared),
+            clock=prepared.clock,
+        )
+        deterministic = _publish_collect_all_deterministic(
+            prepared=prepared,
+            timeout_seconds=timeout_seconds,
+            on_deterministic_ready=on_deterministic_ready,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+
+        completed_runs, route_callback_errors = _execute_model_routes(
+            routes=routes,
+            prepared=prepared,
+            deterministic_result=deterministic.outcome.result,
+            deadline_monotonic=deadline_monotonic,
+            worker_count=worker_count,
+            on_route_complete=on_route_complete,
+            on_attempt_record_ready=on_attempt_record_ready,
+            route_runner_factory=self._route_runner_factory,
+            executor_factory=self._executor_factory,
+            future_waiter=self._future_waiter,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+        route_runs = tuple(completed_runs[route.route_id] for route in routes)
+
+        model_results = tuple(run[0] for run in route_runs)
+        deadline_exceeded_route_count = sum(
+            result.execution_status == "deadline_exceeded" for result in model_results
+        )
+        shared_analysis = _collect_all_shared_analysis(
+            prepared,
+            route_count=len(routes),
+            max_parallel_models=worker_count,
+            config_metadata=config_metadata,
+            timeout_seconds=timeout_seconds,
+            deadline_exceeded_route_count=deadline_exceeded_route_count,
+            deterministic_candidate=deterministic.candidate,
+            deterministic_callback_error=deterministic.callback_error,
+            deterministic_callback_wall_clock_s=deterministic.callback_wall_clock_s,
+            route_completion_callback_errors=route_callback_errors,
+            l0_ready_callback_error=l0_callback_error,
+            l0_ready_callback_wall_clock_s=l0_callback_wall_clock_s,
+        )
+        batch_result = CollectAllAnalysisResult(
+            deterministic_result=deterministic.outcome.result,
+            model_results=model_results,
+            shared_analysis=shared_analysis,
+        )
+        trace = {"routing_mode": "collect_all", "shared_analysis": shared_analysis}
+        if retain_detailed_artifacts:
+            trace.update(
+                {
+                    "deterministic": {
+                        "analysis_result": deterministic.outcome.result.to_payload(),
+                        "analyzer_trace": deterministic.trace,
+                    },
+                    "model_routes": {
+                        route.route_id: {
+                            "route": _model_route_metadata(route),
+                            "execution_status": route_result.execution_status,
+                            "l1_usable": route_result.l1_usable,
+                            "error": route_result.error,
+                            "analysis_result": route_result.analysis_result.to_payload(),
+                            "analyzer_trace": route_trace,
+                        }
+                        for route, (route_result, route_trace, _attempt_record) in zip(
+                            routes, route_runs
+                        )
+                    },
+                }
+            )
+        return CollectAllAnalysisRun(
+            result=batch_result,
+            trace=trace,
+            bundle=bundle if retain_detailed_artifacts else None,
+            decision_evidence=(decision_evidence if retain_detailed_artifacts else None),
+            model_view=prepared.model_view if retain_detailed_artifacts else None,
+            deterministic_candidate=(
+                deterministic.candidate if retain_detailed_artifacts else None
+            ),
+            deterministic_attempt_record=deterministic.outcome.attempt_record,
+            attempt_records_by_route={
+                route.route_id: attempt_record
+                for route, (_result, _trace, attempt_record) in zip(routes, route_runs)
+                if attempt_record is not None
+            },
+        )
+
+
+@dataclass(frozen=True)
+class _DeterministicPublication:
+    outcome: DecisionOutcome
+    candidate: DecisionCandidate
+    trace: dict[str, Any]
+    callback_error: str | None
+    callback_wall_clock_s: float
+
+
+def _prepared_evidence(prepared: PreparedAnalysis) -> tuple[L0Bundle, DecisionEvidence]:
+    if prepared.bundle is None or prepared.decision_evidence is None:
+        raise AssertionError("prepared analysis is missing L0 evidence")
+    return prepared.bundle, prepared.decision_evidence
+
+
+def _publish_collect_all_deterministic(
+    *,
+    prepared: PreparedAnalysis,
+    timeout_seconds: float,
+    on_deterministic_ready: Callable[[DecisionCandidate], None] | None,
+    retain_detailed_artifacts: bool,
+) -> _DeterministicPublication:
+    bundle, decision_evidence = _prepared_evidence(prepared)
+    pending_l1_result = L1EvidenceResult.disabled()
+    pending_l1_health = {"status": "pending", "usable": False, "errors": []}
+    deterministic_outcome = build_decision_outcome(
+        bundle=bundle,
+        decision_evidence=decision_evidence,
+        execution_context=prepared.execution_context,
+        l1_configured=True,
+        l1_result=pending_l1_result,
+        l1_output_health=pending_l1_health,
+        l2_result=L2Result.not_run("l1_pending"),
+        candidate_kind=DecisionCandidateKind.DETERMINISTIC.value,
+        l1_pending=True,
+        clock=prepared.clock,
+    )
+    candidate = DecisionCandidate(
+        candidate_kind=DecisionCandidateKind.DETERMINISTIC.value,
+        result=deterministic_outcome.result,
+        ready_wall_clock_s=round(
+            prepared.clock.monotonic() - prepared.analysis_started,
+            3,
+        ),
+        l1_execution_status="in_flight",
+        history_summary=history_trace(deterministic_outcome.history),
+        stage_timings={
+            "l0_wall_clock_s": prepared.l0_wall_clock_s,
+            "l0a_wall_clock_s": prepared.l0a_wall_clock_s,
+            "decision_evidence_wall_clock_s": prepared.decision_evidence_wall_clock_s,
+            "l0b_wall_clock_s": prepared.l0b_wall_clock_s,
+            "l3_wall_clock_s": deterministic_outcome.l3_wall_clock_s,
+            "l4_wall_clock_s": deterministic_outcome.l4_wall_clock_s,
+        },
+    )
+    callback_error, callback_wall_clock_s = notify_ready(
+        on_deterministic_ready,
+        candidate,
+        clock=prepared.clock,
+    )
+    trace = (
+        build_decision_trace(
+            DecisionTraceInputs(
+                execution_context=prepared.execution_context,
+                result=deterministic_outcome.result,
+                bundle=bundle,
+                decision_evidence=decision_evidence,
+                primary=deterministic_outcome.primary,
+                l2_primary=None,
+                total_wall_clock_s=round(
+                    prepared.clock.monotonic() - prepared.analysis_started,
+                    3,
+                ),
+                l0_wall_clock_s=prepared.l0_wall_clock_s,
+                l0a_wall_clock_s=prepared.l0a_wall_clock_s,
+                decision_evidence_wall_clock_s=prepared.decision_evidence_wall_clock_s,
+                l0b_wall_clock_s=prepared.l0b_wall_clock_s,
+                model_view=prepared.model_view,
+                l1_configured=True,
+                l1_result=pending_l1_result,
+                l1_output_health=pending_l1_health,
+                l1_wall_clock_s=0.0,
+                l2_audit=deterministic_outcome.l2_audit,
+                deterministic_failure_facts=(deterministic_outcome.deterministic_failure_facts),
+                selected_failure_facts=deterministic_outcome.selected_failure_facts,
+                history=deterministic_outcome.history,
+                retry_policy=deterministic_outcome.retry_policy,
+                l0_reused=prepared.l0_reused,
+                l2_wall_clock_s=0.0,
+                l3_wall_clock_s=deterministic_outcome.l3_wall_clock_s,
+                l4_wall_clock_s=deterministic_outcome.l4_wall_clock_s,
+                deterministic_candidate=candidate,
+                selected_candidate_kind=DecisionCandidateKind.DETERMINISTIC.value,
+                deterministic_callback_error=callback_error,
+                deterministic_callback_wall_clock_s=callback_wall_clock_s,
+                analysis_timeout_seconds=timeout_seconds,
+            )
+        )
+        if retain_detailed_artifacts
+        else {}
+    )
+    return _DeterministicPublication(
+        outcome=deterministic_outcome,
+        candidate=candidate,
+        trace=trace,
+        callback_error=callback_error,
+        callback_wall_clock_s=callback_wall_clock_s,
+    )
+
+
+def _log_unavailable_collect_all_run(
+    *,
+    prepared: PreparedAnalysis,
+    routes: tuple[ModelRoute, ...],
+    worker_count: int,
+    config_metadata: Mapping[str, Any] | None,
+    timeout_seconds: float,
+    on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None,
+) -> CollectAllAnalysisRun:
+    reason = prepared.unavailable_reason
+    if reason is None:
+        raise AssertionError("log-unavailable result requires an unavailable reason")
+    deterministic_result = log_unavailable_result(reason)
+    deterministic_trace = build_log_unavailable_trace(
+        deterministic_result,
+        prepared.execution_context,
+        reason,
+        total_wall_clock_s=round(
+            prepared.clock.monotonic() - prepared.analysis_started,
+            3,
+        ),
+    )
+    model_results = tuple(
+        ModelAnalysisResult(
+            route_id=route.route_id,
+            model=route.model,
+            endpoint=route.endpoint,
+            credential_ref=route.credential_ref,
+            execution_status="not_run_log_unavailable",
+            l1_usable=False,
+            analysis_result=deterministic_result,
+        )
+        for route in routes
+    )
+    callback_errors: dict[str, str] = {}
+    for route_result in model_results:
+        _notify_route_complete(
+            on_route_complete,
+            route_result,
+            deterministic_trace,
+            callback_errors,
+        )
+    shared_analysis = _collect_all_shared_analysis(
+        prepared,
+        route_count=len(routes),
+        max_parallel_models=worker_count,
+        config_metadata=config_metadata,
+        timeout_seconds=timeout_seconds,
+        route_completion_callback_errors=callback_errors,
+    )
+    batch_result = CollectAllAnalysisResult(
+        deterministic_result=deterministic_result,
+        model_results=model_results,
+        shared_analysis=shared_analysis,
+    )
+    trace = {
+        "routing_mode": "collect_all",
+        "shared_analysis": shared_analysis,
+        "deterministic": {
+            "analysis_result": deterministic_result.to_payload(),
+            "analyzer_trace": deterministic_trace,
+        },
+        "model_routes": {
+            route.route_id: {
+                "route": _model_route_metadata(route),
+                "execution_status": "not_run_log_unavailable",
+                "l1_usable": False,
+                "analysis_result": deterministic_result.to_payload(),
+                "analyzer_trace": deterministic_trace,
+            }
+            for route in routes
+        },
+    }
+    return CollectAllAnalysisRun(result=batch_result, trace=trace)
+
+
+def _execute_model_routes(
+    *,
+    routes: tuple[ModelRoute, ...],
+    prepared: PreparedAnalysis,
+    deterministic_result: AnalysisResult,
+    deadline_monotonic: float,
+    worker_count: int,
+    on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None,
+    on_attempt_record_ready: Callable[[str, AttemptRecord], None] | None,
+    route_runner_factory: RouteRunnerFactory,
+    executor_factory: ExecutorFactory,
+    future_waiter: FutureWaiter,
+    retain_detailed_artifacts: bool,
+) -> tuple[
+    dict[str, tuple[ModelAnalysisResult, dict[str, Any], AttemptRecord | None]],
+    dict[str, str],
+]:
+    completed: dict[str, tuple[ModelAnalysisResult, dict[str, Any], AttemptRecord | None]] = {}
+    callback_errors: dict[str, str] = {}
+    if remaining_deadline_seconds(deadline_monotonic, clock=prepared.clock) <= 0:
+        for route in routes:
+            run = _deadline_exceeded_route_result(route, deterministic_result)
+            completed[route.route_id] = run
+            _notify_route_complete(on_route_complete, run[0], run[1], callback_errors)
+            _notify_attempt_record_ready(
+                on_attempt_record_ready, route.route_id, run[2], callback_errors
+            )
+            if not retain_detailed_artifacts:
+                completed[route.route_id] = (run[0], {}, run[2])
+        return completed, callback_errors
+
+    pool = executor_factory(
+        max_workers=worker_count,
+        thread_name_prefix="restart-agent-model-route",
+    )
+    future_routes: dict[
+        Future[tuple[ModelAnalysisResult, dict[str, Any], AttemptRecord | None]], ModelRoute
+    ] = {
+        pool.submit(
+            _run_model_route,
+            route,
+            prepared,
+            deterministic_result,
+            deadline_monotonic,
+            route_runner_factory,
+        ): route
+        for route in routes
+    }
+    pending: set[Future[tuple[ModelAnalysisResult, dict[str, Any], AttemptRecord | None]]] = set(
+        future_routes
+    )
+    route_order = {route.route_id: index for index, route in enumerate(routes)}
+    while (
+        pending
+        and remaining_deadline_seconds(
+            deadline_monotonic,
+            clock=prepared.clock,
+        )
+        > 0
+    ):
+        newly_done, pending = future_waiter(
+            pending,
+            timeout=remaining_deadline_seconds(
+                deadline_monotonic,
+                clock=prepared.clock,
+            ),
+            return_when=FIRST_COMPLETED,
+        )
+        if not newly_done:
+            break
+        for future in sorted(
+            newly_done,
+            key=lambda item: route_order[future_routes[item].route_id],
+        ):
+            route = future_routes[future]
+            try:
+                run = future.result()
+            except Exception as exc:  # pragma: no cover - defensive future boundary
+                run = _orchestration_error_route_result(
+                    route,
+                    deterministic_result,
+                    exc,
+                )
+            completed[route.route_id] = run
+            _notify_route_complete(on_route_complete, run[0], run[1], callback_errors)
+            _notify_attempt_record_ready(
+                on_attempt_record_ready, route.route_id, run[2], callback_errors
+            )
+            if not retain_detailed_artifacts:
+                completed[route.route_id] = (run[0], {}, run[2])
+    for future in pending:
+        route = future_routes[future]
+        future.cancel()
+        run = _deadline_exceeded_route_result(route, deterministic_result)
+        completed[route.route_id] = run
+        _notify_route_complete(on_route_complete, run[0], run[1], callback_errors)
+        _notify_attempt_record_ready(
+            on_attempt_record_ready, route.route_id, run[2], callback_errors
+        )
+        if not retain_detailed_artifacts:
+            completed[route.route_id] = (run[0], {}, run[2])
+    pool.shutdown(wait=False, cancel_futures=True)
+    return completed, callback_errors
+
+
+def _run_model_route(
+    route: ModelRoute,
+    prepared: PreparedAnalysis,
+    deterministic_result: AnalysisResult,
+    deadline_monotonic: float,
+    route_runner_factory: RouteRunnerFactory,
+) -> tuple[ModelAnalysisResult, dict[str, Any], AttemptRecord | None]:
+    analyzer = route_runner_factory(route.evidence_extractor)
+    try:
+        run = analyzer.run_prepared(
+            prepared,
+            deadline_monotonic=deadline_monotonic,
+            route_id=route.route_id,
+        )
+    except Exception as exc:  # pragma: no cover - defensive route isolation
+        error = f"{type(exc).__name__}: {exc}"
+        return (
+            ModelAnalysisResult(
+                route_id=route.route_id,
+                model=route.model,
+                endpoint=route.endpoint,
+                credential_ref=route.credential_ref,
+                execution_status="orchestration_error",
+                l1_usable=False,
+                analysis_result=deterministic_result,
+                error=error,
+            ),
+            {
+                "routing_error": error,
+                "route": _model_route_metadata(route),
+            },
+            None,
+        )
+
+    result = run.result
+    trace = run.trace
+    l1_layer = (trace.get("layers") or {}).get("L1") or {}
+    l1_usable = bool(l1_layer.get("output_usable"))
+    l1_trace = trace.get("l1") or {}
+    errors = [str(error) for error in l1_trace.get("errors") or ()]
+    anomalies = l1_trace.get("anomalies") or {}
+    if l1_usable:
+        execution_status = "completed"
+    elif anomalies.get("deadline_exceeded"):
+        execution_status = "deadline_exceeded"
+    elif anomalies.get("provider_error"):
+        execution_status = "provider_error"
+    elif l1_trace.get("malformed"):
+        execution_status = "malformed"
+    else:
+        execution_status = "degraded"
+    route_analysis_result = (
+        deterministic_result if execution_status == "deadline_exceeded" else result
+    )
+    return (
+        ModelAnalysisResult(
+            route_id=route.route_id,
+            model=route.model or l1_trace.get("model"),
+            endpoint=route.endpoint,
+            credential_ref=route.credential_ref,
+            execution_status=execution_status,
+            l1_usable=l1_usable,
+            analysis_result=route_analysis_result,
+            error="; ".join(errors) if errors else None,
+        ),
+        dict(trace),
+        run.attempt_record,
+    )
+
+
+def _collect_all_shared_analysis(
+    prepared: PreparedAnalysis,
+    *,
+    route_count: int,
+    max_parallel_models: int,
+    config_metadata: Mapping[str, Any] | None = None,
+    timeout_seconds: float | None = None,
+    deadline_exceeded_route_count: int = 0,
+    deterministic_candidate: DecisionCandidate | None = None,
+    deterministic_callback_error: str | None = None,
+    deterministic_callback_wall_clock_s: float = 0.0,
+    route_completion_callback_errors: Mapping[str, str] | None = None,
+    l0_ready_callback_error: str | None = None,
+    l0_ready_callback_wall_clock_s: float = 0.0,
+) -> dict[str, Any]:
+    shared_analysis = {
+        "routing_mode": "collect_all",
+        "route_count": route_count,
+        "max_parallel_models": max_parallel_models,
+        "batch_wall_clock_s": round(
+            prepared.clock.monotonic() - prepared.analysis_started,
+            3,
+        ),
+        "l0_wall_clock_s": prepared.l0_wall_clock_s,
+        "l0a_wall_clock_s": prepared.l0a_wall_clock_s,
+        "decision_evidence_wall_clock_s": prepared.decision_evidence_wall_clock_s,
+        "l0b_wall_clock_s": prepared.l0b_wall_clock_s,
+        "l0_reused": prepared.l0_reused,
+        "l0_canonical_hash": prepared.l0_canonical_hash,
+        "l0_read_mode": (
+            prepared.source_log.read_mode if prepared.source_log is not None else None
+        ),
+        "l0_source_storage_mode": (
+            prepared.source_log.storage_mode if prepared.source_log is not None else None
+        ),
+        "progressive_l0": dict(prepared.progressive_metrics or {}),
+        "l0_bundle_hash": _stable_payload_hash(prepared.bundle),
+        "l0_model_view_hash": _stable_payload_hash(prepared.model_view),
+        "analysis_timeout_seconds": timeout_seconds,
+        "deadline_exceeded_route_count": deadline_exceeded_route_count,
+        "deterministic_ready_wall_clock_s": (
+            deterministic_candidate.ready_wall_clock_s
+            if deterministic_candidate is not None
+            else None
+        ),
+        "deterministic_callback_error": deterministic_callback_error,
+        "deterministic_callback_wall_clock_s": deterministic_callback_wall_clock_s,
+        "route_completion_callback_errors": dict(route_completion_callback_errors or {}),
+        "l0_ready_callback_error": l0_ready_callback_error,
+        "l0_ready_callback_wall_clock_s": l0_ready_callback_wall_clock_s,
+    }
+    if config_metadata is not None:
+        shared_analysis["restart_agent_config"] = deepcopy(dict(config_metadata))
+    return shared_analysis
+
+
+def _notify_route_complete(
+    callback: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None,
+    result: ModelAnalysisResult,
+    trace: Mapping[str, Any],
+    errors: dict[str, str],
+) -> None:
+    if callback is None:
+        return
+    try:
+        callback(result, trace)
+    except Exception as exc:
+        errors[result.route_id] = f"{type(exc).__name__}: {exc}"
+
+
+def _notify_attempt_record_ready(
+    callback: Callable[[str, AttemptRecord], None] | None,
+    route_id: str,
+    record: AttemptRecord | None,
+    errors: dict[str, str],
+) -> None:
+    if callback is None or record is None:
+        return
+    try:
+        callback(route_id, record)
+    except Exception as exc:
+        errors[f"attempt_record:{route_id}"] = f"{type(exc).__name__}: {exc}"
+
+
+def _orchestration_error_route_result(
+    route: ModelRoute,
+    deterministic_result: AnalysisResult,
+    exc: BaseException,
+) -> tuple[ModelAnalysisResult, dict[str, Any], AttemptRecord | None]:
+    error = f"{type(exc).__name__}: {exc}"
+    return (
+        ModelAnalysisResult(
+            route_id=route.route_id,
+            model=route.model,
+            endpoint=route.endpoint,
+            credential_ref=route.credential_ref,
+            execution_status="orchestration_error",
+            l1_usable=False,
+            analysis_result=deterministic_result,
+            error=error,
+        ),
+        {"routing_error": error, "route": _model_route_metadata(route)},
+        None,
+    )
+
+
+def _deadline_exceeded_route_result(
+    route: ModelRoute,
+    deterministic_result: AnalysisResult,
+) -> tuple[ModelAnalysisResult, dict[str, Any], AttemptRecord | None]:
+    error = "analysis deadline exceeded before the model route completed"
+    return (
+        ModelAnalysisResult(
+            route_id=route.route_id,
+            model=route.model,
+            endpoint=route.endpoint,
+            credential_ref=route.credential_ref,
+            execution_status="deadline_exceeded",
+            l1_usable=False,
+            analysis_result=deterministic_result,
+            error=error,
+        ),
+        {
+            "route": _model_route_metadata(route),
+            "execution_status": "deadline_exceeded",
+            "deadline_exceeded": True,
+            "routing_error": error,
+        },
+        None,
+    )
+
+
+def _model_route_metadata(route: ModelRoute) -> dict[str, Any]:
+    return {
+        "route_id": route.route_id,
+        "model": route.model,
+        "endpoint": route.endpoint,
+        "credential_ref": route.credential_ref,
+    }
+
+
+def _stable_payload_hash(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "to_payload"):
+        payload = value.to_payload()
+    elif is_dataclass(value):
+        payload = asdict(value)
+    else:
+        payload = value
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/observability/__init__.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/observability/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trace schemas and stage observability builders."""
+
+from .schemas import CLI_COLLECT_ALL_TRACE_SCHEMA_VERSION, CLI_TRACE_SCHEMA_VERSION
+from .trace_builder import (
+    DecisionTraceInputs,
+    build_decision_trace,
+    build_log_unavailable_trace,
+    history_trace,
+    l1_token_limit_summary,
+)
+
+__all__ = [
+    "CLI_COLLECT_ALL_TRACE_SCHEMA_VERSION",
+    "CLI_TRACE_SCHEMA_VERSION",
+    "DecisionTraceInputs",
+    "build_decision_trace",
+    "build_log_unavailable_trace",
+    "history_trace",
+    "l1_token_limit_summary",
+]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/observability/schemas.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/observability/schemas.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public schema identifiers for CLI trace envelopes."""
+
+CLI_TRACE_SCHEMA_VERSION = "restart_agent_cli_trace.v1"
+CLI_COLLECT_ALL_TRACE_SCHEMA_VERSION = "restart_agent_cli_collect_all_trace.v1"

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/observability/trace_builder.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/observability/trace_builder.py
@@ -1,0 +1,925 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trace construction and stage observability for restart-agent runs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, Mapping
+
+from ..l1.contracts import L1EvidenceResult
+from ..l4.policy import RetryPolicyEvaluation
+from ..models import (
+    AnalysisExecutionContext,
+    AnalysisResult,
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    DecisionCandidate,
+    DecisionCandidateKind,
+    DecisionEvidence,
+    FailureEvidence,
+    HistorySummary,
+    L0Bundle,
+    L0ModelFacingView,
+)
+
+
+def _assessment(audit: Mapping[str, Any], name: str) -> dict[str, Any] | None:
+    value = audit.get(name)
+    return dict(value) if isinstance(value, Mapping) else None
+
+
+def _l2_material_finding_count(audit: Mapping[str, Any]) -> int:
+    return sum(
+        1
+        for finding in audit.get("findings") or []
+        if isinstance(finding, Mapping) and bool(finding.get("policy_material", True))
+    )
+
+
+@dataclass(frozen=True)
+class DecisionTraceInputs:
+    """Typed inputs required to render one completed decision trace."""
+
+    execution_context: AnalysisExecutionContext
+    result: AnalysisResult
+    bundle: L0Bundle
+    decision_evidence: DecisionEvidence
+    primary: FailureEvidence | None
+    l2_primary: FailureEvidence | None
+    total_wall_clock_s: float
+    l0_wall_clock_s: float
+    l0a_wall_clock_s: float
+    decision_evidence_wall_clock_s: float
+    l0b_wall_clock_s: float
+    model_view: L0ModelFacingView | None
+    l1_configured: bool
+    l1_result: L1EvidenceResult
+    l1_output_health: Mapping[str, Any]
+    l1_wall_clock_s: float
+    l2_audit: Mapping[str, Any]
+    deterministic_failure_facts: AttemptFailureFacts
+    selected_failure_facts: AttemptFailureFacts
+    history: Any
+    retry_policy: RetryPolicyEvaluation
+    l0_reused: bool
+    l2_wall_clock_s: float
+    l3_wall_clock_s: float
+    l4_wall_clock_s: float
+    deterministic_candidate: DecisionCandidate | None
+    selected_candidate_kind: str
+    deterministic_callback_error: str | None
+    deterministic_callback_wall_clock_s: float
+    analysis_timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class _TraceMetrics:
+    l1_model_wall_clock_s: float
+    failed_model_calls: tuple[Mapping[str, Any], ...]
+    retried_model_calls: tuple[Mapping[str, Any], ...]
+    l1_tool_wall_clock_s: float
+    token_usage: Mapping[str, Any]
+    token_limit: Mapping[str, Any]
+    l0_root_fingerprint: Any
+    l0_root_fingerprint_source: Any
+    l2_root_fingerprint: Any
+    l2_root_fingerprint_source: Any
+    l2_matches_l0_fingerprint: bool | None
+
+    @classmethod
+    def from_inputs(cls, inputs: DecisionTraceInputs) -> "_TraceMetrics":
+        failed_model_calls = tuple(
+            call for call in inputs.l1_result.model_calls if call.get("success") is False
+        )
+        l0_identity = inputs.decision_evidence.canonical_observed_identity
+        l0_root_fingerprint = l0_identity.get("root_fingerprint")
+        l2_root_fingerprint = inputs.l2_audit.get("stable_root_fingerprint")
+        return cls(
+            l1_model_wall_clock_s=round(
+                sum(float(call.get("latency_s") or 0.0) for call in inputs.l1_result.model_calls),
+                3,
+            ),
+            failed_model_calls=failed_model_calls,
+            retried_model_calls=tuple(
+                call for call in failed_model_calls if call.get("retry_scheduled") is True
+            ),
+            l1_tool_wall_clock_s=round(
+                sum(float(call.get("latency_ms") or 0.0) for call in inputs.l1_result.tool_calls)
+                / 1000,
+                3,
+            ),
+            token_usage=_l1_token_usage(inputs.l1_result.model_calls),
+            token_limit=l1_token_limit_summary(inputs.l1_result.model_calls),
+            l0_root_fingerprint=l0_root_fingerprint,
+            l0_root_fingerprint_source=l0_identity.get("root_fingerprint_source"),
+            l2_root_fingerprint=l2_root_fingerprint,
+            l2_root_fingerprint_source=inputs.l2_audit.get("root_fingerprint_source"),
+            l2_matches_l0_fingerprint=(
+                l2_root_fingerprint == l0_root_fingerprint
+                if l2_root_fingerprint and l0_root_fingerprint
+                else None
+            ),
+        )
+
+
+def build_decision_trace(inputs: DecisionTraceInputs) -> dict[str, Any]:
+    metrics = _TraceMetrics.from_inputs(inputs)
+    return {
+        "context_mode": _context_mode(inputs.primary, inputs.l1_result, inputs.l2_audit),
+        "log_path": inputs.execution_context.log_path,
+        "request": inputs.execution_context.request.to_payload(),
+        "job_id": inputs.execution_context.job_id,
+        "cycle_id": inputs.execution_context.cycle_id,
+        "result_provenance": dict(inputs.result.result_provenance),
+        "external_output": inputs.result.to_payload(),
+        "decision_candidates": _decision_candidates_trace(
+            result=inputs.result,
+            history=inputs.history,
+            deterministic_candidate=inputs.deterministic_candidate,
+            selected_candidate_kind=inputs.selected_candidate_kind,
+            l1_output_health=inputs.l1_output_health,
+            total_wall_clock_s=inputs.total_wall_clock_s,
+            l1_configured=inputs.l1_configured,
+        ),
+        "timing": _timing_trace(inputs, metrics),
+        "latency_measurement": {
+            "mode": "terminal_request_to_result",
+            "terminal_total_wall_clock_s": inputs.total_wall_clock_s,
+            "post_progressive_end_wall_clock_s": None,
+            "production_gate_measured": False,
+        },
+        "analysis_deadline": {
+            "timeout_seconds": inputs.analysis_timeout_seconds,
+            "deadline_exceeded": bool(inputs.l1_result.anomalies.get("deadline_exceeded")),
+            "remaining_at_return_s": max(
+                0.0, inputs.analysis_timeout_seconds - inputs.total_wall_clock_s
+            ),
+        },
+        "token_usage": metrics.token_usage,
+        "token_limit": metrics.token_limit,
+        "layers": _layers_trace(inputs, metrics),
+        "l0_summary": _l0_summary_trace(inputs),
+        "decision_evidence": inputs.decision_evidence.to_payload(),
+        "selected_failure_facts": inputs.selected_failure_facts.to_payload(),
+        "l0_model_view": (
+            inputs.model_view.to_payload() if inputs.model_view is not None else None
+        ),
+        "l2_grounded_semantics": _l2_grounded_semantics(inputs.l2_primary, inputs.l2_audit),
+        "l2_audit": _l2_audit_trace(inputs.l2_audit, inputs.l1_result),
+        "l1": inputs.l1_result.to_trace(),
+        "selection_summary": dict(inputs.bundle.selection_summary),
+        "l3_history": history_trace(inputs.history),
+        "l4_policy": {
+            "decision": inputs.result.decision,
+            "decision_basis": inputs.result.decision_basis,
+            "retry_policy": inputs.retry_policy.to_payload(),
+            "history_inputs": history_trace(inputs.history),
+            "result_provenance": dict(inputs.result.result_provenance),
+        },
+        "anomalies": _anomalies_trace(inputs, metrics),
+    }
+
+
+def _timing_trace(inputs: DecisionTraceInputs, metrics: _TraceMetrics) -> dict[str, Any]:
+    return {
+        "total_wall_clock_s": inputs.total_wall_clock_s,
+        "l0_wall_clock_s": inputs.l0_wall_clock_s,
+        "l0a_wall_clock_s": inputs.l0a_wall_clock_s,
+        "decision_evidence_wall_clock_s": inputs.decision_evidence_wall_clock_s,
+        "l0b_wall_clock_s": inputs.l0b_wall_clock_s,
+        "l1_wall_clock_s": round(inputs.l1_wall_clock_s, 3),
+        "l1_model_call_wall_clock_s": metrics.l1_model_wall_clock_s,
+        "l1_tool_wall_clock_s": metrics.l1_tool_wall_clock_s,
+        "l2_wall_clock_s": inputs.l2_wall_clock_s,
+        "l3_wall_clock_s": inputs.l3_wall_clock_s,
+        "l4_wall_clock_s": inputs.l4_wall_clock_s,
+        "l1_model_calls": len(inputs.l1_result.model_calls),
+        "l1_failed_model_calls": len(metrics.failed_model_calls),
+        "l1_retried_model_calls": len(metrics.retried_model_calls),
+        "l1_tool_calls": len(inputs.l1_result.tool_calls),
+        "l0_reused": inputs.l0_reused,
+        "deterministic_callback_wall_clock_s": inputs.deterministic_callback_wall_clock_s,
+    }
+
+
+def _layers_trace(inputs: DecisionTraceInputs, metrics: _TraceMetrics) -> dict[str, Any]:
+    return {
+        "L0": _l0_layer_trace(inputs, metrics),
+        "L1": _l1_layer_trace(inputs, metrics),
+        "L2": _l2_layer_trace(inputs, metrics),
+        "L3": _l3_layer_trace(inputs),
+        "L4": _l4_layer_trace(inputs),
+    }
+
+
+def _l0_layer_trace(inputs: DecisionTraceInputs, metrics: _TraceMetrics) -> dict[str, Any]:
+    bundle = inputs.bundle
+    identity_ready = bool(metrics.l0_root_fingerprint)
+    return {
+        "name": "evidence_assembly_and_projection",
+        "wall_clock_s": inputs.l0_wall_clock_s,
+        "reused": inputs.l0_reused,
+        "model_calls": 0,
+        "tool_calls": 0,
+        "line_count": bundle.line_count,
+        "byte_size": bundle.byte_size,
+        "context_windows": len(bundle.context_windows),
+        "candidate_anchors": len(bundle.candidate_anchors),
+        "failure_episodes": len(bundle.failure_episodes),
+        "distributed_failure_incidents": len(bundle.distributed_failure_incidents),
+        "seconds_from_last_progress_to_terminal_incident": bundle.run_progress_summary.seconds_from_last_progress_to_terminal_incident,
+        "configured_terminal_timeout_seconds": bundle.run_progress_summary.configured_terminal_timeout_seconds,
+        "terminal_detection_lag_seconds": bundle.run_progress_summary.terminal_detection_lag_seconds,
+        "occurrence_groups": len(bundle.occurrence_groups),
+        "root_fingerprint_owner": "L0",
+        "root_fingerprint": metrics.l0_root_fingerprint,
+        "root_fingerprint_source": metrics.l0_root_fingerprint_source,
+        "root_fingerprint_available": identity_ready,
+        "affected_entity": (
+            inputs.deterministic_failure_facts.affected_entity.to_payload()
+            if inputs.deterministic_failure_facts.affected_entity is not None
+            else None
+        ),
+        "affected_entity_available": (
+            inputs.deterministic_failure_facts.affected_entity is not None
+        ),
+        "history_identity_ready": identity_ready,
+        "sub_stages": {
+            "L0A": {
+                "name": "complete_evidence_assembly",
+                "wall_clock_s": inputs.l0a_wall_clock_s,
+                "status": "reused" if inputs.l0_reused else "completed",
+                "line_count": bundle.line_count,
+                "byte_size": bundle.byte_size,
+                "context_windows": len(bundle.context_windows),
+                "candidate_anchors": len(bundle.candidate_anchors),
+                "failure_episodes": len(bundle.failure_episodes),
+                "distributed_failure_incidents": len(bundle.distributed_failure_incidents),
+                "occurrence_groups": len(bundle.occurrence_groups),
+            },
+            "DecisionEvidence": {
+                "name": "canonical_decision_evidence_selection",
+                "wall_clock_s": inputs.decision_evidence_wall_clock_s,
+                "status": "completed",
+                "schema_version": inputs.decision_evidence.schema_version,
+                "primary_available": (
+                    inputs.decision_evidence.deterministic_primary_candidate is not None
+                ),
+                "identity_available": bool(
+                    inputs.decision_evidence.canonical_observed_identity.get("available")
+                ),
+                "root_fingerprint_owner": "L0",
+                "root_fingerprint": metrics.l0_root_fingerprint,
+                "root_fingerprint_source": metrics.l0_root_fingerprint_source,
+                "root_fingerprint_available": identity_ready,
+                "affected_entity": (
+                    inputs.deterministic_failure_facts.affected_entity.to_payload()
+                    if inputs.deterministic_failure_facts.affected_entity is not None
+                    else None
+                ),
+                "affected_entity_available": (
+                    inputs.deterministic_failure_facts.affected_entity is not None
+                ),
+                "history_identity_ready": identity_ready,
+                "referenced_source_lines": len(
+                    inputs.decision_evidence.selected_evidence_references.get("source_lines", ())
+                ),
+            },
+            "L0B": {
+                "name": "initial_model_evidence_view",
+                "wall_clock_s": inputs.l0b_wall_clock_s,
+                "status": "completed" if inputs.model_view is not None else "not_run",
+                **(
+                    dict(inputs.model_view.projection_metrics)
+                    if inputs.model_view is not None
+                    else {}
+                ),
+            },
+        },
+    }
+
+
+def _l1_layer_trace(inputs: DecisionTraceInputs, metrics: _TraceMetrics) -> dict[str, Any]:
+    return {
+        "name": "semantic_analysis",
+        "wall_clock_s": round(inputs.l1_wall_clock_s, 3),
+        "model_call_wall_clock_s": metrics.l1_model_wall_clock_s,
+        "tool_wall_clock_s": metrics.l1_tool_wall_clock_s,
+        "model_calls": len(inputs.l1_result.model_calls),
+        "failed_model_calls": len(metrics.failed_model_calls),
+        "retried_model_calls": len(metrics.retried_model_calls),
+        "tool_calls": len(inputs.l1_result.tool_calls),
+        "provider_response_returned": bool(inputs.l1_result.model_calls),
+        "response_parsed": bool(inputs.l1_result.success),
+        "output_status": inputs.l1_output_health.get("status"),
+        "output_usable": bool(inputs.l1_output_health.get("usable")),
+        "output_errors": list(inputs.l1_output_health.get("errors") or []),
+        "execution_status": inputs.result.result_provenance.get("l1_execution_status"),
+        "execution_issues": list(inputs.result.result_provenance.get("l1_execution_issues") or []),
+        "prompt_tokens": metrics.token_usage["prompt_tokens"],
+        "completion_tokens": metrics.token_usage["completion_tokens"],
+        "total_tokens": metrics.token_usage["total_tokens"],
+    }
+
+
+def _l2_layer_trace(inputs: DecisionTraceInputs, metrics: _TraceMetrics) -> dict[str, Any]:
+    audit = inputs.l2_audit
+    citations = audit.get("citation_audits") or []
+    identity_ready = bool(metrics.l2_root_fingerprint)
+    return {
+        "name": "evidence_grounding_and_identity",
+        "wall_clock_s": inputs.l2_wall_clock_s,
+        "grounding_status": audit.get("grounding_status"),
+        "grounding_method": audit.get("grounding_method"),
+        "enriched_failure_facts_available": bool(
+            inputs.selected_failure_facts.source == AttemptFailureFactsSource.L2_GROUNDED
+        ),
+        "audit_status": audit.get("audit_status"),
+        "primary_available": bool(audit.get("primary_used")),
+        "recovery_assessment_available": bool(audit.get("recovery_assessment_used")),
+        "recovery_assessment_policy_grounded": bool(
+            audit.get("recovery_assessment_policy_grounded")
+        ),
+        "related_failures_audited": len(audit.get("audited_related_failure_roles") or []),
+        "finding_count": sum(len(items) for items in (audit.get("field_findings") or {}).values()),
+        "material_finding_count": _l2_material_finding_count(audit),
+        "finding_severity_counts": _l2_finding_severity_counts(audit),
+        "citation_count": len(citations),
+        "nearby_resolved_count": sum(
+            1 for item in citations if item.get("status") == "nearby_resolved"
+        ),
+        "rendered_exact_count": sum(
+            1 for item in citations if item.get("status") == "rendered_exact"
+        ),
+        "abbreviated_exact_count": sum(
+            1 for item in citations if item.get("status") == "abbreviated_exact"
+        ),
+        "grounding_adjustment_count": len(audit.get("grounding_adjustments") or []),
+        "root_fingerprint_owner": "L2",
+        "root_fingerprint": metrics.l2_root_fingerprint,
+        "root_fingerprint_source": metrics.l2_root_fingerprint_source,
+        "root_fingerprint_available": identity_ready,
+        "affected_entity": (
+            inputs.selected_failure_facts.affected_entity.to_payload()
+            if inputs.selected_failure_facts.source == AttemptFailureFactsSource.L2_GROUNDED
+            and inputs.selected_failure_facts.affected_entity is not None
+            else None
+        ),
+        "affected_entity_available": bool(
+            inputs.selected_failure_facts.source == AttemptFailureFactsSource.L2_GROUNDED
+            and inputs.selected_failure_facts.affected_entity is not None
+        ),
+        "history_identity_ready": identity_ready,
+        "matches_l0_root_fingerprint": metrics.l2_matches_l0_fingerprint,
+    }
+
+
+def _l3_layer_trace(inputs: DecisionTraceInputs) -> dict[str, Any]:
+    history = inputs.history
+    return {
+        "name": "history_enrichment",
+        "wall_clock_s": inputs.l3_wall_clock_s,
+        "selected_failure_facts_source": inputs.selected_failure_facts.source.value,
+        "history_identity_ready": inputs.selected_failure_facts.history_identity_ready,
+        "current_affected_entity": (
+            inputs.selected_failure_facts.affected_entity.to_payload()
+            if inputs.selected_failure_facts.affected_entity is not None
+            else None
+        ),
+        "history_available": bool(getattr(history, "available", False)),
+        "same_job_attempts": int(getattr(history, "same_job_attempts", 0) or 0),
+        "matching_root_attempts": int(getattr(history, "matching_root_attempts", 0) or 0),
+        "observed_advance_attempts": int(getattr(history, "observed_advance_attempts", 0) or 0),
+        "no_observed_advance_attempts": int(
+            getattr(history, "no_observed_advance_attempts", 0) or 0
+        ),
+        "unknown_progress_attempts": int(getattr(history, "unknown_progress_attempts", 0) or 0),
+        "exact_failure_position_attempts": int(
+            getattr(history, "exact_failure_position_attempts", 0) or 0
+        ),
+        "same_rank_iteration_attempts": int(
+            getattr(history, "same_rank_iteration_attempts", 0) or 0
+        ),
+        "same_entity_attempts": int(getattr(history, "same_entity_attempts", 0) or 0),
+        "different_entity_attempts": int(getattr(history, "different_entity_attempts", 0) or 0),
+        "unknown_entity_attempts": int(getattr(history, "unknown_entity_attempts", 0) or 0),
+        "consecutive_same_root_no_advance_attempts": int(
+            getattr(history, "consecutive_same_root_no_advance_attempts", 0) or 0
+        ),
+        "consecutive_same_root_and_entity_no_advance_attempts": int(
+            getattr(
+                history,
+                "consecutive_same_root_and_entity_no_advance_attempts",
+                0,
+            )
+            or 0
+        ),
+        "advanced_beyond_all_comparable_attempts": bool(
+            getattr(history, "advanced_beyond_all_comparable_attempts", False)
+        ),
+        "advanced_beyond_all_same_entity_comparable_attempts": bool(
+            getattr(
+                history,
+                "advanced_beyond_all_same_entity_comparable_attempts",
+                False,
+            )
+        ),
+    }
+
+
+def _l4_layer_trace(inputs: DecisionTraceInputs) -> dict[str, Any]:
+    general_root_ceiling = inputs.retry_policy.general_root_ceiling.to_payload()
+    selected_rule_budget = (
+        inputs.retry_policy.selected_rule_budget.to_payload()
+        if inputs.retry_policy.selected_rule_budget is not None
+        else None
+    )
+    return {
+        "name": "policy_decision",
+        "wall_clock_s": inputs.l4_wall_clock_s,
+        "decision": inputs.result.decision,
+        "decision_basis": inputs.result.decision_basis,
+        "rule": inputs.retry_policy.rule,
+        "general_root_ceiling": general_root_ceiling,
+        "selected_rule_budget": selected_rule_budget,
+        "exhausted_by": list(inputs.retry_policy.exhausted_by),
+        "current_affected_entity": inputs.retry_policy.current_affected_entity,
+        "retry_budget_exhausted": inputs.retry_policy.retry_budget_exhausted,
+        "recovery_assessment_policy_grounded": (
+            inputs.retry_policy.recovery_assessment_policy_grounded
+        ),
+        "current_evidence_qualified": inputs.retry_policy.current_evidence_qualified,
+        "result_quality": inputs.result.result_provenance.get("result_quality"),
+    }
+
+
+def _l0_summary_trace(inputs: DecisionTraceInputs) -> dict[str, Any]:
+    bundle = inputs.bundle
+    return {
+        "line_count": bundle.line_count,
+        "byte_size": bundle.byte_size,
+        "deterministic_primary_candidate": (
+            bundle.deterministic_primary_candidate.to_failure_payload()
+            if bundle.deterministic_primary_candidate is not None
+            else None
+        ),
+        "occurrence_groups": len(bundle.occurrence_groups),
+        "registry_matches": len(bundle.registry_matches),
+        "context_windows": len(bundle.context_windows),
+        "candidate_anchors": len(bundle.candidate_anchors),
+        "distributed_failure_incidents": len(bundle.distributed_failure_incidents),
+        "first_terminal_incident_line": (bundle.run_progress_summary.first_terminal_incident_line),
+        "seconds_from_last_progress_to_terminal_incident": (
+            bundle.run_progress_summary.seconds_from_last_progress_to_terminal_incident
+        ),
+        "terminal_detection_lag_seconds": (
+            bundle.run_progress_summary.terminal_detection_lag_seconds
+        ),
+        "model_view_projection": (
+            dict(inputs.model_view.projection_metrics) if inputs.model_view is not None else None
+        ),
+    }
+
+
+def _anomalies_trace(inputs: DecisionTraceInputs, metrics: _TraceMetrics) -> dict[str, Any]:
+    return {
+        **dict(inputs.bundle.anomalies),
+        "provider_error": bool(inputs.l1_result.anomalies.get("provider_error")),
+        "provider_error_type": inputs.l1_result.anomalies.get("provider_error_type"),
+        "provider_timeout": bool(inputs.l1_result.anomalies.get("provider_timeout")),
+        "context_window_exceeded": bool(inputs.l1_result.anomalies.get("context_window_exceeded")),
+        "provider_retries": len(metrics.retried_model_calls),
+        "token_limit_hit": metrics.token_limit["hit"],
+        "contract_repair_requested": bool(
+            inputs.l1_result.anomalies.get("contract_repair_requested")
+        ),
+        "l1_contract_invalid": inputs.l1_output_health.get("status") == "contract_invalid",
+        "malformed_model_evidence": inputs.l1_output_health.get("status") == "malformed",
+        "model_output_truncated": bool(inputs.l1_result.anomalies.get("model_output_truncated")),
+        "model_prohibited_fields_ignored": bool(inputs.l2_audit.get("ignored_prohibited_fields")),
+        "l0_policy_downgraded": bool(inputs.l2_audit.get("l0_policy_downgraded")),
+        "unsupported_tool_request_seen": bool(inputs.l1_result.unsupported_tool_requests),
+        "forced_final_evidence_call": bool(
+            inputs.l1_result.anomalies.get("forced_final_evidence_call")
+        ),
+        "deterministic_callback_error": inputs.deterministic_callback_error,
+    }
+
+
+def _decision_candidates_trace(
+    *,
+    result: AnalysisResult,
+    history: Any,
+    deterministic_candidate: DecisionCandidate | None,
+    selected_candidate_kind: str,
+    l1_output_health: Mapping[str, Any],
+    total_wall_clock_s: float,
+    l1_configured: bool,
+) -> dict[str, Any]:
+    deterministic_payload = (
+        deterministic_candidate.to_payload() if deterministic_candidate is not None else None
+    )
+    if deterministic_payload is None and selected_candidate_kind == (
+        DecisionCandidateKind.DETERMINISTIC.value
+    ):
+        deterministic_payload = DecisionCandidate(
+            candidate_kind=DecisionCandidateKind.DETERMINISTIC.value,
+            result=result,
+            ready_wall_clock_s=total_wall_clock_s,
+            l1_execution_status=str(
+                result.result_provenance.get("l1_execution_status") or "not_run"
+            ),
+            history_summary=history_trace(history),
+        ).to_payload()
+
+    enriched_ready = selected_candidate_kind == DecisionCandidateKind.L1_ENRICHED.value
+    enriched_payload = None
+    if enriched_ready:
+        enriched_payload = DecisionCandidate(
+            candidate_kind=DecisionCandidateKind.L1_ENRICHED.value,
+            result=result,
+            ready_wall_clock_s=total_wall_clock_s,
+            l1_execution_status=str(result.result_provenance.get("l1_execution_status") or "ok"),
+            history_summary=history_trace(history),
+        ).to_payload()
+
+    selected_ready_wall_clock_s = total_wall_clock_s
+    if deterministic_candidate is not None and not enriched_ready:
+        selected_ready_wall_clock_s = deterministic_candidate.ready_wall_clock_s
+    best_available = DecisionCandidate(
+        candidate_kind=selected_candidate_kind,
+        result=result,
+        ready_wall_clock_s=selected_ready_wall_clock_s,
+        l1_execution_status=str(result.result_provenance.get("l1_execution_status") or "not_run"),
+        history_summary=history_trace(history),
+    ).to_payload()
+
+    if enriched_ready:
+        selection_reason = "structurally_usable_l1_with_l2_grounding_audit"
+    elif not l1_configured:
+        selection_reason = "l1_not_configured"
+    elif l1_output_health.get("usable"):
+        selection_reason = "l1_returned_no_audited_primary"
+    else:
+        selection_reason = f"l1_not_usable:{l1_output_health.get('status')}"
+
+    return {
+        "analysis_state": "completed",
+        "deterministic_ready": deterministic_payload is not None,
+        "enriched_ready": enriched_ready,
+        "best_available_kind": selected_candidate_kind,
+        "best_available": best_available,
+        "selected": selected_candidate_kind,
+        "selection_reason": selection_reason,
+        "deterministic": deterministic_payload,
+        "l1_enriched": enriched_payload,
+    }
+
+
+def _l2_audit_trace(
+    audit: Mapping[str, Any],
+    l1_result: L1EvidenceResult,
+) -> dict[str, Any]:
+    result = dict(audit)
+    grounding_adjustments = [
+        item for item in audit.get("grounding_adjustments") or [] if isinstance(item, Mapping)
+    ]
+    adjusted_fields = {str(item.get("field")) for item in grounding_adjustments}
+    field_findings = audit.get("field_findings") or {}
+    if not isinstance(field_findings, Mapping):
+        field_findings = {}
+    field_finding_codes = audit.get("field_finding_codes") or {}
+    if not isinstance(field_finding_codes, Mapping):
+        field_finding_codes = {}
+
+    primary_status = "not_evaluated"
+    if l1_result.success:
+        primary_status = "available" if audit.get("primary_used") else "not_evaluated"
+        if any(field.startswith("primary_failure.") for field in adjusted_fields):
+            primary_status = "resolved"
+        if field_findings.get("primary_failure") and audit.get("primary_used"):
+            primary_status = "findings"
+
+    recovery_status = "not_evaluated"
+    if audit.get("primary_used"):
+        recovery_status = "available" if audit.get("recovery_assessment_used") else "not_evaluated"
+        if any("recovery" in field for field in adjusted_fields):
+            recovery_status = "resolved"
+        if field_findings.get("model_recovery_assessment"):
+            recovery_status = "findings"
+
+    related_findings = field_findings.get("related_failures") or []
+    audited_related_count = len(audit.get("audited_related_failure_roles") or [])
+    related_status = "not_evaluated"
+    if audit.get("primary_used"):
+        related_status = "audited"
+        if related_findings:
+            related_status = "findings"
+
+    result["field_audits"] = {
+        "primary_failure": {
+            "status": primary_status,
+            "findings": list(field_findings.get("primary_failure") or []),
+            "finding_classes": list(field_finding_codes.get("primary_failure") or []),
+        },
+        "root_cause_assessment": {
+            "status": (
+                "findings"
+                if field_findings.get("root_cause_assessment")
+                else "available" if audit.get("primary_used") else "not_evaluated"
+            ),
+            "findings": list(field_findings.get("root_cause_assessment") or []),
+            "finding_classes": list(field_finding_codes.get("root_cause_assessment") or []),
+        },
+        "model_recovery_assessment": {
+            "status": recovery_status,
+            "findings": list(field_findings.get("model_recovery_assessment") or []),
+            "finding_classes": list(field_finding_codes.get("model_recovery_assessment") or []),
+        },
+        "related_failures": {
+            "status": related_status,
+            "audited_count": audited_related_count,
+            "finding_count": len(related_findings),
+            "findings": list(related_findings),
+            "finding_classes": list(field_finding_codes.get("related_failures") or []),
+        },
+    }
+    return result
+
+
+def _l2_finding_severity_counts(audit: Mapping[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for finding in audit.get("findings") or []:
+        if not isinstance(finding, Mapping):
+            continue
+        severity = str(finding.get("severity") or "credibility")
+        counts[severity] = counts.get(severity, 0) + 1
+    return counts
+
+
+def _l2_grounded_semantics(
+    primary: FailureEvidence | None,
+    audit: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    if not audit.get("used") or primary is None:
+        return None
+    return {
+        "grounding_status": audit.get("grounding_status"),
+        "grounding_method": audit.get("grounding_method"),
+        "audit_status": audit.get("audit_status"),
+        "recovery_assessment_policy_grounded": bool(
+            audit.get("recovery_assessment_policy_grounded")
+        ),
+        "primary_failure": primary.to_failure_payload(),
+        "root_cause_assessment": _assessment(audit, "root_cause_assessment"),
+        "model_recovery_assessment": _assessment(audit, "model_recovery_assessment"),
+        "recovery_field_audits": list(audit.get("recovery_field_audits") or []),
+        "related_failures": list(audit.get("audited_related_failure_roles") or []),
+        "secondary_failures": list(audit.get("audited_related_failures") or []),
+        "evidence": list(audit.get("grounded_evidence") or []),
+    }
+
+
+def history_trace(history: HistorySummary) -> dict[str, Any]:
+    fields = (
+        "available",
+        "availability_reason",
+        "same_job_attempts",
+        "matching_root_attempts",
+        "observed_advance_attempts",
+        "same_progress_attempts",
+        "regressed_progress_attempts",
+        "unknown_progress_attempts",
+        "no_observed_advance_attempts",
+        "matching_root_attempts_with_observed_training_progress",
+        "matching_root_attempts_before_observed_training_progress",
+        "matching_root_attempts_with_unknown_training_progress",
+        "exact_failure_position_attempts",
+        "same_rank_iteration_attempts",
+        "same_entity_attempts",
+        "different_entity_attempts",
+        "unknown_entity_attempts",
+        "consecutive_same_root_no_advance_attempts",
+        "consecutive_same_root_and_entity_no_advance_attempts",
+        "advanced_beyond_all_comparable_attempts",
+        "advanced_beyond_all_same_entity_comparable_attempts",
+        "cross_node_recurrence",
+        "same_node_recurrence",
+        "same_gpu_recurrence",
+        "same_rank_only_recurrence",
+        "rank_to_gpu_mapping_available",
+    )
+    payload = {field: getattr(history, field, None) for field in fields}
+    payload["comparisons"] = [
+        asdict(item) if is_dataclass(item) else item for item in getattr(history, "comparisons", ())
+    ]
+    return payload
+
+
+def l1_token_limit_summary(model_calls: tuple[dict[str, Any], ...]) -> dict[str, Any]:
+    hit_calls = [
+        {
+            "model_turn": call.get("model_turn"),
+            "attempt": call.get("attempt"),
+            "finish_reason": call.get("finish_reason"),
+            "completion_tokens": _usage_int(call.get("usage"), "completion_tokens"),
+            "reasoning_tokens": _nested_usage_int(
+                call.get("usage"),
+                "completion_tokens_details",
+                "reasoning_tokens",
+            ),
+            "max_retries": call.get("max_retries"),
+            "limit_kind": (
+                "context_window"
+                if call.get("error_type") == "context_window_exceeded"
+                else "output"
+            ),
+        }
+        for call in model_calls
+        if call.get("finish_reason") == "length"
+        or call.get("error_type") == "context_window_exceeded"
+    ]
+    return {
+        "hit": bool(hit_calls),
+        "hit_count": len(hit_calls),
+        "hit_calls": hit_calls,
+        "meaning": (
+            "At least one L1 call exhausted output tokens or was rejected because "
+            "input plus requested output exceeded the model context window."
+        ),
+    }
+
+
+def _l1_token_usage(model_calls: tuple[dict[str, Any], ...]) -> dict[str, Any]:
+    prompt_tokens = 0
+    completion_tokens = 0
+    total_tokens = 0
+    cached_prompt_tokens = 0
+    reasoning_tokens = 0
+    calls_with_usage = 0
+
+    for call in model_calls:
+        usage = call.get("usage")
+        if not isinstance(usage, Mapping):
+            continue
+        calls_with_usage += 1
+        call_prompt_tokens = _usage_int(usage, "prompt_tokens")
+        call_completion_tokens = _usage_int(usage, "completion_tokens")
+        call_total_tokens = _usage_int(usage, "total_tokens")
+        prompt_tokens += call_prompt_tokens
+        completion_tokens += call_completion_tokens
+        total_tokens += call_total_tokens
+
+        prompt_details = usage.get("prompt_tokens_details")
+        if isinstance(prompt_details, Mapping):
+            cached_prompt_tokens += _usage_int(prompt_details, "cached_tokens")
+        completion_details = usage.get("completion_tokens_details")
+        if isinstance(completion_details, Mapping):
+            reasoning_tokens += _usage_int(completion_details, "reasoning_tokens")
+
+    return {
+        "model_calls_with_usage": calls_with_usage,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "cached_prompt_tokens": cached_prompt_tokens,
+        "reasoning_tokens": reasoning_tokens,
+    }
+
+
+def _usage_int(usage: Mapping[str, Any], key: str) -> int:
+    if not isinstance(usage, Mapping):
+        return 0
+    try:
+        return int(usage.get(key) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _nested_usage_int(usage: Any, parent_key: str, key: str) -> int:
+    if not isinstance(usage, Mapping):
+        return 0
+    child = usage.get(parent_key)
+    if not isinstance(child, Mapping):
+        return 0
+    return _usage_int(child, key)
+
+
+def _context_mode(
+    primary: FailureEvidence | None,
+    l1_result: L1EvidenceResult,
+    l2_audit: Mapping[str, Any],
+) -> str:
+    if l2_audit.get("used"):
+        return "tool_loop"
+    if l1_result.model:
+        return "initial_model_evidence"
+    return "deterministic_evidence"
+
+
+def build_log_unavailable_trace(
+    result: AnalysisResult,
+    execution_context: AnalysisExecutionContext | None,
+    reason: str,
+    *,
+    total_wall_clock_s: float,
+) -> dict[str, Any]:
+    return {
+        "context_mode": "log_unavailable",
+        "request": execution_context.request.to_payload() if execution_context else None,
+        "log_path": execution_context.log_path if execution_context else None,
+        "job_id": execution_context.job_id if execution_context else None,
+        "cycle_id": execution_context.cycle_id if execution_context else None,
+        "result_provenance": dict(result.result_provenance),
+        "external_output": result.to_payload(),
+        "timing": {
+            "total_wall_clock_s": total_wall_clock_s,
+            "l0_wall_clock_s": 0.0,
+            "l0a_wall_clock_s": 0.0,
+            "l0b_wall_clock_s": 0.0,
+            "l1_wall_clock_s": 0.0,
+            "l1_model_call_wall_clock_s": 0.0,
+            "l1_tool_wall_clock_s": 0.0,
+            "l2_wall_clock_s": 0.0,
+            "l3_wall_clock_s": 0.0,
+            "l4_wall_clock_s": 0.0,
+            "l1_model_calls": 0,
+            "l1_tool_calls": 0,
+        },
+        "latency_measurement": {
+            "mode": "terminal_request_to_result",
+            "terminal_total_wall_clock_s": total_wall_clock_s,
+            "post_progressive_end_wall_clock_s": None,
+            "production_gate_measured": False,
+        },
+        "layers": {
+            "L0": {
+                "name": "evidence_assembly_and_projection",
+                "wall_clock_s": 0.0,
+                "status": "log_unavailable",
+                "sub_stages": {
+                    "L0A": {
+                        "name": "complete_evidence_assembly",
+                        "wall_clock_s": 0.0,
+                        "status": "log_unavailable",
+                    },
+                    "L0B": {
+                        "name": "initial_model_evidence_view",
+                        "wall_clock_s": 0.0,
+                        "status": "not_run",
+                    },
+                },
+            },
+            "L1": {
+                "name": "semantic_analysis",
+                "wall_clock_s": 0.0,
+                "status": "not_run",
+            },
+            "L2": {
+                "name": "evidence_grounding_and_identity",
+                "wall_clock_s": 0.0,
+                "grounding_status": "not_run",
+                "audit_status": "not_run",
+                "not_run_reason": "log_unavailable",
+            },
+            "L3": {
+                "name": "history_enrichment",
+                "wall_clock_s": 0.0,
+                "selected_failure_facts_source": None,
+                "history_identity_ready": False,
+                "history_available": False,
+                "same_job_attempts": 0,
+                "matching_root_attempts": 0,
+                "observed_advance_attempts": 0,
+                "no_observed_advance_attempts": 0,
+                "unknown_progress_attempts": 0,
+            },
+            "L4": {
+                "name": "policy_decision",
+                "wall_clock_s": 0.0,
+                "decision": result.decision,
+                "decision_basis": result.decision_basis,
+                "result_quality": result.result_provenance.get("result_quality"),
+            },
+        },
+        "selected_failure_facts": None,
+        "l2_grounded_semantics": None,
+        "l2_audit": {
+            "used": False,
+            "grounding_status": "not_run",
+            "audit_status": "not_run",
+            "not_run_reason": "log_unavailable",
+        },
+        "l3_history": {"available": False},
+        "l0_model_view": None,
+        "l4_policy": {
+            "decision": result.decision,
+            "decision_basis": result.decision_basis,
+            "retry_policy": dict(result.retry_policy),
+            "history_inputs": {"available": False},
+            "result_provenance": dict(result.result_provenance),
+        },
+        "anomalies": {"log_unavailable": True, "reason": reason},
+    }

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/pipeline.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/pipeline.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small public facade over restart-agent run coordinators."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Callable, Mapping, Sequence
+
+from .execution import AnalysisRun, CollectAllAnalysisRun, L0Artifacts
+from .infrastructure.log_source import LocalLogSource
+from .l0.streaming import FinalizedL0A
+from .l1 import (
+    DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+    EvidenceExtractor,
+    EvidenceToolsFactory,
+    ModelRoute,
+)
+from .models import (
+    AnalysisExecutionContext,
+    AttemptRecord,
+    DecisionCandidate,
+    DeclaredRecoveryCapability,
+    L0Bundle,
+    ModelAnalysisResult,
+    PriorAttemptView,
+    RestartAgentRequest,
+    build_analysis_execution_context,
+    normalize_restart_agent_request,
+)
+from .multi_route import FutureWaiter, LogSourceFactory, MultiRouteCoordinator, RouteRunnerFactory
+from .preparation import prepare_finalized_analysis, validate_timeout_seconds
+from .runtime import SYSTEM_CLOCK, THREAD_EXECUTOR_FACTORY, Clock, ExecutorFactory
+from .single_run import SingleRunCoordinator
+
+
+class RestartAgent:
+    """Run terminal analysis without retaining invocation-owned artifacts."""
+
+    def __init__(
+        self,
+        evidence_extractor: EvidenceExtractor | None = None,
+        *,
+        log_source_factory: LogSourceFactory = LocalLogSource,
+        route_runner_factory: RouteRunnerFactory | None = None,
+        evidence_tools_factory: EvidenceToolsFactory | None = None,
+        clock: Clock = SYSTEM_CLOCK,
+        executor_factory: ExecutorFactory = THREAD_EXECUTOR_FACTORY,
+        future_waiter: FutureWaiter | None = None,
+        retry_policy: Mapping[str, Any] | None = None,
+        declared_recovery_capabilities: (
+            Sequence[DeclaredRecoveryCapability | Mapping[str, Any]] | None
+        ) = None,
+    ) -> None:
+        self._retry_policy = retry_policy
+        self._declared_recovery_capabilities = declared_recovery_capabilities
+        self._clock = clock
+        self._single_run = SingleRunCoordinator(
+            evidence_extractor=evidence_extractor,
+            log_source_factory=log_source_factory,
+            evidence_tools_factory=evidence_tools_factory,
+            clock=clock,
+            executor_factory=executor_factory,
+        )
+        self._multi_route = MultiRouteCoordinator(
+            route_runner_factory=route_runner_factory,
+            log_source_factory=log_source_factory,
+            evidence_tools_factory=evidence_tools_factory,
+            clock=clock,
+            executor_factory=executor_factory,
+            future_waiter=future_waiter,
+        )
+
+    def run(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        *,
+        l0_bundle: L0Bundle | None = None,
+        prior_attempts: PriorAttemptView | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        timeout_seconds: float = DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+        retain_detailed_artifacts: bool = True,
+    ) -> AnalysisRun:
+        run = self._single_run.run(
+            self._execution_context(request, prior_attempts=prior_attempts),
+            l0_bundle=l0_bundle,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            timeout_seconds=timeout_seconds,
+        )
+        return _retained_single_run(run, retain_detailed_artifacts)
+
+    def run_many(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        model_routes: Sequence[ModelRoute],
+        *,
+        l0_bundle: L0Bundle | None = None,
+        prior_attempts: PriorAttemptView | None = None,
+        max_parallel_models: int | None = None,
+        config_metadata: Mapping[str, Any] | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None = None,
+        on_attempt_record_ready: Callable[[str, AttemptRecord], None] | None = None,
+        timeout_seconds: float = DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+        retain_detailed_artifacts: bool = True,
+    ) -> CollectAllAnalysisRun:
+        return self._multi_route.run_many(
+            self._execution_context(request, prior_attempts=prior_attempts),
+            model_routes,
+            l0_bundle=l0_bundle,
+            max_parallel_models=max_parallel_models,
+            config_metadata=config_metadata,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            on_route_complete=on_route_complete,
+            on_attempt_record_ready=on_attempt_record_ready,
+            timeout_seconds=timeout_seconds,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+
+    def run_prepared(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        finalized_l0a: FinalizedL0A,
+        *,
+        prior_attempts: PriorAttemptView | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        timeout_seconds: float = DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+        retain_detailed_artifacts: bool = True,
+    ) -> AnalysisRun:
+        """Run one route without rereading or rebuilding caller-finalized L0A."""
+
+        timeout_seconds = validate_timeout_seconds(timeout_seconds)
+        prepared = prepare_finalized_analysis(
+            self._execution_context(request, prior_attempts=prior_attempts),
+            finalized_l0a,
+            include_model_view=self._single_run.has_evidence_extractor,
+            clock=self._clock,
+        )
+        run = self._single_run.run_prepared(
+            prepared,
+            deadline_monotonic=prepared.analysis_started + timeout_seconds,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+        )
+        return _retained_single_run(run, retain_detailed_artifacts)
+
+    def run_many_prepared(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        finalized_l0a: FinalizedL0A,
+        model_routes: Sequence[ModelRoute],
+        *,
+        prior_attempts: PriorAttemptView | None = None,
+        max_parallel_models: int | None = None,
+        config_metadata: Mapping[str, Any] | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        on_route_complete: Callable[[ModelAnalysisResult, Mapping[str, Any]], None] | None = None,
+        on_attempt_record_ready: Callable[[str, AttemptRecord], None] | None = None,
+        timeout_seconds: float = DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+        retain_detailed_artifacts: bool = True,
+    ) -> CollectAllAnalysisRun:
+        """Run model routes without rereading caller-finalized L0A."""
+
+        prepared = prepare_finalized_analysis(
+            self._execution_context(request, prior_attempts=prior_attempts),
+            finalized_l0a,
+            include_model_view=True,
+            clock=self._clock,
+        )
+        return self._multi_route.run_many_prepared(
+            prepared,
+            model_routes,
+            max_parallel_models=max_parallel_models,
+            config_metadata=config_metadata,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            on_route_complete=on_route_complete,
+            on_attempt_record_ready=on_attempt_record_ready,
+            timeout_seconds=timeout_seconds,
+            retain_detailed_artifacts=retain_detailed_artifacts,
+        )
+
+    def _execution_context(
+        self,
+        request: RestartAgentRequest | Mapping[str, Any],
+        *,
+        prior_attempts: PriorAttemptView | None = None,
+    ) -> AnalysisExecutionContext:
+        normalized_request = normalize_restart_agent_request(request)
+        return build_analysis_execution_context(
+            normalized_request,
+            prior_attempts=prior_attempts,
+            retry_policy=self._retry_policy,
+            declared_recovery_capabilities=self._declared_recovery_capabilities,
+        )
+
+
+def _retained_single_run(run: AnalysisRun, retain_detailed_artifacts: bool) -> AnalysisRun:
+    if retain_detailed_artifacts:
+        return run
+    return replace(
+        run,
+        trace={"retention_mode": "compact_service"},
+        bundle=None,
+        decision_evidence=None,
+        model_view=None,
+        deterministic_candidate=None,
+    )

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/preparation.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/preparation.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Library entrypoint for restart-policy decisions."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, replace
+from typing import Callable, TypeVar
+
+from .execution import L0Artifacts
+from .infrastructure.log_source import LocalLogSource, LogSnapshot, LogSource
+from .l0 import build_l0_model_facing_view
+from .l0.streaming import FinalizedL0A, ProgressiveL0Accumulator, finalize_log_snapshot
+from .models import (
+    AnalysisExecutionContext,
+    AnalysisMode,
+    DecisionEvidence,
+    L0Bundle,
+    L0ModelFacingView,
+)
+from .runtime import SYSTEM_CLOCK, Clock
+
+_T = TypeVar("_T")
+LogSourceFactory = Callable[[str], LogSource]
+
+
+@dataclass(frozen=True)
+class PreparedAnalysis:
+    clock: Clock
+    analysis_started: float
+    execution_context: AnalysisExecutionContext
+    bundle: L0Bundle | None
+    decision_evidence: DecisionEvidence | None
+    model_view: L0ModelFacingView | None
+    source_log: LogSnapshot | None
+    unavailable_reason: str | None
+    l0a_wall_clock_s: float = 0.0
+    decision_evidence_wall_clock_s: float = 0.0
+    l0b_wall_clock_s: float = 0.0
+    l0_wall_clock_s: float = 0.0
+    l0_reused: bool = False
+    l0_canonical_hash: str | None = None
+    progressive_metrics: dict[str, object] | None = None
+
+
+def prepare_analysis(
+    execution_context: AnalysisExecutionContext,
+    *,
+    l0_bundle: L0Bundle | None,
+    include_model_view: bool,
+    log_source_factory: LogSourceFactory = LocalLogSource,
+    clock: Clock = SYSTEM_CLOCK,
+) -> PreparedAnalysis:
+    analysis_started = clock.monotonic()
+    execution_context = _snapshot_execution_context(execution_context)
+    if execution_context.analysis_mode != AnalysisMode.TERMINAL.value:
+        raise NotImplementedError(
+            f"analysis_mode={execution_context.analysis_mode!r} is not implemented"
+        )
+
+    source = log_source_factory(execution_context.log_path)
+    if source.path != execution_context.log_path:
+        raise ValueError("log source path does not match runtime input")
+    unavailable = source.unavailable_reason()
+    if unavailable is not None:
+        return PreparedAnalysis(
+            clock=clock,
+            analysis_started=analysis_started,
+            execution_context=execution_context,
+            bundle=None,
+            decision_evidence=None,
+            model_view=None,
+            source_log=None,
+            unavailable_reason=unavailable,
+            l0_reused=l0_bundle is not None,
+        )
+
+    if l0_bundle is None and isinstance(source, LocalLogSource):
+        finalized = ProgressiveL0Accumulator(
+            source.path,
+            reader=source.chunk_reader,
+            clock=clock,
+        ).finalize()
+    else:
+        finalized = finalize_log_snapshot(
+            source.snapshot(),
+            l0_bundle=l0_bundle,
+            clock=clock,
+        )
+    if finalized.bundle.log_path != execution_context.log_path:
+        raise ValueError("replayed L0 bundle log_path does not match runtime input")
+    return _prepare_finalized_analysis(
+        execution_context,
+        finalized,
+        include_model_view=include_model_view,
+        clock=clock,
+        analysis_started=analysis_started,
+        l0_reused=l0_bundle is not None,
+    )
+
+
+def prepare_finalized_analysis(
+    execution_context: AnalysisExecutionContext,
+    finalized: FinalizedL0A,
+    *,
+    include_model_view: bool,
+    clock: Clock = SYSTEM_CLOCK,
+) -> PreparedAnalysis:
+    """Build route-ready input from a caller-owned terminal L0A boundary."""
+
+    return _prepare_finalized_analysis(
+        _snapshot_execution_context(execution_context),
+        finalized,
+        include_model_view=include_model_view,
+        clock=clock,
+        analysis_started=clock.monotonic(),
+        l0_reused=True,
+    )
+
+
+def _prepare_finalized_analysis(
+    execution_context: AnalysisExecutionContext,
+    finalized: FinalizedL0A,
+    *,
+    include_model_view: bool,
+    clock: Clock,
+    analysis_started: float,
+    l0_reused: bool,
+) -> PreparedAnalysis:
+    if finalized.bundle.log_path != execution_context.log_path:
+        raise ValueError("finalized L0A log_path does not match runtime input")
+    model_view = None
+    l0b_wall_clock_s = 0.0
+    if include_model_view:
+        l0b_started = clock.monotonic()
+        model_view = build_l0_model_facing_view(
+            finalized.bundle,
+            finalized.decision_evidence,
+        )
+        l0b_wall_clock_s = round(clock.monotonic() - l0b_started, 3)
+
+    return PreparedAnalysis(
+        clock=clock,
+        analysis_started=analysis_started,
+        execution_context=execution_context,
+        bundle=finalized.bundle,
+        decision_evidence=finalized.decision_evidence,
+        model_view=model_view,
+        source_log=finalized.source_log,
+        unavailable_reason=None,
+        l0a_wall_clock_s=finalized.l0a_wall_clock_s,
+        decision_evidence_wall_clock_s=finalized.decision_evidence_wall_clock_s,
+        l0b_wall_clock_s=l0b_wall_clock_s,
+        l0_wall_clock_s=round(
+            finalized.l0a_wall_clock_s
+            + finalized.decision_evidence_wall_clock_s
+            + l0b_wall_clock_s,
+            3,
+        ),
+        l0_reused=l0_reused,
+        l0_canonical_hash=finalized.canonical_hash,
+        progressive_metrics=dict(finalized.progressive_metrics),
+    )
+
+
+def _snapshot_execution_context(
+    execution_context: AnalysisExecutionContext,
+) -> AnalysisExecutionContext:
+    return replace(
+        execution_context,
+        request=replace(execution_context.request),
+        prior_attempts=deepcopy(execution_context.prior_attempts),
+        retry_policy=deepcopy(dict(execution_context.retry_policy)),
+        declared_recovery_capabilities=tuple(execution_context.declared_recovery_capabilities),
+    )
+
+
+def validate_timeout_seconds(timeout_seconds: float) -> float:
+    if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, (int, float)):
+        raise TypeError("timeout_seconds must be a number")
+    value = float(timeout_seconds)
+    if value <= 0:
+        raise ValueError("timeout_seconds must be greater than zero")
+    return value
+
+
+def remaining_deadline_seconds(
+    deadline_monotonic: float,
+    *,
+    clock: Clock = SYSTEM_CLOCK,
+) -> float:
+    return max(0.0, deadline_monotonic - clock.monotonic())
+
+
+def l0_artifacts(prepared: PreparedAnalysis) -> L0Artifacts:
+    if prepared.bundle is None or prepared.decision_evidence is None:
+        raise AssertionError("prepared analysis is missing L0 evidence")
+    return L0Artifacts(
+        bundle=prepared.bundle,
+        decision_evidence=prepared.decision_evidence,
+        model_view=prepared.model_view,
+        l0a_wall_clock_s=prepared.l0a_wall_clock_s,
+        decision_evidence_wall_clock_s=prepared.decision_evidence_wall_clock_s,
+        l0b_wall_clock_s=prepared.l0b_wall_clock_s,
+        l0_wall_clock_s=prepared.l0_wall_clock_s,
+        l0_reused=prepared.l0_reused,
+    )
+
+
+def notify_l0_ready(
+    callback: Callable[[L0Artifacts], None] | None,
+    artifacts: L0Artifacts,
+    *,
+    clock: Clock = SYSTEM_CLOCK,
+) -> tuple[str | None, float]:
+    return notify_ready(callback, artifacts, clock=clock)
+
+
+def notify_ready(
+    callback: Callable[[_T], None] | None,
+    value: _T,
+    *,
+    clock: Clock = SYSTEM_CLOCK,
+) -> tuple[str | None, float]:
+    """Invoke a non-critical publication callback and measure its cost."""
+
+    if callback is None:
+        return None, 0.0
+    callback_started = clock.monotonic()
+    error = None
+    try:
+        callback(value)
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    return error, round(clock.monotonic() - callback_started, 3)

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/runtime.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/runtime.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replaceable runtime services used by orchestration and provider adapters."""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import Executor, ThreadPoolExecutor
+from datetime import datetime, timezone
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """Monotonic and wall-clock time source."""
+
+    def monotonic(self) -> float: ...
+
+    def now_utc(self) -> datetime: ...
+
+
+class SystemClock:
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+    def now_utc(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+class Sleeper(Protocol):
+    def sleep(self, seconds: float) -> None: ...
+
+
+class SystemSleeper:
+    def sleep(self, seconds: float) -> None:
+        time.sleep(seconds)
+
+
+class ExecutorFactory(Protocol):
+    """Create an executor without exposing a concrete thread implementation."""
+
+    def __call__(self, *, max_workers: int, thread_name_prefix: str) -> Executor: ...
+
+
+class ThreadExecutorFactory:
+    def __call__(self, *, max_workers: int, thread_name_prefix: str) -> Executor:
+        return ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix=thread_name_prefix,
+        )
+
+
+SYSTEM_CLOCK = SystemClock()
+SYSTEM_SLEEPER = SystemSleeper()
+THREAD_EXECUTOR_FACTORY = ThreadExecutorFactory()

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/single_run.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/single_run.py
@@ -1,0 +1,464 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single-run restart-agent coordination."""
+
+from __future__ import annotations
+
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from .decision_pipeline import DecisionOutcome, build_decision_outcome
+from .execution import AnalysisRun, L0Artifacts
+from .infrastructure.log_source import LocalLogSource, LogSnapshot, LogSource
+from .l1 import (
+    DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+    EvidenceExtractor,
+    EvidenceToolsFactory,
+    L1EvidenceResult,
+    deadline_exceeded_result,
+    extract_timed,
+    output_health,
+)
+from .l2 import L2GroundingInput, L2Result, ground_and_audit_model_evidence
+from .models import (
+    AnalysisExecutionContext,
+    DecisionCandidate,
+    DecisionCandidateKind,
+    DecisionEvidence,
+    L0Bundle,
+    L0ModelFacingView,
+    log_unavailable_result,
+)
+from .observability import (
+    DecisionTraceInputs,
+    build_decision_trace,
+    build_log_unavailable_trace,
+    history_trace,
+)
+from .preparation import (
+    PreparedAnalysis,
+    l0_artifacts,
+    notify_l0_ready,
+    notify_ready,
+    prepare_analysis,
+    remaining_deadline_seconds,
+    validate_timeout_seconds,
+)
+from .runtime import SYSTEM_CLOCK, THREAD_EXECUTOR_FACTORY, Clock, ExecutorFactory
+
+
+class SingleRunCoordinator:
+    """Coordinate one deterministic and optionally model-enriched analysis run.
+
+    L0A always builds the complete deterministic evidence bundle first. When an
+    evidence extractor is supplied, L0B projects that bundle into the bounded
+    model-facing view consumed by L1. L0 matches are candidate evidence; they do
+    not produce semantic STOP decisions by themselves.
+    """
+
+    def __init__(
+        self,
+        evidence_extractor: EvidenceExtractor | None = None,
+        log_source_factory: Callable[[str], LogSource] = LocalLogSource,
+        evidence_tools_factory: EvidenceToolsFactory | None = None,
+        clock: Clock = SYSTEM_CLOCK,
+        executor_factory: ExecutorFactory = THREAD_EXECUTOR_FACTORY,
+    ):
+        self._evidence_extractor = evidence_extractor
+        self._log_source_factory = log_source_factory
+        self._evidence_tools_factory = evidence_tools_factory
+        self._clock = clock
+        self._executor_factory = executor_factory
+
+    @property
+    def has_evidence_extractor(self) -> bool:
+        return self._evidence_extractor is not None
+
+    def run(
+        self,
+        execution_context: AnalysisExecutionContext,
+        *,
+        l0_bundle: L0Bundle | None = None,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        timeout_seconds: float = DEFAULT_ANALYSIS_TIMEOUT_SECONDS,
+        route_id: str = "single",
+    ) -> AnalysisRun:
+        """Return the result and all artifacts owned by this invocation."""
+
+        timeout_seconds = validate_timeout_seconds(timeout_seconds)
+        prepared = prepare_analysis(
+            execution_context,
+            l0_bundle=l0_bundle,
+            include_model_view=self._evidence_extractor is not None,
+            log_source_factory=self._log_source_factory,
+            clock=self._clock,
+        )
+        return self.run_prepared(
+            prepared,
+            deadline_monotonic=prepared.analysis_started + timeout_seconds,
+            on_l0_ready=on_l0_ready,
+            on_deterministic_ready=on_deterministic_ready,
+            route_id=route_id,
+        )
+
+    def run_prepared(
+        self,
+        prepared: PreparedAnalysis,
+        *,
+        deadline_monotonic: float,
+        on_l0_ready: Callable[[L0Artifacts], None] | None = None,
+        on_deterministic_ready: Callable[[DecisionCandidate], None] | None = None,
+        route_id: str = "single",
+    ) -> AnalysisRun:
+        """Execute one route over immutable evidence prepared by the caller."""
+
+        analysis_started = prepared.analysis_started
+        execution_context = prepared.execution_context
+
+        if prepared.unavailable_reason is not None:
+            result = log_unavailable_result(prepared.unavailable_reason)
+            trace = build_log_unavailable_trace(
+                result,
+                execution_context,
+                prepared.unavailable_reason,
+                total_wall_clock_s=round(prepared.clock.monotonic() - analysis_started, 3),
+            )
+            return AnalysisRun(result=result, trace=trace)
+
+        bundle = prepared.bundle
+        decision_evidence = prepared.decision_evidence
+        if bundle is None or decision_evidence is None:
+            raise AssertionError("prepared analysis is missing L0 evidence")
+        l0_callback_error, l0_callback_wall_clock_s = notify_l0_ready(
+            on_l0_ready,
+            l0_artifacts(prepared),
+            clock=prepared.clock,
+        )
+        should_run_l1 = self._evidence_extractor is not None
+        model_view = prepared.model_view if should_run_l1 else None
+        deterministic = _publish_deterministic_recommendation(
+            prepared=prepared,
+            bundle=bundle,
+            decision_evidence=decision_evidence,
+            enrichment_enabled=should_run_l1,
+            on_deterministic_ready=on_deterministic_ready,
+            route_id=route_id,
+        )
+
+        if should_run_l1:
+            extractor = self._evidence_extractor
+            if extractor is None:
+                raise AssertionError("L1 was selected without an evidence extractor")
+            if model_view is None:
+                raise AssertionError("L1 was selected without an L0B model-facing view")
+            enrichment = _run_enrichment(
+                extractor=extractor,
+                prepared=prepared,
+                bundle=bundle,
+                decision_evidence=decision_evidence,
+                model_view=model_view,
+                deadline_monotonic=deadline_monotonic,
+                evidence_tools_factory=self._evidence_tools_factory,
+                executor_factory=self._executor_factory,
+                route_id=route_id,
+            )
+        else:
+            enrichment = _EnrichmentRun.disabled()
+
+        selected_candidate_kind = (
+            DecisionCandidateKind.L1_ENRICHED.value
+            if enrichment.l2_result.used
+            else DecisionCandidateKind.DETERMINISTIC.value
+        )
+        outcome = (
+            build_decision_outcome(
+                bundle=bundle,
+                decision_evidence=decision_evidence,
+                execution_context=execution_context,
+                l1_configured=True,
+                l1_result=enrichment.l1_result,
+                l1_output_health=enrichment.l1_output_health,
+                l2_result=enrichment.l2_result,
+                candidate_kind=selected_candidate_kind,
+                l1_pending=False,
+                route_id=route_id,
+                clock=prepared.clock,
+            )
+            if should_run_l1
+            else deterministic.outcome
+        )
+        trace = _build_single_run_trace(
+            prepared=prepared,
+            enrichment=enrichment,
+            deterministic=deterministic,
+            l1_configured=should_run_l1,
+            outcome=outcome,
+            selected_candidate_kind=selected_candidate_kind,
+            deadline_monotonic=deadline_monotonic,
+        )
+        trace["l0_ready_callback"] = {
+            "error": l0_callback_error,
+            "wall_clock_s": l0_callback_wall_clock_s,
+        }
+        return AnalysisRun(
+            result=outcome.result,
+            trace=trace,
+            bundle=bundle,
+            decision_evidence=decision_evidence,
+            model_view=model_view,
+            deterministic_candidate=deterministic.candidate,
+            attempt_record=outcome.attempt_record,
+        )
+
+
+def _build_single_run_trace(
+    *,
+    prepared: PreparedAnalysis,
+    enrichment: "_EnrichmentRun",
+    deterministic: "_DeterministicPublication",
+    l1_configured: bool,
+    outcome: Any,
+    selected_candidate_kind: str,
+    deadline_monotonic: float,
+) -> dict[str, Any]:
+    bundle = prepared.bundle
+    decision_evidence = prepared.decision_evidence
+    if bundle is None or decision_evidence is None:
+        raise AssertionError("prepared analysis is missing L0 evidence")
+    trace = build_decision_trace(
+        DecisionTraceInputs(
+            execution_context=prepared.execution_context,
+            result=outcome.result,
+            bundle=bundle,
+            decision_evidence=decision_evidence,
+            primary=outcome.primary,
+            l2_primary=outcome.l2_primary,
+            total_wall_clock_s=round(
+                prepared.clock.monotonic() - prepared.analysis_started,
+                3,
+            ),
+            l0_wall_clock_s=prepared.l0_wall_clock_s,
+            l0a_wall_clock_s=prepared.l0a_wall_clock_s,
+            decision_evidence_wall_clock_s=prepared.decision_evidence_wall_clock_s,
+            l0b_wall_clock_s=prepared.l0b_wall_clock_s,
+            model_view=prepared.model_view if enrichment.l1_result.model else None,
+            l1_configured=l1_configured,
+            l1_result=enrichment.l1_result,
+            l1_output_health=enrichment.l1_output_health,
+            l1_wall_clock_s=enrichment.l1_wall_clock_s,
+            l2_audit=outcome.l2_audit,
+            deterministic_failure_facts=outcome.deterministic_failure_facts,
+            selected_failure_facts=outcome.selected_failure_facts,
+            history=outcome.history,
+            retry_policy=outcome.retry_policy,
+            l0_reused=prepared.l0_reused,
+            l2_wall_clock_s=enrichment.l2_wall_clock_s,
+            l3_wall_clock_s=outcome.l3_wall_clock_s,
+            l4_wall_clock_s=outcome.l4_wall_clock_s,
+            deterministic_candidate=deterministic.candidate,
+            selected_candidate_kind=selected_candidate_kind,
+            deterministic_callback_error=deterministic.callback_error,
+            deterministic_callback_wall_clock_s=deterministic.callback_wall_clock_s,
+            analysis_timeout_seconds=round(
+                deadline_monotonic - prepared.analysis_started,
+                3,
+            ),
+        )
+    )
+    trace["l0_source"] = {
+        "canonical_hash": prepared.l0_canonical_hash,
+        "read_mode": (prepared.source_log.read_mode if prepared.source_log is not None else None),
+        "storage_mode": (
+            prepared.source_log.storage_mode if prepared.source_log is not None else None
+        ),
+        "progressive": dict(prepared.progressive_metrics or {}),
+    }
+    return trace
+
+
+@dataclass(frozen=True)
+class _EnrichmentRun:
+    l1_result: L1EvidenceResult
+    l1_output_health: Mapping[str, Any]
+    l2_result: L2Result
+    l1_wall_clock_s: float
+    l2_wall_clock_s: float
+
+    @classmethod
+    def disabled(cls) -> "_EnrichmentRun":
+        l1_result = L1EvidenceResult.disabled()
+        return cls(
+            l1_result=l1_result,
+            l1_output_health=output_health(l1_result),
+            l2_result=L2Result.not_run("l1_not_run"),
+            l1_wall_clock_s=0.0,
+            l2_wall_clock_s=0.0,
+        )
+
+
+@dataclass(frozen=True)
+class _DeterministicPublication:
+    outcome: DecisionOutcome
+    candidate: DecisionCandidate
+    callback_error: str | None
+    callback_wall_clock_s: float
+
+
+def _publish_deterministic_recommendation(
+    *,
+    prepared: PreparedAnalysis,
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+    enrichment_enabled: bool,
+    on_deterministic_ready: Callable[[DecisionCandidate], None] | None,
+    route_id: str,
+) -> _DeterministicPublication:
+    l1_result = L1EvidenceResult.disabled()
+    l1_health = (
+        {"status": "pending", "usable": False, "errors": []}
+        if enrichment_enabled
+        else output_health(l1_result)
+    )
+    outcome = build_decision_outcome(
+        bundle=bundle,
+        decision_evidence=decision_evidence,
+        execution_context=prepared.execution_context,
+        l1_configured=enrichment_enabled,
+        l1_result=l1_result,
+        l1_output_health=l1_health,
+        l2_result=L2Result.not_run("l1_pending" if enrichment_enabled else "l1_not_run"),
+        candidate_kind=DecisionCandidateKind.DETERMINISTIC.value,
+        l1_pending=enrichment_enabled,
+        route_id=route_id,
+        clock=prepared.clock,
+    )
+    candidate = DecisionCandidate(
+        candidate_kind=DecisionCandidateKind.DETERMINISTIC.value,
+        result=outcome.result,
+        ready_wall_clock_s=round(
+            prepared.clock.monotonic() - prepared.analysis_started,
+            3,
+        ),
+        l1_execution_status="in_flight" if enrichment_enabled else "not_run",
+        history_summary=history_trace(outcome.history),
+        stage_timings={
+            "l0_wall_clock_s": prepared.l0_wall_clock_s,
+            "l0a_wall_clock_s": prepared.l0a_wall_clock_s,
+            "decision_evidence_wall_clock_s": prepared.decision_evidence_wall_clock_s,
+            "l0b_wall_clock_s": prepared.l0b_wall_clock_s,
+            "l3_wall_clock_s": outcome.l3_wall_clock_s,
+            "l4_wall_clock_s": outcome.l4_wall_clock_s,
+        },
+    )
+    callback_error, callback_wall_clock_s = notify_ready(
+        on_deterministic_ready,
+        candidate,
+        clock=prepared.clock,
+    )
+    return _DeterministicPublication(
+        outcome=outcome,
+        candidate=candidate,
+        callback_error=callback_error,
+        callback_wall_clock_s=callback_wall_clock_s,
+    )
+
+
+def _run_enrichment(
+    *,
+    extractor: EvidenceExtractor,
+    prepared: PreparedAnalysis,
+    bundle: L0Bundle,
+    decision_evidence: DecisionEvidence,
+    model_view: L0ModelFacingView,
+    deadline_monotonic: float,
+    evidence_tools_factory: EvidenceToolsFactory | None,
+    executor_factory: ExecutorFactory,
+    route_id: str,
+) -> _EnrichmentRun:
+    l1_result, l1_wall_clock_s = _run_l1_until_deadline(
+        extractor,
+        bundle,
+        model_view,
+        _prepared_source_log(prepared),
+        deadline_monotonic,
+        prepared.analysis_started,
+        evidence_tools_factory,
+        prepared.clock,
+        executor_factory,
+    )
+    l1_output_health = output_health(l1_result)
+    if l1_output_health["usable"]:
+        l2_started = prepared.clock.monotonic()
+        l2_result = ground_and_audit_model_evidence(
+            L2GroundingInput(
+                bundle=bundle,
+                model_view=model_view,
+                l1_result=l1_result,
+                source_log=_prepared_source_log(prepared),
+            )
+        )
+        l2_wall_clock_s = round(prepared.clock.monotonic() - l2_started, 3)
+    else:
+        l2_result = L2Result.not_run("l1_output_unusable")
+        l2_wall_clock_s = 0.0
+    return _EnrichmentRun(
+        l1_result=l1_result,
+        l1_output_health=l1_output_health,
+        l2_result=l2_result,
+        l1_wall_clock_s=l1_wall_clock_s,
+        l2_wall_clock_s=l2_wall_clock_s,
+    )
+
+
+def _run_l1_until_deadline(
+    extractor: EvidenceExtractor,
+    bundle: L0Bundle,
+    model_view: L0ModelFacingView,
+    source_log: LogSnapshot,
+    deadline_monotonic: float,
+    analysis_started: float,
+    evidence_tools_factory: EvidenceToolsFactory | None,
+    clock: Clock,
+    executor_factory: ExecutorFactory,
+) -> tuple[L1EvidenceResult, float]:
+    if remaining_deadline_seconds(deadline_monotonic, clock=clock) <= 0:
+        return (
+            deadline_exceeded_result(model=type(extractor).__name__),
+            round(clock.monotonic() - analysis_started, 3),
+        )
+    pool = executor_factory(max_workers=1, thread_name_prefix="restart-agent-l1")
+    future = pool.submit(
+        extract_timed,
+        extractor,
+        bundle,
+        model_view,
+        source_log,
+        deadline_monotonic,
+        evidence_tools_factory,
+        clock,
+    )
+    try:
+        try:
+            l1_result, wall_clock_s, completed_monotonic = future.result(
+                timeout=remaining_deadline_seconds(deadline_monotonic, clock=clock)
+            )
+            if completed_monotonic > deadline_monotonic:
+                l1_result = deadline_exceeded_result(model=type(extractor).__name__)
+            return l1_result, wall_clock_s
+        except FutureTimeoutError:
+            future.cancel()
+            return (
+                deadline_exceeded_result(model=type(extractor).__name__),
+                round(clock.monotonic() - analysis_started, 3),
+            )
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+
+def _prepared_source_log(prepared: PreparedAnalysis) -> LogSnapshot:
+    if prepared.source_log is None:
+        raise AssertionError("prepared analysis is missing its source-log snapshot")
+    return prepared.source_log

--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -434,11 +434,8 @@ def _normalize_analysis_backend(value: Optional[str]) -> Optional[str]:
     normalized = str(value).strip().lower()
     if not normalized:
         return None
-    if normalized != "mcp":
-        raise ValueError(
-            "--ft-attribution-analysis-backend supports only 'mcp'; "
-            f"'lib' is no longer supported by launcher-managed attrsvc, got {value!r}"
-        )
+    if normalized not in {"lib", "mcp"}:
+        raise ValueError(f"--ft-attribution-analysis-backend must be 'lib' or 'mcp', got {value!r}")
     return normalized
 
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -410,11 +410,12 @@ def _add_attribution_args(parser: argparse.ArgumentParser) -> None:
         type=str.lower,
         default=None,
         dest="ft_attribution_analysis_backend",
-        choices=("mcp",),
-        metavar="mcp",
+        choices=("lib", "mcp"),
+        metavar="{lib,mcp}",
         help=(
             "Analysis backend for launcher-managed attribution service. "
-            "Only mcp is supported; use standalone nvrx-attrsvc for lib backend experiments."
+            "lib runs the Restart Agent directly and is the attrsvc default; "
+            "mcp selects the legacy LogSage/Flight Recorder path."
         ),
     )
     parser.add_argument(

--- a/src/nvidia_resiliency_ext/services/attrsvc/app.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/app.py
@@ -17,7 +17,7 @@ from typing import Any
 import uvicorn
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, Response
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, StrictInt, field_validator
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
@@ -105,6 +105,7 @@ class SubmitRequest(BaseModel):
     log_path: str
     user: str = "unknown"  # Optional: SLURM job user, for dataflow records
     job_id: str | None = None  # Optional: SLURM job ID, required for split logging mode
+    cycle_id: StrictInt | None = None
     analysis_intent: str = ANALYSIS_INTENT_TRACK_ONLY  # track_only, progressive, or terminal
 
     @field_validator("analysis_intent")
@@ -275,6 +276,7 @@ def create_app(cfg: Settings) -> FastAPI:
             req.log_path,
             req.user,
             req.job_id,
+            cycle_id=req.cycle_id,
             analysis_intent=req.analysis_intent,
         )
         if isinstance(result, LogAnalyzerError):

--- a/src/nvidia_resiliency_ext/services/attrsvc/config.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/config.py
@@ -119,9 +119,10 @@ def _normalize_optional_override(value: object) -> object:
 class Settings(BaseSettings):
     """Typed configuration loaded from environment/.env (pydantic-settings v2).
 
-    Attribution fields are translated into
-    :class:`~nvidia_resiliency_ext.attribution.controller.AttributionControllerConfig` by
-    :class:`~nvidia_resiliency_ext.services.attrsvc.service.AttributionHttpAdapter`; unset fields keep library defaults.
+    Attribution fields are translated into either a direct Restart Agent config
+    or the legacy controller config by
+    :class:`~nvidia_resiliency_ext.services.attrsvc.service.AttributionHttpAdapter`;
+    unset fields keep the selected implementation's defaults.
 
     ``LOG_LEVEL`` sets the root log level, FastAPI ``debug`` (when ``LOG_LEVEL`` is ``DEBUG``), MCP
     subprocess ``--log-level``, and verbosity for in-process MCP client loggers. Allowed values:
@@ -152,7 +153,7 @@ class Settings(BaseSettings):
         default=None, description="Timeout for compute_fn in seconds (None = library default)"
     )
 
-    # LLM settings -> AttributionControllerConfig when set (see AttributionHttpAdapter)
+    # LLM overrides resolved by the selected backend (see AttributionHttpAdapter).
     LLM_MODEL: str | None = Field(default=None, description="LLM model override")
     LLM_BASE_URL: str | None = Field(default=None, description="LLM base url override")
     LLM_TEMPERATURE: float | None = Field(
@@ -161,13 +162,62 @@ class Settings(BaseSettings):
     LLM_TOP_P: float | None = Field(default=None, description="LLM top-p for nucleus sampling")
     LLM_MAX_TOKENS: int | None = Field(default=None, description="Max tokens for LLM response")
 
-    # Log + FR analysis backend: "lib" = in-process, "mcp" = subprocess MCP (same stdio client)
+    # Analysis product selector retained under the existing backend setting for the first cut.
     ANALYSIS_BACKEND: str = Field(
-        default="mcp",
+        default="lib",
         description=(
-            "How to run LogSage and flight-recorder analysis: "
-            "'mcp' (subprocess MCP, default) or 'lib' (in-process)."
+            "Analysis implementation: 'lib' runs the Restart Agent directly in attrsvc "
+            "(default); 'mcp' preserves the legacy LogSage/flight-recorder MCP path."
         ),
+    )
+    RESTART_AGENT_CONFIG: str | None = Field(
+        default=None,
+        description=(
+            "Optional restart_agent_config.v1 JSON file for the lib backend. When unset, "
+            "attrsvc runs model-enriched analysis unless enrichment is explicitly disabled."
+        ),
+    )
+    RESTART_AGENT_ENRICHMENT_ENABLED: bool = Field(
+        default=True,
+        description=(
+            "Enable the model-enriched Restart Agent path when no explicit "
+            "RESTART_AGENT_CONFIG file is supplied; set false for deterministic-only analysis."
+        ),
+    )
+    RESTART_AGENT_LOG_QUIET_SECONDS: float = Field(
+        default=2.0,
+        description="Required unchanged-log interval before terminal Restart Agent analysis.",
+    )
+    RESTART_AGENT_LOG_MAX_WAIT_SECONDS: float = Field(
+        default=20.0,
+        description="Maximum terminal log-drain wait before Restart Agent analysis starts.",
+    )
+    RESTART_AGENT_LOG_POLL_SECONDS: float = Field(
+        default=0.25,
+        description="Log size/mtime polling interval during the bounded terminal drain wait.",
+    )
+    RESTART_AGENT_PROGRESSIVE_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Enable opt-in Restart Agent L0A polling before terminal submission. "
+            "Terminal-first analysis remains the default."
+        ),
+    )
+    RESTART_AGENT_PRE_END_POLL_SECONDS: float = Field(
+        default=180.0,
+        description="Metadata polling interval for progressive L0A precomputation.",
+    )
+    RESTART_AGENT_ACTIVE_IDLE_SECONDS: float = Field(
+        default=900.0,
+        description="No-growth interval after which progressive state becomes idle.",
+    )
+    RESTART_AGENT_MAX_ACTIVE_STATES: int = Field(
+        default=64,
+        description="Maximum retained non-finalized progressive L0A states.",
+    )
+    RESTART_AGENT_MAX_COMPLETED_RESULTS: int = Field(
+        default=3000,
+        description="Maximum retained completed Restart Agent service results.",
     )
     PROGRESSIVE_ANALYSIS: str = Field(
         default="all_explicit",
@@ -231,6 +281,54 @@ class Settings(BaseSettings):
         if v_lower not in allowed:
             raise ValueError(f"ANALYSIS_BACKEND must be one of {allowed}, got '{v}'")
         return v_lower
+
+    @field_validator("RESTART_AGENT_CONFIG", mode="before")
+    @classmethod
+    def normalize_restart_agent_config(cls, v: object) -> object:
+        return _normalize_optional_override(v)
+
+    @field_validator("RESTART_AGENT_CONFIG")
+    @classmethod
+    def validate_restart_agent_config(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        path = os.path.abspath(os.path.expanduser(v))
+        if not os.path.isfile(path):
+            raise ValueError(f"RESTART_AGENT_CONFIG is not a file: {path}")
+        if not os.access(path, os.R_OK):
+            raise ValueError(f"RESTART_AGENT_CONFIG is not readable: {path}")
+        return path
+
+    @field_validator(
+        "RESTART_AGENT_LOG_QUIET_SECONDS",
+        "RESTART_AGENT_LOG_MAX_WAIT_SECONDS",
+        "RESTART_AGENT_LOG_POLL_SECONDS",
+    )
+    @classmethod
+    def validate_restart_agent_timing(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("Restart Agent log-drain timing values must not be negative")
+        return v
+
+    @field_validator(
+        "RESTART_AGENT_PRE_END_POLL_SECONDS",
+        "RESTART_AGENT_ACTIVE_IDLE_SECONDS",
+    )
+    @classmethod
+    def validate_restart_agent_progressive_timing(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("Restart Agent progressive timing values must be positive")
+        return v
+
+    @field_validator(
+        "RESTART_AGENT_MAX_ACTIVE_STATES",
+        "RESTART_AGENT_MAX_COMPLETED_RESULTS",
+    )
+    @classmethod
+    def validate_restart_agent_bounds(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("Restart Agent state bounds must be greater than zero")
+        return v
 
     @field_validator("PROGRESSIVE_ANALYSIS")
     @classmethod

--- a/src/nvidia_resiliency_ext/services/attrsvc/restart_agent_backend.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/restart_agent_backend.py
@@ -1,0 +1,1071 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-process attrsvc backend for the Restart Agent runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field, replace
+from queue import SimpleQueue
+from threading import Event, RLock, Thread
+from typing import Any, Callable, Hashable, Mapping
+
+from nvidia_resiliency_ext.attribution.coalescing import (
+    CacheResult,
+    InflightResult,
+    SubmittedResult,
+)
+from nvidia_resiliency_ext.attribution.orchestration.config import ErrorCode
+from nvidia_resiliency_ext.attribution.orchestration.log_path_metadata import (
+    CYCLE_NUM_PATTERN,
+    extract_job_metadata,
+)
+from nvidia_resiliency_ext.attribution.orchestration.progressive import (
+    ANALYSIS_INTENT_PROGRESSIVE,
+    ANALYSIS_INTENT_TERMINAL,
+    normalize_analysis_intent,
+)
+from nvidia_resiliency_ext.attribution.orchestration.types import (
+    RECOMMENDATION_RESTART,
+    RECOMMENDATION_STOP,
+    RECOMMENDATION_UNKNOWN,
+    LogAnalysisCycleResult,
+    LogAnalyzerError,
+    LogAnalyzerFilePreview,
+    LogAnalyzerSubmitResult,
+)
+from nvidia_resiliency_ext.attribution.orchestration.utils import validate_log_path
+from nvidia_resiliency_ext.attribution.path_utils import path_is_under_allowed_root
+from nvidia_resiliency_ext.attribution.restart_agent import (
+    AnalysisResult,
+    DecisionCandidate,
+    ModelAnalysisResult,
+    ProgressiveL0Accumulator,
+    ProgressiveSourceUnavailable,
+    RestartAgentConfig,
+    RestartAgentRequest,
+    RestartAgentRuntime,
+)
+
+_STATUS_REGISTERED = "registered"
+_STATUS_ANALYZING = "analyzing"
+_STATUS_COMPLETED = "completed"
+_STATUS_FAILED = "failed"
+_PUBLIC_PENDING = "pending"
+_PUBLIC_IN_FLIGHT = "in_flight"
+_ELIGIBLE_NVRX_USES = frozenset({"eligible", "eligible_degraded"})
+
+
+@dataclass(frozen=True)
+class LogConvergencePolicy:
+    """Bounded wait for log-funnel writes visible after terminal notification."""
+
+    quiet_seconds: float = 2.0
+    max_wait_seconds: float = 20.0
+    poll_seconds: float = 0.25
+
+
+@dataclass(frozen=True)
+class _DrainOutcome:
+    converged: bool
+    max_wait_expired: bool
+    wall_clock_s: float = 0.0
+    poll_count: int = 0
+    growth_count: int = 0
+
+    @property
+    def include_incomplete_tail(self) -> bool:
+        return self.converged or not self.max_wait_expired
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "converged": self.converged,
+            "max_wait_expired": self.max_wait_expired,
+            "wall_clock_s": round(self.wall_clock_s, 6),
+            "poll_count": self.poll_count,
+            "growth_count": self.growth_count,
+        }
+
+
+@dataclass(frozen=True)
+class ProgressiveAnalysisPolicy:
+    """Service-owned scheduling and bounded-state policy."""
+
+    enabled: bool = False
+    pre_end_poll_seconds: float = 180.0
+    active_idle_seconds: float = 900.0
+    max_active_states: int = 64
+    max_completed_results: int = 3000
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.enabled, bool):
+            raise TypeError("enabled must be boolean")
+        for name in ("pre_end_poll_seconds", "active_idle_seconds"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be a number")
+            if value <= 0:
+                raise ValueError(f"{name} must be greater than zero")
+        for name in ("max_active_states", "max_completed_results"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value < 1:
+                raise ValueError(f"{name} must be greater than zero")
+        if self.active_idle_seconds < self.pre_end_poll_seconds:
+            raise ValueError("active_idle_seconds must be at least pre_end_poll_seconds")
+
+
+@dataclass
+class _AttemptExecution:
+    key: Hashable
+    log_path: str
+    user: str
+    job_id: str | None
+    cycle_id: int | None
+    status: str = _STATUS_REGISTERED
+    registered_at: float = field(default_factory=time.monotonic)
+    terminal_at: float | None = None
+    completed_at: float | None = None
+    future: Future[None] | None = None
+    best_result: AnalysisResult | None = None
+    best_source: str = ""
+    candidate_result: AnalysisResult | None = None
+    candidate_source: str = ""
+    final_result: AnalysisResult | None = None
+    error: str | None = None
+    deterministic_ready_count: int = 0
+    route_complete_count: int = 0
+    terminal_drain_wall_clock_s: float | None = None
+    terminal_l0a_ready_wall_clock_s: float | None = None
+    deterministic_ready_wall_clock_s: float | None = None
+    first_route_ready_wall_clock_s: float | None = None
+    analysis_completed_wall_clock_s: float | None = None
+    accumulator: ProgressiveL0Accumulator | None = None
+    precompute_future: Future[bool] | None = None
+    next_poll_at: float | None = None
+    progressive_phase: str = "not_started"
+    progressive_error: str | None = None
+    progressive_evicted: bool = False
+
+
+class RestartAgentServiceBackend:
+    """Adapt attrsvc's progressive HTTP lifecycle to one RestartAgentRuntime."""
+
+    DEFAULT_MAX_CONCURRENT_ATTEMPTS = 4
+
+    def __init__(
+        self,
+        *,
+        allowed_root: str,
+        runtime: RestartAgentRuntime,
+        config: RestartAgentConfig,
+        convergence: LogConvergencePolicy = LogConvergencePolicy(),
+        progressive: ProgressiveAnalysisPolicy = ProgressiveAnalysisPolicy(),
+        executor: ThreadPoolExecutor | None = None,
+        precompute_executor: ThreadPoolExecutor | None = None,
+        accumulator_factory: Callable[[str], ProgressiveL0Accumulator] = (ProgressiveL0Accumulator),
+    ) -> None:
+        self._allowed_root = os.path.realpath(allowed_root)
+        self._runtime = runtime
+        self._config = config
+        self._convergence = convergence
+        self._progressive = progressive
+        self._accumulator_factory = accumulator_factory
+        self._max_completed_results = progressive.max_completed_results
+        self._lock = RLock()
+        self._entries: dict[Hashable, _AttemptExecution] = {}
+        self._path_index: dict[str, Hashable] = {}
+        self._executor = executor or ThreadPoolExecutor(
+            max_workers=self.DEFAULT_MAX_CONCURRENT_ATTEMPTS,
+            thread_name_prefix="nvrx-restart-agent",
+        )
+        self._owns_executor = executor is None
+        self._precompute_executor = precompute_executor or ThreadPoolExecutor(
+            max_workers=min(2, progressive.max_active_states),
+            thread_name_prefix="nvrx-restart-agent-l0",
+        )
+        self._owns_precompute_executor = precompute_executor is None
+        self._scheduler_wakeup = Event()
+        self._scheduler = Thread(
+            target=self._schedule_progressive,
+            name="nvrx-restart-agent-progressive",
+            daemon=True,
+        )
+        self._shutdown = False
+        self._eviction_count = 0
+        self._execution_errors = 0
+        self._progressive_eviction_count = 0
+        self._progressive_precompute_errors = 0
+        self._scheduler.start()
+
+    def shutdown(self) -> None:
+        with self._lock:
+            self._shutdown = True
+        self._scheduler_wakeup.set()
+        self._scheduler.join(timeout=1.0)
+        if self._owns_executor:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+        if self._owns_precompute_executor:
+            self._precompute_executor.shutdown(wait=False, cancel_futures=True)
+        close_runtime = getattr(self._runtime, "close", None)
+        if close_runtime is not None:
+            close_runtime()
+
+    async def shutdown_async(self) -> None:
+        self.shutdown()
+
+    async def start(self, loop: asyncio.AbstractEventLoop | None = None) -> dict[str, Any]:
+        del loop
+        return {"cache_entries_loaded": 0, "backend": "lib"}
+
+    async def save_cache(self, cache_file: str | None = None) -> bool:
+        del cache_file
+        return False
+
+    async def load_cache(self, cache_file: str | None = None) -> int:
+        del cache_file
+        return 0
+
+    async def check_mcp_health(self, timeout_seconds: float = 5.0) -> tuple[str, str]:
+        del timeout_seconds
+        return "unused", "Restart Agent runs directly in attrsvc"
+
+    def validate_path(
+        self,
+        user_path: str,
+        *,
+        require_regular_file: bool = True,
+        reject_empty: bool = False,
+    ) -> str | LogAnalyzerError:
+        if os.path.exists(user_path):
+            return validate_log_path(
+                user_path,
+                self._allowed_root,
+                require_regular_file=require_regular_file,
+                reject_empty=reject_empty,
+            )
+        return self._validate_expected_path(user_path)
+
+    async def submit_log(
+        self,
+        log_path: str,
+        user: str = "unknown",
+        job_id: str | None = None,
+        cycle_id: int | None = None,
+        analysis_intent: str | None = None,
+    ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
+        try:
+            intent = normalize_analysis_intent(analysis_intent)
+        except ValueError as exc:
+            return LogAnalyzerError(ErrorCode.INVALID_PARAMETER, str(exc))
+
+        normalized = self.validate_path(log_path, require_regular_file=False, reject_empty=False)
+        if isinstance(normalized, LogAnalyzerError):
+            return normalized
+        if cycle_id is not None and (isinstance(cycle_id, bool) or not isinstance(cycle_id, int)):
+            return LogAnalyzerError(ErrorCode.INVALID_PARAMETER, "cycle_id must be an integer")
+        identity = self._identity(normalized, job_id, cycle_id)
+        with self._lock:
+            if self._shutdown:
+                return LogAnalyzerError(
+                    ErrorCode.INTERNAL_ERROR, "Restart Agent backend is shut down"
+                )
+            entry_or_error = self._register(
+                normalized,
+                user,
+                *identity,
+                explicit_job_id=job_id,
+                explicit_cycle_id=cycle_id,
+            )
+            if isinstance(entry_or_error, LogAnalyzerError):
+                return entry_or_error
+            entry = entry_or_error
+            if intent == ANALYSIS_INTENT_TERMINAL:
+                self._start_terminal(entry)
+            elif intent == ANALYSIS_INTENT_PROGRESSIVE:
+                self._start_progressive(entry)
+            else:
+                # track_only has the same registration semantics in the direct backend.
+                pass
+
+        return LogAnalyzerSubmitResult(submitted=True, normalized_path=normalized)
+
+    async def analyze_log(
+        self,
+        log_path: str,
+        file: str | None = None,
+        wl_restart: int | None = None,
+        wait: bool = True,
+    ) -> LogAnalysisCycleResult | LogAnalyzerError:
+        if file is not None or wl_restart is not None:
+            return LogAnalyzerError(
+                ErrorCode.INVALID_PARAMETER,
+                "file and wl_restart are not supported by the Restart Agent backend",
+            )
+        normalized = self._normalize_lookup_path(log_path)
+        if isinstance(normalized, LogAnalyzerError):
+            return normalized
+        with self._lock:
+            key = self._path_index.get(normalized)
+            entry = self._entries.get(key) if key is not None else None
+            future = entry.future if entry is not None else None
+        if entry is None:
+            return LogAnalyzerError(ErrorCode.NOT_FOUND, "attempt has not been submitted")
+        if wait and future is not None and not future.done():
+            try:
+                await asyncio.shield(asyncio.wrap_future(future))
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # _execute_terminal records the service-visible failure state.
+                pass
+        return self._public_result(entry)
+
+    def read_file_preview(
+        self, log_path: str, max_bytes: int = 4096
+    ) -> LogAnalyzerFilePreview | LogAnalyzerError:
+        validated = validate_log_path(
+            log_path,
+            self._allowed_root,
+            require_regular_file=True,
+            reject_empty=False,
+        )
+        if isinstance(validated, LogAnalyzerError):
+            return validated
+        try:
+            with open(validated, "r", encoding="utf-8", errors="ignore") as handle:
+                return LogAnalyzerFilePreview(content=handle.read(max_bytes), path=validated)
+        except OSError as exc:
+            return LogAnalyzerError(ErrorCode.INTERNAL_ERROR, f"file read error: {exc}")
+
+    async def get_stats(self) -> dict[str, Any]:
+        with self._lock:
+            counts = self._status_counts()
+            deterministic_count = sum(
+                entry.deterministic_ready_count for entry in self._entries.values()
+            )
+            route_count = sum(entry.route_complete_count for entry in self._entries.values())
+            execution_errors = self._execution_errors
+            eviction_count = self._eviction_count
+            progressive_evictions = self._progressive_eviction_count
+            progressive_errors = self._progressive_precompute_errors
+            progressive_states = self._progressive_state_counts()
+            terminal_entries = tuple(
+                entry for entry in self._entries.values() if entry.terminal_at is not None
+            )
+            accumulators = tuple(
+                entry.accumulator
+                for entry in self._entries.values()
+                if entry.accumulator is not None
+            )
+        accumulator_states = [accumulator.state() for accumulator in accumulators]
+        history_records = self._runtime.attempt_record_control.records()
+        return {
+            "backend": "lib",
+            "restart_agent": {
+                "config": self._config.metadata(),
+                "attempts": counts,
+                "deterministic_ready": deterministic_count,
+                "route_complete": route_count,
+                "execution_errors": execution_errors,
+                "registry_evictions": eviction_count,
+                "history_record_count": len(history_records),
+                "terminal_timing": self._latest_terminal_timing(terminal_entries),
+                "progressive": {
+                    "policy": {
+                        "pre_end_poll_seconds": self._progressive.pre_end_poll_seconds,
+                        "enabled": self._progressive.enabled,
+                        "active_idle_seconds": self._progressive.active_idle_seconds,
+                        "max_active_states": self._progressive.max_active_states,
+                        "max_completed_results": self._progressive.max_completed_results,
+                    },
+                    "states": progressive_states,
+                    "active_state_count": len(accumulator_states),
+                    "state_evictions": progressive_evictions,
+                    "precompute_errors": progressive_errors,
+                    "poll_count": sum(state.poll_count for state in accumulator_states),
+                    "growth_count": sum(state.growth_count for state in accumulator_states),
+                    "l0a_build_count": sum(state.l0a_build_count for state in accumulator_states),
+                    "bytes_ingested": sum(state.bytes_ingested for state in accumulator_states),
+                    "bytes_reread": sum(state.bytes_reread for state in accumulator_states),
+                },
+            },
+        }
+
+    async def get_cache(self) -> CacheResult:
+        return {"count": 0, "entries": []}
+
+    async def get_inflight(self) -> InflightResult:
+        with self._lock:
+            paths = [
+                entry.log_path
+                for entry in self._entries.values()
+                if entry.status == _STATUS_ANALYZING
+            ]
+        return {"count": len(paths), "paths": sorted(paths)}
+
+    async def get_submitted(self) -> SubmittedResult:
+        now = time.monotonic()
+        with self._lock:
+            entries = [
+                {
+                    "path": entry.log_path,
+                    "age_seconds": max(0.0, now - entry.registered_at),
+                    "status": entry.status,
+                }
+                for entry in self._entries.values()
+            ]
+        return {"count": len(entries), "entries": sorted(entries, key=lambda item: item["path"])}
+
+    def get_all_jobs(self) -> dict[str, Any]:
+        jobs: dict[str, list[dict[str, Any]]] = {}
+        with self._lock:
+            for entry in self._entries.values():
+                jobs.setdefault(entry.job_id or "unknown", []).append(
+                    {
+                        "cycle_id": entry.cycle_id,
+                        "log_path": entry.log_path,
+                        "status": entry.status,
+                        "progressive_phase": entry.progressive_phase,
+                    }
+                )
+        return {
+            job_id: sorted(
+                records, key=lambda item: (-1 if item["cycle_id"] is None else item["cycle_id"])
+            )
+            for job_id, records in sorted(jobs.items())
+        }
+
+    async def status(self) -> dict[str, Any]:
+        with self._lock:
+            counts = self._status_counts()
+            shutdown = self._shutdown
+        return {
+            "status": "fail" if shutdown else "ok",
+            "backend": "lib",
+            "issues": (["Restart Agent backend is shut down"] if shutdown else []),
+            "restart_agent": {
+                "config_id": self._config.config_id,
+                "config_version": self._config.config_version,
+                "config_fingerprint": self._config.config_fingerprint,
+                "attempts": counts,
+            },
+        }
+
+    def _register(
+        self,
+        normalized_path: str,
+        user: str,
+        job_id: str | None,
+        cycle_id: int | None,
+        *,
+        explicit_job_id: str | None,
+        explicit_cycle_id: int | None,
+    ) -> _AttemptExecution | LogAnalyzerError:
+        path_key = self._path_index.get(normalized_path)
+        if path_key is not None:
+            existing = self._entries.get(path_key)
+            if existing is None:
+                self._path_index.pop(normalized_path, None)
+            else:
+                if (explicit_job_id or "").strip() and existing.job_id != job_id:
+                    return LogAnalyzerError(
+                        ErrorCode.INVALID_PARAMETER,
+                        "log path is already registered with different job_id",
+                    )
+                if explicit_cycle_id is not None and existing.cycle_id != cycle_id:
+                    return LogAnalyzerError(
+                        ErrorCode.INVALID_PARAMETER,
+                        "log path is already registered with different cycle_id",
+                    )
+                if user and existing.user == "unknown":
+                    existing.user = user
+                return existing
+
+        key: Hashable = (
+            (job_id, cycle_id) if job_id is not None and cycle_id is not None else normalized_path
+        )
+        existing = self._entries.get(key)
+        if existing is not None:
+            if existing.log_path != normalized_path:
+                return LogAnalyzerError(
+                    ErrorCode.INVALID_PARAMETER,
+                    "job_id and cycle_id already identify a different log path",
+                )
+            if user and existing.user == "unknown":
+                existing.user = user
+            return existing
+        if not self._make_room():
+            return LogAnalyzerError(
+                ErrorCode.JOB_LIMIT_REACHED,
+                "Restart Agent attempt registry has no evictable entry",
+            )
+        entry = _AttemptExecution(
+            key=key,
+            log_path=normalized_path,
+            user=user or "unknown",
+            job_id=job_id,
+            cycle_id=cycle_id,
+        )
+        self._entries[key] = entry
+        self._path_index[normalized_path] = key
+        return entry
+
+    def _start_progressive(self, entry: _AttemptExecution) -> None:
+        if entry.status in {_STATUS_ANALYZING, _STATUS_COMPLETED}:
+            return
+        if not self._progressive.enabled:
+            entry.progressive_phase = "disabled"
+            return
+        self._ensure_accumulator(entry)
+        if entry.accumulator is not None:
+            entry.progressive_phase = "scheduled"
+            entry.next_poll_at = time.monotonic()
+            self._scheduler_wakeup.set()
+
+    def _start_terminal(self, entry: _AttemptExecution) -> None:
+        if entry.status in {_STATUS_ANALYZING, _STATUS_COMPLETED}:
+            return
+        self._ensure_accumulator(entry, allow_eviction=False)
+        entry.status = _STATUS_ANALYZING
+        entry.progressive_phase = "finalizing"
+        entry.terminal_at = time.monotonic()
+        entry.error = None
+        entry.next_poll_at = None
+        self._scheduler_wakeup.set()
+        entry.future = self._executor.submit(self._execute_terminal, entry.key)
+
+    def _execute_terminal(self, key: Hashable) -> None:
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return
+            request = RestartAgentRequest(
+                log_path=entry.log_path,
+                job_id=entry.job_id,
+                cycle_id=entry.cycle_id,
+            )
+            accumulator = entry.accumulator
+        try:
+            drain = self._wait_for_log_convergence(request.log_path, accumulator)
+
+            def deterministic_ready(candidate: DecisionCandidate) -> None:
+                with self._lock:
+                    current = self._entries.get(key)
+                    if current is None:
+                        return
+                    current.best_result = candidate.result
+                    current.best_source = candidate.candidate_kind
+                    current.candidate_result = candidate.result
+                    current.candidate_source = candidate.candidate_kind
+                    current.deterministic_ready_count += 1
+                    if current.terminal_at is not None:
+                        current.deterministic_ready_wall_clock_s = (
+                            time.monotonic() - current.terminal_at
+                        )
+
+            def route_complete(result: ModelAnalysisResult, trace: Mapping[str, Any]) -> None:
+                del trace
+                with self._lock:
+                    current = self._entries.get(key)
+                    if current is None:
+                        return
+                    current.best_result = result.analysis_result
+                    current.best_source = (
+                        f"l1_enriched:{result.route_id}" if result.l1_usable else "deterministic"
+                    )
+                    current.candidate_result = result.analysis_result
+                    current.candidate_source = current.best_source
+                    current.route_complete_count += 1
+                    if (
+                        current.first_route_ready_wall_clock_s is None
+                        and current.terminal_at is not None
+                    ):
+                        current.first_route_ready_wall_clock_s = (
+                            time.monotonic() - current.terminal_at
+                        )
+
+            finalized_l0a = None
+            if accumulator is not None:
+                try:
+                    finalized_l0a = accumulator.finalize(
+                        include_incomplete_tail=drain.include_incomplete_tail,
+                    )
+                    terminal_to_l0a_ready_s = (
+                        time.monotonic() - entry.terminal_at
+                        if entry.terminal_at is not None
+                        else None
+                    )
+                    finalized_l0a = replace(
+                        finalized_l0a,
+                        progressive_metrics={
+                            **dict(finalized_l0a.progressive_metrics),
+                            "terminal_drain": drain.to_payload(),
+                            "terminal_to_l0a_ready_wall_clock_s": (
+                                round(terminal_to_l0a_ready_s, 6)
+                                if terminal_to_l0a_ready_s is not None
+                                else None
+                            ),
+                        },
+                    )
+                    with self._lock:
+                        current = self._entries.get(key)
+                        if current is not None:
+                            current.terminal_drain_wall_clock_s = drain.wall_clock_s
+                            current.terminal_l0a_ready_wall_clock_s = terminal_to_l0a_ready_s
+                except ProgressiveSourceUnavailable:
+                    finalized_l0a = None
+                finally:
+                    with self._lock:
+                        current = self._entries.get(key)
+                        if current is not None and current.accumulator is accumulator:
+                            current.accumulator = None
+                            current.precompute_future = None
+                            current.next_poll_at = None
+                    accumulator = None
+            if finalized_l0a is not None and hasattr(self._runtime, "analyze_prepared"):
+                run = self._runtime.analyze_prepared(
+                    request,
+                    finalized_l0a,
+                    on_deterministic_ready=deterministic_ready,
+                    on_route_complete=route_complete,
+                    retain_detailed_artifacts=False,
+                )
+            else:
+                run = self._runtime.analyze(
+                    request,
+                    on_deterministic_ready=deterministic_ready,
+                    on_route_complete=route_complete,
+                    retain_detailed_artifacts=False,
+                )
+            model_results = tuple(getattr(run.result, "model_results", ()))
+            final = model_results[0].analysis_result if model_results else run.result
+            if not isinstance(final, AnalysisResult):
+                raise TypeError("Restart Agent service run did not produce AnalysisResult")
+            with self._lock:
+                current = self._entries.get(key)
+                if current is not None:
+                    current.final_result = final
+                    current.best_result = final
+                    if not current.best_source:
+                        current.best_source = "deterministic"
+                    current.status = _STATUS_COMPLETED
+                    current.progressive_phase = "completed"
+                    current.completed_at = time.monotonic()
+                    if current.terminal_at is not None:
+                        current.analysis_completed_wall_clock_s = (
+                            current.completed_at - current.terminal_at
+                        )
+                    current.future = None
+                    self._trim_completed_results()
+        except Exception as exc:
+            with self._lock:
+                self._execution_errors += 1
+                current = self._entries.get(key)
+                if current is not None:
+                    current.error = f"{type(exc).__name__}: {exc}"
+                    current.completed_at = time.monotonic()
+                    current.status = (
+                        _STATUS_COMPLETED if current.best_result is not None else _STATUS_FAILED
+                    )
+                    current.progressive_phase = current.status
+                    current.accumulator = None
+                    current.precompute_future = None
+                    current.next_poll_at = None
+                    current.future = None
+                    self._trim_completed_results()
+
+    def _public_result(self, entry: _AttemptExecution) -> LogAnalysisCycleResult:
+        with self._lock:
+            result = entry.final_result or entry.best_result
+            candidate_result = entry.candidate_result
+            status = entry.status
+            source = entry.best_source
+            candidate_source = entry.candidate_source
+            error = entry.error
+            cycle_id = entry.cycle_id
+        public_status = {
+            _STATUS_REGISTERED: _PUBLIC_PENDING,
+            _STATUS_ANALYZING: _PUBLIC_IN_FLIGHT,
+            _STATUS_COMPLETED: _STATUS_COMPLETED,
+            _STATUS_FAILED: _STATUS_FAILED,
+        }[status]
+        payload = result.to_payload() if result is not None else ({"error": error} if error else {})
+        return LogAnalysisCycleResult(
+            result=payload,
+            status=public_status,
+            wl_restart=cycle_id or 0,
+            recommendation=self._recommendation(result, source),
+            candidate_recommendation=self._recommendation(candidate_result, candidate_source),
+        )
+
+    @staticmethod
+    def _recommendation(result: AnalysisResult | None, source: str) -> dict[str, str]:
+        if result is None:
+            return {"action": RECOMMENDATION_UNKNOWN, "reason": "", "source": source}
+        nvrx_use = str(result.result_provenance.get("nvrx_use") or "")
+        action = result.decision if nvrx_use in _ELIGIBLE_NVRX_USES else RECOMMENDATION_UNKNOWN
+        if action not in {RECOMMENDATION_STOP, RECOMMENDATION_RESTART}:
+            action = RECOMMENDATION_UNKNOWN
+        return {
+            "action": action,
+            "reason": result.justification,
+            "source": source or "restart_agent",
+        }
+
+    def _identity(
+        self,
+        path: str,
+        explicit_job_id: str | None,
+        explicit_cycle_id: int | None,
+    ) -> tuple[str | None, int | None]:
+        metadata = extract_job_metadata(path, warn_on_missing_job_id=False)
+        job_id = (explicit_job_id or "").strip() or metadata.job_id or None
+        if explicit_cycle_id is not None:
+            cycle_id = explicit_cycle_id
+        else:
+            match = CYCLE_NUM_PATTERN.search(path)
+            cycle_id = int(match.group(1)) if match else None
+        return job_id, cycle_id
+
+    def _validate_expected_path(self, user_path: str) -> str | LogAnalyzerError:
+        if not os.path.isabs(user_path):
+            return LogAnalyzerError(ErrorCode.INVALID_PATH, "path must be absolute")
+        real = os.path.realpath(user_path)
+        if not path_is_under_allowed_root(real, self._allowed_root):
+            return LogAnalyzerError(
+                ErrorCode.OUTSIDE_ROOT,
+                "access outside allowed root is not permitted",
+            )
+        parent = os.path.dirname(real)
+        try:
+            parent_stat = os.stat(parent)
+        except FileNotFoundError:
+            return LogAnalyzerError(ErrorCode.NOT_FOUND, "path parent not found")
+        except PermissionError:
+            return LogAnalyzerError(ErrorCode.NOT_READABLE, "path parent is not readable")
+        if not stat.S_ISDIR(parent_stat.st_mode):
+            return LogAnalyzerError(ErrorCode.INVALID_PATH, "path parent is not a directory")
+        if not os.access(parent, os.R_OK | os.X_OK):
+            return LogAnalyzerError(ErrorCode.NOT_READABLE, "path parent is not accessible")
+        return real
+
+    def _normalize_lookup_path(self, path: str) -> str | LogAnalyzerError:
+        if not os.path.isabs(path):
+            return LogAnalyzerError(ErrorCode.INVALID_PATH, "path must be absolute")
+        normalized = os.path.realpath(path)
+        if not path_is_under_allowed_root(normalized, self._allowed_root):
+            return LogAnalyzerError(
+                ErrorCode.OUTSIDE_ROOT,
+                "access outside allowed root is not permitted",
+            )
+        return normalized
+
+    def _wait_for_log_convergence(
+        self,
+        path: str,
+        accumulator: ProgressiveL0Accumulator | None,
+    ) -> _DrainOutcome:
+        policy = self._convergence
+        if policy.max_wait_seconds <= 0:
+            return _DrainOutcome(converged=True, max_wait_expired=False)
+        reader_ready = Event()
+        stop_observer = Event()
+        notifications: SimpleQueue[str] = SimpleQueue()
+        outcomes: list[_DrainOutcome] = []
+
+        def observe() -> None:
+            try:
+                outcome = self._observe_log_convergence(
+                    path,
+                    reader_ready=reader_ready,
+                    notifications=notifications,
+                    stop_observer=stop_observer,
+                )
+                if outcome is not None:
+                    outcomes.append(outcome)
+            finally:
+                notifications.put("done")
+
+        observer = Thread(
+            target=observe,
+            name="nvrx-restart-agent-log-drain",
+            daemon=True,
+        )
+        observer.start()
+        try:
+            if accumulator is not None:
+                accumulator.refresh(precompute=False)
+        except Exception:
+            stop_observer.set()
+            reader_ready.set()
+            observer.join()
+            raise
+        reader_ready.set()
+        try:
+            while True:
+                notification = notifications.get()
+                if notification == "growth":
+                    if accumulator is not None:
+                        accumulator.refresh(precompute=False)
+                    continue
+                if notification == "quiet_candidate":
+                    if accumulator is not None:
+                        accumulator.refresh(precompute=True)
+                    continue
+                if notification == "done":
+                    break
+            observer.join()
+            if accumulator is not None:
+                accumulator.refresh(precompute=False)
+        except Exception:
+            stop_observer.set()
+            reader_ready.set()
+            observer.join()
+            raise
+        if not outcomes:
+            raise RuntimeError("terminal log-drain observer stopped without an outcome")
+        return outcomes[0]
+
+    def _observe_log_convergence(
+        self,
+        path: str,
+        *,
+        reader_ready: Event,
+        notifications: SimpleQueue[str],
+        stop_observer: Event,
+    ) -> _DrainOutcome | None:
+        policy = self._convergence
+        started = time.monotonic()
+        unchanged_since: float | None = None
+        previous: tuple[int, int] | None = None
+        precompute_notified_for: tuple[int, int] | None = None
+        poll_count = 0
+        growth_count = 0
+        while True:
+            now = time.monotonic()
+            poll_count += 1
+            try:
+                current_stat = os.stat(path)
+                current = (current_stat.st_size, current_stat.st_mtime_ns)
+            except OSError:
+                current = None
+            if current is not None and current == previous:
+                if unchanged_since is None:
+                    unchanged_since = now
+                if reader_ready.is_set() and precompute_notified_for != current:
+                    notifications.put("quiet_candidate")
+                    precompute_notified_for = current
+            else:
+                if previous is not None and current is not None:
+                    growth_count += 1
+                    notifications.put("growth")
+                previous = current
+                precompute_notified_for = None
+                unchanged_since = now if current is not None else None
+            if (
+                current is not None
+                and unchanged_since is not None
+                and now - unchanged_since >= policy.quiet_seconds
+                and reader_ready.is_set()
+            ):
+                return _DrainOutcome(
+                    converged=True,
+                    max_wait_expired=False,
+                    wall_clock_s=now - started,
+                    poll_count=poll_count,
+                    growth_count=growth_count,
+                )
+            if now - started >= policy.max_wait_seconds:
+                return _DrainOutcome(
+                    converged=False,
+                    max_wait_expired=True,
+                    wall_clock_s=now - started,
+                    poll_count=poll_count,
+                    growth_count=growth_count,
+                )
+            remaining = policy.max_wait_seconds - (time.monotonic() - started)
+            if remaining <= 0:
+                return _DrainOutcome(
+                    converged=False,
+                    max_wait_expired=True,
+                    wall_clock_s=time.monotonic() - started,
+                    poll_count=poll_count,
+                    growth_count=growth_count,
+                )
+            if stop_observer.wait(min(max(policy.poll_seconds, 0.01), remaining)):
+                return None
+
+    @staticmethod
+    def _latest_terminal_timing(entries: tuple[_AttemptExecution, ...]) -> dict[str, Any]:
+        if not entries:
+            return {}
+        latest = max(entries, key=lambda entry: entry.terminal_at or 0.0)
+        return {
+            "job_id": latest.job_id,
+            "cycle_id": latest.cycle_id,
+            "drain_wall_clock_s": latest.terminal_drain_wall_clock_s,
+            "l0a_ready_wall_clock_s": latest.terminal_l0a_ready_wall_clock_s,
+            "deterministic_ready_wall_clock_s": latest.deterministic_ready_wall_clock_s,
+            "first_route_ready_wall_clock_s": latest.first_route_ready_wall_clock_s,
+            "analysis_completed_wall_clock_s": latest.analysis_completed_wall_clock_s,
+        }
+
+    def _ensure_accumulator(
+        self,
+        entry: _AttemptExecution,
+        *,
+        allow_eviction: bool = True,
+    ) -> None:
+        if entry.accumulator is not None:
+            return
+        active = [
+            candidate
+            for candidate in self._entries.values()
+            if candidate.accumulator is not None and candidate.status == _STATUS_REGISTERED
+        ]
+        if allow_eviction and len(active) >= self._progressive.max_active_states:
+            evictable = [
+                candidate
+                for candidate in active
+                if candidate.precompute_future is None or candidate.precompute_future.done()
+            ]
+            if not evictable:
+                entry.progressive_phase = "precompute_skipped_capacity"
+                entry.progressive_evicted = True
+                return
+            victim = min(
+                evictable,
+                key=lambda candidate: (
+                    (
+                        candidate.accumulator.state().last_growth_monotonic
+                        if candidate.accumulator is not None
+                        else None
+                    )
+                    or candidate.registered_at
+                ),
+            )
+            victim.accumulator = None
+            victim.precompute_future = None
+            victim.next_poll_at = None
+            victim.progressive_phase = "evicted"
+            victim.progressive_evicted = True
+            self._progressive_eviction_count += 1
+        entry.accumulator = self._accumulator_factory(entry.log_path)
+        entry.progressive_evicted = False
+
+    def _schedule_progressive(self) -> None:
+        """Schedule due pre-end reads from one service coordinator thread."""
+
+        while True:
+            self._scheduler_wakeup.clear()
+            now = time.monotonic()
+            next_due: float | None = None
+            with self._lock:
+                if self._shutdown:
+                    return
+                for entry in self._entries.values():
+                    if (
+                        entry.status != _STATUS_REGISTERED
+                        or entry.accumulator is None
+                        or entry.next_poll_at is None
+                    ):
+                        continue
+                    if entry.precompute_future is not None and not entry.precompute_future.done():
+                        continue
+                    if entry.next_poll_at <= now:
+                        entry.progressive_phase = "precomputing"
+                        entry.precompute_future = self._precompute_executor.submit(
+                            self._execute_precompute,
+                            entry.key,
+                            entry.accumulator,
+                        )
+                        continue
+                    next_due = (
+                        entry.next_poll_at
+                        if next_due is None
+                        else min(next_due, entry.next_poll_at)
+                    )
+            timeout = (
+                self._progressive.pre_end_poll_seconds
+                if next_due is None
+                else max(0.01, next_due - time.monotonic())
+            )
+            self._scheduler_wakeup.wait(timeout=timeout)
+
+    def _execute_precompute(
+        self,
+        key: Hashable,
+        accumulator: ProgressiveL0Accumulator,
+    ) -> bool:
+        changed = False
+        error: str | None = None
+        try:
+            changed = accumulator.refresh()
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+        now = time.monotonic()
+        with self._lock:
+            current = self._entries.get(key)
+            if current is None or current.accumulator is not accumulator:
+                return changed
+            current.progressive_error = error
+            if current.status != _STATUS_REGISTERED:
+                return changed
+            current.next_poll_at = now + self._progressive.pre_end_poll_seconds
+            state = accumulator.state()
+            last_activity = state.last_growth_monotonic or current.registered_at
+            current.progressive_phase = (
+                "idle"
+                if now - last_activity >= self._progressive.active_idle_seconds
+                else "scheduled"
+            )
+            if error is not None:
+                self._progressive_precompute_errors += 1
+                current.progressive_phase = "precompute_error"
+        self._scheduler_wakeup.set()
+        return changed
+
+    def _make_room(self) -> bool:
+        self._trim_completed_results(reserve=1)
+        return True
+
+    def _trim_completed_results(self, *, reserve: int = 0) -> None:
+        limit = max(0, self._max_completed_results - reserve)
+        completed = [
+            entry
+            for entry in self._entries.values()
+            if entry.status in {_STATUS_COMPLETED, _STATUS_FAILED}
+        ]
+        while len(completed) > limit:
+            victim = min(
+                completed,
+                key=lambda item: item.completed_at or item.registered_at,
+            )
+            completed.remove(victim)
+            self._entries.pop(victim.key, None)
+            self._path_index.pop(victim.log_path, None)
+            self._eviction_count += 1
+
+    def _status_counts(self) -> dict[str, int]:
+        counts = {
+            _STATUS_REGISTERED: 0,
+            _STATUS_ANALYZING: 0,
+            _STATUS_COMPLETED: 0,
+            _STATUS_FAILED: 0,
+        }
+        for entry in self._entries.values():
+            counts[entry.status] += 1
+        return counts
+
+    def _progressive_state_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for entry in self._entries.values():
+            counts[entry.progressive_phase] = counts.get(entry.progressive_phase, 0) + 1
+        return counts

--- a/src/nvidia_resiliency_ext/services/attrsvc/restart_agent_config.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/restart_agent_config.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve attrsvc settings into the canonical Restart Agent configuration."""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+from nvidia_resiliency_ext.attribution.restart_agent import (
+    RestartAgentConfig,
+    load_restart_agent_config,
+    parse_restart_agent_config,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.config import (
+    RESTART_AGENT_CONFIG_SCHEMA_VERSION,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l1 import LlmConfig
+
+from .config import Settings
+
+
+def restart_agent_config_from_settings(
+    settings: Settings,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> RestartAgentConfig:
+    """Load an authoritative file or create one attrsvc-managed model route."""
+
+    environment = os.environ if environ is None else environ
+    if settings.ANALYSIS_BACKEND != "lib":
+        if settings.RESTART_AGENT_CONFIG:
+            raise ValueError("RESTART_AGENT_CONFIG requires ANALYSIS_BACKEND=lib")
+        raise ValueError("Restart Agent configuration requires ANALYSIS_BACKEND=lib")
+
+    if settings.RESTART_AGENT_CONFIG:
+        config = load_restart_agent_config(settings.RESTART_AGENT_CONFIG, environ=environment)
+    elif settings.RESTART_AGENT_ENRICHMENT_ENABLED:
+        defaults = LlmConfig.from_env(environ=environment)
+        request: dict[str, object] = {}
+        if settings.LLM_TEMPERATURE is not None:
+            request["temperature"] = settings.LLM_TEMPERATURE
+        if settings.LLM_TOP_P is not None:
+            request["top_p"] = settings.LLM_TOP_P
+        if settings.LLM_MAX_TOKENS is not None:
+            request["max_output_tokens"] = settings.LLM_MAX_TOKENS
+        route: dict[str, object] = {
+            "route_id": "nvrx-default",
+            "model": settings.LLM_MODEL or defaults.model,
+            "base_url": settings.LLM_BASE_URL or defaults.base_url,
+            "credential_ref": "LLM_API_KEY_FILE",
+        }
+        if request:
+            route["request"] = request
+        config = parse_restart_agent_config(
+            {
+                "schema_version": RESTART_AGENT_CONFIG_SCHEMA_VERSION,
+                "config_id": "nvrx-attrsvc-environment",
+                "config_version": 1,
+                "enrichment": {"enabled": True},
+                "routing": {"mode": "collect_all", "max_parallel_models": 1},
+                "model_routes": [route],
+            },
+            environ=environment,
+        )
+    else:
+        config = parse_restart_agent_config(
+            {
+                "schema_version": RESTART_AGENT_CONFIG_SCHEMA_VERSION,
+                "config_id": "nvrx-attrsvc-deterministic",
+                "config_version": 1,
+                "enrichment": {"enabled": False},
+                "routing": {"mode": "collect_all", "max_parallel_models": 0},
+                "model_routes": [],
+            },
+            environ=environment,
+        )
+
+    if config.enrichment_enabled and len(config.model_route_specs) != 1:
+        raise ValueError("attrsvc Restart Agent integration requires exactly one model route")
+    return config

--- a/src/nvidia_resiliency_ext/services/attrsvc/service.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/service.py
@@ -1,29 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""HTTP adapter for the attribution controller boundary.
+"""HTTP adapter selecting the direct Restart Agent or legacy controller.
 
-This module keeps FastAPI-facing concerns in ``services/attrsvc`` while
-delegating attribution ownership to
-:class:`nvidia_resiliency_ext.attribution.controller.AttributionController`.
+This module keeps FastAPI-facing concerns in ``services/attrsvc``. The default
+``lib`` backend owns a direct Restart Agent runtime. ``mcp`` keeps
+the pre-existing LogSage/flight-recorder controller path during migration.
 """
 
 import asyncio
 import logging
-from typing import Any
+from functools import partial
+from typing import TYPE_CHECKING, Any, Protocol
 
 from nvidia_resiliency_ext.attribution.coalescing import (
     CacheResult,
     InflightResult,
     SubmittedResult,
-)
-from nvidia_resiliency_ext.attribution.controller import (
-    AttributionAnalysisConfig,
-    AttributionCacheConfig,
-    AttributionController,
-    AttributionControllerConfig,
-    AttributionPostprocessingConfig,
-    AttributionProgressiveConfig,
 )
 from nvidia_resiliency_ext.attribution.orchestration.types import (
     AttributionRecommendation,
@@ -33,15 +26,32 @@ from nvidia_resiliency_ext.attribution.orchestration.types import (
     LogAnalyzerFilePreview,
     LogAnalyzerSubmitResult,
 )
+from nvidia_resiliency_ext.attribution.restart_agent import (
+    ProgressiveL0Accumulator,
+    build_restart_agent_runtime,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.infrastructure.log_source import (
+    ChunkedLogReader,
+)
 
 from .config import PRINT_PREVIEW_MAX_BYTES, Settings
+from .restart_agent_backend import (
+    LogConvergencePolicy,
+    ProgressiveAnalysisPolicy,
+    RestartAgentServiceBackend,
+)
+from .restart_agent_config import restart_agent_config_from_settings
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from nvidia_resiliency_ext.attribution.controller import AttributionControllerConfig
 
 
 # Re-export result types for convenience
 __all__ = [
     "AttributionHttpAdapter",
+    "AttributionServiceBackend",
     "AttributionRecommendation",
     "LogAnalyzerError",
     "LogAnalysisCycleResult",
@@ -51,8 +61,73 @@ __all__ = [
 ]
 
 
-def _controller_config_from_settings(cfg: Settings) -> AttributionControllerConfig:
+class AttributionServiceBackend(Protocol):
+    """Structural service contract implemented by direct and legacy backends."""
+
+    def shutdown(self) -> None: ...
+
+    async def shutdown_async(self) -> None: ...
+
+    async def start(self, loop: asyncio.AbstractEventLoop | None = None) -> dict[str, Any]: ...
+
+    async def save_cache(self, cache_file: str | None = None) -> bool: ...
+
+    async def load_cache(self, cache_file: str | None = None) -> int: ...
+
+    async def check_mcp_health(self, timeout_seconds: float = 5.0) -> tuple[str, str]: ...
+
+    def validate_path(
+        self,
+        user_path: str,
+        *,
+        require_regular_file: bool = True,
+        reject_empty: bool = False,
+    ) -> str | LogAnalyzerError: ...
+
+    async def submit_log(
+        self,
+        log_path: str,
+        user: str = "unknown",
+        job_id: str | None = None,
+        cycle_id: int | None = None,
+        analysis_intent: str | None = None,
+    ) -> LogAnalyzerSubmitResult | LogAnalyzerError: ...
+
+    async def analyze_log(
+        self,
+        log_path: str,
+        file: str | None = None,
+        wl_restart: int | None = None,
+        wait: bool = True,
+    ) -> LogAnalysisCycleResult | LogAnalysisSplitlogResult | LogAnalyzerError: ...
+
+    def read_file_preview(
+        self, log_path: str, max_bytes: int = PRINT_PREVIEW_MAX_BYTES
+    ) -> LogAnalyzerFilePreview | LogAnalyzerError: ...
+
+    async def get_stats(self) -> dict[str, Any]: ...
+
+    async def get_cache(self) -> CacheResult: ...
+
+    async def get_inflight(self) -> InflightResult: ...
+
+    async def get_submitted(self) -> SubmittedResult: ...
+
+    def get_all_jobs(self) -> dict[str, Any]: ...
+
+    async def status(self) -> dict[str, Any]: ...
+
+
+def _controller_config_from_settings(cfg: Settings) -> "AttributionControllerConfig":
     """Translate HTTP service settings into controller startup config."""
+    from nvidia_resiliency_ext.attribution.controller import (
+        AttributionAnalysisConfig,
+        AttributionCacheConfig,
+        AttributionControllerConfig,
+        AttributionPostprocessingConfig,
+        AttributionProgressiveConfig,
+    )
+
     return AttributionControllerConfig(
         allowed_root=cfg.ALLOWED_ROOT,
         analysis=AttributionAnalysisConfig(
@@ -82,11 +157,11 @@ def _controller_config_from_settings(cfg: Settings) -> AttributionControllerConf
 
 class AttributionHttpAdapter:
     """
-    HTTP adapter facade for :class:`AttributionController`.
+    HTTP adapter facade over the selected attribution implementation.
 
     ``AttributionHttpAdapter`` owns Settings conversion and keeps the public service
-    method names stable for FastAPI routes. The controller owns attribution
-    analysis, cache persistence, side-effect stats, and health/status policy.
+    method names stable for FastAPI routes. ``lib`` bypasses the legacy
+    controller and cache; ``mcp`` delegates to the existing controller.
     """
 
     def __init__(self, cfg: Settings):
@@ -97,34 +172,67 @@ class AttributionHttpAdapter:
             cfg: Application settings (ALLOWED_ROOT must be validated via setup())
         """
         self.cfg = cfg
-        self._controller = AttributionController(_controller_config_from_settings(cfg))
-        logger.info("Initialized AttributionHttpAdapter")
+        if cfg.ANALYSIS_BACKEND == "lib":
+            restart_config = restart_agent_config_from_settings(cfg)
+            self._backend: AttributionServiceBackend = RestartAgentServiceBackend(
+                allowed_root=cfg.ALLOWED_ROOT,
+                runtime=build_restart_agent_runtime(restart_config),
+                config=restart_config,
+                convergence=LogConvergencePolicy(
+                    quiet_seconds=cfg.RESTART_AGENT_LOG_QUIET_SECONDS,
+                    max_wait_seconds=cfg.RESTART_AGENT_LOG_MAX_WAIT_SECONDS,
+                    poll_seconds=cfg.RESTART_AGENT_LOG_POLL_SECONDS,
+                ),
+                progressive=ProgressiveAnalysisPolicy(
+                    enabled=(
+                        cfg.RESTART_AGENT_PROGRESSIVE_ENABLED and cfg.PROGRESSIVE_ANALYSIS != "off"
+                    ),
+                    pre_end_poll_seconds=cfg.RESTART_AGENT_PRE_END_POLL_SECONDS,
+                    active_idle_seconds=cfg.RESTART_AGENT_ACTIVE_IDLE_SECONDS,
+                    max_active_states=cfg.RESTART_AGENT_MAX_ACTIVE_STATES,
+                    max_completed_results=cfg.RESTART_AGENT_MAX_COMPLETED_RESULTS,
+                ),
+                accumulator_factory=partial(
+                    ProgressiveL0Accumulator,
+                    reader=ChunkedLogReader(
+                        chunk_bytes=restart_config.l0_source.chunk_size_bytes,
+                        read_mode=restart_config.l0_source.read_mode,
+                    ),
+                ),
+            )
+        else:
+            if cfg.RESTART_AGENT_CONFIG:
+                raise ValueError("RESTART_AGENT_CONFIG requires ANALYSIS_BACKEND=lib")
+            from nvidia_resiliency_ext.attribution.controller import AttributionController
+
+            self._backend = AttributionController(_controller_config_from_settings(cfg))
+        logger.info("Initialized AttributionHttpAdapter backend=%s", cfg.ANALYSIS_BACKEND)
 
     def shutdown(self) -> None:
         """Shutdown the adapter and stop background threads."""
-        self._controller.shutdown()
+        self._backend.shutdown()
         logger.info("AttributionHttpAdapter shutdown complete")
 
     async def shutdown_async(self) -> None:
         """Shutdown the adapter including MCP client cleanup."""
-        await self._controller.shutdown_async()
+        await self._backend.shutdown_async()
         logger.info("AttributionHttpAdapter shutdown complete")
 
     async def start(self, loop: asyncio.AbstractEventLoop | None = None) -> dict[str, Any]:
         """Start controller-owned runtime dependencies."""
-        return await self._controller.start(loop)
+        return await self._backend.start(loop)
 
     async def save_cache(self, cache_file: str | None = None) -> bool:
         """Save controller cache to file for persistence across restarts."""
-        return await self._controller.save_cache(cache_file)
+        return await self._backend.save_cache(cache_file)
 
     async def load_cache(self, cache_file: str | None = None) -> int:
         """Load controller cache from file."""
-        return await self._controller.load_cache(cache_file)
+        return await self._backend.load_cache(cache_file)
 
     async def check_mcp_health(self, timeout_seconds: float = 5.0) -> tuple[str, str]:
         """Check MCP backend health."""
-        return await self._controller.check_mcp_health(timeout_seconds)
+        return await self._backend.check_mcp_health(timeout_seconds)
 
     def validate_path(
         self,
@@ -134,7 +242,7 @@ class AttributionHttpAdapter:
         reject_empty: bool = False,
     ) -> str | LogAnalyzerError:
         """Validate and normalize a path."""
-        return self._controller.validate_path(
+        return self._backend.validate_path(
             user_path,
             require_regular_file=require_regular_file,
             reject_empty=reject_empty,
@@ -145,13 +253,15 @@ class AttributionHttpAdapter:
         log_path: str,
         user: str = "unknown",
         job_id: str | None = None,
+        cycle_id: int | None = None,
         analysis_intent: str | None = None,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
         """Submit a log file for analysis tracking."""
-        return await self._controller.submit_log(
+        return await self._backend.submit_log(
             log_path,
             user=user,
             job_id=job_id,
+            cycle_id=cycle_id,
             analysis_intent=analysis_intent,
         )
 
@@ -163,7 +273,7 @@ class AttributionHttpAdapter:
         wait: bool = True,
     ) -> LogAnalysisCycleResult | LogAnalysisSplitlogResult | LogAnalyzerError:
         """Analyze a log file using the configured attribution backend."""
-        return await self._controller.analyze_log(
+        return await self._backend.analyze_log(
             log_path,
             file=file,
             wl_restart=wl_restart,
@@ -174,28 +284,28 @@ class AttributionHttpAdapter:
         self, log_path: str, max_bytes: int = PRINT_PREVIEW_MAX_BYTES
     ) -> LogAnalyzerFilePreview | LogAnalyzerError:
         """Read the first N bytes of a file for preview."""
-        return self._controller.read_file_preview(log_path, max_bytes=max_bytes)
+        return self._backend.read_file_preview(log_path, max_bytes=max_bytes)
 
     async def get_stats(self) -> dict[str, Any]:
         """Get controller, cache, posting/dataflow, and Slack statistics."""
-        return await self._controller.get_stats()
+        return await self._backend.get_stats()
 
     async def get_cache(self) -> CacheResult:
         """Get current cache contents."""
-        return await self._controller.get_cache()
+        return await self._backend.get_cache()
 
     async def get_inflight(self) -> InflightResult:
         """Get currently in-flight requests."""
-        return await self._controller.get_inflight()
+        return await self._backend.get_inflight()
 
     async def get_submitted(self) -> SubmittedResult:
         """Get submitted paths."""
-        return await self._controller.get_submitted()
+        return await self._backend.get_submitted()
 
     def get_all_jobs(self) -> dict[str, Any]:
         """Get all tracked jobs."""
-        return self._controller.get_all_jobs()
+        return self._backend.get_all_jobs()
 
     async def get_health(self) -> dict[str, Any]:
         """Get adapter health from controller status."""
-        return await self._controller.status()
+        return await self._backend.status()

--- a/tests/attribution/unit/test_attrsvc_restart_agent_backend.py
+++ b/tests/attribution/unit/test_attrsvc_restart_agent_backend.py
@@ -1,0 +1,745 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral tests for attrsvc's direct Restart Agent backend."""
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+from nvidia_resiliency_ext.attribution.orchestration.types import LogAnalyzerError
+from nvidia_resiliency_ext.attribution.restart_agent import (
+    AnalysisResult,
+    DecisionCandidate,
+    ModelAnalysisResult,
+    ProgressiveL0Accumulator,
+    build_restart_agent_runtime,
+    parse_restart_agent_config,
+)
+from nvidia_resiliency_ext.services.attrsvc import (
+    restart_agent_backend as restart_agent_backend_module,
+)
+from nvidia_resiliency_ext.services.attrsvc.restart_agent_backend import (
+    LogConvergencePolicy,
+    ProgressiveAnalysisPolicy,
+    RestartAgentServiceBackend,
+)
+
+
+def _config(*, max_total_records: int = 8):
+    return parse_restart_agent_config(
+        {
+            "schema_version": "restart_agent_config.v1",
+            "config_id": "attrsvc-test",
+            "config_version": 1,
+            "enrichment": {"enabled": True},
+            "routing": {"mode": "collect_all", "max_parallel_models": 1},
+            "runtime": {
+                "history": {
+                    "enabled": True,
+                    "max_attempts_per_job": 4,
+                    "max_total_records": max_total_records,
+                }
+            },
+            "model_routes": [
+                {
+                    "route_id": "test-route",
+                    "model": "test-model",
+                    "base_url": "https://llm.example.test/v1",
+                    "credential_ref": "TEST_LLM_KEY_FILE",
+                }
+            ],
+        },
+        environ={"TEST_LLM_KEY_FILE": "/unused/test-key"},
+    )
+
+
+def _analysis_result(decision: str, *, eligible: bool = True) -> AnalysisResult:
+    return AnalysisResult(
+        decision=decision,
+        decision_basis="test",
+        result_provenance={"nvrx_use": "eligible" if eligible else "fallback_to_nvrx_default"},
+        justification=f"test {decision.lower()} result",
+    )
+
+
+class _FakeAttemptRecordControl:
+    def records(self):
+        return ()
+
+
+class _FakeRuntime:
+    def __init__(self, *, final_decision: str = "RESTART", block_after_deterministic: bool = False):
+        self.attempt_record_control = _FakeAttemptRecordControl()
+        self.final_decision = final_decision
+        self.block_after_deterministic = block_after_deterministic
+        self.deterministic_published = threading.Event()
+        self.release = threading.Event()
+        self.requests = []
+        self.finalized_l0a = []
+
+    def analyze(
+        self,
+        request,
+        *,
+        on_deterministic_ready,
+        on_route_complete,
+        retain_detailed_artifacts=True,
+    ):
+        assert retain_detailed_artifacts is False
+        self.requests.append(request)
+        return self._complete(on_deterministic_ready, on_route_complete)
+
+    def analyze_prepared(
+        self,
+        request,
+        finalized_l0a,
+        *,
+        on_deterministic_ready,
+        on_route_complete,
+        retain_detailed_artifacts=True,
+    ):
+        assert retain_detailed_artifacts is False
+        self.requests.append(request)
+        self.finalized_l0a.append(finalized_l0a)
+        return self._complete(on_deterministic_ready, on_route_complete)
+
+    def _complete(self, on_deterministic_ready, on_route_complete):
+        deterministic = _analysis_result("STOP")
+        on_deterministic_ready(
+            DecisionCandidate(
+                candidate_kind="deterministic",
+                result=deterministic,
+                ready_wall_clock_s=0.01,
+                l1_execution_status="in_flight",
+            )
+        )
+        self.deterministic_published.set()
+        if self.block_after_deterministic:
+            self.release.wait(timeout=2.0)
+        final = _analysis_result(self.final_decision)
+        model_result = ModelAnalysisResult(
+            route_id="test-route",
+            model="test-model",
+            endpoint="https://llm.example.test/v1",
+            credential_ref="TEST_LLM_KEY_FILE",
+            execution_status="completed",
+            l1_usable=True,
+            analysis_result=final,
+        )
+        on_route_complete(model_result, {})
+        return SimpleNamespace(result=SimpleNamespace(model_results=(model_result,)))
+
+
+def _backend(tmp_path, runtime, *, max_total_records: int = 8):
+    return RestartAgentServiceBackend(
+        allowed_root=str(tmp_path),
+        runtime=runtime,
+        config=_config(max_total_records=max_total_records),
+        convergence=LogConvergencePolicy(quiet_seconds=0, max_wait_seconds=0, poll_seconds=0),
+        progressive=ProgressiveAnalysisPolicy(
+            enabled=True,
+            pre_end_poll_seconds=180,
+            active_idle_seconds=900,
+            max_active_states=64,
+            max_completed_results=max_total_records,
+        ),
+    )
+
+
+def test_progressive_start_accepts_expected_file_before_creation_and_preserves_cycle_zero(
+    tmp_path,
+):
+    runtime = _FakeRuntime()
+    backend = _backend(tmp_path, runtime)
+    log_path = str(tmp_path / "train_cycle0.log")
+
+    async def run():
+        submitted = await backend.submit_log(
+            log_path,
+            user="alice",
+            job_id="job-7",
+            analysis_intent="progressive",
+        )
+        probe = await backend.analyze_log(log_path, wait=False)
+        return submitted, probe
+
+    try:
+        submitted, probe = asyncio.run(run())
+        jobs = backend.get_all_jobs()
+
+        assert not isinstance(submitted, LogAnalyzerError)
+        assert submitted.submitted is True
+        assert probe.status == "pending"
+        assert jobs["job-7"][0]["cycle_id"] == 0
+        assert runtime.requests == []
+    finally:
+        backend.shutdown()
+
+
+def test_default_terminal_first_policy_registers_then_analyzes_at_terminal(tmp_path):
+    runtime = _FakeRuntime()
+    backend = RestartAgentServiceBackend(
+        allowed_root=str(tmp_path),
+        runtime=runtime,
+        config=_config(),
+        convergence=LogConvergencePolicy(
+            quiet_seconds=0,
+            max_wait_seconds=0,
+            poll_seconds=0,
+        ),
+        progressive=ProgressiveAnalysisPolicy(),
+    )
+    log_path = tmp_path / "train_cycle1.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+
+    async def run():
+        await backend.submit_log(
+            str(log_path),
+            job_id="job-7",
+            analysis_intent="progressive",
+        )
+        before_terminal = await backend.get_stats()
+        await backend.submit_log(
+            str(log_path),
+            analysis_intent="terminal",
+        )
+        result = await backend.analyze_log(str(log_path), wait=True)
+        return before_terminal, result
+
+    try:
+        stats, result = asyncio.run(run())
+
+        progressive = stats["restart_agent"]["progressive"]
+        assert progressive["l0a_build_count"] == 0
+        assert progressive["states"] == {"disabled": 1}
+        assert result.status == "completed"
+        assert len(runtime.finalized_l0a) == 1
+    finally:
+        backend.shutdown()
+
+
+def test_progressive_start_precomputes_and_terminal_reuses_finalized_l0a(tmp_path):
+    runtime = _FakeRuntime()
+    backend = RestartAgentServiceBackend(
+        allowed_root=str(tmp_path),
+        runtime=runtime,
+        config=_config(),
+        convergence=LogConvergencePolicy(
+            quiet_seconds=0,
+            max_wait_seconds=0,
+            poll_seconds=0,
+        ),
+        progressive=ProgressiveAnalysisPolicy(
+            enabled=True,
+            pre_end_poll_seconds=60,
+            active_idle_seconds=600,
+            max_active_states=4,
+            max_completed_results=8,
+        ),
+    )
+    log_path = tmp_path / "train_cycle1.log"
+    log_path.write_text(
+        "[2026-01-01 00:00:00] iteration 7 / 100 | consumed samples: 64 |\n"
+        "RuntimeError: CUDA out of memory\n",
+        encoding="utf-8",
+    )
+
+    async def run():
+        await backend.submit_log(
+            str(log_path),
+            job_id="job-7",
+            analysis_intent="progressive",
+        )
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            stats = await backend.get_stats()
+            if stats["restart_agent"]["progressive"]["l0a_build_count"] == 1:
+                break
+            await asyncio.sleep(0.01)
+        await backend.submit_log(
+            str(log_path),
+            analysis_intent="terminal",
+        )
+        return await backend.analyze_log(str(log_path), wait=True)
+
+    try:
+        result = asyncio.run(run())
+
+        assert result.status == "completed"
+        assert len(runtime.finalized_l0a) == 1
+        finalized = runtime.finalized_l0a[0]
+        assert finalized.precomputed is True
+        assert finalized.source_log.lines == (
+            "[2026-01-01 00:00:00] iteration 7 / 100 | consumed samples: 64 |",
+            "RuntimeError: CUDA out of memory",
+        )
+        assert finalized.progressive_metrics["l0a_build_count"] == 1
+        stats = asyncio.run(backend.get_stats())
+        assert stats["restart_agent"]["progressive"]["active_state_count"] == 0
+    finally:
+        backend.shutdown()
+
+
+def test_terminal_drain_ingests_late_rank_output_and_precomputes_final_boundary(tmp_path):
+    # Arrange
+    runtime = _FakeRuntime()
+    first_precompute_completed = threading.Event()
+
+    class _ObservedAccumulator(ProgressiveL0Accumulator):
+        def refresh(self, *, precompute=True):
+            changed = super().refresh(precompute=precompute)
+            if precompute:
+                first_precompute_completed.set()
+            return changed
+
+    backend = RestartAgentServiceBackend(
+        allowed_root=str(tmp_path),
+        runtime=runtime,
+        config=_config(),
+        convergence=LogConvergencePolicy(
+            quiet_seconds=0.04,
+            max_wait_seconds=0.3,
+            poll_seconds=0.01,
+        ),
+        progressive=ProgressiveAnalysisPolicy(
+            pre_end_poll_seconds=180,
+            active_idle_seconds=900,
+            max_active_states=4,
+            max_completed_results=8,
+        ),
+        accumulator_factory=_ObservedAccumulator,
+    )
+    log_path = tmp_path / "train_cycle1.log"
+    log_path.write_text("iteration 7 completed\n", encoding="utf-8")
+
+    async def run():
+        await backend.submit_log(
+            str(log_path),
+            job_id="job-7",
+            analysis_intent="terminal",
+        )
+        assert await asyncio.to_thread(first_precompute_completed.wait, 0.3)
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write("RuntimeError: CUDA out of memory\n")
+        return await backend.analyze_log(str(log_path), wait=True)
+
+    try:
+        # Act
+        result = asyncio.run(run())
+
+        # Assert
+        assert result.status == "completed"
+        finalized = runtime.finalized_l0a[0]
+        assert finalized.source_log.lines == (
+            "iteration 7 completed",
+            "RuntimeError: CUDA out of memory",
+        )
+        assert finalized.progressive_metrics["poll_count"] >= 3
+        assert finalized.progressive_metrics["growth_count"] >= 2
+        assert finalized.precomputed is True
+        assert finalized.progressive_metrics["l0a_build_count"] == 2
+        assert (
+            finalized.canonical_hash
+            == ProgressiveL0Accumulator(str(log_path)).finalize().canonical_hash
+        )
+        assert finalized.progressive_metrics["source_decode_wall_clock_s"] >= 0
+        assert finalized.progressive_metrics["source_index_classify_wall_clock_s"] >= 0
+        assert finalized.progressive_metrics["source_ingest_wall_clock_s"] >= 0
+        assert finalized.progressive_metrics["l0a_reduction_wall_clock_s"] >= 0
+        drain = finalized.progressive_metrics["terminal_drain"]
+        assert drain["converged"] is True
+        assert drain["max_wait_expired"] is False
+        assert drain["poll_count"] >= 2
+
+        stats = asyncio.run(backend.get_stats())
+        terminal_timing = stats["restart_agent"]["terminal_timing"]
+        assert terminal_timing["drain_wall_clock_s"] >= 0
+        assert terminal_timing["l0a_ready_wall_clock_s"] >= terminal_timing["drain_wall_clock_s"]
+        assert (
+            terminal_timing["deterministic_ready_wall_clock_s"]
+            >= terminal_timing["l0a_ready_wall_clock_s"]
+        )
+        assert (
+            terminal_timing["first_route_ready_wall_clock_s"]
+            >= terminal_timing["deterministic_ready_wall_clock_s"]
+        )
+        assert (
+            terminal_timing["analysis_completed_wall_clock_s"]
+            >= terminal_timing["first_route_ready_wall_clock_s"]
+        )
+    finally:
+        backend.shutdown()
+
+
+def test_terminal_drain_observes_source_while_initial_ingest_is_running(tmp_path, monkeypatch):
+    # Arrange
+    runtime = _FakeRuntime()
+    backend = RestartAgentServiceBackend(
+        allowed_root=str(tmp_path),
+        runtime=runtime,
+        config=_config(),
+        convergence=LogConvergencePolicy(
+            quiet_seconds=0.02,
+            max_wait_seconds=0.5,
+            poll_seconds=0.01,
+        ),
+    )
+    log_path = tmp_path / "train_cycle1.log"
+    log_path.write_text("iteration 7 completed\n", encoding="utf-8")
+    source_observed_twice = threading.Event()
+    precompute_requested = threading.Event()
+    real_stat = restart_agent_backend_module.os.stat
+    stat_calls = 0
+
+    def observed_stat(path):
+        nonlocal stat_calls
+        result = real_stat(path)
+        if str(path) == str(log_path):
+            stat_calls += 1
+            if stat_calls >= 2:
+                source_observed_twice.set()
+        return result
+
+    class _BlockedAccumulator:
+        def refresh(self, *, precompute):
+            if precompute:
+                precompute_requested.set()
+            else:
+                assert source_observed_twice.wait(timeout=0.3)
+
+    monkeypatch.setattr(restart_agent_backend_module.os, "stat", observed_stat)
+
+    try:
+        # Act
+        outcome = backend._wait_for_log_convergence(str(log_path), _BlockedAccumulator())
+
+        # Assert
+        assert outcome.converged is True
+        assert outcome.max_wait_expired is False
+        assert outcome.poll_count >= 3
+        assert precompute_requested.is_set()
+    finally:
+        backend.shutdown()
+
+
+def test_terminal_drain_completion_wakes_reader_without_poll_delay(tmp_path, monkeypatch):
+    # Arrange
+    runtime = _FakeRuntime()
+    backend = RestartAgentServiceBackend(
+        allowed_root=str(tmp_path),
+        runtime=runtime,
+        config=_config(),
+        convergence=LogConvergencePolicy(
+            quiet_seconds=0.01,
+            max_wait_seconds=2,
+            poll_seconds=1,
+        ),
+    )
+
+    def finish_after_reader_is_waiting(
+        path,
+        *,
+        reader_ready,
+        notifications,
+        stop_observer,
+    ):
+        del path, notifications, stop_observer
+        assert reader_ready.wait(timeout=0.3)
+        time.sleep(0.05)
+        return restart_agent_backend_module._DrainOutcome(
+            converged=True,
+            max_wait_expired=False,
+        )
+
+    monkeypatch.setattr(
+        backend,
+        "_observe_log_convergence",
+        finish_after_reader_is_waiting,
+    )
+
+    try:
+        # Act
+        started = time.monotonic()
+        outcome = backend._wait_for_log_convergence(str(tmp_path / "job.log"), None)
+        elapsed = time.monotonic() - started
+
+        # Assert
+        assert outcome.converged is True
+        assert elapsed < 0.5
+    finally:
+        backend.shutdown()
+
+
+def test_path_without_cycle_suffix_remains_analyzable_without_inventing_cycle_zero(tmp_path):
+    runtime = _FakeRuntime()
+    backend = _backend(tmp_path, runtime)
+    log_path = tmp_path / "train.log"
+    log_path.write_text("failure\n", encoding="utf-8")
+
+    async def run():
+        return await backend.submit_log(
+            str(log_path),
+            user="alice",
+            job_id="job-7",
+            analysis_intent="progressive",
+        )
+
+    try:
+        submitted = asyncio.run(run())
+        jobs = backend.get_all_jobs()
+
+        assert not isinstance(submitted, LogAnalyzerError)
+        assert jobs["job-7"][0]["cycle_id"] is None
+    finally:
+        backend.shutdown()
+
+
+def test_explicit_cycle_id_takes_precedence_over_path_inference(tmp_path):
+    runtime = _FakeRuntime()
+    backend = _backend(tmp_path, runtime)
+    log_path = tmp_path / "train_cycle2.log"
+    log_path.write_text("failure\n", encoding="utf-8")
+
+    async def run():
+        started = await backend.submit_log(
+            str(log_path),
+            user="alice",
+            job_id="job-7",
+            cycle_id=9,
+            analysis_intent="progressive",
+        )
+        terminal = await backend.submit_log(
+            str(log_path),
+            user="alice",
+            analysis_intent="terminal",
+        )
+        result = await backend.analyze_log(str(log_path), wait=True)
+        return started, terminal, result
+
+    try:
+        started, terminal, result = asyncio.run(run())
+
+        assert not isinstance(started, LogAnalyzerError)
+        assert not isinstance(terminal, LogAnalyzerError)
+        assert result.status == "completed"
+        assert runtime.requests[0].cycle_id == 9
+        assert backend.get_all_jobs()["job-7"][0]["cycle_id"] == 9
+    finally:
+        backend.shutdown()
+
+
+def test_explicit_cycle_id_conflict_is_rejected_after_registration(tmp_path):
+    runtime = _FakeRuntime()
+    backend = _backend(tmp_path, runtime)
+    log_path = tmp_path / "train_cycle2.log"
+
+    async def run():
+        first = await backend.submit_log(
+            str(log_path),
+            job_id="job-7",
+            cycle_id=9,
+            analysis_intent="progressive",
+        )
+        conflicting = await backend.submit_log(
+            str(log_path),
+            job_id="job-7",
+            cycle_id=10,
+            analysis_intent="terminal",
+        )
+        return first, conflicting
+
+    try:
+        first, conflicting = asyncio.run(run())
+
+        assert not isinstance(first, LogAnalyzerError)
+        assert isinstance(conflicting, LogAnalyzerError)
+        assert conflicting.error_code.value == "invalid_parameter"
+    finally:
+        backend.shutdown()
+
+
+def test_direct_backend_rejects_non_integer_explicit_cycle_id(tmp_path):
+    runtime = _FakeRuntime()
+    backend = _backend(tmp_path, runtime)
+
+    async def run():
+        return await backend.submit_log(
+            str(tmp_path / "train.log"),
+            job_id="job-7",
+            cycle_id=True,
+            analysis_intent="progressive",
+        )
+
+    try:
+        result = asyncio.run(run())
+
+        assert isinstance(result, LogAnalyzerError)
+        assert result.error_code.value == "invalid_parameter"
+    finally:
+        backend.shutdown()
+
+
+def test_terminal_missing_log_returns_explicit_restart_agent_unavailable_result(tmp_path):
+    config = _config()
+    backend = RestartAgentServiceBackend(
+        allowed_root=str(tmp_path),
+        runtime=build_restart_agent_runtime(config),
+        config=config,
+        convergence=LogConvergencePolicy(quiet_seconds=0, max_wait_seconds=0, poll_seconds=0),
+    )
+    log_path = tmp_path / "never_created_cycle1.log"
+
+    async def run():
+        submitted = await backend.submit_log(
+            str(log_path), job_id="job-7", analysis_intent="terminal"
+        )
+        result = await backend.analyze_log(str(log_path), wait=True)
+        return submitted, result
+
+    try:
+        submitted, result = asyncio.run(run())
+
+        assert not isinstance(submitted, LogAnalyzerError)
+        assert result.status == "completed"
+        assert result.result["decision"] == "RESTART"
+        assert result.result["decision_basis"] == "log_unavailable"
+        assert result.recommendation["action"] == "UNKNOWN"
+    finally:
+        backend.shutdown()
+
+
+def test_terminal_submission_is_idempotent_and_get_returns_completed_result(tmp_path):
+    runtime = _FakeRuntime(final_decision="RESTART")
+    backend = _backend(tmp_path, runtime)
+    log_path = tmp_path / "train_cycle2.log"
+    log_path.write_text("failure\n", encoding="utf-8")
+
+    async def run():
+        first = await backend.submit_log(str(log_path), job_id="job-7", analysis_intent="terminal")
+        second = await backend.submit_log(str(log_path), job_id="job-7", analysis_intent="terminal")
+        result = await backend.analyze_log(str(log_path), wait=True)
+        return first, second, result
+
+    try:
+        first, second, result = asyncio.run(run())
+
+        assert not isinstance(first, LogAnalyzerError)
+        assert not isinstance(second, LogAnalyzerError)
+        assert len(runtime.requests) == 1
+        assert runtime.requests[0].job_id == "job-7"
+        assert runtime.requests[0].cycle_id == 2
+        assert result.status == "completed"
+        assert result.recommendation["action"] == "RESTART"
+    finally:
+        backend.shutdown()
+
+
+def test_same_path_cannot_be_registered_with_conflicting_job_identity(tmp_path):
+    runtime = _FakeRuntime()
+    backend = _backend(tmp_path, runtime)
+    log_path = tmp_path / "train_cycle2.log"
+    log_path.write_text("failure\n", encoding="utf-8")
+
+    async def run():
+        first = await backend.submit_log(
+            str(log_path), job_id="job-7", analysis_intent="progressive"
+        )
+        conflicting = await backend.submit_log(
+            str(log_path), job_id="job-8", analysis_intent="progressive"
+        )
+        return first, conflicting
+
+    try:
+        first, conflicting = asyncio.run(run())
+
+        assert not isinstance(first, LogAnalyzerError)
+        assert isinstance(conflicting, LogAnalyzerError)
+        assert conflicting.error_code.value == "invalid_parameter"
+    finally:
+        backend.shutdown()
+
+
+def test_nonblocking_get_publishes_deterministic_result_while_model_is_running(tmp_path):
+    runtime = _FakeRuntime(final_decision="RESTART", block_after_deterministic=True)
+    backend = _backend(tmp_path, runtime)
+    log_path = tmp_path / "train_cycle3.log"
+    log_path.write_text("failure\n", encoding="utf-8")
+
+    async def run():
+        await backend.submit_log(str(log_path), job_id="job-7", analysis_intent="terminal")
+        assert runtime.deterministic_published.wait(timeout=1.0)
+        deterministic = await backend.analyze_log(str(log_path), wait=False)
+        runtime.release.set()
+        completed = await backend.analyze_log(str(log_path), wait=True)
+        return deterministic, completed
+
+    try:
+        deterministic, completed = asyncio.run(run())
+
+        assert deterministic.status == "in_flight"
+        assert deterministic.recommendation["action"] == "STOP"
+        assert deterministic.recommendation["source"] == "deterministic"
+        assert deterministic.candidate_recommendation["action"] == "STOP"
+        assert deterministic.candidate_recommendation["source"] == "deterministic"
+        assert completed.status == "completed"
+        assert completed.recommendation["action"] == "RESTART"
+        assert completed.candidate_recommendation["action"] == "RESTART"
+        assert completed.candidate_recommendation["source"] == "l1_enriched:test-route"
+    finally:
+        runtime.release.set()
+        backend.shutdown()
+
+
+def test_registry_evicts_completed_attempt_before_rejecting_new_work(tmp_path):
+    runtime = _FakeRuntime()
+    backend = _backend(tmp_path, runtime, max_total_records=1)
+    first = tmp_path / "train_cycle1.log"
+    second = tmp_path / "train_cycle2.log"
+    first.write_text("failure\n", encoding="utf-8")
+    second.write_text("failure\n", encoding="utf-8")
+
+    async def run():
+        await backend.submit_log(str(first), job_id="job-7", analysis_intent="terminal")
+        await backend.analyze_log(str(first), wait=True)
+        submitted = await backend.submit_log(
+            str(second), job_id="job-7", analysis_intent="progressive"
+        )
+        stats = await backend.get_stats()
+        return submitted, stats
+
+    try:
+        submitted, stats = asyncio.run(run())
+
+        assert not isinstance(submitted, LogAnalyzerError)
+        assert stats["restart_agent"]["registry_evictions"] == 1
+        assert list(backend.get_all_jobs()["job-7"])[0]["cycle_id"] == 2
+    finally:
+        backend.shutdown()
+
+
+def test_outside_root_and_missing_parent_are_rejected(tmp_path):
+    runtime = _FakeRuntime()
+    backend = _backend(tmp_path, runtime)
+
+    async def run():
+        outside = await backend.submit_log(
+            "/tmp/outside_cycle1.log", job_id="job-7", analysis_intent="progressive"
+        )
+        missing_parent = await backend.submit_log(
+            str(tmp_path / "missing" / "train_cycle1.log"),
+            job_id="job-7",
+            analysis_intent="progressive",
+        )
+        return outside, missing_parent
+
+    try:
+        outside, missing_parent = asyncio.run(run())
+
+        assert isinstance(outside, LogAnalyzerError)
+        assert outside.error_code.value == "outside_root"
+        assert isinstance(missing_parent, LogAnalyzerError)
+        assert missing_parent.error_code.value == "not_found"
+    finally:
+        backend.shutdown()

--- a/tests/attribution/unit/test_attrsvc_restart_agent_http.py
+++ b/tests/attribution/unit/test_attrsvc_restart_agent_http.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public HTTP lifecycle tests for attrsvc's direct Restart Agent path."""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("slowapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from nvidia_resiliency_ext.attribution.restart_agent import (  # noqa: E402
+    AnalysisResult,
+    DecisionCandidate,
+    ModelAnalysisResult,
+)
+from nvidia_resiliency_ext.services.attrsvc.app import create_app  # noqa: E402
+from nvidia_resiliency_ext.services.attrsvc.config import Settings  # noqa: E402
+
+
+class _AttemptRecords:
+    def records(self):
+        return ()
+
+
+class _Runtime:
+    def __init__(self):
+        self.attempt_record_control = _AttemptRecords()
+        self.requests = []
+
+    def analyze(
+        self,
+        request,
+        *,
+        on_deterministic_ready,
+        on_route_complete,
+        retain_detailed_artifacts=True,
+    ):
+        assert retain_detailed_artifacts is False
+        self.requests.append(request)
+        result = AnalysisResult(
+            decision="STOP",
+            decision_basis="test",
+            result_provenance={"nvrx_use": "eligible"},
+            justification="test stop result",
+        )
+        on_deterministic_ready(
+            DecisionCandidate(
+                candidate_kind="deterministic",
+                result=result,
+                ready_wall_clock_s=0.01,
+                l1_execution_status="in_flight",
+            )
+        )
+        model_result = ModelAnalysisResult(
+            route_id="nvrx-default",
+            model="test-model",
+            endpoint="https://llm.example.test/v1",
+            credential_ref="LLM_API_KEY_FILE",
+            execution_status="completed",
+            l1_usable=True,
+            analysis_result=result,
+        )
+        on_route_complete(model_result, {})
+        return SimpleNamespace(result=SimpleNamespace(model_results=(model_result,)))
+
+
+def test_public_progressive_terminal_and_get_lifecycle(tmp_path, monkeypatch):
+    key_file = tmp_path / "key"
+    key_file.write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("LLM_API_KEY_FILE", str(key_file))
+    runtime = _Runtime()
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.services.attrsvc.service.build_restart_agent_runtime",
+        lambda config: runtime,
+    )
+    cfg = Settings(
+        ALLOWED_ROOT=str(tmp_path),
+        LLM_MODEL="test-model",
+        LLM_BASE_URL="https://llm.example.test/v1",
+        RESTART_AGENT_LOG_MAX_WAIT_SECONDS=0,
+        _env_file=None,
+    )
+    log_path = tmp_path / "train_cycle0.log"
+
+    with TestClient(create_app(cfg)) as client:
+        start = client.post(
+            "/logs",
+            json={
+                "log_path": str(log_path),
+                "user": "alice",
+                "job_id": "job-7",
+                "cycle_id": 8,
+                "analysis_intent": "progressive",
+            },
+        )
+        pending = client.get("/logs", params={"log_path": str(log_path), "wait": False})
+        log_path.write_text("failure\n", encoding="utf-8")
+        terminal = client.post(
+            "/logs",
+            json={
+                "log_path": str(log_path),
+                "user": "alice",
+                "job_id": "job-7",
+                "cycle_id": 8,
+                "analysis_intent": "terminal",
+            },
+        )
+        completed = client.get("/logs", params={"log_path": str(log_path), "wait": True})
+
+    assert start.status_code == 200
+    assert terminal.status_code == 200
+    assert pending.json()["status"] == "pending"
+    assert completed.status_code == 200
+    assert completed.json()["status"] == "completed"
+    assert completed.json()["recommendation"]["action"] == "STOP"
+    assert completed.json()["candidate_recommendation"]["action"] == "STOP"
+    assert len(runtime.requests) == 1
+    assert runtime.requests[0].job_id == "job-7"
+    assert runtime.requests[0].cycle_id == 8
+
+
+def test_public_submit_rejects_boolean_cycle_id(tmp_path, monkeypatch):
+    key_file = tmp_path / "key"
+    key_file.write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("LLM_API_KEY_FILE", str(key_file))
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.services.attrsvc.service.build_restart_agent_runtime",
+        lambda config: _Runtime(),
+    )
+    cfg = Settings(
+        ALLOWED_ROOT=str(tmp_path),
+        LLM_MODEL="test-model",
+        LLM_BASE_URL="https://llm.example.test/v1",
+        RESTART_AGENT_LOG_MAX_WAIT_SECONDS=0,
+        _env_file=None,
+    )
+
+    with TestClient(create_app(cfg)) as client:
+        response = client.post(
+            "/logs",
+            json={
+                "log_path": str(tmp_path / "train.log"),
+                "job_id": "job-7",
+                "cycle_id": True,
+                "analysis_intent": "progressive",
+            },
+        )
+
+    assert response.status_code == 422

--- a/tests/attribution/unit/test_attrsvc_settings.py
+++ b/tests/attribution/unit/test_attrsvc_settings.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 pytest.importorskip("pydantic")
@@ -5,6 +7,15 @@ pytest.importorskip("pydantic_settings")
 
 attrsvc_config = pytest.importorskip("nvidia_resiliency_ext.services.attrsvc.config")
 Settings = attrsvc_config.Settings
+
+
+def test_attrsvc_analysis_backend_defaults_to_direct_restart_agent(tmp_path, monkeypatch):
+    monkeypatch.delenv("NVRX_ATTRSVC_ANALYSIS_BACKEND", raising=False)
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.ANALYSIS_BACKEND == "lib"
+    assert cfg.RESTART_AGENT_ENRICHMENT_ENABLED is True
 
 
 def test_attrsvc_llm_settings_are_override_only(tmp_path, monkeypatch):
@@ -58,6 +69,11 @@ def test_attrsvc_progressive_analysis_defaults_to_all_explicit(tmp_path, monkeyp
     cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
 
     assert cfg.PROGRESSIVE_ANALYSIS == "all_explicit"
+    assert cfg.RESTART_AGENT_PROGRESSIVE_ENABLED is False
+    assert cfg.RESTART_AGENT_PRE_END_POLL_SECONDS == 180.0
+    assert cfg.RESTART_AGENT_ACTIVE_IDLE_SECONDS == 900.0
+    assert cfg.RESTART_AGENT_MAX_ACTIVE_STATES == 64
+    assert cfg.RESTART_AGENT_MAX_COMPLETED_RESULTS == 3000
 
 
 def test_attrsvc_progressive_analysis_accepts_off(tmp_path, monkeypatch):
@@ -76,13 +92,98 @@ def test_attrsvc_progressive_analysis_accepts_all_explicit(tmp_path, monkeypatch
     assert cfg.PROGRESSIVE_ANALYSIS == "all_explicit"
 
 
+def test_attrsvc_restart_agent_progressive_analysis_accepts_explicit_enable(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("NVRX_ATTRSVC_RESTART_AGENT_PROGRESSIVE_ENABLED", "true")
+
+    cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+    assert cfg.RESTART_AGENT_PROGRESSIVE_ENABLED is True
+
+
 def test_attrsvc_log_analysis_backend_env_is_not_supported(tmp_path, monkeypatch):
     monkeypatch.delenv("NVRX_ATTRSVC_ANALYSIS_BACKEND", raising=False)
     monkeypatch.setenv("NVRX_ATTRSVC_LOG_ANALYSIS_BACKEND", "lib")
 
     cfg = Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
 
-    assert cfg.ANALYSIS_BACKEND == "mcp"
+    assert cfg.ANALYSIS_BACKEND == "lib"
+
+
+def test_attrsvc_restart_agent_config_resolves_existing_llm_environment(tmp_path, monkeypatch):
+    resolver = pytest.importorskip(
+        "nvidia_resiliency_ext.services.attrsvc.restart_agent_config"
+    ).restart_agent_config_from_settings
+    key_file = tmp_path / "key"
+    key_file.write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("LLM_API_KEY_FILE", str(key_file))
+    cfg = Settings(
+        ALLOWED_ROOT=str(tmp_path),
+        LLM_MODEL="model-a",
+        LLM_BASE_URL="https://llm.example.test/v1",
+        _env_file=None,
+    )
+
+    restart_config = resolver(cfg)
+
+    assert restart_config.config_id == "nvrx-attrsvc-environment"
+    assert len(restart_config.model_route_specs) == 1
+    route = restart_config.model_route_specs[0]
+    assert route.route_id == "nvrx-default"
+    assert route.model == "model-a"
+    assert route.endpoint == "https://llm.example.test/v1"
+
+
+def test_attrsvc_restart_agent_allows_explicit_deterministic_only_mode(tmp_path):
+    resolver = pytest.importorskip(
+        "nvidia_resiliency_ext.services.attrsvc.restart_agent_config"
+    ).restart_agent_config_from_settings
+    cfg = Settings(
+        ALLOWED_ROOT=str(tmp_path),
+        RESTART_AGENT_ENRICHMENT_ENABLED=False,
+        _env_file=None,
+    )
+
+    restart_config = resolver(cfg, environ={})
+
+    assert restart_config.config_id == "nvrx-attrsvc-deterministic"
+    assert restart_config.enrichment_enabled is False
+    assert restart_config.model_route_specs == ()
+    assert restart_config.max_parallel_models == 0
+
+
+def test_attrsvc_restart_agent_config_file_is_authoritative_and_single_route(tmp_path):
+    resolver = pytest.importorskip(
+        "nvidia_resiliency_ext.services.attrsvc.restart_agent_config"
+    ).restart_agent_config_from_settings
+    config_path = tmp_path / "restart_agent.json"
+    payload = {
+        "schema_version": "restart_agent_config.v1",
+        "config_id": "file-config",
+        "config_version": 1,
+        "enrichment": {"enabled": True},
+        "routing": {"mode": "collect_all", "max_parallel_models": 2},
+        "model_routes": [
+            {
+                "route_id": route_id,
+                "model": route_id,
+                "base_url": "https://llm.example.test/v1",
+                "credential_ref": "TEST_KEY",
+            }
+            for route_id in ("one", "two")
+        ],
+    }
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    cfg = Settings(
+        ALLOWED_ROOT=str(tmp_path),
+        RESTART_AGENT_CONFIG=str(config_path),
+        _env_file=None,
+    )
+
+    with pytest.raises(ValueError, match="exactly one model route"):
+        resolver(cfg, environ={"TEST_KEY": "/unused/key"})
 
 
 def test_attrsvc_log_level_uses_current_env_name_only(tmp_path, monkeypatch):

--- a/tests/attribution/unit/test_http_api.py
+++ b/tests/attribution/unit/test_http_api.py
@@ -17,10 +17,16 @@ def test_log_submit_payload_omits_empty_optional_fields():
 
 
 def test_log_submit_payload_includes_smon_fields():
-    assert log_submit_payload("/tmp/train.log", user="alice", job_id="123") == {
+    assert log_submit_payload(
+        "/tmp/train.log",
+        user="alice",
+        job_id="123",
+        cycle_id=4,
+    ) == {
         "log_path": "/tmp/train.log",
         "user": "alice",
         "job_id": "123",
+        "cycle_id": 4,
     }
 
 
@@ -52,11 +58,16 @@ def test_log_result_params_includes_wait_when_requested():
 def test_post_log_uses_shared_logs_route():
     client = MagicMock()
 
-    post_log(client, "/tmp/train.log", user="alice", job_id="123")
+    post_log(client, "/tmp/train.log", user="alice", job_id="123", cycle_id=4)
 
     client.post.assert_called_once_with(
         "/logs",
-        json={"log_path": "/tmp/train.log", "user": "alice", "job_id": "123"},
+        json={
+            "log_path": "/tmp/train.log",
+            "user": "alice",
+            "job_id": "123",
+            "cycle_id": 4,
+        },
         headers={"accept": "application/json"},
     )
 

--- a/tests/attribution/unit/test_restart_agent.py
+++ b/tests/attribution/unit/test_restart_agent.py
@@ -1,0 +1,8010 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+import pytest
+
+from nvidia_resiliency_ext.attribution.restart_agent import (
+    Decision,
+    DecisionBasis,
+    ModelRoute,
+    RestartAgentRequest,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.agent_runtime import RestartAgentRuntime
+from nvidia_resiliency_ext.attribution.restart_agent.attempt_records import (
+    InMemoryAttemptRecordStore,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.causality import build_result_cascades
+from nvidia_resiliency_ext.attribution.restart_agent.cli import (
+    _evidence_extractor_from_args,
+    _parse_args,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.cli import main as cli_main
+from nvidia_resiliency_ext.attribution.restart_agent.config import (
+    build_log_source_factory,
+    build_model_routes,
+    load_restart_agent_config,
+    parse_restart_agent_config,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.identity import canonical_observed_fingerprint
+from nvidia_resiliency_ext.attribution.restart_agent.infrastructure.l0_publisher import (
+    L0ArtifactPublisher,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.infrastructure.live_artifacts import (
+    LiveArtifactWriter,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.infrastructure.log_source import LogSnapshot
+from nvidia_resiliency_ext.attribution.restart_agent.infrastructure.route_publisher import (
+    load_route_artifact_manifest,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l0 import assembly as l0_assembly
+from nvidia_resiliency_ext.attribution.restart_agent.l0 import build_l0_bundle
+from nvidia_resiliency_ext.attribution.restart_agent.l0.codec import read_l0_bundle, write_l0_bundle
+from nvidia_resiliency_ext.attribution.restart_agent.l0.decision import (
+    build_decision_evidence,
+    canonical_identity_anchor_line,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l0.projection import _window_preview_lines
+from nvidia_resiliency_ext.attribution.restart_agent.l0.projection import (
+    build_l0_model_facing_view as _build_l0_model_facing_view,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l1.openai_compatible import (
+    L1EvidenceResult,
+    LlmCallError,
+    LlmConfig,
+    LlmEvidenceExtractor,
+    OpenAICompatibleTransport,
+    RetryingChatTransport,
+    _execute_tool_call,
+    _initial_user_message,
+    _is_context_window_exceeded_error,
+    _is_http_timeout_status,
+    _provider_reported_timing,
+    _request_context_budget,
+    _tool_loop_profile,
+    _tool_schemas,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l1.prompts import SYSTEM_PROMPT
+from nvidia_resiliency_ext.attribution.restart_agent.l1.response_contract import (
+    L1_RESPONSE_CONTRACT,
+    model_response_schema,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l1.tools import (
+    LogTools,
+    build_l1_evidence_context,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l1.validation import (
+    model_evidence_contract_errors,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l2.grounding import (
+    model_visible_line_numbers,
+    model_visible_line_texts,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l3.history import DETERMINISTIC_FACT_SELECTOR
+from nvidia_resiliency_ext.attribution.restart_agent.l3.history import (
+    HistoryEvaluationInput as CoreHistoryEvaluationInput,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l3.history import evaluate_history
+from nvidia_resiliency_ext.attribution.restart_agent.l4.policy import L4PolicyInput, evaluate_policy
+from nvidia_resiliency_ext.attribution.restart_agent.models import (
+    AffectedEntity,
+    AffectedEntityKind,
+    AssessmentStatus,
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    AttemptProgressSummary,
+    AttemptRecord,
+    CausalRole,
+    ContextWindow,
+    FailureDomain,
+    FailureDomainAssessment,
+    FailureEvidence,
+    HistorySummary,
+    L0Bundle,
+    LogLine,
+    ModelRecoveryAssessment,
+    NormalizedOccurrenceGroup,
+    PriorAttemptView,
+    ProgressFacts,
+    RetryOutlookAssessment,
+    RetryOutlookWithoutWorkloadChange,
+    RetryPolicyConfig,
+    RetryPolicyRule,
+    normalize_attempt_records,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.observability.trace_builder import (
+    l1_token_limit_summary,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.pipeline import (
+    RestartAgent as CoreRestartAgent,
+)
+
+
+class RestartAgent(CoreRestartAgent):
+    """Test helper that records each thread's invocation-owned run artifacts."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._test_state = threading.local()
+
+    def analyze(self, *args, **kwargs):
+        if args and isinstance(args[0], dict) and "schema_version" not in args[0]:
+            args = ({"schema_version": "restart_agent_request.v1", **args[0]}, *args[1:])
+        run = self.run(*args, **kwargs)
+        self._test_state.run = run
+        return run.result
+
+    def analyze_many(self, *args, **kwargs):
+        if args and isinstance(args[0], dict) and "schema_version" not in args[0]:
+            args = ({"schema_version": "restart_agent_request.v1", **args[0]}, *args[1:])
+        return self.run_many(*args, **kwargs).result
+
+    @property
+    def last_trace(self):
+        return self._test_state.run.trace
+
+    @property
+    def last_bundle(self):
+        return self._test_state.run.bundle
+
+    @property
+    def last_decision_evidence(self):
+        return self._test_state.run.decision_evidence
+
+    @property
+    def last_model_view(self):
+        return self._test_state.run.model_view
+
+
+def build_l0_model_facing_view(bundle):
+    return _build_l0_model_facing_view(bundle, build_decision_evidence(bundle))
+
+
+def _canonical_identity_anchor_line(bundle, line):
+    return canonical_identity_anchor_line(bundle, line, selection_label="model_primary")
+
+
+def _attempt_records(*records):
+    return normalize_attempt_records(tuple(_attempt_record_fixture(item) for item in records))
+
+
+def _attempt_record_fixture(value):
+    completed = value.get("last_completed_step")
+    checkpoint = value.get("last_checkpoint_step")
+    return AttemptRecord(
+        job_id=value["job_id"],
+        cycle_id=value["cycle_id"],
+        progress=AttemptProgressSummary(
+            training_progress="observed" if completed is not None else "unknown",
+            first_completed_step=completed,
+            last_completed_step=completed,
+            completed_step_delta=0 if completed is not None else None,
+            progress_marker_count=1 if completed is not None else 0,
+            checkpoint_progress="observed" if checkpoint is not None else "unknown",
+            first_checkpoint_step=checkpoint,
+            last_checkpoint_step=checkpoint,
+            checkpoint_step_delta=0 if checkpoint is not None else None,
+            checkpoint_marker_count=1 if checkpoint is not None else 0,
+        ),
+        deterministic=AttemptFailureFacts(
+            source=AttemptFailureFactsSource.L0_DETERMINISTIC,
+            root_fingerprint=value.get("root_fingerprint"),
+            root_fingerprint_source=value.get("root_fingerprint_source", "test_fixture"),
+            fault_outcome=value.get("primary_fault_outcome", "terminal"),
+            failure_iteration=value.get("failure_iteration"),
+            affected_entity=_affected_entity_fixture(value),
+            faulting_rank=value.get("faulting_rank"),
+            faulting_node=value.get("faulting_node"),
+            faulting_gpu=value.get("faulting_gpu"),
+            rank_to_gpu_map=value.get("rank_to_gpu_map", {}),
+        ),
+    )
+
+
+def _affected_entity_fixture(value):
+    data_position = value.get("data_position_fingerprint")
+    artifact_path = value.get("artifact_path")
+    if data_position:
+        return AffectedEntity(
+            kind=AffectedEntityKind.DATA_POSITION,
+            identity=data_position,
+            fingerprint=f"test:data_position:{data_position}",
+        )
+    if artifact_path:
+        return AffectedEntity(
+            kind=AffectedEntityKind.ARTIFACT,
+            identity=artifact_path,
+            fingerprint=f"test:artifact:{artifact_path}",
+        )
+    return None
+
+
+def _recovery_assessment(
+    *,
+    domain: str,
+    outlook: str,
+    domain_status: Optional[str] = None,
+    outlook_status: Optional[str] = None,
+) -> ModelRecoveryAssessment:
+    domain_status = domain_status or (
+        AssessmentStatus.UNKNOWN.value
+        if domain == FailureDomain.UNKNOWN.value
+        else AssessmentStatus.SUPPORTED_BUT_UNCONFIRMED.value
+    )
+    outlook_status = outlook_status or (
+        AssessmentStatus.UNKNOWN.value
+        if outlook == RetryOutlookWithoutWorkloadChange.UNKNOWN.value
+        else AssessmentStatus.SUPPORTED_BUT_UNCONFIRMED.value
+    )
+    return ModelRecoveryAssessment(
+        failure_domain=FailureDomainAssessment(
+            value=FailureDomain(domain),
+            status=AssessmentStatus(domain_status),
+            confidence=50,
+        ),
+        retry_outlook_without_workload_change=RetryOutlookAssessment(
+            value=RetryOutlookWithoutWorkloadChange(outlook),
+            status=AssessmentStatus(outlook_status),
+            confidence=50,
+        ),
+        rationale="typed policy test input",
+    )
+
+
+def _attempt_facts_and_progress(
+    primary: FailureEvidence,
+    progress: ProgressFacts,
+) -> tuple[AttemptFailureFacts, AttemptProgressSummary]:
+    facts = AttemptFailureFacts(
+        source=AttemptFailureFactsSource.L0_DETERMINISTIC,
+        root_fingerprint=primary.root_fingerprint,
+        root_fingerprint_source=primary.root_fingerprint_source,
+        fault_outcome=primary.fault_outcome,
+        primary_line=primary.line,
+        failure_iteration=primary.failure_iteration,
+        affected_entity=_affected_entity_fixture(
+            {"data_position_fingerprint": primary.data_position_fingerprint}
+        ),
+        faulting_rank=primary.rank,
+        faulting_node=primary.node,
+        faulting_gpu=primary.gpu,
+    )
+    completed = progress.highest_completed_step
+    checkpoint = progress.last_checkpoint_step
+    return facts, AttemptProgressSummary(
+        training_progress="observed" if completed is not None else "unknown",
+        first_completed_step=completed,
+        last_completed_step=completed,
+        completed_step_delta=0 if completed is not None else None,
+        progress_marker_count=1 if completed is not None else 0,
+        checkpoint_progress="observed" if checkpoint is not None else "unknown",
+        first_checkpoint_step=checkpoint,
+        last_checkpoint_step=checkpoint,
+        checkpoint_step_delta=0 if checkpoint is not None else None,
+        checkpoint_marker_count=1 if checkpoint is not None else 0,
+    )
+
+
+def _history_evaluation_input(*, current_attempt, job_id, cycle_id, prior_records):
+    facts, progress = current_attempt
+    current_record = AttemptRecord(
+        job_id=job_id,
+        cycle_id=cycle_id,
+        progress=progress,
+        deterministic=facts,
+    )
+    prior = tuple(
+        record for record in prior_records if record.job_id == job_id and record.cycle_id < cycle_id
+    )
+    return CoreHistoryEvaluationInput(
+        current_record=current_record,
+        fact_selector=DETERMINISTIC_FACT_SELECTOR,
+        prior_attempts=PriorAttemptView(
+            records=prior,
+            available=True,
+            availability_reason="ready",
+        ),
+    )
+
+
+def _prior_attempt_view(*records):
+    return PriorAttemptView(
+        records=_attempt_records(*records),
+        available=True,
+        availability_reason="ready",
+    )
+
+
+def _current_evidence(value):
+    fixture = dict(value)
+    old_primary = dict(fixture.get("primary_failure") or {})
+    existing_root = fixture.get("root_cause_assessment")
+    existing_related = fixture.get("related_failures")
+    existing_assessment = dict(
+        fixture.get("model_recovery_assessment") or fixture.get("model_policy_assessment") or {}
+    )
+    primary_line = old_primary.get("line")
+    primary = None
+    if primary_line is not None:
+        old_identity = old_primary.get("failure_identity")
+        identity = dict(old_identity) if isinstance(old_identity, dict) else {}
+        primary = {
+            "line": primary_line,
+            "causal_role": old_primary.get("causal_role") or "initiating",
+            "failure_identity": {
+                "operation": identity.get("operation"),
+                "mechanism": identity.get("mechanism") or old_primary.get("failure_class"),
+                "component": identity.get("component"),
+                "artifact_path": identity.get("artifact_path"),
+            },
+        }
+    related = []
+    for item in [
+        *(fixture.get("secondary_failures", []) or []),
+        *(fixture.get("cascades", []) or []),
+    ]:
+        if not isinstance(item, dict) or item.get("line") is None:
+            continue
+        related.append(
+            {
+                "line": item["line"],
+                "causal_role": item.get("causal_role") or "unknown",
+                "rationale": "Related failure from the test fixture.",
+            }
+        )
+    root_cause = (
+        dict(existing_root)
+        if isinstance(existing_root, dict)
+        else {
+            "summary": fixture.get("justification") or "Test root cause.",
+            "plausible_causes": ["test cause"],
+        }
+    )
+    root_cause = {
+        "summary": root_cause.get("summary") or "Test root cause.",
+        "status": root_cause.get("status") or "established_by_current_log",
+        "plausible_causes": list(root_cause.get("plausible_causes") or []),
+        "missing_evidence": list(root_cause.get("missing_evidence") or []),
+    }
+    analysis_status = fixture.get("analysis_status") or (
+        "primary_identified" if primary is not None else "insufficient_evidence"
+    )
+    if primary is None:
+        missing_evidence = root_cause["missing_evidence"]
+        if analysis_status == "insufficient_evidence" and not missing_evidence:
+            missing_evidence = ["test fixture did not identify a primary failure"]
+        if analysis_status == "no_failure_observed":
+            summary = L1_RESPONSE_CONTRACT.no_failure_summary
+            rationale = L1_RESPONSE_CONTRACT.no_failure_rationale
+        else:
+            summary = L1_RESPONSE_CONTRACT.insufficient_summary
+            rationale = L1_RESPONSE_CONTRACT.insufficient_rationale
+        return {
+            "schema_version": "restart_agent_evidence.v1",
+            "analysis_status": analysis_status,
+            "primary_failure": None,
+            "root_cause_assessment": {
+                "summary": summary,
+                "status": "unknown",
+                "plausible_causes": [],
+                "missing_evidence": (
+                    [] if analysis_status == "no_failure_observed" else missing_evidence
+                ),
+            },
+            "model_recovery_assessment": {
+                "failure_domain": {
+                    "value": "unknown",
+                    "status": "unknown",
+                    "confidence": 1,
+                },
+                "retry_outlook_without_workload_change": {
+                    "value": "unknown",
+                    "status": "unknown",
+                    "confidence": 1,
+                },
+                "rationale": rationale,
+            },
+            "related_failures": [],
+            "evidence": [],
+        }
+    persistence = existing_assessment.get(
+        "current_attempt_persistence_evidence",
+        "none",
+    )
+    old_recovery_path = existing_assessment.get("retry_recovery_path", "unknown")
+    retry_outlook = existing_assessment.get(
+        "retry_outlook_without_workload_change",
+        old_primary.get("retry_outlook_without_workload_change"),
+    )
+    retry_outlook_mapping = retry_outlook if isinstance(retry_outlook, dict) else None
+    if retry_outlook is None:
+        retry_outlook = (
+            "cannot_recover"
+            if old_recovery_path in {"workload_change", "external_intervention"}
+            else (
+                "may_recover"
+                if old_recovery_path
+                in {"ordinary_retry", "wait_or_teardown", "workload_managed_retry_grace"}
+                else "unknown"
+            )
+        )
+    domain = existing_assessment.get("failure_domain", old_primary.get("failure_domain"))
+    domain_mapping = domain if isinstance(domain, dict) else None
+    if domain_mapping is None:
+        domain = domain or "unknown"
+    claim_status = (
+        "established_by_current_log"
+        if persistence == "affirmative"
+        else "unknown" if domain == "unknown" else "supported_but_unconfirmed"
+    )
+    raw_evidence = list(fixture.get("evidence") or [])
+    evidence = []
+    for index, item in enumerate(raw_evidence, start=1):
+        if not isinstance(item, dict):
+            continue
+        supports = item.get("supports")
+        if not isinstance(supports, list):
+            supports = [supports] if isinstance(supports, str) else []
+        if primary is not None and item.get("line") == primary_line:
+            supports = [
+                "primary_failure",
+                "root_cause_assessment",
+                "failure_domain",
+                "retry_outlook_without_workload_change",
+            ]
+        else:
+            supports = [
+                tag
+                for tag in supports
+                if tag
+                in {
+                    "primary_failure",
+                    "root_cause_assessment",
+                    "failure_domain",
+                    "retry_outlook_without_workload_change",
+                }
+            ]
+        evidence.append(
+            {
+                "id": item.get("id") or f"e{index}",
+                "line": item.get("line"),
+                "quote": item.get("quote") or "test evidence",
+                "supports": supports or ["root_cause_assessment"],
+            }
+        )
+    return {
+        "schema_version": "restart_agent_evidence.v1",
+        "analysis_status": analysis_status,
+        "primary_failure": primary,
+        "root_cause_assessment": root_cause,
+        "model_recovery_assessment": {
+            "failure_domain": domain_mapping
+            or {
+                "value": domain,
+                "status": claim_status,
+                "confidence": existing_assessment.get("confidence", 90),
+            },
+            "retry_outlook_without_workload_change": retry_outlook_mapping
+            or {
+                "value": retry_outlook,
+                "status": ("unknown" if retry_outlook == "unknown" else claim_status),
+                "confidence": existing_assessment.get("confidence", 90),
+            },
+            "rationale": existing_assessment.get("rationale")
+            or fixture.get("justification")
+            or "Test recovery assessment.",
+        },
+        "related_failures": (existing_related if isinstance(existing_related, list) else related),
+        "evidence": evidence,
+    }
+
+
+class _FakeEvidenceExtractor:
+    def __init__(
+        self,
+        evidence,
+        *,
+        success=True,
+        malformed=False,
+        errors=(),
+        anomalies=None,
+        finish_reason="stop",
+        transcript_events=(),
+    ):
+        self.evidence = _current_evidence(evidence)
+        self.success = success
+        self.malformed = malformed
+        self.errors = tuple(errors)
+        self.anomalies = dict(anomalies or {})
+        self.finish_reason = finish_reason
+        self.transcript_events = tuple(transcript_events)
+        self.model_view = None
+
+    def extract_evidence(self, context, *, deadline_monotonic=None):
+        self.model_view = context.model_view
+        return L1EvidenceResult(
+            evidence=self.evidence,
+            model="fake-model",
+            raw_model_output=json.dumps(self.evidence),
+            success=self.success,
+            malformed=self.malformed,
+            errors=self.errors,
+            model_calls=(
+                {
+                    "layer": "L1",
+                    "model": "fake-model",
+                    "success": self.success,
+                    "latency_s": 0.001,
+                    "finish_reason": self.finish_reason,
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 5,
+                        "total_tokens": 15,
+                        "prompt_tokens_details": {"cached_tokens": 3},
+                        "completion_tokens_details": {"reasoning_tokens": 2},
+                    },
+                },
+            ),
+            anomalies=self.anomalies,
+            transcript_events=self.transcript_events,
+        )
+
+
+class _BlockingEvidenceExtractor(_FakeEvidenceExtractor):
+    def __init__(self, evidence):
+        super().__init__(evidence)
+        self.started = threading.Event()
+        self.release = threading.Event()
+        self.completed = threading.Event()
+
+    def extract_evidence(self, context, *, deadline_monotonic=None):
+        self.started.set()
+        if not self.release.wait(timeout=5):
+            raise TimeoutError("test did not release the L1 extractor")
+        result = super().extract_evidence(
+            context,
+            deadline_monotonic=deadline_monotonic,
+        )
+        self.completed.set()
+        return result
+
+
+class _RetryOnceEvidenceExtractor(LlmEvidenceExtractor):
+    def __init__(self, evidence):
+        super().__init__(
+            LlmConfig(
+                api_key="test-key",
+                max_retries=1,
+                retry_backoff_seconds=0.0,
+                tools_enabled=False,
+            )
+        )
+        self.evidence = _current_evidence(evidence)
+        self.calls = 0
+
+    def _call_model(
+        self,
+        *,
+        api_key,
+        messages,
+        include_tools,
+        model_turn,
+        attempt=1,
+        max_retries=None,
+        deadline_monotonic=None,
+    ):
+        self.calls += 1
+        if self.calls == 1:
+            raise LlmCallError(
+                "HTTP 502: bad gateway",
+                {
+                    "layer": "L1",
+                    "model": "nvidia/qwen/qwen3.5-35b-a3b",
+                    "model_turn": model_turn,
+                    "attempt": attempt,
+                    "max_retries": max_retries,
+                    "success": False,
+                    "latency_s": 0.01,
+                    "finish_reason": None,
+                    "usage": None,
+                    "tools_advertised": include_tools,
+                    "error_type": "http_error",
+                    "error": "HTTP 502",
+                    "http_status": 502,
+                    "response_body": "bad gateway",
+                    "retryable": True,
+                    "retry_scheduled": False,
+                    "timeout": False,
+                },
+            )
+        return (
+            {
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {"content": json.dumps(self.evidence)},
+                    }
+                ],
+                "usage": {"total_tokens": 100},
+            },
+            {
+                "layer": "L1",
+                "model": "nvidia/qwen/qwen3.5-35b-a3b",
+                "model_turn": model_turn,
+                "attempt": attempt,
+                "max_retries": max_retries,
+                "success": True,
+                "latency_s": 0.02,
+                "finish_reason": "stop",
+                "usage": {"total_tokens": 100},
+                "tools_advertised": include_tools,
+            },
+        )
+
+
+class _ContractRepairEvidenceExtractor(LlmEvidenceExtractor):
+    def __init__(self, complete_evidence):
+        super().__init__(
+            LlmConfig(
+                api_key="test-key",
+                max_retries=0,
+                tools_enabled=False,
+            )
+        )
+        self.complete_evidence = _current_evidence(complete_evidence)
+        self.calls = 0
+
+    def _call_model(
+        self,
+        *,
+        api_key,
+        messages,
+        include_tools,
+        model_turn,
+        attempt=1,
+        max_retries=None,
+        deadline_monotonic=None,
+    ):
+        self.calls += 1
+        content = (
+            json.dumps(
+                {
+                    "primary_failure": self.complete_evidence["primary_failure"],
+                    "related_failures": [],
+                }
+            )
+            if self.calls == 1
+            else json.dumps(self.complete_evidence)
+        )
+        return (
+            {
+                "choices": [{"finish_reason": "stop", "message": {"content": content}}],
+                "usage": {"total_tokens": 100},
+            },
+            {
+                "layer": "L1",
+                "model": "nvidia/qwen/qwen3.5-35b-a3b",
+                "model_turn": model_turn,
+                "attempt": attempt,
+                "max_retries": max_retries,
+                "success": True,
+                "latency_s": 0.01,
+                "finish_reason": "stop",
+                "usage": {"total_tokens": 100},
+                "tools_advertised": include_tools,
+            },
+        )
+
+
+class _SingleResponseEvidenceExtractor(LlmEvidenceExtractor):
+    def __init__(self, evidence):
+        super().__init__(
+            LlmConfig(
+                api_key="test-key",
+                max_retries=0,
+                tools_enabled=False,
+            )
+        )
+        self.evidence = _current_evidence(evidence)
+        self.calls = 0
+
+    def _call_model(
+        self,
+        *,
+        api_key,
+        messages,
+        include_tools,
+        model_turn,
+        attempt=1,
+        max_retries=None,
+        deadline_monotonic=None,
+    ):
+        self.calls += 1
+        return (
+            {
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {"content": json.dumps(self.evidence)},
+                    }
+                ],
+                "usage": {"total_tokens": 100},
+            },
+            {
+                "layer": "L1",
+                "model": "nvidia/qwen/qwen3.5-35b-a3b",
+                "model_turn": model_turn,
+                "attempt": attempt,
+                "max_retries": max_retries,
+                "success": True,
+                "latency_s": 0.01,
+                "finish_reason": "stop",
+                "usage": {"total_tokens": 100},
+                "tools_advertised": include_tools,
+            },
+        )
+
+
+def test_l0_terminal_episode_does_not_claim_unobserved_prior_progress(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "Traceback (most recent call last):\nUnicodeDecodeError: invalid byte\n",
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.failure_episodes
+    assert bundle.failure_episodes[0].last_progress_before is None
+    assert "no prior progress marker was observed" in bundle.failure_episodes[0].reason
+    assert bundle.post_fault_summaries[0].progress_after_observed is False
+
+
+def test_l0_batch_text_lookup_preserves_requests_larger_than_reuse_cache():
+    observations = l0_assembly.L0ObservationAccumulator()
+    requested_count = l0_assembly.MAX_REDUCTION_TEXT_CACHE_LINES + 17
+    for index in range(1, requested_count + 1):
+        observations.append_text(f"line {index}")
+
+    observations._begin_reduction()
+    try:
+        text_by_line = observations.text_map(range(1, requested_count + 1))
+    finally:
+        observations._end_reduction()
+
+    assert len(text_by_line) == requested_count
+    assert text_by_line[1] == "line 1"
+    assert text_by_line[requested_count] == f"line {requested_count}"
+
+
+def test_l0_coverage_separates_failure_candidate_from_taxonomy_primary(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "ERROR: checkpoint writer unexpected position 704 vs 598\n",
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.candidate_anchors
+    assert bundle.deterministic_primary_candidate is None
+    assert bundle.evidence_coverage["first_failure_candidate"] == "found"
+    assert bundle.evidence_coverage["deterministic_taxonomy_primary"] == "not_found"
+    assert "first_fault" not in bundle.evidence_coverage
+
+
+def test_canonical_observed_fingerprint_ignores_runtime_locality_and_iteration():
+    first = canonical_observed_fingerprint(
+        "180: [rank180]: RuntimeError: Rank 180, node nvl72005-T14, device 0, "
+        "iteration 670314: Unexpected result inf in bucket #0"
+    )
+    second = canonical_observed_fingerprint(
+        "22: [rank22]: RuntimeError: Rank 22, node nvl99999-T01, device 7, "
+        "iteration 670315: Unexpected result inf in bucket #9"
+    )
+
+    assert first == second
+
+
+def test_observed_fingerprint_excludes_conditional_diagnostic_hypotheses():
+    shared_memory = canonical_observed_fingerprint(
+        "RuntimeError: DataLoader worker is killed by signal: Bus error. "
+        "It is possible that workers are out of shared memory. "
+        "Please try to raise your shared memory limit."
+    )
+    storage = canonical_observed_fingerprint(
+        "RuntimeError: DataLoader worker is killed by signal: Bus error. "
+        "This may be caused by an intermittent storage read."
+    )
+
+    assert shared_memory == storage
+    assert "shared_memory" not in str(shared_memory)
+    assert "storage" not in str(storage)
+
+
+def test_llm_default_output_ceiling_is_64k():
+    assert LlmConfig().max_output_tokens == 64_000
+
+
+def test_prompt_exposes_exactly_two_l1_recovery_concepts(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("OSError: address already in use\n", encoding="utf-8")
+    bundle = build_l0_bundle(str(log_path))
+    model_view = build_l0_model_facing_view(bundle)
+    user_payload = json.loads(_initial_user_message(model_view))
+    normalized_system_prompt = " ".join(SYSTEM_PROMPT.split())
+
+    assert "Return exactly these two current-attempt recovery claims" in SYSTEM_PROMPT
+    assert "retry_outlook_without_workload_change" in SYSTEM_PROMPT
+    assert "current_attempt_persistence_evidence" not in SYSTEM_PROMPT
+    assert "recovery_requirement" not in SYSTEM_PROMPT
+    assert "fixed request" in SYSTEM_PROMPT
+    assert "missing cleanup message" in SYSTEM_PROMPT
+    assert "Confidence is a 1..99 calibration signal" in SYSTEM_PROMPT
+    assert "multi-rank fanout" in SYSTEM_PROMPT
+    assert "Durable remediation" in SYSTEM_PROMPT
+    assert "workload-selected framework or library behavior" in SYSTEM_PROMPT
+    assert "Megatron" not in SYSTEM_PROMPT
+    assert "CUDA_LAUNCH_BLOCKING" not in SYSTEM_PROMPT
+    assert "NVLink" not in SYSTEM_PROMPT
+    assert "namespace evidence" not in SYSTEM_PROMPT.lower()
+    assert "Do not decide STOP or RESTART" not in SYSTEM_PROMPT
+    assert "Do not use attempt history" not in SYSTEM_PROMPT
+    assert "L0 evidence" not in SYSTEM_PROMPT
+    assert "registry matches" not in SYSTEM_PROMPT
+
+    assert "not a STOP/RESTART decision or policy input" not in SYSTEM_PROMPT
+    assert "Prior progress proves runnability, not transience" in normalized_system_prompt
+    assert "Replay distance and failure position do not establish" in normalized_system_prompt
+    assert "Later aggregate progress" in normalized_system_prompt
+    assert "Inspect supplied context before calling tools" in normalized_system_prompt
+    assert "under these product guarantees" in normalized_system_prompt
+    assert "the workload is unchanged" in normalized_system_prompt
+    assert "process state is recreated" in normalized_system_prompt
+    assert "normal restart delay applies" in normalized_system_prompt
+    assert "hardware allocation may change" in normalized_system_prompt
+    assert "external-service state may change" in normalized_system_prompt
+    assert set(user_payload) == {
+        "attempt_execution_context",
+        "decision_evidence",
+        "evidence_bundle",
+        "response_schema",
+    }
+    assert user_payload["evidence_bundle"] == model_view.evidence_bundle
+    assert "l0_bundle" not in user_payload
+    assert "interpretation_constraints" not in user_payload["attempt_execution_context"]
+    assert "task" not in user_payload
+    assert "instructions" not in user_payload
+    assert "available_tools" not in user_payload
+    assert "tool_loop_profile" not in user_payload
+    assert "restart_environment_context" not in user_payload
+    response_schema = user_payload["response_schema"]
+    assessment_schema = response_schema["properties"]["model_recovery_assessment"]["properties"]
+    assert response_schema["additionalProperties"] is False
+    assert response_schema["properties"]["evidence"]["maxItems"] == 12
+    assert response_schema["properties"]["related_failures"]["maxItems"] == 3
+    assert (
+        response_schema["semanticConstraints"]["no_failure_observed"]["recovery_claims"]
+        == "unknown value, unknown status, confidence 1"
+    )
+    assert set(assessment_schema) == {
+        "failure_domain",
+        "retry_outlook_without_workload_change",
+        "rationale",
+    }
+    assert set(assessment_schema["failure_domain"]["properties"]) == {
+        "value",
+        "status",
+        "confidence",
+    }
+    assert set(assessment_schema["retry_outlook_without_workload_change"]["properties"]) == {
+        "value",
+        "status",
+        "confidence",
+    }
+
+
+def test_l1_response_contract_single_sources_advertised_validation_constraints():
+    schema = model_response_schema()
+    properties = schema["properties"]
+    evidence = properties["evidence"]
+    claim = properties["model_recovery_assessment"]["properties"]["failure_domain"]
+
+    assert set(schema["required"]) == L1_RESPONSE_CONTRACT.top_level_fields
+    assert evidence["maxItems"] == L1_RESPONSE_CONTRACT.max_evidence_items
+    assert set(evidence["items"]["properties"]["supports"]["items"]["enum"]) == (
+        L1_RESPONSE_CONTRACT.evidence_support_tags
+    )
+    assert claim["properties"]["confidence"] == {
+        "type": "integer",
+        "minimum": L1_RESPONSE_CONTRACT.min_confidence,
+        "maximum": L1_RESPONSE_CONTRACT.max_confidence,
+        "description": "Calibration-only confidence in this claim.",
+    }
+    assert claim["semanticConstraint"] == (
+        "value=unknown if and only if status=unknown; otherwise neither is unknown"
+    )
+    assert schema["semanticConstraints"]["evidence_ids"] == "unique non-empty strings"
+
+
+@pytest.mark.parametrize("analysis_status", ["no_failure_observed", "insufficient_evidence"])
+def test_l1_non_primary_contract_has_canonical_unknown_semantics(analysis_status):
+    payload = _current_evidence(
+        {
+            "analysis_status": analysis_status,
+            "justification": "The current log does not establish a primary failure.",
+        }
+    )
+
+    assert model_evidence_contract_errors(payload) == []
+    assert payload["primary_failure"] is None
+    expected_summary = (
+        L1_RESPONSE_CONTRACT.no_failure_summary
+        if analysis_status == "no_failure_observed"
+        else L1_RESPONSE_CONTRACT.insufficient_summary
+    )
+    assert payload["root_cause_assessment"]["summary"] == expected_summary
+    assert payload["model_recovery_assessment"]["failure_domain"] == {
+        "value": "unknown",
+        "status": "unknown",
+        "confidence": 1,
+    }
+    assert payload["related_failures"] == []
+    assert payload["evidence"] == []
+
+
+def test_l1_non_primary_contract_rejects_noncanonical_recovery_claim():
+    payload = _current_evidence({"analysis_status": "no_failure_observed"})
+    payload["model_recovery_assessment"]["failure_domain"]["confidence"] = 80
+
+    assert model_evidence_contract_errors(payload) == [
+        "non-primary failure_domain.confidence must be 1"
+    ]
+
+
+def test_l1_non_primary_contract_rejects_free_form_summary_and_rationale():
+    payload = _current_evidence({"analysis_status": "no_failure_observed"})
+    payload["root_cause_assessment"]["summary"] = "This is probably a workload bug."
+    payload["model_recovery_assessment"]["rationale"] = "Stop the workload."
+
+    assert model_evidence_contract_errors(payload) == [
+        "non-primary root_cause_assessment.summary must be "
+        f"{L1_RESPONSE_CONTRACT.no_failure_summary!r}",
+        "non-primary model_recovery_assessment.rationale must be "
+        f"{L1_RESPONSE_CONTRACT.no_failure_rationale!r}",
+    ]
+
+
+def test_l2_visibility_uses_exact_full_model_visible_payload(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: invalid configuration"
+    log_path.write_text(failure_line + "\n", encoding="utf-8")
+    model_view = build_l0_model_facing_view(build_l0_bundle(str(log_path)))
+    result = L1EvidenceResult(
+        evidence=None,
+        model="test-model",
+        transcript_events=(
+            {
+                "event_type": "bundle_snapshot",
+                "model_visible_payload": {
+                    "decision_evidence": {
+                        "deterministic_primary_candidate": {
+                            "line": 1,
+                            "quote": failure_line,
+                        }
+                    },
+                    "distributed_failure_incidents": [
+                        {
+                            "primary_observed_line": 2,
+                            "primary_observed_quote": "Watchdog observed timeout",
+                        }
+                    ],
+                    "post_fault_summaries": [
+                        {
+                            "last_high_signal_line": 3,
+                            "last_high_signal_quote": "scheduler cancelled step",
+                        }
+                    ],
+                    "evidence_bundle": {},
+                },
+            },
+        ),
+    )
+
+    assert model_visible_line_numbers(model_view, result) == {1, 2, 3}
+    assert model_visible_line_texts(model_view, result) == {
+        1: {failure_line},
+        2: {"Watchdog observed timeout"},
+        3: {"scheduler cancelled step"},
+    }
+
+
+def test_decision_evidence_references_are_explicitly_provenance_only(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: invalid configuration\n", encoding="utf-8")
+
+    model_view = build_l0_model_facing_view(build_l0_bundle(str(log_path)))
+    references = model_view.decision_evidence.selected_evidence_references
+
+    assert references["semantics"] == "provenance_only"
+    assert references["resolution"] == "get_evidence_objects_when_advertised"
+    assert set(model_view.attempt_execution_context) == {"scope", "terminal_timing"}
+
+
+def test_l1_contract_rejects_retired_recovery_fields():
+    payload = _current_evidence(
+        {
+            "primary_failure": {
+                "line": 1,
+                "failure_class": "observed_exception",
+                "causal_role": "initiating",
+            },
+            "model_recovery_assessment": {
+                "failure_domain": "workload",
+                "retry_outlook_without_workload_change": "cannot_recover",
+            },
+            "evidence": [
+                {
+                    "line": 1,
+                    "quote": "RuntimeError: invalid configuration",
+                    "supports": "primary_failure",
+                }
+            ],
+        }
+    )
+    payload["model_recovery_assessment"]["current_attempt_persistence_evidence"] = "affirmative"
+
+    assert model_evidence_contract_errors(payload) == [
+        "model_recovery_assessment has unsupported fields: " "current_attempt_persistence_evidence"
+    ]
+
+
+def test_decision_evidence_is_shared_with_l0b_and_trace(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "7: iteration 418 completed",
+                "7: RuntimeError: CUDA out of memory",
+                "7: destroy_process_group() called during shutdown",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    bundle = build_l0_bundle(str(log_path))
+    decision_evidence = build_decision_evidence(bundle)
+    model_view = _build_l0_model_facing_view(bundle, decision_evidence)
+
+    assert decision_evidence.schema_version == "restart_agent_decision_evidence.v1"
+    assert decision_evidence.deterministic_primary_candidate is not None
+    assert decision_evidence.deterministic_primary_candidate.line == 2
+    assert decision_evidence.provenance == {
+        "source": "l0a_deterministic_selection",
+        "log_line_count": 3,
+        "log_byte_size": log_path.stat().st_size,
+        "log_rescanned": False,
+        "model_used": False,
+    }
+    assert model_view.prompt_payload()["decision_evidence"] == decision_evidence.to_payload()
+    assert model_view.prompt_payload()["evidence_bundle"] == model_view.evidence_bundle
+    assert "l0_bundle" not in model_view.prompt_payload()
+
+    analyzer = RestartAgent(
+        evidence_extractor=_FakeEvidenceExtractor({}, success=False, malformed=True)
+    )
+    analyzer.analyze({"log_path": str(log_path)}, l0_bundle=bundle)
+
+    assert analyzer.last_decision_evidence == decision_evidence
+    assert analyzer.last_model_view is not None
+    assert analyzer.last_model_view.decision_evidence is analyzer.last_decision_evidence
+    assert analyzer.last_trace["decision_evidence"] == decision_evidence.to_payload()
+    assert (
+        analyzer.last_trace["l0_model_view"]["decision_evidence"]
+        == analyzer.last_trace["decision_evidence"]
+    )
+    assert (
+        analyzer.last_trace["layers"]["L0"]["sub_stages"]["DecisionEvidence"]["status"]
+        == "completed"
+    )
+
+
+def test_l0_records_path_namespace_mismatch_and_distributed_exception_fanout(tmp_path):
+    log_path = tmp_path / "job.log"
+    lock_path = "/lustre/fsw/users/wdai/hf_home/datasets/cache.lock"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0:   data_cache_path ........................ /lustre/fsw/users/rwaleffe/cache",
+                "0:   load ................................... /lustre/fsw/users/wdai/checkpoint",
+                "0: successfully loaded checkpoint at iteration 0",
+                "80: [rank80]: Traceback (most recent call last):",
+                f"80: [rank80]: PermissionError: [Errno 13] Permission denied: '{lock_path}'",
+                f"96: [rank96]: PermissionError: [Errno 13] Permission denied: '{lock_path}'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+
+    assert bundle.path_namespace_summary["failed_vs_configured_write_mismatch"] is True
+    assert bundle.path_namespace_summary["ownership_verified"] is False
+    assert bundle.path_namespace_summary["namespaces_by_role"] == {
+        "configured_write": ["rwaleffe"],
+        "configured_read": ["wdai"],
+        "failed_access": ["wdai"],
+    }
+    failed = next(item for item in bundle.path_access_facts if item["role"] == "failed_access")
+    assert failed["access_intent"] == "write_or_create"
+    assert failed["path"] == lock_path
+    assert prompt_bundle["path_namespace_summary"] == bundle.path_namespace_summary
+    assert prompt_bundle["path_access_facts"] == list(bundle.path_access_facts)
+
+    permission_matches = [item for item in bundle.registry_matches if item.line in {5, 6}]
+    assert any(item.registry_id == "filesystem_permission_denied" for item in permission_matches)
+    assert all(
+        item.registry_id != "configuration_validation_failure" for item in permission_matches
+    )
+    assert len(bundle.distributed_failure_incidents) == 1
+    incident = bundle.distributed_failure_incidents[0]
+    assert incident.incident_kind == "distributed_fanout"
+    assert incident.incident_type == "distributed_exception_fanout"
+    assert incident.member_event_lines == (5, 6)
+    assert incident.event_count == 2
+    assert incident.observed_rank_count == 2
+    assert incident.interpretation == "same_attempt_rank_fanout_not_cross_cycle_recurrence"
+    prompt_incident = prompt_bundle["distributed_failure_incidents"][0]
+    assert prompt_incident["sample_lines"] == [5, 6]
+    assert "member_event_lines" not in prompt_incident
+
+
+def test_observed_collective_identity_ignores_c10d_severity_date_prefix():
+    first = (
+        "115: [rank115]:[E207 19:04:38.123186550 ProcessGroupNCCL.cpp:697] "
+        "[Rank 14] Watchdog caught collective operation timeout: "
+        "WorkNCCL(SeqNum=2, OpType=ALLGATHER, NumelIn=306689, "
+        "NumelOut=29442144, Timeout(ms)=600000)"
+    )
+    second = first.replace("E207 19:04:38.123186550", "E208 03:17:02.987654321")
+
+    first_fingerprint = canonical_observed_fingerprint(first)
+    second_fingerprint = canonical_observed_fingerprint(second)
+    assert first_fingerprint == second_fingerprint
+    assert "e207" not in (first_fingerprint or "")
+    assert "e208" not in (second_fingerprint or "")
+
+
+def test_observed_transport_identity_ignores_timestamp_node_and_process_routing():
+    line = (
+        "1000: [2026-02-02 12:15:56] nvl72026-T11:393849:395082 [0] "
+        "transport/net_ib.cc:253 NCCL WARN NET/IB : mlx5_3:1 "
+        "Got non-fatal async event: port error(10)"
+    )
+
+    fingerprint = canonical_observed_fingerprint(line)
+
+    assert fingerprint is not None
+    assert "nvl72026" not in fingerprint
+    assert "393849" not in fingerprint
+    assert "transport_net_ib" in fingerprint
+
+
+def test_l0_links_timeout_aligned_precursor_to_terminal_episode(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: [2026-02-02 12:15:29] iteration 589290/993410 | " "consumed samples: 1000 |",
+                (
+                    "1000: [2026-02-02 12:15:56] host-a:393849:395082 [0] "
+                    "transport/net_ib.cc:253 NCCL WARN NET/IB : mlx5_3:1 "
+                    "Got non-fatal async event: port error(10)"
+                ),
+                (
+                    "5995: [rank5995]:[E202 12:25:57.436 ProcessGroupNCCL.cpp:697] "
+                    "Watchdog caught collective operation timeout: "
+                    "WorkNCCL(SeqNum=126639, OpType=COALESCED, NumelIn=10, "
+                    "NumelOut=20, Timeout(ms)=600000) ran for 600000 milliseconds "
+                    "before timing out."
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    episode = bundle.failure_episodes[0]
+    prompt_episode = build_l0_model_facing_view(bundle).evidence_bundle["failure_episodes"][0]
+
+    assert episode.precursor_lines == (2,)
+    assert episode.identity_anchor_line == 2
+    assert episode.identity_anchor_reason == ("observed_precursor_aligned_with_terminal_timeout")
+    assert prompt_episode["identity_anchor_line"] == 2
+    assert prompt_episode["precursor_lines"] == [2]
+
+    def evidence(line, quote, failure_class):
+        return {
+            "schema_version": "restart_agent_evidence.v1",
+            "primary_failure": {
+                "failure_class": failure_class,
+                "signature": failure_class,
+                "proposed_root_fingerprint": None,
+                "fault_outcome": "terminal",
+                "causal_role": "initiating",
+                "data_position_fingerprint": None,
+                "line": line,
+                "rank": None,
+                "phase": "steady_mid",
+            },
+            "root_cause_assessment": {
+                "summary": "The communication path stopped making progress.",
+                "plausible_causes": ["transport disruption"],
+                "persistence_evidence": [],
+                "transient_alternatives": ["temporary link disruption"],
+            },
+            "model_recovery_assessment": {
+                "failure_domain": "infrastructure",
+                "next_attempt_same_failure_likelihood": "plausible",
+                "current_attempt_persistence_evidence": "none",
+                "retry_recovery_path": "unknown",
+                "confidence": 80,
+                "rationale": "A retry may recover from a transient transport event.",
+                "supporting_evidence_lines": [line],
+            },
+            "related_failures": [],
+            "evidence": [{"line": line, "quote": quote, "supports": "primary_failure"}],
+            "justification": "The transport event precedes the collective timeout.",
+        }
+
+    precursor_analyzer = RestartAgent(
+        evidence_extractor=_FakeEvidenceExtractor(
+            evidence(2, log_path.read_text().splitlines()[1], "ib_port_error")
+        )
+    )
+    timeout_analyzer = RestartAgent(
+        evidence_extractor=_FakeEvidenceExtractor(
+            evidence(3, log_path.read_text().splitlines()[2], "nccl_watchdog_timeout")
+        )
+    )
+    precursor_result = precursor_analyzer.analyze(
+        {"log_path": str(log_path)}, l0_bundle=bundle
+    ).to_payload()
+    timeout_result = timeout_analyzer.analyze(
+        {"log_path": str(log_path)}, l0_bundle=bundle
+    ).to_payload()
+
+    assert precursor_result["primary_failure"]["root_fingerprint"] == (
+        timeout_result["primary_failure"]["root_fingerprint"]
+    )
+    assert "transport_net_ib" in precursor_result["primary_failure"]["root_fingerprint"]
+    assert precursor_analyzer.last_trace["l2_audit"]["stable_identity_anchor_line"] == 2
+    assert timeout_analyzer.last_trace["l2_audit"]["stable_identity_anchor_line"] == 2
+    assert timeout_result["primary_failure"]["affected_entity"] is None
+
+
+def test_l2_accepts_abbreviated_quote_without_treating_same_event_fanout_as_persistence(
+    tmp_path,
+):
+    log_path = tmp_path / "job.log"
+    timeout = (
+        "Watchdog caught collective operation timeout: "
+        "WorkNCCL(SeqNum=7, OpType=ALLGATHER, NumelIn=10, NumelOut=20, "
+        "Timeout(ms)=600000) ran for 600000 milliseconds before timing out."
+    )
+    lines = [
+        "0: [2026-02-02 12:00:00] iteration 10/100 | consumed samples: 100 |",
+        f"0: [rank0]: {timeout}",
+        f"1: [rank1]: {timeout}",
+    ]
+    log_path.write_text("\n".join(lines), encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "nccl_watchdog_timeout",
+            "signature": "collective timeout",
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": "0",
+            "phase": "steady_mid",
+            "failure_identity": {
+                "operation": "allgather",
+                "mechanism": "collective_timeout",
+                "component": "nccl",
+                "artifact_path": None,
+            },
+        },
+        "root_cause_assessment": {
+            "summary": "The collective timed out.",
+            "status": "supported_but_unconfirmed",
+            "plausible_causes": ["communication failure"],
+            "missing_evidence": ["cross-attempt recurrence"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": {
+                "value": "infrastructure",
+                "status": "supported_but_unconfirmed",
+                "confidence": 70,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "may_recover",
+                "status": "supported_but_unconfirmed",
+                "confidence": 65,
+            },
+            "rationale": "The fanout is one collective incident; a restart may recover.",
+        },
+        "related_failures": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": (
+                    "Watchdog caught collective operation timeout: "
+                    "WorkNCCL(SeqNum=7, OpType=ALLGATHER, ... "
+                    "Timeout(ms)=600000)"
+                ),
+                "supports": "primary_failure",
+            },
+            {"line": 3, "quote": lines[2], "supports": "root_cause_assessment"},
+        ],
+        "justification": "The timeout stopped progress.",
+    }
+    extractor = _FakeEvidenceExtractor(evidence)
+    analyzer = RestartAgent(evidence_extractor=extractor)
+
+    result = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+    audit = analyzer.last_trace["l2_audit"]
+
+    assert result["decision"] == "RESTART"
+    assert extractor.model_view is analyzer.last_model_view
+    assert analyzer.last_trace["l0_model_view"] == analyzer.last_model_view.to_payload()
+    l0_trace = analyzer.last_trace["layers"]["L0"]
+    assert l0_trace["sub_stages"]["L0A"]["status"] == "completed"
+    assert l0_trace["sub_stages"]["L0B"]["status"] == "completed"
+    assert l0_trace["sub_stages"]["L0B"]["compaction_counts"]["model_facing_context_lines"] > 0
+    l2_trace = analyzer.last_trace["layers"]["L2"]
+    assert l2_trace["name"] == "evidence_grounding_and_identity"
+    assert l2_trace["grounding_status"] == "grounded"
+    assert l2_trace["grounding_method"] == "exact_source_line"
+    assert l2_trace["root_fingerprint_owner"] == "L2"
+    assert l2_trace["root_fingerprint_available"] is True
+    assert l2_trace["history_identity_ready"] is True
+    assert l2_trace["root_fingerprint"] == result["primary_failure"]["root_fingerprint"]
+    assert (
+        l2_trace["root_fingerprint_source"] == result["primary_failure"]["root_fingerprint_source"]
+    )
+    assert l2_trace["matches_l0_root_fingerprint"] is True
+    assert analyzer.last_trace["selected_failure_facts"]["source"] == "l2_grounded"
+    assert analyzer.last_trace["selected_failure_facts"]["history_identity_ready"] is True
+    assert analyzer.last_trace["layers"]["L3"]["selected_failure_facts_source"] == ("l2_grounded")
+    assert audit["citation_audits"][0]["status"] == "abbreviated_exact"
+    assert audit["model_recovery_assessment"]["failure_domain"]["value"] == ("infrastructure")
+    assert (
+        audit["model_recovery_assessment"]["retry_outlook_without_workload_change"]["value"]
+        == "may_recover"
+    )
+    assert audit["recovery_field_audits"] == []
+    assert audit.get("grounding_adjustments", []) == []
+    assert all("persistence" not in item["code"] for item in audit["findings"])
+
+
+def test_l2_does_not_create_history_identity_from_an_ungrounded_model_line(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: checkpoint metadata decode failed"
+    log_path.write_text(f"iteration 10 completed\n{failure_line}\n", encoding="utf-8")
+    bundle = build_l0_bundle(str(log_path))
+    l0_identity = build_decision_evidence(bundle).canonical_observed_identity
+    evidence = {
+        "primary_failure": {
+            "failure_class": "checkpoint_metadata_decode_error",
+            "signature": failure_line,
+            "proposed_root_fingerprint": "model:checkpoint_metadata_decode_error",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 999,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "unknown",
+            "retry_outlook_without_workload_change": "unknown",
+            "supporting_evidence_lines": [999],
+        },
+        "evidence": [{"line": 999, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The model cited a source line that does not exist.",
+    }
+    history = [
+        {
+            "job_id": "job-1",
+            "cycle_id": 1,
+            "root_fingerprint": l0_identity["root_fingerprint"],
+            "primary_fault_outcome": "terminal",
+            "last_completed_step": 10,
+        }
+    ]
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+
+    analyzer.analyze(
+        {
+            "log_path": str(log_path),
+            "job_id": "job-1",
+            "cycle_id": 2,
+        },
+        l0_bundle=bundle,
+        prior_attempts=_prior_attempt_view(*history),
+    )
+
+    l2 = analyzer.last_trace["layers"]["L2"]
+    current = analyzer.last_trace["selected_failure_facts"]
+    assert l2["grounding_status"] == "unavailable"
+    assert l2["root_fingerprint_available"] is False
+    assert current["source"] == "l2_grounded"
+    assert current["root_fingerprint"] is None
+    assert current["history_identity_ready"] is False
+    assert analyzer.last_trace["l3_history"]["matching_root_attempts"] == 0
+
+
+@pytest.mark.parametrize(
+    ("model_artifact_path", "expected_entity"),
+    [
+        (
+            "/checkpoints/job-1/iter_5000/metadata",
+            "/checkpoints/job-1/iter_5000/metadata",
+        ),
+        ("/checkpoints/invented/metadata", None),
+    ],
+)
+def test_l2_promotes_only_source_grounded_artifact_paths(
+    tmp_path,
+    model_artifact_path,
+    expected_entity,
+):
+    log_path = tmp_path / "job.log"
+    artifact_path = "/checkpoints/job-1/iter_5000/metadata"
+    failure_line = (
+        "4175: [rank4175]: UnicodeDecodeError: 'utf-8' codec can't decode "
+        "byte 0xde in position 8"
+    )
+    log_path.write_text(
+        f"0: loading distributed checkpoint from {artifact_path}\n{failure_line}\n",
+        encoding="utf-8",
+    )
+    bundle = build_l0_bundle(str(log_path))
+    evidence = {
+        "primary_failure": {
+            "failure_class": "checkpoint_metadata_decode_error",
+            "signature": failure_line,
+            "causal_role": "initiating",
+            "line": 2,
+            "failure_identity": {
+                "operation": "checkpoint_load",
+                "mechanism": "metadata_deserialization",
+                "component": "torch.distributed.checkpoint",
+                "artifact_path": model_artifact_path,
+            },
+        },
+        "evidence": [{"line": 2, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "Checkpoint metadata decoding failed.",
+    }
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+
+    result = analyzer.analyze({"log_path": str(log_path)}, l0_bundle=bundle).to_payload()
+
+    entity = result["primary_failure"]["affected_entity"]
+    if expected_entity is None:
+        assert entity is None
+        assert analyzer.last_trace["layers"]["L2"]["affected_entity"] is None
+        return
+    assert entity["kind"] == "artifact"
+    assert entity["identity"] == expected_entity
+    assert entity["evidence_line"] == 2
+    assert analyzer.last_trace["selected_failure_facts"]["affected_entity"] == entity
+
+
+def test_qwen_context_budget_reduces_only_the_effective_output_cap():
+    config = LlmConfig(model="nvidia/qwen/eccn-qwen-235b", max_output_tokens=64_000)
+    messages = [{"role": "user", "content": "x" * 450_000}]
+
+    budget = _request_context_budget(config, messages, include_tools=False)
+
+    assert budget["context_window_tokens"] == 200_000
+    assert budget["estimated_input_tokens"] > budget["raw_estimated_input_tokens"]
+    assert budget["estimation_multiplier"] == 1.15
+    assert budget["configured_max_output_tokens"] == 64_000
+    assert budget["effective_max_output_tokens"] < 64_000
+    assert budget["adjusted"] is True
+    assert (
+        budget["estimated_input_tokens"]
+        + budget["effective_max_output_tokens"]
+        + budget["safety_tokens"]
+        <= budget["context_window_tokens"]
+    )
+
+
+def test_qwen397b_context_window_is_known():
+    config = LlmConfig(model="nvidia/qwen/eccn-qwen3-5-397b-a17b")
+
+    assert config.resolved_context_window_tokens() == 262_144
+
+
+def test_context_window_rejection_is_reported_as_token_limit():
+    detail = (
+        "ContextWindowExceededError: This model's maximum context length is "
+        "200000 tokens; prompt contains 136001 input tokens"
+    )
+
+    assert _is_context_window_exceeded_error(detail) is True
+    summary = l1_token_limit_summary(
+        (
+            {
+                "model_turn": 5,
+                "attempt": 1,
+                "finish_reason": None,
+                "error_type": "context_window_exceeded",
+                "usage": None,
+                "max_retries": 1,
+            },
+        )
+    )
+
+    assert summary["hit"] is True
+    assert summary["hit_count"] == 1
+    assert summary["hit_calls"][0]["limit_kind"] == "context_window"
+
+
+def test_one_tool_round_profile_allows_two_model_turns():
+    profile = _tool_loop_profile(
+        LlmConfig(
+            model="nvidia/qwen/eccn-qwen-235b",
+            tools_enabled=True,
+            max_tool_rounds=1,
+        )
+    )
+
+    assert profile["max_tool_rounds"] == 1
+    assert profile["max_model_turns"] == 2
+    assert "tools-disabled final turn" in profile["meaning"]
+
+
+def test_default_tool_profile_does_not_advertise_evidence_object_lookup():
+    config = LlmConfig()
+
+    assert config.resolved_advertised_tools() == ("overview", "grep_log", "read_window")
+    assert [schema["function"]["name"] for schema in _tool_schemas(config)] == [
+        "overview",
+        "grep_log",
+        "read_window",
+    ]
+
+
+def test_evidence_object_lookup_requires_explicit_tool_profile_opt_in():
+    config = LlmConfig(advertised_tools=("get_evidence_objects",))
+
+    assert [schema["function"]["name"] for schema in _tool_schemas(config)] == [
+        "get_evidence_objects"
+    ]
+    assert _tool_loop_profile(config)["advertised_tools"] == ["get_evidence_objects"]
+
+
+def test_unknown_advertised_tool_is_rejected_by_configuration():
+    with pytest.raises(ValueError, match="unknown advertised tools: made_up_tool"):
+        LlmConfig(advertised_tools=("made_up_tool",))
+
+
+def test_get_evidence_objects_resolves_l0a_refs_without_log_read():
+    bundle = L0Bundle(
+        log_path="/path/that/must/not/be/read.log",
+        byte_size=120,
+        line_count=3,
+        occurrence_groups=(
+            NormalizedOccurrenceGroup(
+                occurrence_group_id="og-1",
+                normalized_shape="RuntimeError: <value>",
+                first_line=2,
+                count=1,
+                sample_lines=(2,),
+            ),
+        ),
+        context_windows=(
+            ContextWindow(
+                window_id="w-1",
+                selected_by="failure_episode",
+                start_line=1,
+                end_line=3,
+                seed_lines=(2,),
+                occurrence_group_ids=("og-1",),
+                lines=(
+                    LogLine(line=1, text="iteration 10 completed"),
+                    LogLine(line=2, text="RuntimeError: observed failure"),
+                    LogLine(line=3, text="shutdown"),
+                ),
+            ),
+        ),
+    )
+
+    result = LogTools(
+        bundle,
+        LogSnapshot(path=bundle.log_path, lines=(), byte_size=bundle.byte_size),
+    ).get_evidence_objects(["w-1", "og-1", "missing"])
+
+    assert result["schema_version"] == "restart_agent_evidence_objects.v1"
+    assert [item["object_type"] for item in result["objects"]] == [
+        "context_window",
+        "occurrence_group",
+    ]
+    assert result["objects"][0]["payload"]["lines"][1] == {
+        "line": 2,
+        "text": "RuntimeError: observed failure",
+    }
+    assert result["missing_refs"] == ["missing"]
+    assert result["truncated"] is False
+
+
+def test_get_evidence_objects_bounds_large_object_payloads():
+    bundle = L0Bundle(
+        log_path="/not/read.log",
+        byte_size=100_000,
+        line_count=1,
+        context_windows=(
+            ContextWindow(
+                window_id="w-large",
+                selected_by="test",
+                start_line=1,
+                end_line=1,
+                lines=(LogLine(line=1, text="x" * 100_000),),
+            ),
+        ),
+    )
+
+    result = LogTools(
+        bundle,
+        LogSnapshot(path=bundle.log_path, lines=(), byte_size=bundle.byte_size),
+    ).get_evidence_objects(["w-large"])
+
+    assert len(json.dumps(result, sort_keys=True)) <= 50_000
+    assert result["truncated"] is True
+    assert result["objects"][0]["truncated"] is True
+    assert result["objects"][0]["payload"]["lines"][0]["text"]
+
+
+def test_unadvertised_evidence_object_call_is_rejected_before_dispatch():
+    bundle = L0Bundle(
+        log_path="/not/read.log",
+        byte_size=0,
+        line_count=1,
+        context_windows=(
+            ContextWindow(
+                window_id="w-1",
+                selected_by="test",
+                start_line=1,
+                end_line=1,
+                lines=(LogLine(line=1, text="observed failure"),),
+            ),
+        ),
+    )
+    tool_call = {
+        "id": "call-1",
+        "name": "get_evidence_objects",
+        "arguments": json.dumps({"refs": ["w-1"]}),
+    }
+
+    result, record, unsupported = _execute_tool_call(
+        LogTools(bundle, LogSnapshot(path=bundle.log_path, lines=(), byte_size=0)),
+        tool_call,
+        model_turn=1,
+    )
+
+    assert result["error"] == "tool_not_advertised"
+    assert record["error"] == "tool_not_advertised"
+    assert unsupported["rejection_reason"] == "tool_not_advertised"
+
+    result, record, unsupported = _execute_tool_call(
+        LogTools(bundle, LogSnapshot(path=bundle.log_path, lines=(), byte_size=0)),
+        tool_call,
+        model_turn=1,
+        advertised_tools=("get_evidence_objects",),
+    )
+
+    assert result["objects"][0]["ref"] == "w-1"
+    assert record["result_lines"] == 1
+    assert unsupported is None
+
+
+def test_model_primary_lines_in_same_episode_share_history_and_client_identity(tmp_path):
+    log_path = tmp_path / "job.log"
+    summary = (
+        "0: ERROR:megatron.core.utils:Exception in async function: "
+        "CUDA out of memory. Tried to allocate 12.12 GiB."
+    )
+    terminal = (
+        "0: torch.OutOfMemoryError: iteration 71: CUDA out of memory. "
+        "Tried to allocate 12.12 GiB."
+    )
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: INFO: server ready",
+                summary,
+                "0: Traceback (most recent call last):",
+                '0:   File "/workspace/experts.py", line 751, in bias_act_func',
+                terminal,
+                "1: ProcessGroupNCCL watchdog caught collective operation timeout",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    bundle = build_l0_bundle(str(log_path))
+
+    def evidence(line, quote):
+        return {
+            "schema_version": "restart_agent_evidence.v1",
+            "primary_failure": {
+                "failure_class": "cuda_oom",
+                "signature": "CUDA out of memory",
+                "proposed_root_fingerprint": None,
+                "fault_outcome": "terminal",
+                "causal_role": "initiating",
+                "data_position_fingerprint": None,
+                "line": line,
+                "rank": "0",
+                "phase": "setup",
+            },
+            "root_cause_assessment": {
+                "summary": "The workload exhausted accelerator memory.",
+                "plausible_causes": ["insufficient memory headroom"],
+                "persistence_evidence": [],
+                "transient_alternatives": ["fresh allocator state"],
+            },
+            "model_recovery_assessment": {
+                "failure_domain": "workload",
+                "next_attempt_same_failure_likelihood": "likely",
+                "recurrence_confidence": 70,
+                "current_attempt_persistence_evidence": "none",
+                "retry_recovery_path": "workload_change",
+                "confidence": 70,
+                "rationale": "A fresh process may recover once.",
+                "supporting_evidence_lines": [line],
+            },
+            "related_failures": [],
+            "evidence": [{"line": line, "quote": quote, "supports": "primary_failure"}],
+            "justification": "The OOM is the initiating failure.",
+        }
+
+    summary_analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence(2, summary)))
+    summary_result = summary_analyzer.analyze(
+        {"log_path": str(log_path)},
+        l0_bundle=bundle,
+    ).to_payload()
+    terminal_analyzer = RestartAgent(
+        evidence_extractor=_FakeEvidenceExtractor(evidence(5, terminal))
+    )
+    terminal_result = terminal_analyzer.analyze(
+        {"log_path": str(log_path)},
+        l0_bundle=bundle,
+    ).to_payload()
+
+    assert summary_result["primary_failure"]["line"] == 2
+    assert terminal_result["primary_failure"]["line"] == 5
+    assert summary_result["primary_failure"]["root_fingerprint"] == (
+        terminal_result["primary_failure"]["root_fingerprint"]
+    )
+    assert summary_result["primary_failure"]["failure_iteration"] == 71
+    assert terminal_result["primary_failure"]["failure_iteration"] == 71
+    assert summary_result["primary_failure"]["root_fingerprint"] == ("cuda_oom:allocation_failure")
+    assert summary_result["primary_failure"]["affected_entity"] is None
+    assert terminal_result["primary_failure"]["affected_entity"] is None
+    assert summary_analyzer.last_trace["l2_audit"]["stable_identity_anchor_line"] == 2
+    assert summary_analyzer.last_trace["l2_audit"]["stable_identity_anchor_reason"] == (
+        "model_primary_is_episode_identity_anchor:"
+        "nearby_high_signal_error_precedes_failure_episode"
+    )
+    assert terminal_analyzer.last_trace["l2_audit"]["stable_identity_anchor_reason"] == (
+        "failure_episode_identity_anchor:nearby_high_signal_error_precedes_failure_episode"
+    )
+
+
+def test_logger_error_name_does_not_create_failure_episode(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "INFO:hypercorn.error:Running on http://0.0.0.0:51470 (CTRL + C to quit)\n",
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.failure_episodes == ()
+
+
+def test_info_logger_error_name_is_not_failure_episode_precursor(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: INFO:hypercorn.error:Running on http://0.0.0.0:51470",
+                (
+                    "0: ERROR:workload.runtime:Exception in async function: "
+                    "CUDA error: out of memory"
+                ),
+                "0: Traceback (most recent call last):",
+                '0:   File "/workspace/client.py", line 10, in receive',
+                "0: torch.AcceleratorError: CUDA error: out of memory",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 2
+    assert bundle.failure_episodes[0].precursor_lines == (2,)
+    assert bundle.failure_episodes[0].identity_anchor_line == 2
+    assert bundle.failure_episodes[0].identity_anchor_reason == (
+        "nearby_high_signal_error_precedes_failure_episode"
+    )
+
+
+def test_l0_bundle_json_round_trip_is_replayable(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "Traceback (most recent call last):\nValueError: invalid option\n",
+        encoding="utf-8",
+    )
+    bundle_path = tmp_path / "bundle.json"
+    bundle = build_l0_bundle(str(log_path))
+
+    write_l0_bundle(bundle_path, bundle)
+    replayed = read_l0_bundle(bundle_path, expected_log_path=str(log_path))
+    analyzer = RestartAgent()
+    original = analyzer.analyze({"log_path": str(log_path)}, l0_bundle=bundle)
+    replayed_result = analyzer.analyze({"log_path": str(log_path)}, l0_bundle=replayed)
+
+    assert replayed == bundle
+    assert replayed_result.to_payload() == original.to_payload()
+    assert analyzer.last_trace["timing"]["l0_reused"] is True
+
+
+def test_l1_overlay_rebuilds_related_failures_and_cascades_from_validated_primary(
+    tmp_path,
+):
+    log_path = tmp_path / "job.log"
+    unicode_line = "7: [rank7]: UnicodeDecodeError: invalid continuation byte"
+    cleanup_line = "8: FileNotFoundError: semaphore already removed"
+    log_path.write_text(
+        "\n".join(
+            [
+                "7: [rank7]: Traceback (most recent call last):",
+                unicode_line,
+                "8: NCCL watchdog caught collective operation timeout",
+                "8: File multiprocessing/synchronize.py, line 87, in _cleanup",
+                cleanup_line,
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "checkpoint_metadata_decode_error",
+            "signature": "UnicodeDecodeError while decoding metadata",
+            "proposed_root_fingerprint": "model:free_form",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": "7",
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "Checkpoint metadata could not be decoded.",
+            "plausible_causes": ["persistent corruption", "transient exchange failure"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["transient exchange failure"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "unknown",
+            "retry_outlook_without_workload_change": "unknown",
+            "confidence": 85,
+            "rationale": "One load attempt cannot establish persistence.",
+            "supporting_evidence_lines": [2],
+        },
+        "related_failures": [
+            {
+                "line": 5,
+                "causal_role": "teardown",
+                "rationale": "Multiprocessing finalizer cleanup after termination.",
+            }
+        ],
+        "evidence": [{"line": 2, "quote": unicode_line, "supports": "primary_failure"}],
+        "justification": "The decode failure precedes NCCL and cleanup symptoms.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["primary_failure"]["line"] == 2
+    assert payload["primary_failure"]["root_fingerprint"] != "model:free_form"
+    assert payload["root_cause_assessment"]["plausible_causes"]
+    assert payload["model_recovery_assessment"]["failure_domain"]["value"] == "unknown"
+    assert payload["model_recovery_assessment"]["retry_outlook_without_workload_change"][
+        "value"
+    ] == ("unknown")
+    assert payload["model_recovery_assessment"]["failure_domain"]["confidence"] == 85
+    assert payload["secondary_failures"] == []
+    cascades_by_line = {item["first_line"]: item for item in payload["cascades"]}
+    assert cascades_by_line[3]["causal_role"] == "cascade"
+    assert cascades_by_line[3]["relationship_rationales"] == []
+    assert cascades_by_line[5]["causal_role"] == "teardown"
+    assert cascades_by_line[5]["relationship_rationales"] == [
+        "Multiprocessing finalizer cleanup after termination."
+    ]
+
+
+def test_l1_only_cascade_is_retained_in_public_result(tmp_path):
+    log_path = tmp_path / "job.log"
+    primary_line = "ValueError: invalid workload configuration"
+    cascade_line = "opaque downstream worker failure report"
+    log_path.write_text(f"{primary_line}\n{cascade_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "workload_configuration_error",
+            "signature": primary_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "The workload configuration was invalid.",
+            "plausible_causes": ["invalid configuration"],
+            "persistence_evidence": [],
+            "transient_alternatives": [],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "unknown",
+            "retry_outlook_without_workload_change": "unknown",
+            "confidence": 80,
+            "rationale": "The first line is the initiating failure.",
+            "supporting_evidence_lines": [1],
+        },
+        "related_failures": [
+            {
+                "line": 2,
+                "causal_role": "cascade",
+                "rationale": "The worker report followed the configuration failure.",
+            }
+        ],
+        "evidence": [{"line": 1, "quote": primary_line, "supports": "primary_failure"}],
+        "justification": "The configuration error preceded the worker report.",
+    }
+
+    payload = (
+        RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+        .analyze({"log_path": str(log_path)})
+        .to_payload()
+    )
+
+    assert payload["secondary_failures"] == []
+    assert len(payload["cascades"]) == 1
+    cascade = payload["cascades"][0]
+    assert cascade["failure_class"] == "related_failure"
+    assert cascade["causal_role"] == "cascade"
+    assert cascade["first_line"] == 2
+    assert cascade["last_line"] == 2
+    assert cascade["count"] == 1
+    assert cascade["sample_lines"] == [2]
+    assert cascade["relationship_rationales"] == [
+        "The worker report followed the configuration failure."
+    ]
+
+
+def test_l2_uses_canonical_evidence_tags_for_recovery_support(tmp_path):
+    log_path = tmp_path / "job.log"
+    load_line = "loading distributed checkpoint at iteration 622125"
+    failure_line = "7: [rank7]: UnicodeDecodeError: invalid continuation byte"
+    log_path.write_text(
+        f"{load_line}\nTraceback (most recent call last):\n{failure_line}\n",
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "checkpoint_metadata_decode_error",
+            "signature": "UnicodeDecodeError while decoding metadata",
+            "proposed_root_fingerprint": "model:checkpoint_decode",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 3,
+            "rank": "7",
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "Checkpoint metadata could not be decoded.",
+            "plausible_causes": ["checkpoint corruption", "transient read failure"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["transient read failure"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "unknown",
+            "retry_outlook_without_workload_change": "unknown",
+            "confidence": 75,
+            "rationale": "The load context and decode failure do not prove persistence.",
+            "supporting_evidence_lines": [1, 3],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 3, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The decode failure occurred while loading a checkpoint.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+    validation = analyzer.last_trace["l2_audit"]
+
+    assert validation["audit_status"] == "clean"
+    assert validation["recovery_assessment_used"] is True
+    assert validation["failure_domain_supporting_lines"] == [3]
+    assert validation["retry_outlook_supporting_lines"] == [3]
+    assert validation["field_audits"]["model_recovery_assessment"]["status"] == "available"
+    assert analyzer.last_trace["l1"]["parsed_evidence"] == _current_evidence(evidence)
+    assert payload["primary_failure"]["line"] == 3
+    assert payload["model_recovery_assessment"]["failure_domain"]["value"] == "unknown"
+
+
+def test_l2_resolves_unique_nearby_citation_without_discarding_l1(tmp_path):
+    log_path = tmp_path / "job.log"
+    lines = [
+        "loading distributed checkpoint at iteration 622125",
+        'File "validation.py", line 558, in determine_global_metadata',
+        "torch.distributed.all_gather_object(global_metadata, local_metadata)",
+        "4175: [rank4175]: UnicodeDecodeError: invalid continuation byte",
+    ]
+    log_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "checkpoint_metadata_corruption",
+            "signature": "UnicodeDecodeError: invalid continuation byte",
+            "proposed_root_fingerprint": "checkpoint_metadata_corruption:unpickle_failure",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 4,
+            "rank": "4175",
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "Checkpoint metadata could not be decoded.",
+            "plausible_causes": ["persistent corruption", "transient read failure"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["transient read failure"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "unknown",
+            "retry_outlook_without_workload_change": "unknown",
+            "confidence": 85,
+            "rationale": "One load failure does not prove persistence.",
+            "supporting_evidence_lines": [1, 2, 4],
+        },
+        "related_failures": [],
+        "evidence": [
+            {"line": 1, "quote": lines[0], "supports": "checkpoint load context"},
+            {"line": 2, "quote": lines[2], "supports": "distributed metadata gather"},
+            {"line": 4, "quote": lines[3], "supports": "primary failure"},
+        ],
+        "justification": "Checkpoint metadata deserialization failed during load.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+    audit = analyzer.last_trace["l2_audit"]
+
+    assert audit["used"] is True
+    assert audit["audit_status"] == "resolved", audit
+    assert audit["failure_domain_supporting_lines"] == [4]
+    assert audit["retry_outlook_supporting_lines"] == [4]
+    assert audit["citation_audits"][1]["original_line"] == 2
+    assert audit["citation_audits"][1]["resolved_line"] == 3
+    assert audit["citation_audits"][1]["status"] == "nearby_resolved"
+    assert payload["primary_failure"]["line"] == 4
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["result_provenance"]["model_contribution"] == (
+        "attempted_used_with_resolved_findings"
+    )
+    assert payload["result_provenance"]["result_quality"] == "normal"
+
+
+def test_l2_accepts_exact_model_visible_truncated_rendering(tmp_path):
+    log_path = tmp_path / "job.log"
+    progress_line = "iteration 634870 | " + ("metric=1.0 | " * 80)
+    failure_line = "RuntimeError: checkpoint write failed"
+    log_path.write_text(f"{progress_line}\n{failure_line}\n", encoding="utf-8")
+    rendered_progress = progress_line[:120] + "...[truncated]"
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "checkpoint_write_failure",
+            "signature": failure_line,
+            "proposed_root_fingerprint": "checkpoint:write",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "checkpointing",
+        },
+        "root_cause_assessment": {
+            "summary": "Checkpoint writing failed after training progress.",
+            "plausible_causes": ["storage or writer failure"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["transient storage failure"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "unknown",
+            "retry_outlook_without_workload_change": "unknown",
+            "confidence": 60,
+            "rationale": "One write failure does not prove persistence.",
+            "supporting_evidence_lines": [1, 2],
+        },
+        "related_failures": [],
+        "evidence": [
+            {"line": 1, "quote": rendered_progress, "supports": "prior progress"},
+            {"line": 2, "quote": failure_line, "supports": "primary failure"},
+        ],
+        "justification": "The checkpoint write failed after prior progress.",
+    }
+    extractor = _FakeEvidenceExtractor(
+        evidence,
+        transcript_events=(
+            {
+                "event_type": "bundle_snapshot",
+                "model_visible_payload": {
+                    "context": [
+                        {"line": 1, "text": rendered_progress},
+                        {"line": 2, "text": failure_line},
+                    ]
+                },
+            },
+        ),
+    )
+
+    analyzer = RestartAgent(evidence_extractor=extractor)
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+    audit = analyzer.last_trace["l2_audit"]
+
+    assert [item["status"] for item in audit["citation_audits"]] == [
+        "rendered_exact",
+        "exact",
+    ]
+    assert audit["field_findings"] == {}
+    assert audit["audit_status"] == "resolved"
+    assert payload["result_provenance"]["model_contribution"] == (
+        "attempted_used_with_resolved_findings"
+    )
+
+
+def test_l2_does_not_ground_exact_source_quote_that_was_not_model_visible(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: checkpoint write failed"
+    log_path.write_text(f"iteration 10 completed\n{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "primary_failure": {
+            "line": 2,
+            "failure_class": "checkpoint_write_failure",
+            "causal_role": "initiating",
+        },
+        "evidence": [{"line": 2, "quote": failure_line}],
+        "justification": "The checkpoint write failed.",
+    }
+    extractor = _FakeEvidenceExtractor(
+        evidence,
+        transcript_events=(
+            {
+                "event_type": "bundle_snapshot",
+                "model_visible_payload": {
+                    "context": [{"line": 1, "text": "iteration 10 completed"}]
+                },
+            },
+        ),
+    )
+
+    analyzer = RestartAgent(evidence_extractor=extractor)
+    analyzer.analyze({"log_path": str(log_path)})
+    audit = analyzer.last_trace["l2_audit"]
+
+    assert audit["citation_audits"][0]["status"] == "not_model_visible"
+    assert "evidence_not_model_visible" in audit["field_finding_codes"]["evidence"]
+    assert audit["recovery_assessment_policy_grounded"] is False
+
+
+def test_invalid_related_role_is_l1_contract_failure(tmp_path):
+    log_path = tmp_path / "job.log"
+    initiating_line = "ERROR: checkpoint writer unexpected position"
+    terminal_line = "CheckpointException: write failed"
+    log_path.write_text(f"{initiating_line}\n{terminal_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "checkpoint_write_exception",
+            "signature": terminal_line,
+            "proposed_root_fingerprint": "checkpoint:write",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "checkpointing",
+        },
+        "root_cause_assessment": {
+            "summary": "Checkpoint writing failed.",
+            "plausible_causes": ["storage or serialization failure"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["transient storage failure"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "unknown",
+            "retry_outlook_without_workload_change": "unknown",
+            "confidence": 50,
+            "rationale": "Persistence is unknown.",
+            "supporting_evidence_lines": [1, 2],
+        },
+        "related_failures": [
+            {
+                "line": 1,
+                "causal_role": "initiating",
+                "rationale": "Earlier initiating writer error.",
+            }
+        ],
+        "evidence": [
+            {"line": 1, "quote": initiating_line, "supports": "earlier mechanism"},
+            {"line": 2, "quote": terminal_line, "supports": "terminal exception"},
+        ],
+        "justification": "The terminal exception followed the writer error.",
+    }
+
+    assert model_evidence_contract_errors(_current_evidence(evidence)) == [
+        "related_failures[0].causal_role is invalid"
+    ]
+
+
+def test_l2_rejects_related_failure_line_not_visible_to_model(tmp_path):
+    log_path = tmp_path / "job.log"
+    primary_line = "RuntimeError: invalid configuration"
+    teardown_line = "FileNotFoundError: cleanup marker missing"
+    log_path.write_text(f"{primary_line}\n{teardown_line}\n", encoding="utf-8")
+    evidence = {
+        "primary_failure": {
+            "line": 1,
+            "causal_role": "initiating",
+            "failure_class": "invalid_configuration",
+        },
+        "root_cause_assessment": {
+            "summary": "The configuration is invalid.",
+            "status": "established_by_current_log",
+            "plausible_causes": ["invalid workload configuration"],
+            "missing_evidence": [],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "rationale": "The unchanged configuration remains invalid.",
+        },
+        "related_failures": [
+            {
+                "line": 2,
+                "causal_role": "teardown",
+                "rationale": "Cleanup failed after the initiating error.",
+            }
+        ],
+        "evidence": [{"line": 1, "quote": primary_line, "supports": "primary_failure"}],
+    }
+    extractor = _FakeEvidenceExtractor(
+        evidence,
+        transcript_events=(
+            {
+                "event_type": "bundle_snapshot",
+                "model_visible_payload": {
+                    "evidence_bundle": {"lines": [{"line": 1, "text": primary_line}]}
+                },
+            },
+        ),
+    )
+
+    analyzer = RestartAgent(evidence_extractor=extractor)
+    analyzer.analyze({"log_path": str(log_path)})
+    audit = analyzer.last_trace["l2_audit"]
+
+    assert audit["field_finding_codes"]["related_failures"] == [
+        "related_failure_line_not_model_visible"
+    ]
+    assert audit["audited_related_failures"] == []
+
+
+def test_l2_uses_canonical_evidence_tags_instead_of_removed_supporting_line_field(
+    tmp_path,
+):
+    log_path = tmp_path / "job.log"
+    failure_line = "7: [rank7]: UnicodeDecodeError: invalid continuation byte"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "checkpoint_metadata_decode_error",
+            "signature": "UnicodeDecodeError while decoding metadata",
+            "proposed_root_fingerprint": "model:checkpoint_decode",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": "7",
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "Checkpoint metadata could not be decoded.",
+            "plausible_causes": ["checkpoint corruption"],
+            "persistence_evidence": [],
+            "transient_alternatives": [],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "confidence": 95,
+            "rationale": "An unseen line allegedly proves persistence.",
+            "supporting_evidence_lines": [999],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The decode failure is the initiating exception.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+    validation = analyzer.last_trace["l2_audit"]
+
+    assert validation["audit_status"] == "clean"
+    assert validation["primary_used"] is True
+    assert validation["recovery_assessment_used"] is True
+    assert validation["failure_domain_supporting_lines"] == [1]
+    assert validation["retry_outlook_supporting_lines"] == [1]
+    assert payload["primary_failure"]["line"] == 1
+    assert payload["model_recovery_assessment"]["failure_domain"]["value"] == "workload"
+    assert "recovery_requirement" not in payload["model_recovery_assessment"]
+    assert validation["recovery_assessment_policy_grounded"] is True
+    assert payload["retry_policy"]["recovery_assessment_policy_grounded"] is True
+    assert payload["decision"] == Decision.STOP.value
+    assert payload["result_provenance"]["model_contribution"] == "attempted_used"
+    assert payload["result_provenance"]["result_quality"] == "normal"
+
+
+def test_trace_exposes_distinct_l0_through_l4_layers(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: CUDA initialization failed\n", encoding="utf-8")
+
+    analyzer = RestartAgent()
+    candidates = []
+    result = analyzer.analyze(
+        {"log_path": str(log_path)},
+        on_deterministic_ready=candidates.append,
+    )
+
+    layers = analyzer.last_trace["layers"]
+    assert result == candidates[0].result
+    assert candidates[0].candidate_kind == "deterministic"
+    assert candidates[0].l1_execution_status == "not_run"
+    assert analyzer.last_trace["decision_candidates"]["selected"] == "deterministic"
+    assert list(layers) == ["L0", "L1", "L2", "L3", "L4"]
+    assert layers["L0"]["name"] == "evidence_assembly_and_projection"
+    assert layers["L0"]["sub_stages"]["L0A"]["name"] == "complete_evidence_assembly"
+    assert layers["L0"]["sub_stages"]["L0A"]["status"] == "completed"
+    assert layers["L0"]["root_fingerprint_owner"] == "L0"
+    assert layers["L0"]["root_fingerprint_available"] is True
+    assert layers["L0"]["history_identity_ready"] is True
+    assert layers["L0"]["root_fingerprint"]
+    assert layers["L0"]["sub_stages"]["DecisionEvidence"]["root_fingerprint"] == (
+        layers["L0"]["root_fingerprint"]
+    )
+    assert layers["L0"]["sub_stages"]["L0B"] == {
+        "name": "initial_model_evidence_view",
+        "wall_clock_s": 0.0,
+        "status": "not_run",
+    }
+    assert analyzer.last_trace["l0_model_view"] is None
+    assert layers["L1"]["name"] == "semantic_analysis"
+    assert layers["L2"]["name"] == "evidence_grounding_and_identity"
+    assert layers["L2"]["grounding_status"] == "not_run"
+    assert layers["L2"]["root_fingerprint_owner"] == "L2"
+    assert layers["L2"]["root_fingerprint_available"] is False
+    assert layers["L2"]["history_identity_ready"] is False
+    assert layers["L2"]["matches_l0_root_fingerprint"] is None
+    assert layers["L3"]["name"] == "history_enrichment"
+    assert layers["L3"]["selected_failure_facts_source"] == "l0_deterministic"
+    assert layers["L3"]["history_identity_ready"] is True
+    assert layers["L4"]["name"] == "policy_decision"
+    assert "operational_policy_mapping" not in analyzer.last_trace["l3_history"]
+    assert analyzer.last_trace["l4_policy"]["retry_policy"]["rule"] == ("general_retry")
+    assert analyzer.last_trace["latency_measurement"] == {
+        "mode": "terminal_request_to_result",
+        "terminal_total_wall_clock_s": analyzer.last_trace["timing"]["total_wall_clock_s"],
+        "post_progressive_end_wall_clock_s": None,
+        "production_gate_measured": False,
+    }
+
+
+def test_log_unavailable_returns_restart(tmp_path):
+    result = RestartAgent().analyze({"log_path": str(tmp_path / "missing.log")})
+
+    payload = result.to_payload()
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.LOG_UNAVAILABLE.value
+    assert payload["primary_failure"] is None
+    assert payload["evidence"] == []
+    assert payload["result_provenance"]["evidence_source"] == "log_unavailable"
+    assert payload["result_provenance"]["result_quality"] == "unusable"
+    assert payload["result_provenance"]["nvrx_use"] == "fallback_to_nvrx_default"
+
+
+def test_missing_log_path_is_rejected():
+    with pytest.raises(TypeError, match="log_path is required"):
+        RestartAgent().analyze({})
+
+
+def test_relative_log_path_is_rejected():
+    with pytest.raises(ValueError, match="log_path must be absolute"):
+        RestartAgent().analyze({"log_path": "relative.log"})
+
+
+def test_non_integer_cycle_id_is_rejected(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failed", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="cycle_id must be an integer"):
+        RestartAgent().analyze({"log_path": str(log_path), "cycle_id": "1"})
+
+
+def test_training_runtime_gpu_error_uses_generic_cuda_assert(tmp_path):
+    log_path = tmp_path / "service_input.sanitized.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "7:  [2026-05-27 07:58:10.261551] iteration        1/       4 | "
+                    "consumed samples:           64 | lm loss: 1.339357E+01 | "
+                    "number of skipped iterations:   0 | number of nan iterations:   0 |"
+                ),
+                "INFO number of nan iterations: 0",
+                "CRITICAL:training.runtime:raising GPU error on cuda:0",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = RestartAgent().analyze({"log_path": str(log_path), "job_id": "job-1"})
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+    assert payload["primary_failure"]["failure_class"] == "observed_exception"
+
+
+def test_ambiguous_cuda_assert_defaults_to_restart(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO training iteration 120",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = RestartAgent().analyze({"log_path": str(log_path), "job_id": "job-1"})
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+    assert payload["primary_failure"]["failure_class"] == "observed_exception"
+
+
+def test_cuda_debugging_advice_is_context_not_failure_candidate(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing",
+                "CUDA kernel errors might be asynchronously reported at some other API call.",
+                "For debugging consider passing CUDA_LAUNCH_BLOCKING=1.",
+                "Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 1
+    assert bundle.deterministic_primary_candidate.failure_class == "observed_exception"
+    assert {match.line for match in bundle.registry_matches} == {1}
+    assert {anchor.line for anchor in bundle.candidate_anchors}.isdisjoint({2, 3, 4})
+    prompt_lines = {
+        item["line"]: item
+        for window in prompt_bundle["context_windows"]
+        for item in window["lines"]
+    }
+    assert prompt_lines[1]["line_role"] == "observed_log"
+    assert prompt_lines[2]["line_role"] == "diagnostic_context"
+    assert prompt_lines[3]["line_role"] == "diagnostic_context"
+    assert prompt_lines[4]["line_role"] == "diagnostic_context"
+
+
+def test_peer_gpu_memory_access_is_ambiguous_and_forms_failure_episode(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "7: [2026-02-21 03:30:33.910316] iteration 686650/794728 | "
+                    "consumed samples: 2109388800 | lm loss: 9.602139E-01 |"
+                ),
+                (
+                    "171: [rank171]: Process group watchdog thread terminated with "
+                    "exception: CUDA error: Invalid access of peer GPU memory over "
+                    "nvlink or a hardware error"
+                ),
+                (
+                    "171: what(): Process group watchdog thread terminated with "
+                    "exception: CUDA error: Invalid access of peer GPU memory over "
+                    "nvlink or a hardware error"
+                ),
+                "171: Fatal Python error: Aborted",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 2
+    assert bundle.deterministic_primary_candidate.failure_class == "peer_gpu_memory_access_failure"
+    assert bundle.deterministic_primary_candidate.root_fingerprint == (
+        "peer_gpu_memory_access_failure:peer_gpu_memory_access"
+    )
+    assert "gpu_hardware_fault" not in {match.registry_id for match in bundle.registry_matches}
+    assert len(bundle.failure_episodes) == 1
+    assert bundle.failure_episodes[0].start_line == 2
+    assert bundle.failure_episodes[0].terminal_exception_line == 2
+    assert bundle.failure_episodes[0].duplicate_rendering_lines == (3,)
+    assert bundle.failure_episodes[0].status == "terminal"
+
+
+def test_direct_nvlink_link_failure_remains_hardware_evidence(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "NVRM: Xid 74: NVLink fatal link down on GPU 3",
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.failure_class == "gpu_hardware_fault"
+
+
+def test_concatenated_cuda_peer_error_is_not_hardware_confirmation(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "7: [2026-02-24 23:01:00.201888] iteration 745580/794728 | "
+                    "consumed samples: 2290421760 | lm loss: 9.240151E-01 |"
+                ),
+                (
+                    "5250: CUDA error encountered at: file=/home/DeepEP/csrc/"
+                    "hybrid_ep/extension/permute.cu, line=535, "
+                    "call='cudaGetLastError()', Reason=cudaErrorContained:Invalid "
+                    "access of peer GPU memory over nvlink or a hardware errorFatal "
+                    "Python error: Aborted"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 2
+    assert bundle.deterministic_primary_candidate.failure_class == "peer_gpu_memory_access_failure"
+    assert "gpu_hardware_fault" not in {match.registry_id for match in bundle.registry_matches}
+    assert len(bundle.failure_episodes) == 1
+    assert bundle.failure_episodes[0].terminal_exception_line == 2
+    assert bundle.failure_episodes[0].first_process_termination_line == 2
+    assert bundle.failure_episodes[0].status == "terminal"
+
+
+def test_conditional_cause_language_remains_observed_but_is_marked_hypothetical(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "RuntimeError: worker was killed. It is possible that memory is exhausted.\n",
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+    prompt_line = next(
+        item
+        for window in prompt_bundle["context_windows"]
+        for item in window["lines"]
+        if item["line"] == 1
+    )
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert prompt_line["line_role"] == "observed_log_with_causal_hypothesis"
+    assert prompt_line["diagnostic_uncertainty_kind"] == "conditional_cause_language"
+
+
+def test_attempt_execution_context_highlights_runtime_and_checkpoint_replay_distance(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: [2026-02-18 08:00:00] iteration 100/1000 | consumed samples: 1000 |",
+                "0: successfully saved checkpoint from iteration 100 to /checkpoints/",
+                "0: [2026-02-18 08:01:00] iteration 110/1000 | consumed samples: 1100 |",
+                "0: RuntimeError: terminal failure",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    model_view = build_l0_model_facing_view(bundle)
+    context = model_view.attempt_execution_context
+    progress = model_view.decision_evidence.progress_checkpoint_state
+
+    assert progress["iteration_delta"] == 10
+    assert progress["successful_runtime_seconds"] == 60.0
+    assert progress["checkpoint_marker_count"] == 1
+    assert progress["iterations_since_checkpoint"] == 10
+    assert progress["progress_after_failure_episode"] is False
+    assert set(context) == {"scope", "terminal_timing"}
+
+
+def test_later_progress_after_fault_does_not_claim_component_recovery(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: [2026-02-18 08:00:00] iteration 100/1000 | consumed samples: 1000 |",
+                "1: RuntimeError: temporary network disturbance",
+                "0: [2026-02-18 08:01:00] iteration 110/1000 | consumed samples: 1100 |",
+                "2: RuntimeError: terminal failure",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    continuation = next(
+        item
+        for item in bundle.later_progress_after_fault_observations
+        if item.sample_event_lines == (2,)
+    )
+
+    assert continuation.sample_later_progress_lines == (3,)
+    assert continuation.interpretation == "job_progress_observed_after_event"
+    assert continuation.component_recovery_proven is False
+
+
+def test_l0_consolidates_serialized_inner_and_outer_exception_renderings(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: [2026-02-18 08:00:00] iteration 100/1000 | consumed samples: 1000 |",
+                "7: ['Traceback (most recent call last):\\n', 'RuntimeError: worker SIGBUS\\n']",
+                "7: [rank7]: Traceback (most recent call last):",
+                "7: [rank7]: RuntimeError: worker SIGBUS",
+                "7: [rank7]: The above exception was the direct cause of the following exception:",
+                "7: [rank7]: Traceback (most recent call last):",
+                "7: [rank7]: RuntimeError: worker exited unexpectedly",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert len(bundle.failure_episodes) == 1
+    episode = bundle.failure_episodes[0]
+    assert episode.terminal_exception_line == 4
+    assert episode.exception_chain_lines == (2, 4, 7)
+    assert episode.duplicate_rendering_lines == (2,)
+    assert episode.wrapper_exception_lines == (7,)
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 4
+
+    payload = RestartAgent().analyze({"log_path": str(log_path)}).to_payload()
+    assert payload["primary_failure"]["line"] == 4
+    assert {item["line"] for item in payload["secondary_failures"]}.isdisjoint(
+        episode.exception_chain_lines
+    )
+
+
+def test_l0_structural_candidate_does_not_stop_without_l1(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO loading checkpoint",
+                "FileNotFoundError: [Errno 2] No such file or directory",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    analyzer = RestartAgent()
+    result = analyzer.analyze({"log_path": str(log_path), "job_id": "job-1"})
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+    assert payload["primary_failure"]["failure_class"] == "observed_exception"
+    assert "policy_class" not in payload["primary_failure"]
+    assert all("policy_class" not in item for item in payload["secondary_failures"])
+    assert payload["result_provenance"]["evidence_source"] == "l0_deterministic"
+    assert payload["result_provenance"]["model_contribution"] == "not_enabled"
+    assert payload["result_provenance"]["notes"] == []
+    assert (
+        "policy_class" not in analyzer.last_trace["l0_summary"]["deterministic_primary_candidate"]
+    )
+    assert analyzer.last_trace["l2_grounded_semantics"] is None
+    assert "policy_class" not in analyzer.last_trace["external_output"]["primary_failure"]
+
+
+def test_l1_runs_for_l0_structural_candidate(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO loading checkpoint",
+                "ValueError: invalid config option tensor_model_parallel_size",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "python_user_exception",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "ValueError:",
+            "root_fingerprint": "python_user_exception:valueerror",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "setup",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "ValueError: invalid config option tensor_model_parallel_size",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "The cited current-log error was selected as user failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    result = analyzer.analyze({"log_path": str(log_path), "job_id": "job-1"})
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.STOP.value
+    assert payload["decision_basis"] == DecisionBasis.WORKLOAD_UNRECOVERABLE.value
+    assert payload["result_provenance"]["evidence_source"] == "l1_model_audited"
+    assert payload["result_provenance"]["model_contribution"] == "attempted_used"
+    assert analyzer.last_trace["timing"]["l1_model_calls"] == 1
+    assert analyzer.last_trace["l2_audit"]["used"] is True
+    assert not analyzer.last_trace["l2_audit"].get("l0_policy_downgraded")
+    assert payload["evidence"] == _current_evidence(evidence)["evidence"]
+    assert payload["justification"] == evidence["justification"]
+
+
+def test_incomplete_l1_contract_is_rejected_without_manufactured_evidence(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "ValueError: invalid config option tensor_model_parallel_size\n",
+        encoding="utf-8",
+    )
+    incomplete = {
+        "primary_failure": {
+            "failure_class": "python_user_exception",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "ValueError:",
+            "root_fingerprint": "python_user_exception:valueerror",
+            "fault_outcome": "terminal",
+            "line": 1,
+        },
+        "secondary_failures": [],
+        "cascades": [],
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(incomplete))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["result_provenance"]["model_contribution"] == "attempted_not_used_malformed"
+    assert analyzer.last_trace["l2_audit"]["used"] is False
+    assert analyzer.last_trace["l2_audit"]["audit_status"] == "not_run"
+    assert analyzer.last_trace["layers"]["L1"]["output_status"] == "contract_invalid"
+    assert any(
+        "evidence must support primary_failure" in error
+        for error in analyzer.last_trace["layers"]["L1"]["output_errors"]
+    )
+    assert payload["justification"] != ""
+
+
+def test_l2_reports_suspect_primary_role_without_discarding_l1(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "FileNotFoundError: [Errno 2] No such file or directory\n",
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "multiprocessing_cleanup",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "FileNotFoundError:",
+            "root_fingerprint": "multiprocessing_cleanup:filenotfounderror",
+            "fault_outcome": "terminal",
+            "causal_role": "teardown",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "teardown",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 1,
+                "quote": "FileNotFoundError: [Errno 2] No such file or directory",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "This exception occurred during teardown.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    analyzer.analyze({"log_path": str(log_path)})
+
+    validation = analyzer.last_trace["l2_audit"]
+    assert validation["used"] is True
+    assert validation["audit_status"] == "findings"
+    assert validation["field_audits"]["primary_failure"]["finding_classes"] == [
+        "primary_causal_role_suspect"
+    ]
+
+
+def test_non_utf8_log_localizes_replacement_without_losing_failure_evidence(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_bytes(
+        b"INFO training iteration 120\n"
+        b"RuntimeError: CUDA error: device-side assert triggered \xff\n"
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    window = LogTools(bundle, LogSnapshot.read(log_path)).read_window(2, before=0, after=0)
+    payload = RestartAgent().analyze({"log_path": str(log_path), "job_id": "job-1"})
+
+    assert bundle.line_count == 2
+    assert bundle.deterministic_primary_candidate is not None
+    assert "\ufffd" in (bundle.deterministic_primary_candidate.quote or "")
+    assert "\ufffd" in window["lines"][0]["text"]
+    assert payload.to_payload()["primary_failure"]["failure_class"] == "observed_exception"
+
+
+def test_llm_prompt_and_tools_do_not_expose_path_labels(tmp_path):
+    log_dir = tmp_path / "cuda_oom_logs" / "observed_label_user_failure"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "misleading_user_failure_name.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "1: iteration 1/4 | consumed samples: 64 |",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_payload = build_l0_model_facing_view(bundle).evidence_bundle
+    overview_payload = LogTools(bundle, LogSnapshot.read(log_path)).overview()
+
+    assert "cuda_oom_logs" in bundle.path_hints
+    for payload in (prompt_payload, overview_payload):
+        serialized = json.dumps(payload, sort_keys=True)
+        assert "cuda_oom_logs" not in serialized
+        assert "observed_label_user_failure" not in serialized
+        assert "misleading_user_failure_name.log" not in serialized
+        assert str(log_path) not in serialized
+
+
+def test_context_preview_preserves_high_signal_lines_between_head_seed_and_tail():
+    lines = [LogLine(line=line, text=f"INFO ordinary line {line}") for line in range(1152, 1253)]
+    lines[1159 - 1152] = LogLine(
+        line=1159,
+        text="1: CRITICAL:training.runtime:raising GPU error on cuda:0",
+    )
+
+    preview = _window_preview_lines(lines, seed_lines=(1172,))
+    preview_lines = [item["line"] for item in preview]
+
+    assert 1159 in preview_lines
+    assert 1172 in preview_lines
+    assert len(preview_lines) <= 8
+    assert preview_lines == sorted(preview_lines)
+
+
+def test_bundle_prompt_uses_bounded_excerpts_for_top_context_windows():
+    setup_window = ContextWindow(
+        window_id="w-setup",
+        selected_by="registry_match",
+        start_line=800,
+        end_line=840,
+        seed_lines=(820,),
+        lines=tuple(LogLine(line=line, text=f"INFO setup line {line}") for line in range(800, 841)),
+    )
+    candidate_lines = []
+    for line in range(1119, 1280):
+        text = f"INFO ordinary line {line}"
+        if line == 1151:
+            text = "7: iteration        1/       4 | consumed samples: 64 |"
+        elif line == 1159:
+            text = "1: CRITICAL:training.runtime:raising GPU error on cuda:0"
+        elif line == 1162:
+            text = "7: iteration        2/       4 | consumed samples: 128 |"
+        elif line == 1172:
+            text = "0: ProcessGroupNCCL watchdog caught collective operation timeout"
+        elif line == 1272:
+            text = "1: IndexKernel.cu:111: Assertion `index < sizes[i]` failed."
+        candidate_lines.append(LogLine(line=line, text=text))
+    early_fault_window = ContextWindow(
+        window_id="w-early",
+        selected_by="registry_match",
+        start_line=1119,
+        end_line=1252,
+        seed_lines=(1159,),
+        occurrence_group_ids=("og-critical",),
+        lines=tuple(item for item in candidate_lines if item.line <= 1252),
+    )
+    primary_window = ContextWindow(
+        window_id="w-primary",
+        selected_by="registry_match",
+        start_line=1202,
+        end_line=1279,
+        seed_lines=(1272,),
+        occurrence_group_ids=("og-assert",),
+        lines=tuple(item for item in candidate_lines if item.line >= 1202),
+    )
+    bundle = L0Bundle(
+        log_path="/tmp/job.log",
+        byte_size=1,
+        line_count=1280,
+        context_windows=(setup_window, early_fault_window, primary_window),
+        deterministic_primary_candidate=FailureEvidence(
+            failure_class="cuda_device_assert",
+            signature="bounds assertion",
+            root_fingerprint="cuda_device_assert:bounds",
+            fault_outcome="terminal",
+            line=1272,
+        ),
+    )
+
+    model_view = build_l0_model_facing_view(bundle)
+    prompt_bundle = model_view.evidence_bundle
+    candidate = next(
+        window
+        for window in prompt_bundle["context_windows"]
+        if window["window_id"] == "w-early+w-primary"
+    )
+    candidate_prompt_lines = [item["line"] for item in candidate["lines"]]
+
+    assert candidate["prompt_view"] == "bounded_excerpt"
+    assert candidate["occurrence_group_ids"] == ["og-assert", "og-critical"]
+    assert "pattern_ids" not in candidate
+    assert candidate["source_line_count"] > 8
+    assert candidate["lines_in_prompt"] > 8
+    assert {1151, 1159, 1162, 1172, 1272}.issubset(candidate_prompt_lines)
+    metrics = model_view.projection_metrics
+    assert model_view.schema_version == "restart_agent_l0_model_view.v1"
+    assert metrics["view_size"]["compact_json_characters"] > 0
+    assert metrics["view_size"]["estimated_tokens"] > 0
+    assert metrics["budget_utilization"]["context_window_slots"] == {
+        "used": 3,
+        "limit": 4,
+        "utilization_pct": 75.0,
+    }
+    assert metrics["selection_counts"]["context_windows"] == {
+        "available": 3,
+        "selected": 3,
+        "omitted": 0,
+        "limit": 4,
+        "projected_after_merge": 2,
+    }
+    assert metrics["compaction_counts"]["context_windows_merged"] == 1
+    assert metrics["compaction_counts"]["context_windows_omitted"] == 0
+    assert metrics["projection_integrity"]["status"] == "ok"
+    assert metrics["projection_integrity"]["checks"]["decision_evidence_references_resolve"]
+
+
+def test_candidate_anchors_include_high_signal_line_without_registry_match(tmp_path):
+    log_path = tmp_path / "service_input.sanitized.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "7:  [2026-05-27 07:58:10.261551] iteration        1/       4 | "
+                    "consumed samples:           64 | lm loss: 1.339357E+01 |"
+                ),
+                "INFO warmup continues",
+                "1: CRITICAL:training.runtime:raising GPU error on cuda:0",
+                (
+                    "7:  [2026-05-27 07:58:11.261551] iteration        2/       4 | "
+                    "consumed samples:          128 | lm loss: 1.239357E+01 |"
+                ),
+                "0: ProcessGroupNCCL watchdog caught collective operation timeout",
+                "1: RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    anchor = next(item for item in bundle.candidate_anchors if item.line == 3)
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+    prompt_anchor = next(item for item in prompt_bundle["candidate_anchors"] if item["line"] == 3)
+
+    assert "high_signal" in anchor.sources
+    assert anchor.taxonomy_match is None
+    assert anchor.anchor_rank == "1"
+    assert anchor.prior_observed_progress_line == 1
+    assert anchor.later_observed_progress_line == 4
+    assert anchor.prior_progress_rank == "7"
+    assert anchor.later_progress_rank == "7"
+    assert anchor.later_progress_rank_relation == "different_rank"
+    assert anchor.later_observation_proves_recovery is False
+    assert anchor.first_downstream_registry_match is not None
+    assert anchor.first_downstream_registry_match.line == 5
+    assert anchor.first_downstream_cascade is not None
+    assert anchor.first_downstream_cascade.line == 5
+    assert anchor.context_window_ids
+    assert prompt_anchor["taxonomy_hint"] is None
+    assert prompt_anchor["nearby_progress_observations"] == {
+        "later_observation_proves_recovery": False,
+        "later_observed_progress_line": 4,
+        "later_progress_rank": "7",
+        "later_progress_rank_relation": "different_rank",
+        "prior_observed_progress_line": 1,
+        "prior_progress_rank": "7",
+    }
+    assert prompt_anchor["first_downstream_registry_hint"]["line"] == 5
+    assert prompt_anchor["first_downstream_cascade"]["line"] == 5
+    assert prompt_anchor["covered_by_excerpt"] is True
+
+
+def test_l4_maps_established_unrecoverable_workload_failure_to_stop(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO training iteration 120",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "runtime_assertion",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "device-side assert triggered",
+            "root_fingerprint": "runtime_assertion:device_side_assert_terminal",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "RuntimeError: CUDA error: device-side assert triggered",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "The cited current-log error was selected as user failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    result = analyzer.analyze(
+        {
+            "log_path": str(log_path),
+            "job_id": "job-1",
+        }
+    )
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.STOP.value
+    assert payload["decision_basis"] == DecisionBasis.WORKLOAD_UNRECOVERABLE.value
+    assert payload["primary_failure"]["failure_class"] == "observed_exception"
+    assert payload["primary_failure"]["root_fingerprint"].startswith("observed:runtimeerror:")
+    assert payload["result_provenance"]["evidence_source"] == "l1_model_audited"
+    assert payload["result_provenance"]["model_contribution"] == "attempted_used"
+    assert payload["result_provenance"]["result_quality"] == "normal"
+    assert payload["result_provenance"]["nvrx_use"] == "eligible"
+    assert analyzer.last_trace["context_mode"] == "tool_loop"
+    assert analyzer.last_trace["result_provenance"] == payload["result_provenance"]
+    assert analyzer.last_trace["l2_audit"]["used"] is True
+    assert analyzer.last_trace["l2_audit"]["model_failure_domain"] == "workload"
+    assert (
+        analyzer.last_trace["l2_audit"]["model_retry_outlook_without_workload_change"]
+        == "cannot_recover"
+    )
+    assert analyzer.last_trace["l4_policy"]["retry_policy"]["rule"] == ("workload_unrecoverable")
+    assert (
+        analyzer.last_trace["l4_policy"]["retry_policy"]["general_root_ceiling"][
+            "inapplicable_reason"
+        ]
+        == "immediate_unrecoverable"
+    )
+    assert analyzer.last_trace["token_usage"]["prompt_tokens"] == 10
+    assert analyzer.last_trace["token_usage"]["completion_tokens"] == 5
+    assert analyzer.last_trace["token_usage"]["reasoning_tokens"] == 2
+    assert analyzer.last_trace["token_usage"]["cached_prompt_tokens"] == 3
+    assert analyzer.last_trace["token_usage"]["model_calls_with_usage"] == 1
+    assert analyzer.last_trace["token_limit"]["hit"] is False
+
+
+def test_deterministic_is_ready_while_l1_is_pending(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "INFO training iteration 120\nRuntimeError: CUDA error: device-side assert triggered\n",
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "runtime_assertion",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "device-side assert triggered",
+            "root_fingerprint": "runtime_assertion:device_side_assert_terminal",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "RuntimeError: CUDA error: device-side assert triggered",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "The current-log assertion is likely to repeat.",
+    }
+    extractor = _BlockingEvidenceExtractor(evidence)
+    observed = []
+
+    def on_deterministic_ready(candidate):
+        assert not extractor.started.is_set()
+        assert not extractor.completed.is_set()
+        observed.append(candidate)
+        extractor.release.set()
+
+    analyzer = RestartAgent(evidence_extractor=extractor)
+    result = analyzer.analyze(
+        {"log_path": str(log_path), "job_id": "job-1"},
+        on_deterministic_ready=on_deterministic_ready,
+    )
+
+    assert len(observed) == 1
+    deterministic = observed[0]
+    assert deterministic.candidate_kind == "deterministic"
+    assert deterministic.l1_execution_status == "in_flight"
+    assert deterministic.result.decision == Decision.RESTART.value
+    assert deterministic.result.result_provenance["model_contribution"] == "pending_not_used"
+    assert deterministic.result.result_provenance["result_quality"] == "degraded"
+    assert result.decision == Decision.STOP.value
+    assert result.result_provenance["candidate_kind"] == "l1_enriched"
+    candidates = analyzer.last_trace["decision_candidates"]
+    assert candidates["deterministic_ready"] is True
+    assert candidates["enriched_ready"] is True
+    assert candidates["selected"] == "l1_enriched"
+    assert candidates["best_available_kind"] == "l1_enriched"
+    assert candidates["best_available"]["result"]["decision"] == "STOP"
+    assert candidates["deterministic"]["result"]["decision"] == "RESTART"
+    assert candidates["l1_enriched"]["result"]["decision"] == "STOP"
+
+    failing_callback_extractor = _BlockingEvidenceExtractor(evidence)
+
+    def failing_callback(candidate):
+        failing_callback_extractor.release.set()
+        raise RuntimeError("candidate sink is unavailable")
+
+    failing_callback_analyzer = RestartAgent(evidence_extractor=failing_callback_extractor)
+    callback_result = failing_callback_analyzer.analyze(
+        {"log_path": str(log_path), "job_id": "job-1"},
+        on_deterministic_ready=failing_callback,
+    )
+
+    assert callback_result.decision == Decision.STOP.value
+    assert (
+        failing_callback_analyzer.last_trace["anomalies"]["deterministic_callback_error"]
+        == "RuntimeError: candidate sink is unavailable"
+    )
+
+
+def test_deterministic_can_apply_history_before_l1_finishes(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        (
+            "7: [2026-05-27 07:58:10.261551] iteration 120/400 | "
+            "consumed samples: 7680 | lm loss: 1.3E+01 |\n"
+            "RuntimeError: CUDA error: device-side assert triggered\n"
+        ),
+        encoding="utf-8",
+    )
+    bundle = build_l0_bundle(str(log_path))
+    current = bundle.deterministic_primary_candidate
+    assert current is not None
+    history = [
+        {
+            "job_id": "job-1",
+            "cycle_id": 1,
+            "root_fingerprint": current.root_fingerprint,
+            "primary_fault_outcome": "terminal",
+            "last_completed_step": 120,
+        },
+        {
+            "job_id": "job-1",
+            "cycle_id": 2,
+            "root_fingerprint": current.root_fingerprint,
+            "primary_fault_outcome": "terminal",
+            "last_completed_step": 120,
+        },
+    ]
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "runtime_assertion",
+            "failure_domain": "unknown",
+            "retry_outlook_without_workload_change": "unknown",
+            "signature": "device-side assert triggered",
+            "root_fingerprint": current.root_fingerprint,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "line": 2,
+            "phase": "steady_mid",
+        },
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "RuntimeError: CUDA error: device-side assert triggered",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "The assertion is ambiguous in one cycle.",
+    }
+    extractor = _BlockingEvidenceExtractor(evidence)
+    observed = []
+    prior_attempts = _prior_attempt_view(*history)
+
+    def on_deterministic_ready(candidate):
+        observed.append(candidate)
+        for record in history:
+            record["root_fingerprint"] = "caller-mutated-after-publication"
+        extractor.release.set()
+
+    result = RestartAgent(evidence_extractor=extractor).analyze(
+        {
+            "log_path": str(log_path),
+            "job_id": "job-1",
+            "cycle_id": 3,
+        },
+        l0_bundle=bundle,
+        prior_attempts=prior_attempts,
+        on_deterministic_ready=on_deterministic_ready,
+    )
+
+    assert observed[0].result.decision == Decision.RESTART.value
+    assert observed[0].result.decision_basis == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+    assert observed[0].result.result_provenance["history_contribution"] == ("checked_no_effect")
+    assert observed[0].result.result_provenance["result_quality"] == "degraded"
+    assert result.decision == Decision.RESTART.value
+    assert result.decision_basis == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+
+
+def test_l4_keeps_retryable_port_with_wait_precondition_ambiguous(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "OSError: [Errno 98] Address already in use"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "socket_bind_address_in_use",
+            "signature": failure_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "A workload server found its selected port occupied.",
+            "plausible_causes": ["mutable external socket state"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["normal teardown or delay may release the port"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "likely",
+            "current_attempt_persistence_evidence": "none",
+            "retry_recovery_path": "wait_or_teardown",
+            "confidence": 60,
+            "rationale": "The same port will be requested, but its future occupancy is unknown.",
+            "supporting_evidence_lines": [1],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The socket bind failure is the initiating failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.RETRY_RECOVERY_AVAILABLE.value
+    assert "recovery_requirement" not in payload["model_recovery_assessment"]
+    assert "model_recovery_requirement" not in analyzer.last_trace["l2_audit"]
+    assert analyzer.last_trace["l4_policy"]["retry_policy"]["rule"] == "bounded_retry"
+
+
+def test_model_recovery_confidence_is_preserved_without_recurrence_score(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "OSError: [Errno 98] Address already in use"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "socket_bind_address_in_use",
+            "signature": failure_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "The selected port was occupied.",
+            "plausible_causes": ["mutable socket state"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["normal teardown may release the port"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "unknown",
+            "current_attempt_persistence_evidence": "none",
+            "retry_recovery_path": "wait_or_teardown",
+            "confidence": 80,
+            "rationale": "A restart delay may satisfy the retry precondition.",
+            "supporting_evidence_lines": [1],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The bind failure ended setup.",
+    }
+    extractor = _FakeEvidenceExtractor(evidence)
+
+    analyzer = RestartAgent(evidence_extractor=extractor)
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["result_provenance"]["model_contribution"] == "attempted_used"
+    assert payload["result_provenance"]["result_quality"] == "normal"
+    assert payload["result_provenance"]["nvrx_use"] == "eligible"
+    assert payload["model_recovery_assessment"]["failure_domain"]["confidence"] == 80
+    assert "recurrence_confidence" not in payload["model_recovery_assessment"]
+    audit = analyzer.last_trace["l2_audit"]
+    assert audit["field_findings"] == {}
+    assert analyzer.last_trace["layers"]["L2"]["material_finding_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("persistence_strength", "expected_decision", "expected_rule"),
+    [
+        (
+            "affirmative",
+            Decision.STOP.value,
+            "workload_unrecoverable",
+        ),
+        ("circumstantial", Decision.RESTART.value, "general_retry"),
+    ],
+)
+def test_immediate_stop_requires_affirmative_grounded_persistence_evidence(
+    tmp_path,
+    persistence_strength,
+    expected_decision,
+    expected_rule,
+):
+    log_path = tmp_path / "job.log"
+    failure_line = "PermissionError: [Errno 13] Permission denied: '/shared/cache.lock'"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "filesystem_permission_denied",
+            "signature": failure_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "The process could not create a cache lock.",
+            "plausible_causes": ["filesystem permission or ACL state"],
+            "persistence_evidence": ["the denied path is unchanged"],
+            "transient_alternatives": ["the access state may be repaired externally"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "likely",
+            "recurrence_confidence": 80,
+            "current_attempt_persistence_evidence": persistence_strength,
+            "retry_recovery_path": "external_intervention",
+            "confidence": 80,
+            "rationale": "The access condition must change before retry.",
+            "supporting_evidence_lines": [1],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The permission error ended setup.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == expected_decision
+    assert payload["retry_policy"]["rule"] == expected_rule
+    assert payload["retry_policy"]["recovery_assessment_policy_grounded"] is True
+
+
+def test_l2_flags_unverified_path_owner_without_treating_rank_fanout_as_persistence(
+    tmp_path,
+):
+    log_path = tmp_path / "job.log"
+    lock_path = "/lustre/fsw/users/wdai/hf_home/datasets/cache.lock"
+    failure_line = f"PermissionError: [Errno 13] Permission denied: '{lock_path}'"
+    log_path.write_text(
+        "\n".join(
+            [
+                "data_cache_path ........ /lustre/fsw/users/rwaleffe/cache",
+                "load ................... /lustre/fsw/users/wdai/checkpoint",
+                f"[rank80]: {failure_line}",
+                f"[rank96]: {failure_line}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "filesystem_permission_denied",
+            "signature": failure_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 3,
+            "rank": "80",
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "The lock belongs to wdai while the job runs as a different user.",
+            "status": "supported_but_unconfirmed",
+            "plausible_causes": ["cross-user cache permissions"],
+            "persistence_evidence": ["multiple ranks prove persistence"],
+            "transient_alternatives": ["external ACL repair"],
+            "missing_evidence": ["effective UID and ownership metadata"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "likely",
+            "recurrence_confidence": 90,
+            "current_attempt_persistence_evidence": "affirmative",
+            "retry_recovery_path": "external_intervention",
+            "confidence": 90,
+            "rationale": "The same permission error occurred across multiple ranks.",
+            "supporting_evidence_lines": [3, 4],
+        },
+        "related_failures": [],
+        "evidence": [
+            {"line": 3, "quote": f"[rank80]: {failure_line}", "supports": "primary_failure"},
+            {"line": 4, "quote": f"[rank96]: {failure_line}", "supports": "persistence"},
+        ],
+        "justification": "The denied cache lock ended setup on the ranks.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+    audit = analyzer.last_trace["l2_audit"]
+
+    assert payload["decision"] == Decision.STOP.value
+    assert payload["model_recovery_assessment"]["failure_domain"]["status"] == (
+        "established_by_current_log"
+    )
+    assert payload["retry_policy"]["rule"] == "workload_unrecoverable"
+    assert "model_recovery_assessment" not in audit["field_finding_codes"]
+    assert audit["field_finding_codes"]["root_cause_assessment"] == [
+        "path_namespace_identity_unverified"
+    ]
+    assert audit.get("grounding_adjustments", []) == []
+    assert all("persistence" not in item["code"] for item in audit["findings"])
+
+
+def test_l4_stops_for_established_unrecoverable_workload_claims(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "torch.AcceleratorError: CUDA error: out of memory"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "cuda_out_of_memory",
+            "signature": failure_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": "0",
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "The workload exhausted its allocated accelerator memory.",
+            "plausible_causes": ["insufficient workload memory headroom"],
+            "persistence_evidence": ["the workload crossed its memory budget"],
+            "transient_alternatives": ["process teardown may clear allocator state"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "likely",
+            "current_attempt_persistence_evidence": "affirmative",
+            "retry_recovery_path": "workload_change",
+            "confidence": 85,
+            "rationale": (
+                "A restart may clear allocator state, but the workload must restore "
+                "reliable memory headroom."
+            ),
+            "supporting_evidence_lines": [1],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The workload OOM is the initiating failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == Decision.STOP.value
+    assessment = payload["model_recovery_assessment"]
+    assert assessment["retry_outlook_without_workload_change"]["value"] == "cannot_recover"
+    assert assessment["retry_outlook_without_workload_change"]["status"] == (
+        "established_by_current_log"
+    )
+    assert "recovery_requirement" not in assessment
+    assert payload["retry_policy"]["rule"] == "workload_unrecoverable"
+    assert payload["retry_policy"]["general_root_ceiling"]["applicable"] is False
+
+
+def test_l4_does_not_stop_on_circumstantial_persistence_hypothesis(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = (
+        "RuntimeError: worker was killed. It is possible that shared memory is exhausted."
+    )
+    log_path.write_text(failure_line + "\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "worker_failure",
+            "signature": "worker was killed",
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": "0",
+            "phase": "steady_mid",
+        },
+        "root_cause_assessment": {
+            "summary": "Resource exhaustion is only a diagnostic hypothesis.",
+            "status": "hypothesis_only",
+            "plausible_causes": ["resource exhaustion"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["transient worker or external-resource fault"],
+            "missing_evidence": ["direct resource-capacity evidence"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "likely",
+            "recurrence_confidence": 70,
+            "current_attempt_persistence_evidence": "circumstantial",
+            "retry_recovery_path": "workload_change",
+            "confidence": 70,
+            "rationale": "The diagnostic suggests a workload resource issue.",
+            "supporting_evidence_lines": [1],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The worker failure terminated the attempt.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["retry_policy"]["rule"] == "general_retry"
+
+
+def test_l4_preserves_retry_recovery_for_ordinary_retry_recovery_path(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "torch.OutOfMemoryError: CUDA out of memory"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "cuda_oom",
+            "signature": failure_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": "0",
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "The workload exhausted accelerator memory.",
+            "plausible_causes": ["insufficient workload memory headroom"],
+            "persistence_evidence": ["the workload crossed its memory budget"],
+            "transient_alternatives": ["process teardown may clear allocator state"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "likely",
+            "recurrence_confidence": 75,
+            "current_attempt_persistence_evidence": "none",
+            "retry_recovery_path": "ordinary_retry",
+            "confidence": 75,
+            "rationale": (
+                "A fresh process may recover once, while durable workload change "
+                "is still required."
+            ),
+            "supporting_evidence_lines": [1],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The workload OOM is the initiating failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.RETRY_RECOVERY_AVAILABLE.value
+    assert "recovery_requirement" not in payload["model_recovery_assessment"]
+    assert payload["retry_policy"]["rule"] == "bounded_retry"
+
+
+def test_l4_keeps_retry_recoverable_workload_failure_restartable(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO training iteration 120",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "runtime_assertion",
+            "signature": "device-side assert triggered",
+            "proposed_root_fingerprint": "runtime_assertion:device_side_assert_terminal",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "root_cause_assessment": {
+            "summary": "The runtime assertion may be handled by workload retry logic.",
+            "plausible_causes": ["retryable workload data"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["workload retry recovery"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "likely",
+            "current_attempt_persistence_evidence": "none",
+            "retry_recovery_path": "workload_managed_retry_grace",
+            "confidence": 80,
+            "rationale": "The workload is expected to skip the item after retries.",
+            "supporting_evidence_lines": [2],
+        },
+        "related_failures": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "RuntimeError: CUDA error: device-side assert triggered",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "The cited current-log error was selected as user failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    result = analyzer.analyze(
+        {
+            "log_path": str(log_path),
+            "job_id": "job-1",
+        }
+    )
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.RETRY_RECOVERY_AVAILABLE.value
+    assert payload["primary_failure"]["failure_class"] == "observed_exception"
+    assert analyzer.last_trace["l2_audit"]["used"] is True
+    assert payload["model_recovery_assessment"]["retry_outlook_without_workload_change"][
+        "value"
+    ] == ("may_recover")
+    assert "recovery_requirement" not in payload["model_recovery_assessment"]
+    assert payload["retry_policy"]["rule"] == "bounded_retry"
+    assert "workload_managed_retry_grace" not in json.dumps(payload, sort_keys=True)
+
+
+def test_l4_maps_infrastructure_domain_to_restart(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: GPU has fallen off the bus"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "gpu_device_loss",
+            "signature": "GPU has fallen off the bus",
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "root_cause_assessment": {
+            "summary": "The accelerator became unavailable.",
+            "plausible_causes": ["GPU or PCIe infrastructure fault"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["replacement placement"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "infrastructure",
+            "next_attempt_same_failure_likelihood": "plausible",
+            "current_attempt_persistence_evidence": "none",
+            "retry_recovery_path": "ordinary_retry",
+            "confidence": 95,
+            "rationale": "A restart can move the workload to healthy infrastructure.",
+            "supporting_evidence_lines": [1],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The device-loss exception is the initiating failure.",
+    }
+
+    payload = (
+        RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+        .analyze({"log_path": str(log_path)})
+        .to_payload()
+    )
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["retry_policy"]["rule"] == "bounded_retry"
+
+
+def test_l4_does_not_immediately_stop_established_infrastructure_failure(
+    tmp_path,
+):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: GPU has fallen off the bus"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "primary_failure": {
+            "failure_class": "gpu_device_loss",
+            "signature": failure_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "root_cause_assessment": {
+            "summary": "The current accelerator became unavailable.",
+            "plausible_causes": ["GPU or PCIe infrastructure fault"],
+            "persistence_evidence": ["the device-loss event terminated this attempt"],
+            "transient_alternatives": ["replacement placement or recovered hardware"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "infrastructure",
+            "next_attempt_same_failure_likelihood": "likely",
+            "current_attempt_persistence_evidence": "affirmative",
+            "retry_recovery_path": "external_intervention",
+            "confidence": 90,
+            "rationale": "The device fault may require intervention.",
+            "supporting_evidence_lines": [1],
+        },
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The device-loss exception is the initiating failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["model_recovery_assessment"]["failure_domain"] == {
+        "value": "infrastructure",
+        "status": "established_by_current_log",
+        "confidence": 90,
+    }
+    assert payload["retry_policy"]["rule"] == "general_retry"
+    assert analyzer.last_trace["l2_audit"]["recovery_field_audits"] == []
+
+
+def test_l4_uses_general_retry_for_single_immutable_infrastructure_failure(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "Xid 79: GPU reset required before reuse"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "primary_failure": {
+            "failure_class": "gpu_reset_required",
+            "signature": failure_line,
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "root_cause_assessment": {
+            "summary": "The assigned GPU requires an external reset.",
+            "plausible_causes": ["latched accelerator fault"],
+            "persistence_evidence": ["the driver explicitly requires a reset"],
+            "transient_alternatives": [],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "infrastructure",
+            "next_attempt_same_failure_likelihood": "likely",
+            "current_attempt_persistence_evidence": "affirmative",
+            "retry_recovery_path": "external_intervention",
+            "confidence": 95,
+            "rationale": "The immutable allocation requires a GPU reset before retry.",
+            "supporting_evidence_lines": [1],
+        },
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The reset-required Xid is the initiating failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+    assert payload["retry_policy"]["rule"] == "general_retry"
+
+
+def test_history_can_stop_repeated_infrastructure_failure_without_progress(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: GPU has fallen off the bus"
+    log_path.write_text(
+        (
+            "7: [2026-05-27 07:58:10] iteration 120/400 | "
+            f"consumed samples: 7680 |\n{failure_line}\n"
+        ),
+        encoding="utf-8",
+    )
+    bundle = build_l0_bundle(str(log_path))
+    current = bundle.deterministic_primary_candidate
+    assert current is not None
+    evidence = {
+        "primary_failure": {
+            "failure_class": "gpu_device_loss",
+            "signature": failure_line,
+            "proposed_root_fingerprint": current.root_fingerprint,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "root_cause_assessment": {
+            "summary": "The accelerator became unavailable.",
+            "plausible_causes": ["GPU or PCIe infrastructure fault"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["replacement placement"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "infrastructure",
+            "next_attempt_same_failure_likelihood": "plausible",
+            "current_attempt_persistence_evidence": "none",
+            "retry_recovery_path": "ordinary_retry",
+            "confidence": 80,
+            "rationale": "A fresh allocation may recover.",
+            "supporting_evidence_lines": [2],
+        },
+        "evidence": [{"line": 2, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The device-loss exception is the initiating failure.",
+    }
+    history = [
+        {
+            "job_id": "job-1",
+            "cycle_id": 1,
+            "root_fingerprint": current.root_fingerprint,
+            "primary_fault_outcome": "terminal",
+            "last_completed_step": 120,
+        },
+        {
+            "job_id": "job-1",
+            "cycle_id": 2,
+            "root_fingerprint": current.root_fingerprint,
+            "primary_fault_outcome": "terminal",
+            "last_completed_step": 120,
+        },
+    ]
+
+    payload = (
+        RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+        .analyze(
+            {
+                "log_path": str(log_path),
+                "job_id": "job-1",
+                "cycle_id": 3,
+            },
+            l0_bundle=bundle,
+            prior_attempts=_prior_attempt_view(*history),
+        )
+        .to_payload()
+    )
+
+    assert payload["decision"] == Decision.STOP.value
+    assert payload["decision_basis"] == DecisionBasis.RETRY_BUDGET_EXHAUSTED.value
+    assert payload["retry_policy"]["rule"] == "bounded_retry"
+    assert payload["result_provenance"]["history_contribution"] == ("retry_budget_exhausted")
+
+
+def test_l1_recovery_assessment_drives_policy(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = (
+        "180: [rank180]: RuntimeError: Rank 180, node nvl72005-T14, "
+        "device 0, iteration 670314: Unexpected result inf "
+        "(message='found Inf in local grad norm for bucket #0 in "
+        "backward pass before data-parallel communication collective')"
+    )
+    log_path.write_text(
+        "\n".join(
+            [
+                "6143: iteration   670310/  794728 | consumed samples: 2059192320 |",
+                failure_line,
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "numeric_instability",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "inf_in_grad_norm",
+            "root_fingerprint": "numeric_instability:inf_in_grad_norm",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": "180",
+            "phase": "steady_mid",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": failure_line,
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "The model selected an unmapped L1-only numeric instability.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    result = analyzer.analyze({"log_path": str(log_path), "job_id": "job-1"})
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.STOP.value
+    assert payload["decision_basis"] == DecisionBasis.WORKLOAD_UNRECOVERABLE.value
+    assert payload["primary_failure"]["failure_class"] == "observed_exception"
+    assert payload["primary_failure"]["root_fingerprint"].startswith("observed:runtimeerror:")
+    assert payload["primary_failure"]["root_fingerprint_source"] == ("observed_exception")
+    assert (
+        analyzer.last_trace["l2_audit"]["stable_root_fingerprint"]
+        == payload["primary_failure"]["root_fingerprint"]
+    )
+    assert analyzer.last_trace["l2_audit"]["used"] is True
+    assert analyzer.last_trace["l2_audit"]["model_failure_domain"] == "workload"
+    assert analyzer.last_trace["l4_policy"]["retry_policy"]["rule"] == ("workload_unrecoverable")
+
+
+def test_l1_retries_retryable_provider_failure_then_uses_valid_evidence(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO training iteration 120",
+                "ValueError: invalid config option tensor_model_parallel_size",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "python_user_exception",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "ValueError:",
+            "root_fingerprint": "python_user_exception:ValueError:",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "setup",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "ValueError: invalid config option tensor_model_parallel_size",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "The cited current-log error was selected as user failure.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_RetryOnceEvidenceExtractor(evidence))
+    result = analyzer.analyze(
+        {
+            "log_path": str(log_path),
+            "job_id": "job-1",
+        }
+    )
+    payload = result.to_payload()
+    l1_trace = analyzer.last_trace["l1"]
+
+    assert payload["decision"] == Decision.STOP.value
+    assert payload["decision_basis"] == DecisionBasis.WORKLOAD_UNRECOVERABLE.value
+    assert analyzer.last_trace["l2_audit"]["used"] is True
+    assert len(l1_trace["model_calls"]) == 2
+    assert l1_trace["model_calls"][0]["success"] is False
+    assert l1_trace["model_calls"][0]["retry_scheduled"] is True
+    assert l1_trace["model_calls"][1]["success"] is True
+    assert analyzer.last_trace["timing"]["l1_failed_model_calls"] == 1
+    assert analyzer.last_trace["timing"]["l1_retried_model_calls"] == 1
+    assert analyzer.last_trace["anomalies"]["provider_retries"] == 1
+    assert payload["result_provenance"]["l1_execution_status"] == "degraded"
+    assert payload["result_provenance"]["l1_execution_issues"] == [
+        "model_call_failed",
+        "retry_used",
+        "provider_http_error",
+    ]
+    assert analyzer.last_trace["layers"]["L1"]["execution_status"] == "degraded"
+    request_events = [
+        event
+        for event in l1_trace["interaction_transcript"]
+        if event.get("event_type") == "model_request"
+    ]
+    assert len(request_events) == 2
+    assert request_events[0]["request_body"]["messages"][0]["role"] == "system"
+    assert request_events[0]["advertised_tool_schemas"] == []
+    assert request_events[0]["payload_sha256"].startswith("sha256:")
+    assert request_events[0]["payload_bytes"] > 0
+    assert request_events[0]["truncated"] is False
+    assert "test-key" not in json.dumps(request_events, sort_keys=True)
+
+
+def test_http_504_is_classified_as_endpoint_timeout():
+    assert _is_http_timeout_status(504) is True
+    assert _is_http_timeout_status(500) is False
+
+
+def test_provider_reported_timing_extracts_only_valid_proxy_headers():
+    timing = _provider_reported_timing(
+        {
+            "X-LiteLLM-Timing-LLM-API-MS": "156.64",
+            "x-litellm-timing-pre-processing-ms": "1.839",
+            "x-litellm-timing-post-processing-ms": "0.69",
+            "x-litellm-timing-message-copy-ms": "0.0017",
+            "x-litellm-timing-ignored-ms": "22",
+        }
+    )
+
+    assert timing == {
+        "source": "response_headers",
+        "downstream_llm_api_ms": 156.64,
+        "proxy_pre_processing_ms": 1.839,
+        "proxy_post_processing_ms": 0.69,
+        "proxy_message_copy_ms": 0.0017,
+    }
+    assert (
+        _provider_reported_timing(
+            {
+                "x-litellm-timing-llm-api-ms": "not-a-number",
+                "x-litellm-timing-pre-processing-ms": "-1",
+            }
+        )
+        == {}
+    )
+
+
+def test_l1_http_timeout_is_clamped_to_remaining_analysis_budget():
+    observed = {}
+
+    def handler(request):
+        observed["timeout"] = request.extensions["timeout"]["read"]
+        return httpx.Response(
+            200,
+            json={"choices": [{"finish_reason": "stop", "message": {"content": "{}"}}]},
+            headers={"x-litellm-timing-llm-api-ms": "156.64"},
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = LlmConfig(api_key="test-key", timeout_seconds=120, tools_enabled=False)
+    extractor = LlmEvidenceExtractor(
+        config,
+        transport=OpenAICompatibleTransport(config, http_client=client),
+    )
+    deadline = time.monotonic() + 0.25
+
+    try:
+        _, call_record = extractor._call_model(
+            api_key="test-key",
+            messages=[{"role": "user", "content": "test"}],
+            include_tools=False,
+            model_turn=1,
+            deadline_monotonic=deadline,
+        )
+    finally:
+        client.close()
+
+    assert 0 < observed["timeout"] <= 0.25
+    assert call_record["effective_request_timeout_seconds"] == observed["timeout"]
+    assert call_record["configured_request_timeout_seconds"] == 120
+    assert call_record["provider_reported_timing"] == {
+        "source": "response_headers",
+        "downstream_llm_api_ms": 156.64,
+    }
+
+
+def test_l1_does_not_start_provider_call_after_analysis_deadline():
+    called = False
+
+    def handler(request):
+        nonlocal called
+        called = True
+        raise AssertionError("provider request must not start after deadline")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = LlmConfig(api_key="test-key")
+    extractor = LlmEvidenceExtractor(
+        config,
+        transport=OpenAICompatibleTransport(config, http_client=client),
+    )
+
+    try:
+        with pytest.raises(LlmCallError) as error:
+            extractor._call_model(
+                api_key="test-key",
+                messages=[{"role": "user", "content": "test"}],
+                include_tools=False,
+                model_turn=1,
+                deadline_monotonic=time.monotonic() - 1,
+            )
+    finally:
+        client.close()
+
+    assert called is False
+    assert error.value.call_record["error_type"] == "analysis_deadline_exceeded"
+    assert error.value.call_record["retryable"] is False
+
+
+def test_l1_deadline_prevents_retry_after_slow_provider_failure(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+
+    class _SlowRetryExtractor(LlmEvidenceExtractor):
+        def __init__(self):
+            super().__init__(
+                LlmConfig(
+                    api_key="test-key",
+                    tools_enabled=False,
+                    max_retries=5,
+                    retry_backoff_seconds=0.05,
+                )
+            )
+            self.calls = 0
+
+        def _call_model(self, **kwargs):
+            self.calls += 1
+            time.sleep(0.02)
+            raise LlmCallError(
+                "HTTP 502: bad gateway",
+                {
+                    "layer": "L1",
+                    "model": self._config.model,
+                    "model_turn": kwargs["model_turn"],
+                    "attempt": kwargs["attempt"],
+                    "max_retries": kwargs["max_retries"],
+                    "success": False,
+                    "latency_s": 0.02,
+                    "retryable": True,
+                    "retry_scheduled": False,
+                    "timeout": False,
+                    "error_type": "http_error",
+                    "error": "HTTP 502",
+                },
+            )
+
+    extractor = _SlowRetryExtractor()
+    bundle = build_l0_bundle(str(log_path))
+    result = extractor.extract_evidence(
+        build_l1_evidence_context(
+            bundle,
+            build_l0_model_facing_view(bundle),
+            LogSnapshot.read(log_path),
+        ),
+        deadline_monotonic=time.monotonic() + 0.01,
+    )
+
+    assert extractor.calls == 1
+    assert result.success is False
+    assert result.anomalies["deadline_exceeded"] is True
+    assert result.model_calls[0]["retry_blocked_by_deadline"] is True
+
+
+def test_l1_tool_loop_stops_at_configured_round_limit(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+
+    class _AlwaysToolExtractor(LlmEvidenceExtractor):
+        def __init__(self):
+            super().__init__(
+                LlmConfig(
+                    api_key="test-key",
+                    max_retries=0,
+                    max_tool_rounds=2,
+                )
+            )
+            self.calls = 0
+
+        def _call_model(self, **kwargs):
+            self.calls += 1
+            return (
+                {
+                    "choices": [
+                        {
+                            "finish_reason": "tool_calls",
+                            "message": {
+                                "content": "",
+                                "tool_calls": [
+                                    {
+                                        "id": f"tool-{self.calls}",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "overview",
+                                            "arguments": "{}",
+                                        },
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                },
+                {
+                    "layer": "L1",
+                    "model": self._config.model,
+                    "model_turn": kwargs["model_turn"],
+                    "attempt": kwargs["attempt"],
+                    "max_retries": kwargs["max_retries"],
+                    "success": True,
+                    "latency_s": 0.001,
+                    "finish_reason": "tool_calls",
+                    "usage": {"total_tokens": 10},
+                    "tools_advertised": kwargs["include_tools"],
+                },
+            )
+
+    extractor = _AlwaysToolExtractor()
+    bundle = build_l0_bundle(str(log_path))
+    result = extractor.extract_evidence(
+        build_l1_evidence_context(
+            bundle,
+            build_l0_model_facing_view(bundle),
+            LogSnapshot.read(log_path),
+        ),
+        deadline_monotonic=time.monotonic() + 5,
+    )
+
+    assert extractor.calls == 3
+    assert len(result.tool_calls) == 2
+    assert result.success is False
+    assert result.anomalies["forced_final_evidence_call"] is True
+
+
+def test_l1_repairs_incomplete_contract_once_without_tools(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_line = "ValueError: invalid config option tensor_model_parallel_size"
+    log_path.write_text(log_line + "\n", encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "python_user_exception",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "ValueError:",
+            "root_fingerprint": "python_user_exception:valueerror",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "setup",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [{"line": 1, "quote": log_line, "supports": "primary_failure"}],
+        "justification": "The configuration error is the initiating failure.",
+    }
+    extractor = _ContractRepairEvidenceExtractor(evidence)
+    bundle = build_l0_bundle(str(log_path))
+
+    result = extractor.extract_evidence(
+        build_l1_evidence_context(
+            bundle,
+            build_l0_model_facing_view(bundle),
+            LogSnapshot.read(log_path),
+        )
+    )
+
+    assert result.success is True
+    assert extractor.calls == 2
+    assert result.anomalies["contract_repair_requested"] is True
+    assert len(result.model_calls) == 2
+    request_events = [
+        event for event in result.transcript_events if event.get("event_type") == "model_request"
+    ]
+    assert len(request_events) == 2
+    repair_messages = request_events[1]["request_body"]["messages"]
+    assert repair_messages[-2]["role"] == "assistant"
+    assert repair_messages[-1]["role"] == "user"
+    assert "could not be accepted" in repair_messages[-1]["content"]
+    assert request_events[1]["advertised_tool_schemas"] == []
+
+
+def test_l1_prohibited_action_field_is_rejected_by_closed_contract(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO training iteration 120",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "decision": "STOP",
+        "primary_failure": {
+            "failure_class": "cuda_device_assert",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "device-side assert triggered",
+            "root_fingerprint": "cuda_device_assert:device_side_assert",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "RuntimeError: CUDA error: device-side assert triggered",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "Bad model output.",
+    }
+
+    current = _current_evidence(evidence)
+    current["decision"] = "STOP"
+
+    assert model_evidence_contract_errors(current) == ["top-level has unsupported fields: decision"]
+
+
+def test_l1_provider_timeout_is_not_trusted_even_with_evidence(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO training iteration 120",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "cuda_device_assert",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "device-side assert triggered",
+            "root_fingerprint": "cuda_device_assert:device_side_assert",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "RuntimeError: CUDA error: device-side assert triggered",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "Should not be trusted because provider timed out.",
+    }
+
+    analyzer = RestartAgent(
+        evidence_extractor=_FakeEvidenceExtractor(
+            evidence,
+            success=False,
+            errors=("LLM request timed out",),
+            anomalies={"provider_error": True, "provider_timeout": True},
+        )
+    )
+    result = analyzer.analyze({"log_path": str(log_path), "job_id": "job-1"})
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+    assert payload["result_provenance"]["model_contribution"] == "attempted_not_used_timeout"
+    assert payload["result_provenance"]["candidate_kind"] == "deterministic"
+    assert payload["result_provenance"]["result_quality"] == "degraded"
+    assert payload["result_provenance"]["nvrx_use"] == "eligible_degraded"
+    assert analyzer.last_trace["l2_audit"]["used"] is False
+    assert analyzer.last_trace["l2_audit"]["audit_status"] == "not_run"
+    assert analyzer.last_trace["layers"]["L1"]["output_status"] == "provider_timeout"
+    assert "LLM request timed out" in analyzer.last_trace["layers"]["L1"]["output_errors"]
+    candidates = analyzer.last_trace["decision_candidates"]
+    assert candidates["selected"] == "deterministic"
+    assert candidates["deterministic"]["l1_execution_status"] == "in_flight"
+    assert candidates["best_available"]["l1_execution_status"] == "failed"
+    assert candidates["best_available"]["result"] == payload
+
+
+def test_l1_truncated_output_is_not_trusted_even_with_evidence(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO training iteration 120",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "cuda_device_assert",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "device-side assert triggered",
+            "root_fingerprint": "cuda_device_assert:device_side_assert",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "RuntimeError: CUDA error: device-side assert triggered",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "Should not be trusted because output was truncated.",
+    }
+
+    analyzer = RestartAgent(
+        evidence_extractor=_FakeEvidenceExtractor(
+            evidence,
+            success=True,
+            anomalies={"model_output_truncated": True},
+        )
+    )
+    result = analyzer.analyze({"log_path": str(log_path), "job_id": "job-1"})
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+    assert payload["result_provenance"]["model_contribution"] == "attempted_not_used_truncated"
+    assert payload["result_provenance"]["result_quality"] == "degraded"
+    assert payload["result_provenance"]["nvrx_use"] == "eligible_degraded"
+    assert analyzer.last_trace["l2_audit"]["used"] is False
+    assert analyzer.last_trace["l2_audit"]["audit_status"] == "not_run"
+    assert analyzer.last_trace["layers"]["L1"]["output_status"] == "truncated"
+    assert "model output was truncated" in analyzer.last_trace["layers"]["L1"]["output_errors"]
+
+
+def test_l1_token_limit_hit_is_reported_from_finish_reason_length(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO training iteration 120",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "cuda_device_assert",
+            "failure_domain": {
+                "value": "workload",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "established_by_current_log",
+                "confidence": 95,
+            },
+            "signature": "device-side assert triggered",
+            "root_fingerprint": "cuda_device_assert:device_side_assert",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 2,
+            "rank": None,
+            "phase": "steady_mid",
+        },
+        "secondary_failures": [],
+        "cascades": [],
+        "evidence": [
+            {
+                "line": 2,
+                "quote": "RuntimeError: CUDA error: device-side assert triggered",
+                "supports": "primary_failure",
+            }
+        ],
+        "justification": "Token limit hit should be visible in trace.",
+    }
+
+    analyzer = RestartAgent(
+        evidence_extractor=_FakeEvidenceExtractor(evidence, finish_reason="length")
+    )
+    analyzer.analyze({"log_path": str(log_path), "job_id": "job-1"})
+
+    assert analyzer.last_trace["token_limit"]["hit"] is True
+    assert analyzer.last_trace["token_limit"]["hit_count"] == 1
+    assert analyzer.last_trace["token_limit"]["hit_calls"][0]["model_turn"] is None
+    assert analyzer.last_trace["token_limit"]["hit_calls"][0]["completion_tokens"] == 5
+    assert analyzer.last_trace["token_limit"]["hit_calls"][0]["reasoning_tokens"] == 2
+    assert analyzer.last_trace["anomalies"]["token_limit_hit"] is True
+
+
+def test_same_root_no_progress_history_waits_for_general_retry_budget(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "7:  [2026-05-27 07:58:10.261551] iteration      120/     400 | "
+                    "consumed samples:         7680 | lm loss: 1.339357E+01 |"
+                ),
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    current = build_l0_bundle(str(log_path)).deterministic_primary_candidate
+    assert current is not None
+    history = [
+        {
+            "job_id": "job-1",
+            "cycle_id": 1,
+            "root_fingerprint": current.root_fingerprint,
+            "primary_fault_outcome": "terminal",
+            "last_completed_step": 120,
+        },
+        {
+            "job_id": "job-1",
+            "cycle_id": 2,
+            "root_fingerprint": current.root_fingerprint,
+            "primary_fault_outcome": "terminal",
+            "last_completed_step": 120,
+        },
+    ]
+
+    result = RestartAgent().analyze(
+        {
+            "log_path": str(log_path),
+            "job_id": "job-1",
+            "cycle_id": 3,
+        },
+        prior_attempts=_prior_attempt_view(*history),
+    )
+    payload = result.to_payload()
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert payload["decision_basis"] == DecisionBasis.GENERAL_RETRY_AVAILABLE.value
+    assert payload["result_provenance"]["evidence_source"] == "l0_deterministic"
+    assert payload["result_provenance"]["history_contribution"] == "checked_no_effect"
+    assert payload["result_provenance"]["nvrx_use"] == "eligible"
+
+
+def test_history_requires_exact_observed_failure_iteration_when_available():
+    primary = FailureEvidence(
+        failure_class="numeric_instability",
+        signature="Unexpected result inf",
+        root_fingerprint="observed:runtimeerror:validate_result",
+        fault_outcome="terminal",
+        failure_iteration=337071,
+    )
+    progress = ProgressFacts(
+        latest_observed_failure_iteration=337071,
+        latest_observed_failure_iteration_line=200,
+    )
+    base_record = {
+        "job_id": "job-1",
+        "cycle_id": 1,
+        "root_fingerprint": primary.root_fingerprint,
+        "primary_fault_outcome": "terminal",
+    }
+
+    mismatch = evaluate_history(
+        _history_evaluation_input(
+            current_attempt=_attempt_facts_and_progress(primary, progress),
+            job_id="job-1",
+            cycle_id=2,
+            prior_records=_attempt_records({**base_record, "failure_iteration": 337072}),
+        )
+    )
+    assert mismatch.matching_root_attempts == 1
+    assert mismatch.no_observed_advance_attempts == 1
+    assert mismatch.exact_failure_position_attempts == 0
+    assert mismatch.comparisons[0].relation == "regressed"
+    assert mismatch.comparisons[0].same_failure_iteration is False
+
+    exact = evaluate_history(
+        _history_evaluation_input(
+            current_attempt=_attempt_facts_and_progress(primary, progress),
+            job_id="job-1",
+            cycle_id=2,
+            prior_records=_attempt_records({**base_record, "failure_iteration": 337071}),
+        )
+    )
+    assert exact.no_observed_advance_attempts == 1
+    assert exact.exact_failure_position_attempts == 1
+    assert exact.comparisons[0].relation == "same"
+    assert exact.comparisons[0].same_failure_iteration is True
+
+
+def test_history_reports_one_step_observed_advance_without_policy_decision():
+    primary = FailureEvidence(
+        failure_class="numeric_instability",
+        signature="Unexpected result inf",
+        root_fingerprint="observed:runtimeerror:validate_result",
+        fault_outcome="terminal",
+    )
+    summary = evaluate_history(
+        _history_evaluation_input(
+            current_attempt=_attempt_facts_and_progress(
+                primary,
+                ProgressFacts(highest_completed_step=121),
+            ),
+            job_id="job-1",
+            cycle_id=2,
+            prior_records=_attempt_records(
+                {
+                    "job_id": "job-1",
+                    "cycle_id": 1,
+                    "root_fingerprint": primary.root_fingerprint,
+                    "primary_fault_outcome": "terminal",
+                    "last_completed_step": 120,
+                },
+            ),
+        )
+    )
+
+    assert summary.observed_advance_attempts == 1
+    assert summary.no_observed_advance_attempts == 0
+    assert summary.advanced_beyond_all_comparable_attempts is True
+    assert summary.comparisons[0].selected_basis == "completed_step"
+    assert summary.comparisons[0].dimension_comparisons[0].delta == 1
+    assert summary.comparisons[0].relation == "advanced"
+
+
+def test_history_marks_different_progress_marker_types_unknown():
+    primary = FailureEvidence(
+        failure_class="numeric_instability",
+        signature="Unexpected result inf",
+        root_fingerprint="observed:runtimeerror:validate_result",
+        fault_outcome="terminal",
+    )
+    summary = evaluate_history(
+        _history_evaluation_input(
+            current_attempt=_attempt_facts_and_progress(
+                primary,
+                ProgressFacts(highest_completed_step=121),
+            ),
+            job_id="job-1",
+            cycle_id=2,
+            prior_records=_attempt_records(
+                {
+                    "job_id": "job-1",
+                    "cycle_id": 1,
+                    "root_fingerprint": primary.root_fingerprint,
+                    "primary_fault_outcome": "terminal",
+                    "last_checkpoint_step": 120,
+                },
+            ),
+        )
+    )
+
+    assert summary.unknown_progress_attempts == 1
+    assert summary.no_observed_advance_attempts == 0
+    assert summary.comparisons[0].relation == "unknown"
+
+
+def test_single_weak_no_advance_history_does_not_stop(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "INFO training iteration 120\nRuntimeError: CUDA error: device-side assert triggered\n",
+        encoding="utf-8",
+    )
+    current = build_l0_bundle(str(log_path)).deterministic_primary_candidate
+    assert current is not None
+    history = [
+        {
+            "job_id": "job-1",
+            "cycle_id": 1,
+            "root_fingerprint": current.root_fingerprint,
+            "primary_fault_outcome": "terminal",
+            "last_completed_step": 120,
+        }
+    ]
+    result = RestartAgent().analyze(
+        {
+            "log_path": str(log_path),
+            "job_id": "job-1",
+            "cycle_id": 2,
+        },
+        prior_attempts=_prior_attempt_view(*history),
+    )
+
+    assert result.decision == Decision.RESTART.value
+    assert result.result_provenance["history_contribution"] == "checked_no_effect"
+
+
+def test_l4_history_thresholds_are_not_owned_by_l3():
+    primary = FailureEvidence(
+        failure_class="numeric_instability",
+        signature="Unexpected result inf",
+        root_fingerprint="observed:runtimeerror:validate_result",
+        fault_outcome="terminal",
+    )
+
+    bounded_once = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(
+                available=True,
+                matching_root_attempts=1,
+                consecutive_same_root_no_advance_attempts=1,
+            ),
+            model_recovery_assessment=_recovery_assessment(
+                domain="unknown",
+                outlook="may_recover",
+            ),
+            assessment_grounded=True,
+        )
+    ).retry_policy
+    assert bounded_once.decision == Decision.STOP.value
+    assert bounded_once.rule == "bounded_retry"
+    assert bounded_once.general_root_ceiling.matching_prior_failures == 1
+    assert bounded_once.general_root_ceiling.allowed_retries == 3
+    assert bounded_once.selected_rule_budget is not None
+    assert bounded_once.selected_rule_budget.matching_prior_failures == 1
+    assert bounded_once.selected_rule_budget.allowed_retries == 1
+    assert bounded_once.retry_budget_exhausted is True
+    assert bounded_once.exhausted_by == ("selected_rule_budget",)
+
+    general_twice = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(
+                available=True,
+                matching_root_attempts=2,
+                consecutive_same_root_no_advance_attempts=2,
+            ),
+            model_recovery_assessment=_recovery_assessment(
+                domain="unknown",
+                outlook="unknown",
+            ),
+            assessment_grounded=True,
+        )
+    ).retry_policy
+    assert general_twice.decision == Decision.RESTART.value
+    assert general_twice.general_root_ceiling.allowed_retries == 3
+    assert general_twice.selected_rule_budget is None
+    assert general_twice.retry_budget_exhausted is False
+
+    general_exhausted = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(
+                available=True,
+                matching_root_attempts=3,
+                consecutive_same_root_no_advance_attempts=3,
+            ),
+            model_recovery_assessment=_recovery_assessment(
+                domain="unknown",
+                outlook="unknown",
+            ),
+            assessment_grounded=True,
+        )
+    ).retry_policy
+    assert general_exhausted.decision == Decision.STOP.value
+    assert general_exhausted.retry_budget_exhausted is True
+    assert general_exhausted.exhausted_by == ("general_root_ceiling",)
+
+
+def test_l4_missing_primary_is_a_degraded_result_not_a_retry_rule():
+    policy = evaluate_policy(
+        L4PolicyInput(
+            primary=None,
+            history=HistorySummary(
+                available=False,
+                availability_reason="missing_root_fingerprint",
+            ),
+        )
+    ).retry_policy
+
+    assert policy.rule is None
+    assert policy.decision == Decision.RESTART.value
+    assert policy.decision_basis == DecisionBasis.NO_PRIMARY_FAILURE.value
+    assert policy.general_root_ceiling.applicable is False
+    assert policy.general_root_ceiling.inapplicable_reason == "missing_primary"
+    assert policy.selected_rule_budget is None
+
+
+def test_l4_time_limit_uses_ordinary_root_retry_policy():
+    primary = FailureEvidence(
+        failure_class="time_limit",
+        signature="CANCELLED DUE TO TIME LIMIT",
+        root_fingerprint="observed:scheduler:time_limit",
+        fault_outcome="terminal",
+        registry_id="time_limit",
+    )
+    policy = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_no_advance_attempts=3,
+            ),
+        )
+    ).retry_policy
+
+    assert policy.rule == RetryPolicyRule.GENERAL_RETRY.value
+    assert policy.general_root_ceiling.exhausted is True
+    assert policy.exhausted_by == ("general_root_ceiling",)
+    assert policy.decision == Decision.STOP.value
+
+
+def test_retry_policy_rejects_bounded_budget_above_general_ceiling():
+    with pytest.raises(
+        ValueError,
+        match="bounded_retry_allowed_retries must not exceed",
+    ):
+        RetryPolicyConfig(
+            bounded_retry_allowed_retries=4,
+            general_retry_allowed_retries=3,
+        )
+
+
+def test_retry_policy_rejects_confirmation_budget_above_general_ceiling():
+    with pytest.raises(
+        ValueError,
+        match="confirmation_retry_allowed_retries must not exceed",
+    ):
+        RetryPolicyConfig(
+            confirmation_retry_allowed_retries=4,
+            general_retry_allowed_retries=3,
+        )
+
+
+def test_l4_stops_for_grounded_unrecoverable_workload_evidence():
+    primary = FailureEvidence(
+        failure_class="code_failure",
+        signature="deterministic code failure",
+        root_fingerprint="observed:code:failure",
+        fault_outcome="terminal",
+    )
+    assessment = _recovery_assessment(
+        domain="workload",
+        outlook="cannot_recover",
+        domain_status="established_by_current_log",
+        outlook_status="established_by_current_log",
+    )
+
+    grounded = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(available=False),
+            model_recovery_assessment=assessment,
+            assessment_grounded=True,
+        )
+    ).retry_policy
+    assert grounded.decision == Decision.STOP.value
+    assert grounded.rule == "workload_unrecoverable"
+    assert grounded.general_root_ceiling.applicable is False
+    assert grounded.general_root_ceiling.inapplicable_reason == "immediate_unrecoverable"
+
+    ungrounded = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(available=False),
+            model_recovery_assessment=assessment,
+            assessment_grounded=False,
+        )
+    ).retry_policy
+    assert ungrounded.decision == Decision.RESTART.value
+    assert ungrounded.rule == "general_retry"
+
+
+@pytest.mark.parametrize(
+    ("domain", "outlook", "domain_status", "outlook_status"),
+    [
+        (
+            "infrastructure",
+            "cannot_recover",
+            "established_by_current_log",
+            "established_by_current_log",
+        ),
+        (
+            "workload",
+            "may_recover",
+            "established_by_current_log",
+            "established_by_current_log",
+        ),
+        (
+            "workload",
+            "cannot_recover",
+            "supported_but_unconfirmed",
+            "established_by_current_log",
+        ),
+        (
+            "workload",
+            "cannot_recover",
+            "established_by_current_log",
+            "supported_but_unconfirmed",
+        ),
+    ],
+)
+def test_l4_does_not_stop_for_incomplete_current_evidence_predicate(
+    domain,
+    outlook,
+    domain_status,
+    outlook_status,
+):
+    primary = FailureEvidence(
+        failure_class="observed_failure",
+        signature="observed failure",
+        root_fingerprint="observed:failure",
+        fault_outcome="terminal",
+    )
+
+    policy = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(available=False),
+            model_recovery_assessment=_recovery_assessment(
+                domain=domain,
+                outlook=outlook,
+                domain_status=domain_status,
+                outlook_status=outlook_status,
+            ),
+            assessment_grounded=True,
+        )
+    ).retry_policy
+
+    assert policy.decision == Decision.RESTART.value
+    assert policy.current_evidence_qualified is False
+
+
+def test_l4_uses_general_retry_when_recovery_assessment_is_not_grounded():
+    primary = FailureEvidence(
+        failure_class="observed_failure",
+        signature="observed failure",
+        root_fingerprint="observed:failure",
+        fault_outcome="terminal",
+    )
+
+    policy = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(available=False),
+            model_recovery_assessment=_recovery_assessment(
+                domain="unknown",
+                outlook="may_recover",
+            ),
+            assessment_grounded=False,
+        )
+    ).retry_policy
+
+    assert policy.rule == "general_retry"
+    assert policy.general_root_ceiling.allowed_retries == 3
+    assert policy.selected_rule_budget is None
+
+
+def test_l4_observed_advance_does_not_exhaust_retry_budget():
+    primary = FailureEvidence(
+        failure_class="numeric_instability",
+        signature="Unexpected result inf",
+        root_fingerprint="observed:runtimeerror:validate_result",
+        fault_outcome="terminal",
+    )
+    policy = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(
+                available=True,
+                matching_root_attempts=5,
+                consecutive_same_root_no_advance_attempts=3,
+                advanced_beyond_all_comparable_attempts=True,
+            ),
+            retry_policy=RetryPolicyConfig(general_retry_allowed_retries=3),
+        )
+    ).retry_policy
+    assert policy.decision == Decision.RESTART.value
+    assert policy.decision_basis == DecisionBasis.OBSERVED_ADVANCE.value
+    assert policy.retry_budget_exhausted is False
+
+
+def test_history_distinguishes_iteration_from_same_rank_iteration_replay():
+    primary = FailureEvidence(
+        failure_class="bad_token_or_window",
+        signature="Unexpected result inf",
+        root_fingerprint="observed:data:non_finite",
+        fault_outcome="terminal",
+        rank="7",
+        failure_iteration=418,
+    )
+    summary = evaluate_history(
+        _history_evaluation_input(
+            current_attempt=_attempt_facts_and_progress(
+                primary,
+                ProgressFacts(latest_observed_failure_iteration=418),
+            ),
+            job_id="job-1",
+            cycle_id=3,
+            prior_records=_attempt_records(
+                {
+                    "job_id": "job-1",
+                    "cycle_id": 1,
+                    "root_fingerprint": primary.root_fingerprint,
+                    "primary_fault_outcome": "terminal",
+                    "failure_iteration": 418,
+                    "faulting_rank": "7",
+                },
+                {
+                    "job_id": "job-1",
+                    "cycle_id": 2,
+                    "root_fingerprint": primary.root_fingerprint,
+                    "primary_fault_outcome": "terminal",
+                    "failure_iteration": 418,
+                    "faulting_rank": "9",
+                },
+            ),
+        )
+    )
+
+    assert summary.exact_failure_position_attempts == 2
+    assert summary.same_rank_iteration_attempts == 1
+    assert [item.same_rank for item in summary.comparisons] == [True, False]
+
+
+def test_history_rejects_duplicate_job_cycle_records():
+    primary = FailureEvidence(
+        failure_class="numeric_instability",
+        signature="Unexpected result inf",
+        root_fingerprint="observed:runtimeerror:validate_result",
+        fault_outcome="terminal",
+    )
+    record = {
+        "job_id": "job-1",
+        "cycle_id": 1,
+        "root_fingerprint": primary.root_fingerprint,
+        "primary_fault_outcome": "terminal",
+        "last_completed_step": 120,
+    }
+    with pytest.raises(ValueError, match="duplicate job_id/cycle_id"):
+        _attempt_records(record, dict(record))
+
+
+@pytest.mark.parametrize("cycle_id", [None, True, "1"])
+def test_history_requires_integer_cycle_id(cycle_id):
+    record = {
+        "job_id": "job-1",
+        "cycle_id": cycle_id,
+        "root_fingerprint": "observed:runtimeerror:validate_result",
+    }
+
+    expected_error = TypeError if cycle_id is not None else ValueError
+    with pytest.raises(expected_error, match=r"attempt records\[0\]\.cycle_id"):
+        _attempt_records(record)
+
+
+def test_history_normalization_orders_records_by_cycle_id():
+    records = _attempt_records(
+        {
+            "job_id": "job-1",
+            "cycle_id": 3,
+            "root_fingerprint": "observed:runtimeerror:validate_result",
+        },
+        {
+            "job_id": "job-1",
+            "cycle_id": 1,
+            "root_fingerprint": "observed:runtimeerror:validate_result",
+        },
+    )
+
+    assert [record.cycle_id for record in records] == [1, 3]
+
+
+def test_history_revalidates_typed_records_at_runtime_boundary():
+    with pytest.raises(TypeError, match=r"attempt records\[0\]\.cycle_id"):
+        normalize_attempt_records(
+            (
+                AttemptRecord(
+                    job_id="job-1",
+                    cycle_id=True,
+                    progress=AttemptProgressSummary(),
+                    deterministic=AttemptFailureFacts(
+                        source=AttemptFailureFactsSource.L0_DETERMINISTIC,
+                        root_fingerprint="observed:runtimeerror:validate_result",
+                        root_fingerprint_source="test_fixture",
+                        fault_outcome="terminal",
+                    ),
+                ),
+            )
+        )
+
+
+def test_history_locality_uses_only_qualifying_terminal_records():
+    primary = FailureEvidence(
+        failure_class="numeric_instability",
+        signature="Unexpected result inf",
+        root_fingerprint="observed:runtimeerror:validate_result",
+        fault_outcome="terminal",
+        node="node-b",
+    )
+    summary = evaluate_history(
+        _history_evaluation_input(
+            current_attempt=_attempt_facts_and_progress(
+                primary,
+                ProgressFacts(highest_completed_step=120),
+            ),
+            job_id="job-1",
+            cycle_id=3,
+            prior_records=_attempt_records(
+                {
+                    "job_id": "job-1",
+                    "cycle_id": 1,
+                    "root_fingerprint": primary.root_fingerprint,
+                    "primary_fault_outcome": "recovered",
+                    "last_completed_step": 120,
+                    "faulting_node": "node-b",
+                },
+                {
+                    "job_id": "job-1",
+                    "cycle_id": 2,
+                    "root_fingerprint": primary.root_fingerprint,
+                    "primary_fault_outcome": "terminal",
+                    "last_completed_step": 120,
+                    "faulting_node": "node-a",
+                },
+            ),
+        )
+    )
+
+    assert summary.same_node_recurrence is False
+    assert summary.cross_node_recurrence is True
+
+
+def test_megatron_progress_pattern_ignores_nan_iteration_metric(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO number of nan iterations:   0 |",
+                "INFO training iteration 120",
+                (
+                    "31:  [2026-05-26 19:52:15.571763] iteration        5/       8 | "
+                    "consumed samples:          160 | lm loss: 1.214552E+01 | "
+                    "number of nan iterations:   0 |"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.progress.highest_completed_step == 5
+    assert bundle.progress.progress_lines == (3,)
+    assert any(group.classification == "progress" for group in bundle.occurrence_groups)
+
+
+def test_l0_records_setup_progress_without_promoting_it_to_forward_progress(tmp_path):
+    log_path = tmp_path / "setup.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: successfully loaded checkpoint from /checkpoints/680000 "
+                    "at iteration 661000"
+                ),
+                "7: INFO:root:> built cuda graph(s) in 46.77 sec",
+                "8: INFO:root:> built cuda graph(s) in 46.78 sec",
+                "0: OSError: [Errno 98] Address already in use",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+
+    assert [marker.marker_type for marker in bundle.progress.setup_markers] == [
+        "checkpoint_load",
+        "cuda_graph_build",
+    ]
+    assert bundle.progress.setup_markers[0].value == 661000
+    assert bundle.progress.setup_lines == (1, 2)
+    assert bundle.progress.progress_markers == ()
+    assert bundle.progress.checkpoint_markers == ()
+    assert bundle.progress.highest_completed_step is None
+    assert bundle.progress.last_checkpoint_step is None
+    assert bundle.run_progress_summary.setup_marker_count == 2
+    assert bundle.run_progress_summary.last_setup_marker_type == "cuda_graph_build"
+    assert bundle.run_progress_summary.last_setup_line == 2
+    assert bundle.evidence_coverage["setup_progress"] == "found"
+    assert bundle.evidence_coverage["application_progress"] == "not_found"
+    assert bundle.evidence_coverage["checkpoint_progress"] == "not_found"
+    assert [
+        marker["marker_type"] for marker in prompt_bundle["progress"]["recent_setup_markers"]
+    ] == ["checkpoint_load", "cuda_graph_build"]
+
+
+def test_l0_uses_observed_failure_iteration_without_claiming_completed_progress(tmp_path):
+    log_path = tmp_path / "iteration_failure.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: successfully loaded checkpoint at iteration 337000",
+                (
+                    "404: [rank404]: RuntimeError: Rank 404, device 0, iteration 337071: "
+                    "Unexpected result inf"
+                ),
+                "910: [rank910]: Traceback (most recent call last):",
+                (
+                    '910: [rank910]:   File "/usr/lib/python3.12/multiprocessing/util.py", '
+                    "line 303, in _run_finalizers"
+                ),
+                "910: [rank910]:     finalizer()",
+                (
+                    '910: [rank910]:   File "/usr/lib/python3.12/multiprocessing/'
+                    'connection.py", line 399, in _finalize_listener'
+                ),
+                (
+                    "910: [rank910]: FileNotFoundError: [Errno 2] No such file or "
+                    "directory: '/tmp/pymp-a/listener-b'"
+                ),
+                (
+                    "910: [rank910]: FileNotFoundError: [Errno 2] No such file or "
+                    "directory: '/tmp/pymp-a/listener-b'"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+
+    assert bundle.progress.highest_completed_step is None
+    assert bundle.progress.latest_observed_failure_iteration == 337071
+    assert bundle.progress.latest_observed_failure_iteration_line == 2
+    assert bundle.run_progress_summary.checkpoint_load_iteration == 337000
+    assert bundle.run_progress_summary.latest_observed_failure_iteration == 337071
+    assert bundle.run_progress_summary.observed_iterations_after_checkpoint_load == 71
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.failure_iteration == 337071
+    assert bundle.deterministic_primary_candidate.phase == "steady_mid"
+    assert bundle.evidence_coverage["application_progress"] == "not_found"
+    assert bundle.evidence_coverage["observed_failure_iteration"] == "found"
+    assert prompt_bundle["run_progress_summary"]["observed_iterations_after_checkpoint_load"] == 71
+
+    cleanup_matches = [match for match in bundle.registry_matches if match.line in {7, 8}]
+    assert len(cleanup_matches) == 2
+    assert all(match.causal_role == CausalRole.TEARDOWN.value for match in cleanup_matches)
+    assert all(match.causal_role == "teardown" for match in cleanup_matches)
+    assert all(match.phase == "teardown" for match in cleanup_matches)
+    assert all(
+        match.root_fingerprint_source == "l0_teardown_structure" for match in cleanup_matches
+    )
+    assert len({match.root_fingerprint for match in cleanup_matches}) == 1
+    assert len(bundle.cascades) == 1
+    assert bundle.cascades[0].count == 2
+
+
+def test_job_metadata_uses_rank_lower_bound_without_explicit_world_size(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: INFO rank zero started",
+                ("7: [2026-02-20 09:00:00.000000] iteration 10/100 | " "consumed samples: 100 |"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+
+    assert bundle.job_metadata.explicit_world_size is None
+    assert bundle.job_metadata.observed_rank_min == 0
+    assert bundle.job_metadata.observed_rank_max == 7
+    assert bundle.job_metadata.observed_rank_count == 2
+    assert bundle.job_metadata.inferred_world_size_lower_bound == 8
+    assert bundle.job_metadata.world_size_source == "observed_rank_lower_bound"
+    assert bundle.job_metadata.world_size_confidence == "observed_lower_bound"
+    assert prompt_bundle["job_metadata"]["inferred_world_size_lower_bound"] == 8
+
+
+def test_late_terminal_exception_gets_context_from_generic_structural_match(tmp_path):
+    log_path = tmp_path / "job.log"
+    lines = [
+        "0: NCCL WARN NET/IB : Got non-fatal async event: port error",
+        "1: NCCL WARN NET/IB : Got non-fatal async event: port error",
+        "2: NCCL WARN NET/IB : Got non-fatal async event: port error",
+        (
+            "6143: [2026-02-20 03:44:26] iteration   670310/  1000000 | "
+            "consumed samples:     123456 | lm loss: 1.234E+00 | "
+            "number of nan iterations:   0 |"
+        ),
+    ]
+    lines.extend(f"INFO ordinary training log line {line}" for line in range(5, 52))
+    lines.append(
+        "180: [rank180]: RuntimeError: Rank 180, node nvl72005-T14, "
+        "device 0, iteration 670314: Unexpected result inf "
+        "(message='found Inf in local grad norm for bucket #0 in "
+        "backward pass before data-parallel communication collective')"
+    )
+    log_path.write_text("\n".join(lines), encoding="utf-8")
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+    late_line = len(lines)
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.failure_class == "observed_exception"
+    anchor = next(item for item in bundle.candidate_anchors if item.line == late_line)
+    prompt_anchor = next(
+        item for item in prompt_bundle["candidate_anchors"] if item["line"] == late_line
+    )
+
+    assert "high_signal" in anchor.sources
+    assert anchor.taxonomy_match is not None
+    assert anchor.taxonomy_match.registry_id == "observed_exception"
+    assert anchor.prior_observed_progress_line == 4
+    assert anchor.context_window_ids
+    assert prompt_anchor["taxonomy_hint"]["registry_id"] == "observed_exception"
+    assert prompt_anchor["covered_by_excerpt"] is True
+    assert any(late_line in window["seed_lines"] for window in prompt_bundle["context_windows"])
+
+
+def test_failure_episode_uses_progress_then_terminal_exception(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO world_size ...................................... 6144",
+                (
+                    "6143:  [2026-02-20 09:05:52.888966] iteration   670250/  794728 | "
+                    "consumed samples:   2059008000 | lm loss: 9.709713E-01 | "
+                    "grad norm: 0.153 | number of skipped iterations:   0 | "
+                    "number of nan iterations:   0 |"
+                ),
+                (
+                    "0:   [2026-02-20 09:06:27.646389] successfully saved checkpoint "
+                    "from iteration  670250 to /checkpoints/phase2/"
+                ),
+                (
+                    "6143:  [2026-02-20 09:09:24.491434] iteration   670310/  794728 | "
+                    "consumed samples:   2059192320 | lm loss: 9.726213E-01 | "
+                    "grad norm: 0.098 | number of skipped iterations:   0 | "
+                    "number of nan iterations:   0 |"
+                ),
+                "180: [rank180]: Traceback (most recent call last):",
+                "180: [rank180]:   File \"/train.py\", line 1, in <module>",
+                "180: [rank180]:     raise RuntimeError(full_message)",
+                (
+                    "180: [rank180]: RuntimeError: Rank 180, node nvl72005-T14, "
+                    "device 0, iteration 670314: Unexpected result inf "
+                    "(message='found Inf in local grad norm')"
+                ),
+                "0: error: *** STEP 1745223.0 ON nvl72003-T01 CANCELLED ***",
+                (
+                    "4717: [rank4717]: TCPStore recvValue failed: Failed to recv, "
+                    "got 0 bytes. Connection was likely closed."
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+    episode = bundle.failure_episodes[0]
+    prompt_episode = prompt_bundle["failure_episodes"][0]
+
+    assert bundle.progress.highest_completed_step == 670310
+    assert bundle.progress.last_checkpoint_step == 670250
+    assert bundle.progress.progress_markers[-1].value == 670310
+    assert bundle.progress.checkpoint_markers[-1].value == 670250
+    assert bundle.run_progress_summary.first_iteration == 670250
+    assert bundle.run_progress_summary.last_iteration == 670310
+    assert bundle.run_progress_summary.iteration_delta == 60
+    assert bundle.run_progress_summary.total_iterations == 794728
+    assert bundle.run_progress_summary.last_checkpoint_iteration == 670250
+    assert bundle.run_progress_summary.progress_after_failure_episode is False
+    assert bundle.job_metadata.explicit_world_size == 6144
+    assert bundle.job_metadata.explicit_world_size_line == 1
+    assert bundle.job_metadata.observed_rank_min == 0
+    assert bundle.job_metadata.observed_rank_max == 6143
+    assert bundle.job_metadata.observed_rank_count == 4
+    assert bundle.job_metadata.inferred_world_size_lower_bound == 6144
+    assert bundle.job_metadata.world_size_source == "explicit"
+    assert episode.status == "terminal"
+    assert episode.start_line == 5
+    assert episode.terminal_exception_line == 8
+    assert episode.terminal_exception_iteration == 670314
+    assert episode.exception_rank == "180"
+    assert episode.exception_node == "nvl72005-T14"
+    assert episode.exception_gpu == "0"
+    assert episode.last_progress_before is not None
+    assert episode.last_progress_before.value == 670310
+    assert episode.first_progress_after is None
+    assert episode.first_teardown_line is None
+    assert episode.first_process_termination_line is None
+    assert episode.first_scheduler_cancel_line == 9
+    assert episode.context_window_ids
+    assert prompt_bundle["job_metadata"]["explicit_world_size"] == 6144
+    assert prompt_bundle["run_progress_summary"]["last_iteration"] == 670310
+    assert prompt_episode["last_progress_before"]["value"] == 670310
+    assert prompt_episode["first_progress_after"] is None
+    assert prompt_episode["first_scheduler_cancel_line"] == 9
+    assert "first_cancellation_line" not in prompt_episode
+
+
+def test_l0_promotes_nearby_specific_error_ahead_of_distributed_wrapper_fanout(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: iteration 42/100 | consumed samples: 1024 |",
+                (
+                    "7: ERROR:checkpoint.writer:Local process encountered an error: "
+                    "unexpected pos 704 vs 598"
+                ),
+                "8: [rank8]: Traceback (most recent call last):",
+                '8: [rank8]:   File "/workspace/checkpoint_writer.py", line 10, in save',
+                (
+                    "8: [rank8]: torch.distributed.checkpoint.api.CheckpointException: "
+                    "CheckpointException ranks:dict_keys([])"
+                ),
+                "9: [rank9]: Traceback (most recent call last):",
+                '9: [rank9]:   File "/workspace/checkpoint_writer.py", line 10, in save',
+                (
+                    "9: [rank9]: torch.distributed.checkpoint.api.CheckpointException: "
+                    "CheckpointException ranks:dict_keys([])"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 2
+    assert bundle.deterministic_primary_candidate.failure_class == "observed_failure"
+    assert bundle.deterministic_primary_candidate.phase == "checkpoint"
+    assert bundle.failure_episodes[0].precursor_lines == (2,)
+    assert bundle.failure_episodes[0].identity_anchor_line == 2
+    assert bundle.failure_episodes[0].identity_anchor_reason == (
+        "nearby_high_signal_error_precedes_failure_episode"
+    )
+    assert _canonical_identity_anchor_line(bundle, 5)[0] == 2
+    assert len(bundle.cascades) == 1
+    assert bundle.cascades[0].first_line == 5
+    assert bundle.cascades[0].count == 2
+    assert bundle.cascades[0].sample_lines == (5, 8)
+
+    alternate_primary = FailureEvidence(
+        failure_class="observed_exception",
+        signature="different selected episode",
+        root_fingerprint="observed:different_episode",
+        fault_outcome="terminal",
+        causal_role="initiating",
+        line=8,
+        phase="checkpoint",
+    )
+    assert build_result_cascades(bundle, alternate_primary, {}) == ()
+
+
+def test_different_checkpoint_success_is_structured_without_overriding_l1(
+    tmp_path,
+):
+    log_path = tmp_path / "job.log"
+    checkpoint_path = "/checkpoints/phase2/"
+    lines = [
+        "0: world_size ...................................... 6144",
+        (
+            "0: [2026-02-16 10:20:00.000000] iteration 656120/ 993410 | "
+            "consumed samples: 2015000000 |"
+        ),
+        f"0: saving checkpoint at iteration 656125 to {checkpoint_path} in torch_dist format",
+        ("0: successfully saved checkpoint from iteration 656125 to " f"{checkpoint_path}"),
+        (
+            "0: [2026-02-16 10:38:00.000000] iteration 656250/ 993410 | "
+            "consumed samples: 2016000000 |"
+        ),
+        f"0: saving checkpoint at iteration 656250 to {checkpoint_path} in torch_dist format",
+        ("0: successfully saved checkpoint from iteration 656250 to " f"{checkpoint_path}"),
+        (
+            "0: [2026-02-16 10:46:16.000000] iteration 656370/ 993410 | "
+            "consumed samples: 2016368640 |"
+        ),
+        f"0: saving checkpoint at iteration 656375 to {checkpoint_path} in torch_dist format",
+        "261: [rank261]: Traceback (most recent call last):",
+        (
+            "261: [rank261]:   File \"/megatron/training/training.py\", line 569, "
+            "in get_start_time_from_progress_log"
+        ),
+        (
+            "261: [rank261]: AssertionError: Should have seen at least one "
+            "'Starting job' entry with same world_size"
+        ),
+    ]
+    log_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    bundle = build_l0_bundle(str(log_path))
+    assert len(bundle.operation_artifact_comparisons) == 1
+    comparison = bundle.operation_artifact_comparisons[0]
+    assert comparison.operation == "checkpoint_save"
+    assert comparison.artifact_path == checkpoint_path.rstrip("/")
+    assert comparison.success_count == 2
+    assert comparison.success_logical_artifact_ids == (
+        "/checkpoints/phase2#checkpoint_iteration=656125",
+        "/checkpoints/phase2#checkpoint_iteration=656250",
+    )
+    assert comparison.logical_artifact_id == ("/checkpoints/phase2#checkpoint_iteration=656375")
+    assert comparison.comparison_level == "same_operation_different_artifact"
+    assert comparison.current_start_line == 9
+    assert comparison.current_outcome == "started_not_completed"
+    assert comparison.failure_line == 12
+    assert bundle.evidence_coverage["operation_artifact_comparisons"] == "found"
+
+    prompt_evidence = build_l0_model_facing_view(bundle).decision_evidence
+    prompt_comparison = prompt_evidence.operation_artifact_facts[0]
+    assert prompt_comparison["comparison_level"] == "same_operation_different_artifact"
+    assert prompt_comparison["interpretation"] == (
+        "operation_pipeline_was_runnable; current_artifact_health_not_established"
+    )
+
+    bundle_path = tmp_path / "l0.json"
+    write_l0_bundle(bundle_path, bundle)
+    replay = read_l0_bundle(bundle_path, expected_log_path=str(log_path))
+    assert replay.operation_artifact_comparisons == bundle.operation_artifact_comparisons
+
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "progress_log_assertion",
+            "signature": lines[11],
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 12,
+            "rank": "261",
+            "phase": "checkpoint",
+        },
+        "root_cause_assessment": {
+            "summary": "The progress-log assertion failed during checkpoint save.",
+            "status": "established_by_current_log",
+            "plausible_causes": ["missing matching progress-log entry"],
+            "persistence_evidence": ["the assertion is deterministic"],
+            "transient_alternatives": [],
+            "missing_evidence": [],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "likely",
+            "recurrence_confidence": 95,
+            "current_attempt_persistence_evidence": "affirmative",
+            "retry_recovery_path": "workload_change",
+            "confidence": 95,
+            "rationale": "The assertion will repeat on restart.",
+            "supporting_evidence_lines": [10, 11, 12],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 12, "quote": lines[11], "supports": "primary_failure"}],
+        "justification": "The progress-log assertion terminated checkpoint save.",
+    }
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+    audit = analyzer.last_trace["l2_audit"]
+
+    assert payload["decision"] == Decision.STOP.value
+    assert (
+        payload["model_recovery_assessment"]["retry_outlook_without_workload_change"]["status"]
+        == "established_by_current_log"
+    )
+    assert payload["retry_policy"]["rule"] == "workload_unrecoverable"
+    assert "model_recovery_assessment" not in audit["field_finding_codes"]
+    assert audit["grounding_adjustments"] == []
+    assert audit["recovery_field_audits"] == []
+
+
+def test_checkpoint_load_fanout_preserves_shard_uncertainty(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: [rank0]: loading distributed checkpoint from "
+                    "/checkpoints/model/ at iteration 42"
+                ),
+                (
+                    "0: [rank0]: successfully loaded checkpoint from "
+                    "/checkpoints/model/ at iteration 42"
+                ),
+                (
+                    "7: [rank7]: RuntimeError: checkpoint metadata "
+                    "UnicodeDecodeError: invalid continuation byte"
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    comparison = next(
+        item
+        for item in bundle.operation_artifact_comparisons
+        if item.operation == "checkpoint_load"
+    )
+
+    assert comparison.logical_artifact_id == ("/checkpoints/model#checkpoint_iteration=42")
+    assert comparison.physical_unit_id is None
+    assert comparison.comparison_level == ("same_logical_artifact_other_or_unknown_unit")
+    assert comparison.observation_kind == "distributed_fanout"
+    assert comparison.current_outcome == "mixed_success_and_failure"
+    assert comparison.successful_observer_ranks == ("0",)
+    assert comparison.failed_observer_ranks == ("7",)
+    assert comparison.interpretation == (
+        "same_logical_artifact_success_observed_on_another_or_unknown_shard"
+    )
+    primary = bundle.deterministic_primary_candidate
+    assert primary is not None
+    assert primary.affected_entity is not None
+    assert primary.affected_entity.kind == AffectedEntityKind.ARTIFACT
+    assert primary.affected_entity.identity == ("/checkpoints/model#checkpoint_iteration=42")
+
+
+def test_checkpoint_entity_ignores_buffer_local_decode_position(tmp_path):
+    identities = []
+    fingerprints = []
+    for position in (8, 8192):
+        log_path = tmp_path / f"job-{position}.log"
+        log_path.write_text(
+            "\n".join(
+                [
+                    (
+                        "0: loading distributed checkpoint from "
+                        "/checkpoints/model/ at iteration 42"
+                    ),
+                    (
+                        "0: UnicodeDecodeError: 'utf-8' codec can't decode byte "
+                        f"0xde in position {position}: invalid continuation byte"
+                    ),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        primary = build_l0_bundle(str(log_path)).deterministic_primary_candidate
+        assert primary is not None
+        assert primary.affected_entity is not None
+        identities.append(primary.affected_entity.identity)
+        fingerprints.append(primary.affected_entity.fingerprint)
+
+    assert identities == [
+        "/checkpoints/model#checkpoint_iteration=42",
+        "/checkpoints/model#checkpoint_iteration=42",
+    ]
+    assert len(set(fingerprints)) == 1
+
+
+def test_dataloader_comparison_retains_file_region_and_observer_identity(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: [rank0]: DataLoader successfully read file "
+                    "/data/train/shard-0001.bin offset=100"
+                ),
+                (
+                    "1: [rank1]: RuntimeError: DataLoader failed to read file "
+                    "/data/train/shard-0001.bin offset=200 "
+                    "checksum mismatch expected=abc actual=def"
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    comparison = next(
+        item
+        for item in bundle.operation_artifact_comparisons
+        if item.operation == "dataloader_read"
+    )
+
+    assert comparison.physical_unit_id == "/data/train/shard-0001.bin"
+    assert comparison.data_region == "offset=200"
+    assert comparison.success_data_regions == ("offset=100",)
+    assert comparison.integrity_marker == "checksum mismatch expected=abc actual=def"
+    assert comparison.comparison_level == "exact_physical_unit"
+    assert comparison.observation_kind == "distributed_fanout"
+    assert comparison.successful_observer_ranks == ("0",)
+    assert comparison.failed_observer_ranks == ("1",)
+    primary = bundle.deterministic_primary_candidate
+    assert primary is not None
+    assert primary.affected_entity is not None
+    assert primary.affected_entity.identity == ("/data/train/shard-0001.bin#data_region=offset=200")
+
+
+def test_dataloader_success_on_different_file_is_pipeline_evidence_only(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: [rank0]: DataLoader successfully read file /data/train/shard-0001.bin",
+                "1: [rank1]: DataLoader failed to read file /data/train/shard-0002.bin",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    comparison = next(
+        item
+        for item in bundle.operation_artifact_comparisons
+        if item.physical_unit_id == "/data/train/shard-0002.bin"
+    )
+
+    assert comparison.comparison_level == "same_operation_different_artifact"
+    assert comparison.current_outcome == "started_not_completed"
+    assert comparison.observation_kind == "current_log_comparison"
+    assert comparison.interpretation == (
+        "operation_pipeline_was_runnable; current_artifact_health_not_established"
+    )
+
+
+def test_failure_episode_separates_teardown_process_and_scheduler_lines(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: [2026-02-20 09:00:00.000000] iteration   10/  100 | "
+                    "consumed samples:  100 | lm loss: 1.0 |"
+                ),
+                "180: [rank180]: Traceback (most recent call last):",
+                "180: [rank180]: RuntimeError: found Inf in local grad norm",
+                (
+                    "180: [rank180]: Warning: destroy_process_group() was not called "
+                    "before program exit"
+                ),
+                (
+                    "180: [rank180]: Producer process has been terminated before all "
+                    "shared CUDA tensors released"
+                ),
+                "0: slurmstepd: error: *** STEP 1745223.0 CANCELLED AT 2026-02-20T09:10:13 ***",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+    episode = bundle.failure_episodes[0]
+    prompt_episode = prompt_bundle["failure_episodes"][0]
+
+    assert episode.status == "terminal"
+    assert episode.first_teardown_line == 4
+    assert episode.first_process_termination_line == 5
+    assert episode.first_scheduler_cancel_line == 6
+    assert prompt_episode["first_teardown_line"] == 4
+    assert prompt_episode["first_process_termination_line"] == 5
+    assert prompt_episode["first_scheduler_cancel_line"] == 6
+    assert "first_cancellation_line" not in prompt_episode
+
+
+def test_l0_links_late_explicit_oom_confirmation_to_abrupt_kill_episode(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: [2026-02-16 11:35:17.842705] iteration 656001/993410 | "
+                    "consumed samples: 100 | lm loss: 1.0 |"
+                ),
+                "48: Killed",
+                "72: TCPStore recvValue failed: Connection reset by peer",
+                "72: Failed to check should dump on TCPStore: Broken pipe",
+                (
+                    "48: Feb 16 11:46:12.517314 slurmstepd: error: Detected 6 "
+                    "oom_kill events in StepId=1742530.0. Some of the step tasks "
+                    "have been OOM Killed."
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+    episode = bundle.failure_episodes[0]
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 5
+    assert bundle.deterministic_primary_candidate.failure_class == "linux_oom_kill_confirmation"
+    assert bundle.deterministic_primary_candidate.causal_role == "initiating"
+    assert bundle.selection_summary["primary_selection_basis"] == ("explicit_cause_confirmation")
+    assert len(bundle.cause_confirmations) == 1
+    assert bundle.cause_confirmations[0].registry_id == "linux_oom_kill_confirmation"
+    assert bundle.cause_confirmations[0].line == 5
+    assert episode.terminal_exception_line == 2
+    assert episode.terminal_exception_quote == "48: Killed"
+    assert episode.first_process_termination_line == 2
+    assert episode.identity_anchor_line == 5
+    assert episode.identity_anchor_reason == "explicit_cause_confirmation"
+    assert [item.line for item in episode.cause_confirmations] == [5]
+    assert _canonical_identity_anchor_line(bundle, 2) == (
+        5,
+        "failure_episode_identity_anchor:explicit_cause_confirmation",
+    )
+    assert _canonical_identity_anchor_line(bundle, 5) == (
+        5,
+        "model_primary_is_episode_identity_anchor:explicit_cause_confirmation",
+    )
+    assert any(
+        5 in window.seed_lines and window.selected_by == "cause_confirmation"
+        for window in bundle.context_windows
+    )
+    assert any(
+        anchor.line == 5 and "cause_confirmation" in anchor.sources
+        for anchor in bundle.candidate_anchors
+    )
+    assert prompt_bundle["failure_episodes"][0]["cause_confirmations"][0]["line"] == 5
+    assert prompt_bundle["cause_confirmations"][0]["line"] == 5
+
+    bundle_path = tmp_path / "bundle.json"
+    write_l0_bundle(bundle_path, bundle)
+    replayed = read_l0_bundle(bundle_path, expected_log_path=str(log_path))
+    assert replayed.failure_episodes[0].cause_confirmations[0].line == 5
+
+
+def test_bare_killed_does_not_infer_oom_without_confirmation(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: [2026-02-16 11:35:17.842705] iteration 656001/993410 | "
+                    "consumed samples: 100 | lm loss: 1.0 |"
+                ),
+                "48: Killed",
+                "72: TCPStore recvValue failed: Connection reset by peer",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.deterministic_primary_candidate is None
+    assert bundle.cause_confirmations == ()
+    assert bundle.failure_episodes[0].terminal_exception_quote == "48: Killed"
+    assert bundle.failure_episodes[0].cause_confirmations == ()
+    assert "oom" not in bundle.failure_episodes[0].terminal_exception_quote.lower()
+
+
+def test_l0_uses_terminal_episode_when_registry_has_no_root_candidate(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: [2026-02-11 16:09:39.335065] iteration 645750/993410 | "
+                    "consumed samples: 1983744000 |"
+                ),
+                (
+                    "132: [rank132]: Process group watchdog thread terminated with "
+                    "exception: CUDA error: unspecified launch failure"
+                ),
+                "132: frame #5: c10d::ProcessGroupNCCL::watchdogHandler()",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 2
+    assert bundle.deterministic_primary_candidate.failure_class == "observed_failure"
+    assert bundle.deterministic_primary_candidate.causal_role == "initiating"
+    assert bundle.selection_summary["primary_selection_basis"] == ("failure_episode_identity")
+
+
+def test_l0_keeps_specific_terminal_exception_over_generic_error_announcement(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: ERROR:worker:Exception in async function serve: "
+                    "object NoneType can't be used in 'await' expression"
+                ),
+                "0: [rank0]: Traceback (most recent call last):",
+                '0: [rank0]:   File "/workspace/server.py", line 10, in serve',
+                "0: OSError: [Errno 98] Address already in use",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.line == 4
+    assert bundle.failure_episodes[0].identity_anchor_line == 4
+    assert bundle.failure_episodes[0].precursor_lines == ()
+
+
+def test_checkpoint_traceback_anchors_terminal_exception_and_marks_cleanup(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: loading distributed checkpoint at iteration 622125",
+                "4175: [rank4175]: Traceback (most recent call last):",
+                "4175: [rank4175]:   File \"checkpointing.py\", line 1710, in load_checkpoint",
+                "4175: [rank4175]:     torch.distributed.all_gather_object(metadata)",
+                "4175: [rank4175]:     return _unpickler(buf).load()",
+                (
+                    "4175: [rank4175]: UnicodeDecodeError: 'utf-8' codec can't "
+                    "decode byte 0xde in position 8: invalid continuation byte"
+                ),
+                "0: slurmstepd: error: *** STEP 1.0 CANCELLED AT 2026-02-13T23:23:41 ***",
+                "5124: Traceback (most recent call last):",
+                "5124:   File \"multiprocessing/util.py\", line 303, in _run_finalizers",
+                "5124:   File \"multiprocessing/synchronize.py\", line 87, in _cleanup",
+                "5124:     sem_unlink(name)",
+                (
+                    "5124: FileNotFoundError: [Errno 2] No such file or directory: "
+                    "'/tmp/pymp-a/listener-a'"
+                ),
+                "5125: Traceback (most recent call last):",
+                "5125:   File \"multiprocessing/util.py\", line 303, in _run_finalizers",
+                "5125:   File \"multiprocessing/synchronize.py\", line 87, in _cleanup",
+                "5125:     sem_unlink(name)",
+                (
+                    "5125: FileNotFoundError: [Errno 2] No such file or directory: "
+                    "'/tmp/pymp-b/listener-b'"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    prompt_bundle = build_l0_model_facing_view(bundle).evidence_bundle
+
+    assert bundle.failure_episodes[0].terminal_exception_line == 6
+    assert bundle.failure_episodes[0].terminal_exception_causal_role_hint == "unknown"
+    assert len(bundle.failure_episodes) == 1
+    assert bundle.failure_episodes[0].wrapper_exception_lines == (12, 17)
+
+    terminal_anchor = next(anchor for anchor in bundle.candidate_anchors if anchor.line == 6)
+    cleanup_anchor = next(anchor for anchor in bundle.candidate_anchors if anchor.line == 12)
+    assert "terminal_exception" in terminal_anchor.sources
+    assert cleanup_anchor.causal_role_hint == "teardown"
+
+    assert "deterministic_primary_candidate" not in prompt_bundle
+    assert "registry_matches" not in prompt_bundle
+    assert "pattern_groups" not in prompt_bundle
+    assert prompt_bundle["occurrence_groups"]
+    occurrence_group = prompt_bundle["occurrence_groups"][0]
+    assert occurrence_group["occurrence_group_id"].startswith("og-")
+    assert occurrence_group["normalized_shape"]
+    assert "pattern_id" not in occurrence_group
+    assert "normalized_pattern" not in occurrence_group
+    assert prompt_bundle["registry_candidate"]["provisional"] is True
+    assert prompt_bundle["registry_candidate"]["line"] == 6
+    assert prompt_bundle["registry_candidate"]["causal_role_hint"] == "unknown"
+    file_not_found_groups = [
+        group
+        for group in prompt_bundle["registry_candidate_groups"]
+        if group["signature_hint"] == "FileNotFoundError:"
+    ]
+    assert len(file_not_found_groups) == 1
+    assert file_not_found_groups[0]["count"] == 2
+    assert file_not_found_groups[0]["causal_role_hint"] == "teardown"
+    assert "policy_class" not in file_not_found_groups[0]
+    cleanup_occurrence_groups = [
+        group
+        for group in bundle.occurrence_groups
+        if group.classification == "cascade"
+        and "filenotfounderror" in group.normalized_shape.casefold()
+    ]
+    assert len(cleanup_occurrence_groups) == 1
+    assert cleanup_occurrence_groups[0].count == 2
+
+
+def test_l0_consolidates_rank_fanout_and_finalizer_cleanup_into_one_episode(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: loading checkpoint at iteration 337000",
+                "404: [rank404]: Traceback (most recent call last):",
+                "404: [rank404]:   File \"rerun_state_machine.py\", line 88, in validate_result",
+                "404: [rank404]: RuntimeError: raising error at iteration 337071: Inf grad norm",
+                "405: [rank405]: Traceback (most recent call last):",
+                "405: [rank405]:   File \"rerun_state_machine.py\", line 88, in validate_result",
+                "405: [rank405]: RuntimeError: raising error at iteration 337071: Inf grad norm",
+                "99: Traceback (most recent call last):",
+                "99:   File \"multiprocessing/util.py\", line 303, in _run_finalizers",
+                "99:   File \"multiprocessing/synchronize.py\", line 87, in _cleanup",
+                "99:     sem_unlink(name)",
+                (
+                    "99: FileNotFoundError: [Errno 2] No such file or directory: "
+                    "'/tmp/pymp-random/listener-random'"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert len(bundle.distributed_failure_incidents) == 1
+    assert bundle.distributed_failure_incidents[0].member_event_lines == (4, 7)
+    assert len(bundle.failure_episodes) == 1
+    episode = bundle.failure_episodes[0]
+    assert episode.terminal_exception_line == 4
+    assert episode.duplicate_rendering_lines == (7,)
+    assert episode.wrapper_exception_lines == (12,)
+
+
+def test_l2_does_not_treat_current_attempt_fanout_as_cross_attempt_persistence(tmp_path):
+    log_path = tmp_path / "job.log"
+    lines = [
+        "0: successfully loaded checkpoint at iteration 337000",
+        "404: [rank404]: Traceback (most recent call last):",
+        "404: [rank404]: RuntimeError: raising error at iteration 337071: Inf grad norm",
+        "405: [rank405]: Traceback (most recent call last):",
+        "405: [rank405]: RuntimeError: raising error at iteration 337071: Inf grad norm",
+    ]
+    log_path.write_text("\n".join(lines), encoding="utf-8")
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "numeric_instability",
+            "signature": lines[2],
+            "proposed_root_fingerprint": None,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 3,
+            "rank": "404",
+            "phase": "steady_mid",
+        },
+        "root_cause_assessment": {
+            "summary": "The observed Inf mechanism is established; its cause is unconfirmed.",
+            "status": "supported_but_unconfirmed",
+            "plausible_causes": ["data or model numerical instability"],
+            "missing_evidence": ["whether iteration 337071 failed in a prior attempt"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": {
+                "value": "workload",
+                "status": "supported_but_unconfirmed",
+                "confidence": 88,
+            },
+            "retry_outlook_without_workload_change": {
+                "value": "cannot_recover",
+                "status": "supported_but_unconfirmed",
+                "confidence": 70,
+            },
+            "rationale": "The unchanged attempt will likely reach the same failure quickly.",
+        },
+        "related_failures": [],
+        "evidence": [
+            {"line": 3, "quote": lines[2], "supports": "primary_failure"},
+            {"line": 5, "quote": lines[4], "supports": "same_attempt_fanout"},
+            {"line": 1, "quote": lines[0], "supports": "execution_position"},
+        ],
+        "justification": "The mechanism is observed, while recurrence remains unproven.",
+    }
+
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
+    audit = analyzer.last_trace["l2_audit"]
+
+    assert payload["decision"] == Decision.RESTART.value
+    assert (
+        payload["model_recovery_assessment"]["retry_outlook_without_workload_change"]["status"]
+        == "supported_but_unconfirmed"
+    )
+    assert "model_recovery_assessment" not in audit["field_finding_codes"]
+    assert analyzer.last_trace["layers"]["L2"]["material_finding_count"] == 0
+    assert audit["grounding_adjustments"] == []
+    assert audit["recovery_field_audits"] == []
+
+
+def test_l0_compacts_rank_fanout_and_preserves_timeout_episode_context(tmp_path):
+    log_path = tmp_path / "job.log"
+    timeout_lines = [
+        (
+            f"{rank}: [rank{rank}]: Watchdog caught collective operation timeout: "
+            "WorkNCCL(SeqNum=2, OpType=ALLGATHER, NumelIn=10, NumelOut=20, "
+            "Timeout(ms)=600000) ran for 600000 milliseconds before timing out."
+        )
+        for rank in range(20)
+    ]
+    log_path.write_text(
+        "\n".join(
+            [
+                "0: INFO:trainer:Setting up optimizer with config OptimizerConfig()",
+                "0: sharded_state_dict metadata loaded from the checkpoint: {}",
+                "0: Job sharding has changed: Rerun state will be ignored",
+                "0: loading distributed checkpoint from /checkpoints/a/ at iteration 635000",
+                *timeout_lines,
+                "0: slurmstepd: error: *** STEP 1.0 CANCELLED AT 2026-02-13T23:23:41 ***",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert bundle.selection_summary["candidate_lines_after_filters"] == 20
+    assert bundle.selection_summary["retained_registry_matches"] == 7
+    assert bundle.selection_summary["dropped_duplicate_registry_matches"] == 13
+    assert len(bundle.registry_matches) == 7
+    timeout_group = next(
+        group
+        for group in bundle.occurrence_groups
+        if group.registry_id == "observed_distributed_operation_timeout"
+    )
+    assert timeout_group.count == 20
+    assert len(bundle.failure_episodes) == 1
+    assert bundle.failure_episodes[0].terminal_exception_line == 5
+    assert len(bundle.distributed_failure_incidents) == 1
+    incident = bundle.distributed_failure_incidents[0]
+    assert incident.incident_kind == "distributed_mechanism"
+    assert incident.event_count == 20
+    assert incident.unique_operation_count == 1
+    assert incident.operation_types == ("allgather",)
+    assert incident.observed_rank_count == 20
+    assert incident.history_fingerprint == (
+        "distributed_incident:collective_operation_timeout:checkpoint_load_start"
+    )
+    assert bundle.deterministic_primary_candidate is not None
+    assert bundle.deterministic_primary_candidate.root_fingerprint == incident.history_fingerprint
+    assert (
+        bundle.deterministic_primary_candidate.root_fingerprint_source == "l0_distributed_incident"
+    )
+    assert bundle.run_progress_summary.checkpoint_load_iteration == 635000
+    assert bundle.run_progress_summary.checkpoint_load_line == 4
+    assert bundle.run_progress_summary.last_setup_marker_type == "checkpoint_load_start"
+
+
+def test_single_rank_ordinary_failure_is_episode_only(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "7: iteration 418 completed",
+                "7: [rank7]: Traceback (most recent call last):",
+                "7: [rank7]: RuntimeError: failed to decode input record",
+                "7: destroy_process_group() called during shutdown",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert len(bundle.failure_episodes) == 1
+    assert bundle.failure_episodes[0].exception_rank == "7"
+    assert bundle.distributed_failure_incidents == ()
+
+
+def test_single_observer_collective_timeout_is_mechanism_incident_and_episode(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "7: iteration 418 completed",
+                (
+                    "7: [rank7]: Watchdog caught collective operation timeout: "
+                    "WorkNCCL(SeqNum=2, OpType=ALLGATHER, Timeout(ms)=600000) "
+                    "ran for 600000 milliseconds before timing out."
+                ),
+                "7: destroy_process_group() called during shutdown",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert len(bundle.failure_episodes) == 1
+    assert len(bundle.distributed_failure_incidents) == 1
+    incident = bundle.distributed_failure_incidents[0]
+    assert incident.incident_kind == "distributed_mechanism"
+    assert incident.event_count == 1
+    assert incident.observed_rank_count == 1
+    prompt_incident = build_l0_model_facing_view(bundle).evidence_bundle[
+        "distributed_failure_incidents"
+    ][0]
+    assert prompt_incident["incident_kind"] == "distributed_mechanism"
+
+    bundle_path = tmp_path / "bundle.json"
+    write_l0_bundle(bundle_path, bundle)
+    replayed = read_l0_bundle(bundle_path, expected_log_path=str(log_path))
+    assert replayed.distributed_failure_incidents[0].incident_kind == ("distributed_mechanism")
+
+
+def test_distributed_timeout_incident_groups_operations_and_has_order_invariant_history_key(
+    tmp_path,
+):
+    progress = (
+        "0: [2026-02-24 18:52:02.194471] iteration 743490/900000 | " "consumed samples: 1000 |"
+    )
+
+    def timeout(rank, timestamp, sequence, operation):
+        return (
+            f"{rank}: [rank{rank}]:[E224 {timestamp} ProcessGroupNCCL.cpp:697] "
+            "Watchdog caught collective operation timeout: "
+            f"WorkNCCL(SeqNum={sequence}, OpType={operation}, NumelIn=10, "
+            "NumelOut=20, Timeout(ms)=600000) ran for 600001 milliseconds "
+            "before timing out."
+        )
+
+    first_path = tmp_path / "first.log"
+    first_lines = [
+        progress,
+        timeout(42, "19:02:08.080684864", 100, "COALESCED"),
+        (
+            "42: [rank42]:[E224 19:02:08.100000000 ProcessGroupNCCL.cpp:2403] "
+            "[PG ID 5 PG GUID 7563(TENSOR_MODEL_PARALLEL_GROUP) Rank 0] "
+            "failure detected by watchdog at work sequence id: 100"
+        ),
+        timeout(7, "19:02:08.900000000", 200, "_ALLGATHER_BASE"),
+    ]
+    first_path.write_text("\n".join(first_lines), encoding="utf-8")
+
+    second_path = tmp_path / "second.log"
+    second_lines = [
+        progress,
+        timeout(999, "19:02:08.200000000", 901, "_ALLGATHER_BASE"),
+        timeout(3, "19:02:08.700000000", 902, "COALESCED"),
+    ]
+    second_path.write_text("\n".join(second_lines), encoding="utf-8")
+
+    first_bundle = build_l0_bundle(str(first_path))
+    second_bundle = build_l0_bundle(str(second_path))
+
+    first_incident = first_bundle.distributed_failure_incidents[0]
+    second_incident = second_bundle.distributed_failure_incidents[0]
+    assert len(first_bundle.failure_episodes) == 1
+    assert first_bundle.failure_episodes[0].exception_chain_lines == (2, 4)
+    assert first_incident.event_count == 2
+    assert first_incident.unique_operation_count == 2
+    assert first_incident.operation_types == ("allgather_base", "coalesced")
+    assert first_incident.process_group_types == ("tensor_model_parallel_group",)
+    assert first_incident.last_progress_line == 1
+    assert first_incident.last_progress_timestamp == "2026-02-24 18:52:02.194471"
+    assert first_incident.first_detection_timestamp == "19:02:08.080684864"
+    assert first_incident.seconds_since_last_progress == pytest.approx(605.886, abs=0.001)
+    assert first_incident.detection_lag_seconds == pytest.approx(5.886, abs=0.001)
+    assert first_incident.root_cause_status == "unknown"
+    assert first_incident.history_fingerprint == second_incident.history_fingerprint
+    assert first_incident.history_fingerprint == (
+        "distributed_incident:collective_operation_timeout:steady_mid"
+    )
+    assert first_bundle.deterministic_primary_candidate is not None
+    assert second_bundle.deterministic_primary_candidate is not None
+    assert all(
+        cascade.failure_class != "observed_distributed_operation_timeout"
+        for cascade in first_bundle.cascades
+    )
+    assert (
+        first_bundle.deterministic_primary_candidate.root_fingerprint
+        == second_bundle.deterministic_primary_candidate.root_fingerprint
+    )
+    assert first_bundle.run_progress_summary.first_terminal_incident_line == 2
+    assert first_bundle.run_progress_summary.terminal_detection_lag_seconds == pytest.approx(
+        5.886,
+        abs=0.001,
+    )
+
+    evidence = {
+        "schema_version": "restart_agent_evidence.v1",
+        "primary_failure": {
+            "failure_class": "collective_operation_timeout",
+            "signature": "collective operation timeout",
+            "proposed_root_fingerprint": "model:operation_specific",
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 4,
+            "rank": "7",
+            "phase": "steady_mid",
+        },
+        "root_cause_assessment": {
+            "summary": "The collective watchdog timed out; the initiating cause is unknown.",
+            "plausible_causes": ["communication progress stopped"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["transient communication disruption"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "unknown",
+            "next_attempt_same_failure_likelihood": "unknown",
+            "current_attempt_persistence_evidence": "none",
+            "retry_recovery_path": "unknown",
+            "confidence": 70,
+            "rationale": "One attempt does not establish persistence.",
+            "supporting_evidence_lines": [4],
+        },
+        "related_failures": [],
+        "evidence": [{"line": 4, "quote": first_lines[3], "supports": "primary_failure"}],
+        "justification": "The later operation belongs to the same timeout wave.",
+    }
+    analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
+    payload = analyzer.analyze(
+        {"log_path": str(first_path)},
+        l0_bundle=first_bundle,
+    ).to_payload()
+    assert payload["primary_failure"]["root_fingerprint"] == first_incident.history_fingerprint
+    assert payload["primary_failure"]["root_fingerprint_source"] == ("l0_distributed_incident")
+    assert analyzer.last_trace["l2_audit"]["distributed_incident_id"] == "di-1"
+
+
+def test_failure_episode_records_progress_after_exception(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "0: [2026-02-20 09:00:00.000000] iteration   10/  100 | "
+                    "consumed samples:  100 | lm loss: 1.0 |"
+                ),
+                "0: RuntimeError: retryable data loader hiccup",
+                (
+                    "0: [2026-02-20 09:01:00.000000] iteration   20/  100 | "
+                    "consumed samples:  200 | lm loss: 0.9 |"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = build_l0_bundle(str(log_path))
+    episode = bundle.failure_episodes[0]
+
+    assert episode.status == "progressed_after"
+    assert episode.last_progress_before is not None
+    assert episode.last_progress_before.value == 10
+    assert episode.first_progress_after is not None
+    assert episode.first_progress_after.value == 20
+
+
+def test_cli_trace_json_writes_l0_bundle_and_optional_summary(tmp_path, capsys):
+    log_path = tmp_path / "service_input.sanitized.log"
+    trace_path = tmp_path / "trace.json"
+    log_path.write_text(
+        "\n".join(
+            [
+                (
+                    "7:  [2026-05-27 07:58:10.261551] iteration        1/       4 | "
+                    "consumed samples:           64 | lm loss: 1.339357E+01 |"
+                ),
+                "CRITICAL:training.runtime:raising GPU error on cuda:0",
+                "RuntimeError: CUDA error: device-side assert triggered",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    rc = cli_main(
+        [
+            str(log_path),
+            "--job-id",
+            "job-1",
+            "--trace-json",
+            str(trace_path),
+            "--disable-l1",
+            "--summary",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert "restart_agent summary:" in captured.err
+    assert trace["analyzer_trace"]["context_mode"] == "deterministic_evidence"
+    assert trace["analysis_result"]["result_provenance"]["evidence_source"] == "l0_deterministic"
+    assert trace["analyzer_trace"]["result_provenance"]["evidence_source"] == "l0_deterministic"
+    assert trace["analysis_result"]["primary_failure"]["failure_class"] == "observed_exception"
+    assert trace["l0_bundle"]["progress"]["highest_completed_step"] == 1
+    assert (
+        trace["l0_bundle"]["deterministic_primary_candidate"]["failure_class"]
+        == "observed_exception"
+    )
+
+
+def test_cli_defaults_to_model_enrichment_with_explicit_deterministic_opt_out():
+    default_args = _parse_args(["/tmp/job.log"])
+    deterministic_args = _parse_args(["/tmp/job.log", "--disable-l1"])
+
+    assert isinstance(_evidence_extractor_from_args(default_args), LlmEvidenceExtractor)
+    assert _evidence_extractor_from_args(deterministic_args) is None
+
+
+def test_analyze_many_runs_routes_in_parallel_over_shared_l0(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: CUDA error: device-side assert triggered"
+    log_path.write_text(f"{failure_line}\n", encoding="utf-8")
+    evidence = {
+        "primary_failure": {
+            "failure_class": "runtime_assertion",
+            "signature": failure_line,
+            "fault_outcome": "terminal",
+            "causal_role": "initiating",
+            "data_position_fingerprint": None,
+            "line": 1,
+            "rank": None,
+            "phase": "setup",
+        },
+        "root_cause_assessment": {
+            "summary": "A runtime assertion terminated setup.",
+            "plausible_causes": ["workload code or data"],
+            "persistence_evidence": [],
+            "transient_alternatives": ["retry may recover"],
+        },
+        "model_recovery_assessment": {
+            "failure_domain": "workload",
+            "next_attempt_same_failure_likelihood": "plausible",
+            "current_attempt_persistence_evidence": "none",
+            "retry_recovery_path": "ordinary_retry",
+            "confidence": 70,
+            "rationale": "One attempt does not prove persistence.",
+            "supporting_evidence_lines": [1],
+        },
+        "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
+        "justification": "The assertion is the initiating observed failure.",
+    }
+    barrier = threading.Barrier(2)
+    observed_model_views: list[int] = []
+
+    class _BarrierExtractor(_FakeEvidenceExtractor):
+        def extract_evidence(self, context, *, deadline_monotonic=None):
+            observed_model_views.append(id(context.model_view))
+            barrier.wait(timeout=2)
+            return super().extract_evidence(
+                context,
+                deadline_monotonic=deadline_monotonic,
+            )
+
+    result = RestartAgent().analyze_many(
+        RestartAgentRequest(log_path=str(log_path)),
+        (
+            ModelRoute(
+                route_id="first",
+                evidence_extractor=_BarrierExtractor(evidence),
+                model="model-a",
+                endpoint="https://endpoint-a/v1",
+                credential_ref="KEY_A",
+            ),
+            ModelRoute(
+                route_id="second",
+                evidence_extractor=_BarrierExtractor(evidence),
+                model="model-b",
+                endpoint="https://endpoint-b/v1",
+                credential_ref="KEY_B",
+            ),
+        ),
+        max_parallel_models=2,
+    )
+
+    assert [item.route_id for item in result.model_results] == ["first", "second"]
+    assert all(item.execution_status == "completed" for item in result.model_results)
+    assert len(set(observed_model_views)) == 1
+    assert result.shared_analysis["route_count"] == 2
+    assert result.shared_analysis["max_parallel_models"] == 2
+    assert result.shared_analysis["l0_bundle_hash"].startswith("sha256:")
+    assert result.shared_analysis["l0_model_view_hash"].startswith("sha256:")
+
+
+def test_analyze_many_publishes_deterministic_before_starting_model_routes(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: failure"
+    log_path.write_text(failure_line + "\n", encoding="utf-8")
+    deterministic_published = threading.Event()
+    observed_candidates = []
+
+    class _PublicationAwareExtractor(_FakeEvidenceExtractor):
+        def extract_evidence(self, context, *, deadline_monotonic=None):
+            assert deterministic_published.is_set()
+            return super().extract_evidence(
+                context,
+                deadline_monotonic=deadline_monotonic,
+            )
+
+    def on_deterministic_ready(candidate):
+        observed_candidates.append(candidate)
+        deterministic_published.set()
+
+    result = RestartAgent().analyze_many(
+        RestartAgentRequest(log_path=str(log_path)),
+        (
+            ModelRoute(
+                route_id="first",
+                evidence_extractor=_PublicationAwareExtractor(
+                    {
+                        "primary_failure": {
+                            "failure_class": "runtime_error",
+                            "signature": failure_line,
+                            "fault_outcome": "terminal",
+                            "causal_role": "initiating",
+                            "line": 1,
+                            "rank": None,
+                            "phase": "setup",
+                        },
+                        "evidence": [
+                            {"line": 1, "quote": failure_line, "supports": "primary_failure"}
+                        ],
+                        "justification": "The runtime error ended setup.",
+                    }
+                ),
+            ),
+        ),
+        on_deterministic_ready=on_deterministic_ready,
+    )
+
+    assert deterministic_published.is_set()
+    assert len(observed_candidates) == 1
+    assert observed_candidates[0].l1_execution_status == "in_flight"
+    assert observed_candidates[0].result == result.deterministic_result
+    assert result.deterministic_result.result_provenance["model_contribution"] == (
+        "pending_not_used"
+    )
+    assert result.deterministic_result.result_provenance["l1_execution_status"] == "in_flight"
+    assert result.shared_analysis["deterministic_ready_wall_clock_s"] is not None
+
+
+def test_analyze_many_publishes_canonical_l0_artifacts_while_route_is_running(tmp_path):
+    log_path = tmp_path / "job.log"
+    failure_line = "RuntimeError: failure"
+    log_path.write_text(failure_line + "\n", encoding="utf-8")
+    bundle_path = tmp_path / "l0_bundle.json"
+    decision_evidence_path = tmp_path / "decision_evidence.json"
+    model_view_path = tmp_path / "l0_model_view.json"
+    published = threading.Event()
+    slow_extractor = _BlockingEvidenceExtractor({"justification": "slow route"})
+    publisher = L0ArtifactPublisher(
+        bundle_path=bundle_path,
+        decision_evidence_path=decision_evidence_path,
+        model_view_path=model_view_path,
+        on_published=lambda artifacts, paths: published.set(),
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(
+            RestartAgent().analyze_many,
+            RestartAgentRequest(log_path=str(log_path)),
+            (ModelRoute(route_id="slow", evidence_extractor=slow_extractor),),
+            on_l0_ready=publisher.publish,
+            timeout_seconds=2,
+        )
+        assert slow_extractor.started.wait(timeout=1)
+        assert published.wait(timeout=1)
+        assert not slow_extractor.completed.is_set()
+        assert read_l0_bundle(bundle_path, expected_log_path=str(log_path)).line_count == 1
+        decision_payload = json.loads(decision_evidence_path.read_text(encoding="utf-8"))
+        model_view_payload = json.loads(model_view_path.read_text(encoding="utf-8"))
+        assert decision_payload["schema_version"].startswith("restart_agent_decision_evidence")
+        assert model_view_payload["schema_version"].startswith("restart_agent_l0_model_view")
+        slow_extractor.release.set()
+        result = future.result(timeout=2)
+
+    assert result.model_results[0].execution_status == "completed"
+    assert publisher.wait()["l0_bundle"] == str(bundle_path)
+    publisher.close()
+
+
+def test_l0_artifact_publisher_uses_injected_executor_factory():
+    calls = []
+
+    def executor_factory(*, max_workers, thread_name_prefix):
+        calls.append((max_workers, thread_name_prefix))
+        return ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix=thread_name_prefix,
+        )
+
+    publisher = L0ArtifactPublisher(executor_factory=executor_factory)
+    publisher.close()
+
+    assert calls == [(1, "restart-agent-l0-artifacts")]
+
+
+def test_analyze_many_publishes_each_route_without_waiting_for_slowest(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+    slow_extractor = _BlockingEvidenceExtractor({"justification": "slow route"})
+    observed_routes = []
+
+    def on_route_complete(route_result, route_trace):
+        observed_routes.append(route_result.route_id)
+        assert route_trace
+        if route_result.route_id == "fast":
+            assert not slow_extractor.completed.is_set()
+            slow_extractor.release.set()
+
+    result = RestartAgent().analyze_many(
+        RestartAgentRequest(log_path=str(log_path)),
+        (
+            ModelRoute(
+                route_id="fast",
+                evidence_extractor=_FakeEvidenceExtractor({"justification": "fast route"}),
+            ),
+            ModelRoute(
+                route_id="slow",
+                evidence_extractor=slow_extractor,
+            ),
+        ),
+        max_parallel_models=2,
+        on_route_complete=on_route_complete,
+        timeout_seconds=2,
+    )
+
+    assert observed_routes == ["fast", "slow"]
+    assert [route.route_id for route in result.model_results] == ["fast", "slow"]
+    assert result.shared_analysis["route_completion_callback_errors"] == {}
+
+
+def test_compact_service_retention_publishes_route_trace_without_retaining_it(tmp_path):
+    # Arrange
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+    published_traces = []
+
+    # Act
+    run = RestartAgent().run_many(
+        RestartAgentRequest(log_path=str(log_path)),
+        (
+            ModelRoute(
+                route_id="fast",
+                evidence_extractor=_FakeEvidenceExtractor({"justification": "fast route"}),
+            ),
+        ),
+        on_route_complete=lambda _result, trace: published_traces.append(trace),
+        retain_detailed_artifacts=False,
+    )
+
+    # Assert
+    assert published_traces and published_traces[0]
+    assert set(run.trace) == {"routing_mode", "shared_analysis"}
+    assert run.bundle is None
+    assert run.decision_evidence is None
+    assert run.model_view is None
+    assert run.deterministic_candidate is None
+
+
+def test_analyze_many_isolates_route_completion_callback_failure(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+
+    def failing_callback(route_result, route_trace):
+        raise RuntimeError(f"cannot publish {route_result.route_id}")
+
+    result = RestartAgent().analyze_many(
+        RestartAgentRequest(log_path=str(log_path)),
+        (
+            ModelRoute(
+                route_id="route-a",
+                evidence_extractor=_FakeEvidenceExtractor({"justification": "route"}),
+            ),
+        ),
+        on_route_complete=failing_callback,
+    )
+
+    assert result.model_results[0].route_id == "route-a"
+    assert result.shared_analysis["route_completion_callback_errors"] == {
+        "route-a": "RuntimeError: cannot publish route-a"
+    }
+
+
+def test_live_artifact_writer_uses_injected_clock(tmp_path):
+    class _Clock:
+        def __init__(self):
+            self.monotonic_values = iter((10.0, 12.5))
+
+        def monotonic(self):
+            return next(self.monotonic_values)
+
+        def now_utc(self):
+            return datetime(2026, 7, 19, 1, 2, 3, tzinfo=timezone.utc)
+
+    live_dir = tmp_path / "live"
+    writer = LiveArtifactWriter(live_dir, clock=_Clock())
+    writer.start(routes=[], config_metadata={})
+
+    status = json.loads((live_dir / "run_status.json").read_text(encoding="utf-8"))
+    event = json.loads((live_dir / "events.jsonl").read_text(encoding="utf-8"))
+    assert status["started_at_utc"] == "2026-07-19T01:02:03+00:00"
+    assert event["timestamp_utc"] == "2026-07-19T01:02:03+00:00"
+    assert event["elapsed_s"] == 2.5
+
+
+def test_live_artifacts_publish_deterministic_and_routes_before_final_result(tmp_path):
+    live_dir = tmp_path / "live"
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+    l0_artifacts = []
+    RestartAgent().run(
+        RestartAgentRequest(log_path=str(log_path)),
+        on_l0_ready=l0_artifacts.append,
+    )
+    writer = LiveArtifactWriter(live_dir)
+    writer.start(
+        routes=[
+            {
+                "route_id": "route-a",
+                "model": "test-model",
+                "endpoint": "https://example.invalid/v1",
+                "credential_ref": "TEST_KEY_FILE",
+            }
+        ],
+        config_metadata={"config_id": "test"},
+    )
+    writer.publish_l0_artifacts(
+        l0_artifacts[0],
+        {
+            "l0_bundle": str(tmp_path / "l0_bundle.json"),
+            "decision_evidence": str(tmp_path / "decision_evidence.json"),
+        },
+    )
+
+    deterministic_path = tmp_path / "deterministic.json"
+    deterministic_path.write_text("{}\n", encoding="utf-8")
+    writer.publish_deterministic(
+        {
+            "ready_wall_clock_s": 0.25,
+            "result": {
+                "decision": "RESTART",
+                "decision_basis": "general_retry",
+            },
+        },
+        artifact_path=str(deterministic_path),
+    )
+    assert deterministic_path.is_file()
+    assert not (live_dir / "deterministic.json").exists()
+    assert not (live_dir / "collect_all.result.json").exists()
+
+    route_result_path = tmp_path / "model.test-model.result.json"
+    route_trace_path = tmp_path / "model.test-model.trace.json"
+    route_trace_path.write_text("{}\n", encoding="utf-8")
+    route_result_path.write_text("{}\n", encoding="utf-8")
+    writer.publish_route(
+        {
+            "route_id": "route-a",
+            "model": "test-model",
+            "execution_status": "ok",
+            "l1_usable": True,
+            "analysis_result": {"decision": "STOP"},
+        },
+        artifact_paths={
+            "result_json": str(route_result_path),
+            "trace_json": str(route_trace_path),
+        },
+    )
+    status = json.loads((live_dir / "run_status.json").read_text(encoding="utf-8"))
+    assert status["status"] == "running"
+    assert status["deterministic"]["status"] == "ready"
+    assert status["routes"]["route-a"]["status"] == "ok"
+    assert status["routes"]["route-a"]["result_artifact"] == route_result_path.name
+    assert status["routes"]["route-a"]["trace_artifact"] == route_trace_path.name
+    assert not (live_dir / "routes").exists()
+
+    writer.complete(
+        final_artifacts={"trace_json": "batch.trace.json"},
+    )
+    final_status = json.loads((live_dir / "run_status.json").read_text(encoding="utf-8"))
+    events = [
+        json.loads(line)
+        for line in (live_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert final_status["status"] == "completed"
+    assert final_status["l0"]["status"] == "ready"
+    assert [event["event"] for event in events] == [
+        "run_started",
+        "l0_artifacts_ready",
+        "deterministic_recommendation_ready",
+        "route_completed",
+        "run_completed",
+    ]
+
+
+def test_route_artifact_manifest_resolves_relative_paths_and_rejects_aliases(tmp_path):
+    manifest_path = tmp_path / "route-artifacts.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "restart_agent_route_artifacts.v1",
+                "routes": {
+                    "fast": {
+                        "result_json": "model.fast.result.json",
+                        "trace_json": "model.fast.trace.json",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manifest = load_route_artifact_manifest(
+        manifest_path,
+        expected_route_ids=["fast"],
+    )
+
+    assert manifest["fast"].result_json == (tmp_path / "model.fast.result.json")
+    assert manifest["fast"].trace_json == (tmp_path / "model.fast.trace.json")
+
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "restart_agent_route_artifacts.v1",
+                "routes": {
+                    "fast": {
+                        "result_json": "shared.json",
+                        "trace_json": "shared.json",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="artifact path .* is shared"):
+        load_route_artifact_manifest(
+            manifest_path,
+            expected_route_ids=["fast"],
+        )
+
+
+def test_analyze_many_returns_deterministic_when_route_exceeds_deadline(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+    extractor = _BlockingEvidenceExtractor({"justification": "unused"})
+
+    started = time.monotonic()
+    result = RestartAgent().analyze_many(
+        RestartAgentRequest(log_path=str(log_path)),
+        (ModelRoute(route_id="slow", evidence_extractor=extractor),),
+        timeout_seconds=0.05,
+    )
+    elapsed = time.monotonic() - started
+    extractor.release.set()
+    extractor.completed.wait(timeout=2)
+
+    route_result = result.model_results[0]
+    assert elapsed < 0.5
+    assert route_result.execution_status == "deadline_exceeded"
+    assert route_result.l1_usable is False
+    assert route_result.analysis_result == result.deterministic_result
+    assert result.shared_analysis["analysis_timeout_seconds"] == 0.05
+    assert result.shared_analysis["deadline_exceeded_route_count"] == 1
+
+
+def test_analyze_many_isolates_route_orchestration_failure(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+
+    class _ExplodingExtractor:
+        def extract_evidence(self, context, *, deadline_monotonic=None):
+            raise RuntimeError("route failed")
+
+    result = RestartAgent().analyze_many(
+        RestartAgentRequest(log_path=str(log_path)),
+        (
+            ModelRoute(
+                route_id="broken",
+                evidence_extractor=_ExplodingExtractor(),
+                model="broken-model",
+            ),
+        ),
+    )
+
+    route_result = result.model_results[0]
+    assert route_result.execution_status == "provider_error"
+    assert route_result.l1_usable is False
+    assert route_result.error == "RuntimeError: route failed"
+    assert route_result.analysis_result.decision == result.deterministic_result.decision
+    assert route_result.analysis_result.result_provenance["model_contribution"] == (
+        "attempted_not_used_provider_error"
+    )
+
+
+def test_restart_agent_config_resolves_defaults_overrides_and_credentials(tmp_path, monkeypatch):
+    primary_key = tmp_path / "primary.key"
+    secondary_key = tmp_path / "secondary.key"
+    primary_key.write_text("primary", encoding="utf-8")
+    secondary_key.write_text("secondary", encoding="utf-8")
+    monkeypatch.setenv("PRIMARY_ROUTE_KEY", str(primary_key))
+    monkeypatch.setenv("SECONDARY_ROUTE_KEY", str(secondary_key))
+    monkeypatch.setenv("LLM_API_KEY", "ambient-secret-must-not-win")
+    config_path = tmp_path / "restart_agent.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "restart_agent_config.v1",
+                "config_id": "qwen-fast-and-enriched",
+                "config_version": 1,
+                "enrichment": {"enabled": True},
+                "routing": {"mode": "collect_all", "max_parallel_models": 2},
+                "runtime": {
+                    "l0_source": {
+                        "read_mode": "single_snapshot",
+                        "chunk_size_bytes": 4096,
+                    }
+                },
+                "retry_policy": {
+                    "bounded_retry_allowed_retries": 2,
+                    "general_retry_allowed_retries": 4,
+                },
+                "model_defaults": {
+                    "base_url": "https://shared.example/v1",
+                    "credential_ref": "PRIMARY_ROUTE_KEY",
+                    "request": {"temperature": 0, "top_p": 1},
+                    "tools": {"enabled": False, "max_rounds": 0},
+                    "reasoning": {"thinking_mode": "disable"},
+                },
+                "model_routes": [
+                    {
+                        "route_id": "fast",
+                        "model": "provider/fast",
+                    },
+                    {
+                        "route_id": "enriched",
+                        "model": "provider/fast",
+                        "base_url": "https://accurate.example/v1",
+                        "credential_ref": "SECONDARY_ROUTE_KEY",
+                        "tools": {
+                            "enabled": True,
+                            "advertisement": {
+                                "overview": True,
+                                "grep_log": False,
+                                "read_window": True,
+                                "get_evidence_objects": True,
+                            },
+                            "max_rounds": 2,
+                        },
+                        "reasoning": {"thinking_mode": "allow"},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_restart_agent_config(config_path)
+    routes = build_model_routes(config, LlmEvidenceExtractor)
+
+    assert [(route.route_id, route.model, route.credential_ref) for route in routes] == [
+        ("fast", "provider/fast", "PRIMARY_ROUTE_KEY"),
+        ("enriched", "provider/fast", "SECONDARY_ROUTE_KEY"),
+    ]
+    assert config.max_parallel_models == 2
+    assert config.timeout_seconds == 240.0
+    assert config.l0_source.read_mode == "single_snapshot"
+    assert config.l0_source.chunk_size_bytes == 4096
+    assert config.effective_config["runtime"]["l0_source"] == {
+        "read_mode": "single_snapshot",
+        "chunk_size_bytes": 4096,
+    }
+    configured_source = build_log_source_factory(config)(str(tmp_path / "unused.log"))
+    assert configured_source.chunk_reader.read_mode == "single_snapshot"
+    assert configured_source.chunk_reader.chunk_bytes == 4096
+    assert config.retry_policy["confirmation_retry_allowed_retries"] == 1
+    assert config.retry_policy["bounded_retry_allowed_retries"] == 2
+    assert config.retry_policy["general_retry_allowed_retries"] == 4
+    assert "policy_version" not in config.retry_policy
+    assert "policy_version" not in config.effective_config["retry_policy"]
+    assert config.config_fingerprint.startswith("sha256:")
+    effective_routes = config.effective_config["model_routes"]
+    assert effective_routes[0]["request"]["temperature"] == 0.0
+    assert effective_routes[0]["tools"] == {
+        "enabled": False,
+        "advertisement": {
+            "overview": True,
+            "grep_log": True,
+            "read_window": True,
+            "get_evidence_objects": False,
+        },
+        "effective_advertised": [],
+        "max_rounds": 0,
+    }
+    assert effective_routes[1]["tools"] == {
+        "enabled": True,
+        "advertisement": {
+            "overview": True,
+            "grep_log": False,
+            "read_window": True,
+            "get_evidence_objects": True,
+        },
+        "effective_advertised": [
+            "overview",
+            "read_window",
+            "get_evidence_objects",
+        ],
+        "max_rounds": 2,
+    }
+    assert routes[0].evidence_extractor._config.api_key is None
+    assert routes[0].evidence_extractor._config.api_key_file == str(primary_key)
+    assert "ambient-secret-must-not-win" not in json.dumps(config.metadata())
+    assert "primary" not in json.dumps(config.metadata())
+    assert "secondary" not in json.dumps(config.metadata())
+
+
+def test_restart_agent_config_defaults_to_enrichment_and_requires_model_routes():
+    with pytest.raises(ValueError, match="must be non-empty when enrichment is enabled"):
+        parse_restart_agent_config(
+            {
+                "schema_version": "restart_agent_config.v1",
+                "config_id": "missing-enrichment-route",
+                "config_version": 1,
+            },
+            environ={},
+        )
+
+
+def test_restart_agent_config_allows_explicit_deterministic_only_mode():
+    config = parse_restart_agent_config(
+        {
+            "schema_version": "restart_agent_config.v1",
+            "config_id": "deterministic-only",
+            "config_version": 1,
+            "enrichment": {"enabled": False},
+        },
+        environ={},
+    )
+
+    assert config.enrichment_enabled is False
+    assert config.model_route_specs == ()
+    assert config.max_parallel_models == 0
+    assert build_model_routes(config, LlmEvidenceExtractor) == ()
+    assert config.metadata()["enrichment"] == {"enabled": False}
+
+
+def test_restart_agent_config_rejects_unimplemented_top_level_sections(tmp_path):
+    config_path = tmp_path / "restart_agent.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "restart_agent_config.v1",
+                "config_id": "unsupported-section",
+                "config_version": 1,
+                "routing": {"mode": "collect_all"},
+                "model_routes": [{"route_id": "model-a", "model": "provider/model-a"}],
+                "history": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unsupported fields: history"):
+        load_restart_agent_config(config_path, environ={"LLM_API_KEY_FILE": "/tmp/key"})
+
+
+@pytest.mark.parametrize(
+    ("l0_source", "error_type", "error_match"),
+    [
+        (
+            {"read_mode": "whole_file"},
+            ValueError,
+            "runtime.l0_source.read_mode must be one of",
+        ),
+        (
+            {"chunk_size_bytes": 0},
+            ValueError,
+            "runtime.l0_source.chunk_size_bytes must be greater than zero",
+        ),
+        (
+            {"chunk_size_bytes": True},
+            TypeError,
+            "runtime.l0_source.chunk_size_bytes must be an integer",
+        ),
+    ],
+)
+def test_restart_agent_config_rejects_invalid_l0_source_settings(
+    l0_source,
+    error_type,
+    error_match,
+):
+    payload = {
+        "schema_version": "restart_agent_config.v1",
+        "config_id": "invalid-l0-source",
+        "config_version": 1,
+        "runtime": {"l0_source": l0_source},
+        "model_routes": [],
+    }
+
+    with pytest.raises(error_type, match=error_match):
+        parse_restart_agent_config(payload, environ={})
+
+
+def test_cli_collect_all_writes_batch_result_and_trace_for_unavailable_log(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    key_path = tmp_path / "route.key"
+    key_path.write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("ROUTE_KEY", str(key_path))
+    config_path = tmp_path / "restart_agent.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "restart_agent_config.v1",
+                "config_id": "unavailable-log-test",
+                "config_version": 1,
+                "enrichment": {"enabled": True},
+                "routing": {
+                    "mode": "collect_all",
+                    "max_parallel_models": 1,
+                    "timeout_seconds": 37,
+                },
+                "model_routes": [
+                    {
+                        "route_id": "model-a",
+                        "model": "provider/model-a",
+                        "credential_ref": "ROUTE_KEY",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    trace_path = tmp_path / "batch.trace.json"
+    result_path = tmp_path / "batch.result.json"
+    route_result_path = tmp_path / "model-a.result.json"
+    route_trace_path = tmp_path / "model-a.trace.json"
+    route_manifest_path = tmp_path / "route-artifacts.json"
+    route_manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "restart_agent_route_artifacts.v1",
+                "routes": {
+                    "model-a": {
+                        "result_json": str(route_result_path),
+                        "trace_json": str(route_trace_path),
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    live_dir = tmp_path / "live"
+    missing_log = tmp_path / "missing.log"
+
+    rc = cli_main(
+        [
+            str(missing_log),
+            "--config",
+            str(config_path),
+            "--trace-json",
+            str(trace_path),
+            "--result-json",
+            str(result_path),
+            "--route-artifact-manifest",
+            str(route_manifest_path),
+            "--incremental-artifact-dir",
+            str(live_dir),
+            "--summary",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert result["schema_version"] == "restart_agent_collect_all.v1"
+    assert result["model_results"][0]["execution_status"] == ("not_run_log_unavailable")
+    assert trace["schema_version"] == "restart_agent_cli_collect_all_trace.v1"
+    assert json.loads(result_path.read_text(encoding="utf-8")) == result
+    assert trace["analyzer_trace"]["routing_mode"] == "collect_all"
+    config_metadata = result["shared_analysis"]["restart_agent_config"]
+    assert config_metadata["config_id"] == "unavailable-log-test"
+    assert config_metadata["config_fingerprint"].startswith("sha256:")
+    assert result["shared_analysis"]["analysis_timeout_seconds"] == 37.0
+    assert config_metadata["timeout_seconds"] == 37.0
+    assert "restart_agent collect_all:" in captured.err
+    live_status = json.loads((live_dir / "run_status.json").read_text(encoding="utf-8"))
+    live_events = [
+        json.loads(line)
+        for line in (live_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert live_status["status"] == "completed"
+    assert live_status["deterministic"]["status"] == "not_published"
+    assert live_status["routes"]["model-a"]["status"] == "not_run_log_unavailable"
+    assert route_result_path.is_file()
+    assert route_trace_path.is_file()
+    assert not (live_dir / "routes").exists()
+    assert [event["event"] for event in live_events] == [
+        "run_started",
+        "route_completed",
+        "run_completed",
+    ]
+
+
+def test_run_owns_serializable_immutable_execution_artifacts(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+
+    run = RestartAgent().run(RestartAgentRequest(log_path=str(log_path)))
+
+    assert run.result.decision == Decision.RESTART.value
+    assert run.bundle is not None
+    assert run.decision_evidence is not None
+    assert run.trace["log_path"] == str(log_path)
+    json.dumps(run.trace, sort_keys=True)
+    with pytest.raises(TypeError, match="frozen JSON payload"):
+        run.trace["log_path"] = "other.log"
+
+
+def test_core_restart_agent_exposes_only_invocation_owned_artifacts(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+
+    analyzer = CoreRestartAgent()
+    run = analyzer.run(RestartAgentRequest(log_path=str(log_path)))
+
+    assert run.bundle is not None
+    assert not hasattr(analyzer, "last_trace")
+    assert not hasattr(analyzer, "analyze")
+
+
+def test_public_request_requires_exact_schema_and_rejects_internal_fields(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+    analyzer = CoreRestartAgent()
+
+    with pytest.raises(ValueError, match="schema_version"):
+        analyzer.run({"log_path": str(log_path)})
+    with pytest.raises(ValueError, match="attempt_history"):
+        analyzer.run(
+            {
+                "schema_version": "restart_agent_request.v1",
+                "log_path": str(log_path),
+                "attempt_history": [],
+            }
+        )
+    with pytest.raises(TypeError, match="job_id must be a string"):
+        analyzer.run(
+            {
+                "schema_version": "restart_agent_request.v1",
+                "log_path": str(log_path),
+                "job_id": 123,
+            }
+        )
+    with pytest.raises(ValueError, match="unsupported analysis_mode"):
+        analyzer.run(
+            {
+                "schema_version": "restart_agent_request.v1",
+                "log_path": str(log_path),
+                "analysis_mode": "eventually",
+            }
+        )
+
+
+def test_runtime_selects_history_behind_public_request_boundary(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+    request = RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=2)
+    runtime = RestartAgentRuntime(
+        CoreRestartAgent(),
+        attempt_record_store=InMemoryAttemptRecordStore(),
+    )
+    run = runtime.analyze_one(request)
+
+    assert run.trace["request"] == request.to_payload()
+    assert "attempt_history" not in run.trace["request"]
+    assert run.trace["runtime_history"]["availability_reason"] == "ready"
+    assert run.result.schema_version == "restart_agent_response.v1"
+
+
+def test_l0b_shared_payload_is_deeply_immutable_and_json_compatible(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+    model_view = build_l0_model_facing_view(build_l0_bundle(str(log_path)))
+
+    json.dumps(model_view.evidence_bundle, sort_keys=True)
+    with pytest.raises(TypeError, match="frozen JSON payload"):
+        model_view.evidence_bundle["line_count"] = 2
+    with pytest.raises(TypeError, match="frozen JSON payload"):
+        model_view.evidence_bundle["context_windows"].append({})
+
+
+def test_same_agent_concurrent_calls_do_not_overwrite_run_artifacts(tmp_path):
+    paths = []
+    for index in range(2):
+        path = tmp_path / f"job-{index}.log"
+        path.write_text(f"RuntimeError: failure {index}\n", encoding="utf-8")
+        paths.append(path)
+    analyzer = RestartAgent()
+
+    def analyze(path):
+        result = analyzer.analyze(RestartAgentRequest(log_path=str(path)))
+        return result, analyzer.last_trace["log_path"], analyzer.last_bundle.log_path
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        observed = list(pool.map(analyze, paths))
+
+    assert [item[1] for item in observed] == [str(path) for path in paths]
+    assert [item[2] for item in observed] == [str(path) for path in paths]
+
+
+def test_l0_contract_contains_no_history_input_or_coverage(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failure\n", encoding="utf-8")
+
+    bundle = build_l0_bundle(str(log_path))
+
+    assert "history" not in bundle.evidence_coverage
+
+
+def test_l4_rejects_untyped_stage_inputs():
+    with pytest.raises(TypeError, match="model_recovery_assessment must be typed"):
+        L4PolicyInput(
+            primary=None,
+            history=HistorySummary(),
+            model_recovery_assessment={"failure_domain": "unknown"},
+        )
+    with pytest.raises(TypeError, match="retry_policy must be typed"):
+        L4PolicyInput(
+            primary=None,
+            history=HistorySummary(),
+            retry_policy={"general_retry_allowed_retries": 3},
+        )
+
+
+def test_restart_agent_reuses_injected_log_snapshot_across_stages(tmp_path):
+    log_path = tmp_path / "job.log"
+    text = "iteration 1 completed\nRuntimeError: observed failure\n"
+    log_path.write_text(text, encoding="utf-8")
+    snapshot = LogSnapshot(
+        path=str(log_path),
+        lines=tuple(text.splitlines()),
+        byte_size=len(text.encode("utf-8")),
+    )
+
+    class _CountingLogSource:
+        def __init__(self, path):
+            assert path == str(log_path)
+            self.path = path
+            self.snapshot_calls = 0
+
+        def unavailable_reason(self):
+            return None
+
+        def snapshot(self):
+            self.snapshot_calls += 1
+            return snapshot
+
+    sources = []
+
+    def source_factory(path):
+        source = _CountingLogSource(path)
+        sources.append(source)
+        return source
+
+    run = CoreRestartAgent(log_source_factory=source_factory).run(
+        RestartAgentRequest(log_path=str(log_path))
+    )
+
+    assert run.bundle is not None
+    assert run.bundle.line_count == 2
+    assert len(sources) == 1
+    assert sources[0].snapshot_calls == 1
+
+
+def test_llm_evidence_extractor_accepts_injected_transport():
+    class _Transport:
+        def __init__(self):
+            self.calls = []
+
+        def call(self, **kwargs):
+            self.calls.append(kwargs)
+            return {"choices": []}, {"success": True}
+
+    transport = _Transport()
+    extractor = LlmEvidenceExtractor(
+        LlmConfig(api_key="test-key"),
+        transport=transport,
+    )
+
+    response, record = extractor._call_model(model_turn=1)
+
+    assert response == {"choices": []}
+    assert record == {"success": True}
+    assert transport.calls == [{"model_turn": 1}]
+
+
+def test_llm_config_reads_only_supplied_environment():
+    config = LlmConfig.from_env(
+        environ={
+            "NVRX_LLM_MODEL": "test/model",
+            "NVRX_LLM_TIMEOUT_SECONDS": "17",
+            "LLM_API_KEY": "supplied-key",
+        }
+    )
+
+    assert config.model == "test/model"
+    assert config.timeout_seconds == 17.0
+    assert config.api_key == "supplied-key"
+
+
+def test_restart_agent_config_parser_has_no_file_dependency(tmp_path):
+    key_path = tmp_path / "key"
+    key_path.write_text("secret", encoding="utf-8")
+    config = parse_restart_agent_config(
+        {
+            "schema_version": "restart_agent_config.v1",
+            "config_id": "pure-parser",
+            "config_version": 1,
+            "model_routes": [{"route_id": "route-a"}],
+        },
+        environ={"LLM_API_KEY_FILE": str(key_path)},
+    )
+
+    assert config.config_id == "pure-parser"
+    assert config.enrichment_enabled is True
+    assert config.model_route_specs[0].route_id == "route-a"
+
+
+def test_llm_extractor_uses_injected_credential_provider(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: failed\n", encoding="utf-8")
+    snapshot = LogSnapshot.read(log_path)
+    bundle = build_l0_bundle(str(log_path), source_log=snapshot)
+    decision_evidence = build_decision_evidence(bundle)
+    model_view = _build_l0_model_facing_view(bundle, decision_evidence)
+    context = build_l1_evidence_context(bundle, model_view, snapshot)
+
+    class _CredentialProvider:
+        def __init__(self):
+            self.configs = []
+
+        def load(self, config):
+            self.configs.append(config)
+            raise RuntimeError("credential sentinel")
+
+    provider = _CredentialProvider()
+    extractor = LlmEvidenceExtractor(
+        LlmConfig(api_key_file="must-not-be-read"),
+        credential_provider=provider,
+    )
+
+    result = extractor.extract_evidence(context)
+
+    assert result.success is False
+    assert result.errors == ("credential sentinel",)
+    assert provider.configs == [extractor._config]
+
+
+def test_openai_transport_uses_injected_httpx_client_and_clock():
+    class _Clock:
+        def __init__(self):
+            self.values = iter((10.0, 12.0))
+
+        def monotonic(self):
+            return next(self.values)
+
+    class _HttpClient:
+        def __init__(self):
+            self.calls = []
+
+        def post(self, url, *, content, headers, timeout):
+            self.calls.append((url, content, headers, timeout))
+            return httpx.Response(
+                200,
+                json={"choices": [{"finish_reason": "stop", "message": {"content": "{}"}}]},
+            )
+
+        def close(self):
+            raise AssertionError("injected client ownership remains with its caller")
+
+    client = _HttpClient()
+    transport = OpenAICompatibleTransport(
+        LlmConfig(base_url="https://provider.example/v1", timeout_seconds=9),
+        http_client=client,
+        clock=_Clock(),
+    )
+
+    _payload, record = transport.call(
+        api_key="secret",
+        messages=[],
+        include_tools=False,
+        model_turn=1,
+    )
+
+    assert len(client.calls) == 1
+    url, content, headers, timeout = client.calls[0]
+    assert url == "https://provider.example/v1/chat/completions"
+    assert json.loads(content)["model"] == "nvidia/qwen/qwen3.5-35b-a3b"
+    assert headers["Authorization"] == "Bearer secret"
+    assert timeout == 9
+    assert record["latency_s"] == 2.0
+    assert record["http_transport"] == "httpx"
+    transport.close()
+
+
+def test_openai_transport_reuses_and_closes_route_owned_httpx_client(monkeypatch):
+    clients = []
+
+    class _HttpClient:
+        def __init__(self, **kwargs):
+            self.options = kwargs
+            self.calls = 0
+            self.close_calls = 0
+            clients.append(self)
+
+        def post(self, url, *, content, headers, timeout):
+            del url, content, headers, timeout
+            self.calls += 1
+            return httpx.Response(
+                200,
+                json={"choices": [{"finish_reason": "stop", "message": {"content": "{}"}}]},
+            )
+
+        def close(self):
+            self.close_calls += 1
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.attribution.restart_agent.l1.openai_compatible.httpx.Client",
+        _HttpClient,
+    )
+    transport = OpenAICompatibleTransport(LlmConfig())
+
+    for turn in (1, 2):
+        transport.call(
+            api_key="secret",
+            messages=[],
+            include_tools=False,
+            model_turn=turn,
+        )
+    transport.close()
+    transport.close()
+
+    assert len(clients) == 1
+    assert clients[0].options == {"follow_redirects": True}
+    assert clients[0].calls == 2
+    assert clients[0].close_calls == 1
+
+
+def test_openai_transport_classifies_http_and_network_failures():
+    outcomes = iter(("http", "connect", "timeout"))
+
+    def handler(request):
+        outcome = next(outcomes)
+        if outcome == "http":
+            return httpx.Response(
+                503,
+                text="temporarily unavailable",
+                headers={"x-litellm-timing-llm-api-ms": "17.5"},
+            )
+        if outcome == "connect":
+            raise httpx.ConnectError("connection refused", request=request)
+        raise httpx.ReadTimeout("provider read timed out", request=request)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    transport = OpenAICompatibleTransport(
+        LlmConfig(base_url="https://provider.example/v1"),
+        http_client=client,
+    )
+
+    try:
+        with pytest.raises(LlmCallError) as unavailable:
+            transport.call(
+                api_key="secret",
+                messages=[],
+                include_tools=False,
+                model_turn=1,
+            )
+        with pytest.raises(LlmCallError) as connect:
+            transport.call(
+                api_key="secret",
+                messages=[],
+                include_tools=False,
+                model_turn=1,
+            )
+        with pytest.raises(LlmCallError) as timeout:
+            transport.call(
+                api_key="secret",
+                messages=[],
+                include_tools=False,
+                model_turn=1,
+            )
+    finally:
+        client.close()
+
+    assert unavailable.value.call_record["error_type"] == "http_error"
+    assert unavailable.value.call_record["http_status"] == 503
+    assert unavailable.value.call_record["retryable"] is True
+    assert unavailable.value.call_record["provider_reported_timing"] == {
+        "downstream_llm_api_ms": 17.5,
+        "source": "response_headers",
+    }
+    assert connect.value.call_record["error_type"] == "connect_error"
+    assert connect.value.call_record["retryable"] is True
+    assert timeout.value.call_record["error_type"] == "timeout"
+    assert timeout.value.call_record["timeout"] is True
+
+
+def test_retry_transport_uses_injected_sleeper():
+    calls = []
+
+    def request_call(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise LlmCallError(
+                "retry",
+                {"retryable": True, "latency_s": 0.1, "error_type": "http_error"},
+            )
+        return {"choices": []}, {"success": True}
+
+    class _Sleeper:
+        def __init__(self):
+            self.delays = []
+
+        def sleep(self, seconds):
+            self.delays.append(seconds)
+
+    sleeper = _Sleeper()
+    transport = RetryingChatTransport(
+        LlmConfig(max_retries=1, retry_backoff_seconds=0.75),
+        request_call,
+        sleeper=sleeper,
+    )
+
+    outcome = transport.call(
+        api_key="secret",
+        messages=[],
+        include_tools=False,
+        model_turn=1,
+        deadline_monotonic=None,
+    )
+
+    assert outcome.call_record == {"success": True}
+    assert sleeper.delays == [0.75]
+
+
+def test_model_route_specs_are_composed_by_injected_factory(tmp_path):
+    key_path = tmp_path / "key"
+    key_path.write_text("secret", encoding="utf-8")
+    config_path = tmp_path / "restart_agent.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "restart_agent_config.v1",
+                "config_id": "injected-factory",
+                "config_version": 1,
+                "enrichment": {"enabled": True},
+                "model_routes": [
+                    {
+                        "route_id": "route-a",
+                        "model": "provider/model-a",
+                        "base_url": "https://provider.example/v1",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = load_restart_agent_config(
+        config_path,
+        environ={"LLM_API_KEY_FILE": str(key_path)},
+    )
+    captured = []
+
+    class _Extractor:
+        def extract_evidence(self, context, *, deadline_monotonic=None):
+            raise AssertionError("not invoked")
+
+    def extractor_factory(llm_config):
+        captured.append(llm_config)
+        return _Extractor()
+
+    routes = build_model_routes(config, extractor_factory)
+
+    assert [spec.route_id for spec in config.model_route_specs] == ["route-a"]
+    assert [route.route_id for route in routes] == ["route-a"]
+    assert captured == [config.model_route_specs[0].llm_config]
+
+
+def test_runtime_closes_each_unique_route_extractor_once():
+    class _Extractor:
+        def __init__(self):
+            self.close_count = 0
+
+        def extract_evidence(self, context, *, deadline_monotonic=None):
+            raise AssertionError("not invoked")
+
+        def close(self):
+            self.close_count += 1
+
+    extractor = _Extractor()
+    runtime = RestartAgentRuntime(
+        RestartAgent(),
+        model_routes=(
+            ModelRoute(route_id="route-a", evidence_extractor=extractor),
+            ModelRoute(route_id="route-b", evidence_extractor=extractor),
+        ),
+    )
+
+    runtime.close()
+    runtime.close()
+
+    assert extractor.close_count == 1

--- a/tests/attribution/unit/test_restart_agent_attempt_records.py
+++ b/tests/attribution/unit/test_restart_agent_attempt_records.py
@@ -1,0 +1,776 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral tests for attempt-record assembly, history storage, and runtime state."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from nvidia_resiliency_ext.attribution.restart_agent.agent_runtime import RestartAgentRuntime
+from nvidia_resiliency_ext.attribution.restart_agent.attempt_records import (
+    AttemptRecordAssembler,
+    AttemptRecordControl,
+    InMemoryAttemptRecordStore,
+    NullAttemptRecordStore,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.cli import main as cli_main
+from nvidia_resiliency_ext.attribution.restart_agent.config import parse_restart_agent_config
+from nvidia_resiliency_ext.attribution.restart_agent.l1 import L1EvidenceResult, ModelRoute
+from nvidia_resiliency_ext.attribution.restart_agent.l3 import (
+    DETERMINISTIC_FACT_SELECTOR,
+    HistoryEvaluationInput,
+    evaluate_history,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.models import (
+    AffectedEntity,
+    AffectedEntityKind,
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    AttemptProgressSummary,
+    AttemptRecord,
+    PriorAttemptView,
+    RestartAgentRequest,
+    normalize_attempt_records,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.pipeline import RestartAgent
+
+
+class _EvidenceExtractor:
+    def __init__(self, line: str) -> None:
+        self._line = line
+
+    def extract_evidence(self, context, *, deadline_monotonic=None):
+        evidence = {
+            "schema_version": "restart_agent_evidence.v1",
+            "analysis_status": "primary_identified",
+            "primary_failure": {
+                "causal_role": "initiating",
+                "line": 1,
+                "failure_identity": {
+                    "operation": "cuda_initialization",
+                    "mechanism": "runtime_error",
+                    "component": "cuda",
+                    "artifact_path": None,
+                },
+            },
+            "root_cause_assessment": {
+                "summary": "CUDA initialization failed.",
+                "status": "supported_but_unconfirmed",
+                "plausible_causes": ["runtime initialization failure"],
+                "missing_evidence": ["device diagnostics"],
+            },
+            "model_recovery_assessment": {
+                "failure_domain": {
+                    "value": "unknown",
+                    "status": "unknown",
+                    "confidence": 50,
+                },
+                "retry_outlook_without_workload_change": {
+                    "value": "unknown",
+                    "status": "unknown",
+                    "confidence": 50,
+                },
+                "rationale": "The current log does not establish recovery behavior.",
+            },
+            "related_failures": [],
+            "evidence": [
+                {
+                    "id": "e1",
+                    "line": 1,
+                    "quote": self._line,
+                    "supports": [
+                        "primary_failure",
+                        "root_cause_assessment",
+                        "failure_domain",
+                        "retry_outlook_without_workload_change",
+                    ],
+                }
+            ],
+        }
+        return L1EvidenceResult(
+            evidence=evidence,
+            model="test-model",
+            raw_model_output=json.dumps(evidence),
+            success=True,
+        )
+
+
+class _SlowEvidenceExtractor(_EvidenceExtractor):
+    def extract_evidence(self, context, *, deadline_monotonic=None):
+        time.sleep(0.1)
+        return super().extract_evidence(context, deadline_monotonic=deadline_monotonic)
+
+
+class _BlockingFirstEvidenceExtractor(_EvidenceExtractor):
+    def __init__(self, line: str) -> None:
+        super().__init__(line)
+        self._lock = threading.Lock()
+        self._calls = 0
+        self.first_started = threading.Event()
+        self.release_first = threading.Event()
+        self.second_started = threading.Event()
+
+    def extract_evidence(self, context, *, deadline_monotonic=None):
+        with self._lock:
+            self._calls += 1
+            call = self._calls
+        if call == 1:
+            self.first_started.set()
+            self.release_first.wait(timeout=2)
+        else:
+            self.second_started.set()
+        return super().extract_evidence(context, deadline_monotonic=deadline_monotonic)
+
+
+def _facts(
+    root: str = "observed:runtimeerror:test",
+    *,
+    outcome: str = "terminal",
+    failure_iteration: int | None = None,
+    affected_entity: AffectedEntity | None = None,
+    source: AttemptFailureFactsSource = AttemptFailureFactsSource.L0_DETERMINISTIC,
+) -> AttemptFailureFacts:
+    return AttemptFailureFacts(
+        source=source,
+        root_fingerprint=root,
+        root_fingerprint_source="test_fixture",
+        fault_outcome=outcome,
+        failure_iteration=failure_iteration,
+        affected_entity=affected_entity,
+    )
+
+
+def _progress(
+    completed: int | None = None,
+    checkpoint: int | None = None,
+) -> AttemptProgressSummary:
+    return AttemptProgressSummary(
+        training_progress="observed" if completed is not None else "not_observed",
+        first_completed_step=completed,
+        last_completed_step=completed,
+        completed_step_delta=0 if completed is not None else None,
+        progress_marker_count=1 if completed is not None else 0,
+        checkpoint_progress="observed" if checkpoint is not None else "not_observed",
+        first_checkpoint_step=checkpoint,
+        last_checkpoint_step=checkpoint,
+        checkpoint_step_delta=0 if checkpoint is not None else None,
+        checkpoint_marker_count=1 if checkpoint is not None else 0,
+    )
+
+
+def _record(
+    job_id: str,
+    cycle_id: int,
+    *,
+    root: str = "observed:runtimeerror:test",
+    completed: int | None = None,
+    checkpoint: int | None = None,
+    failure_iteration: int | None = None,
+    affected_entity: AffectedEntity | None = None,
+) -> AttemptRecord:
+    return AttemptRecord(
+        job_id=job_id,
+        cycle_id=cycle_id,
+        progress=_progress(completed, checkpoint),
+        deterministic=_facts(
+            root,
+            failure_iteration=failure_iteration,
+            affected_entity=affected_entity,
+        ),
+    )
+
+
+def _entity(identity: str, *, kind: AffectedEntityKind) -> AffectedEntity:
+    return AffectedEntity(
+        kind=kind,
+        identity=identity,
+        fingerprint=f"test:{kind.value}:{identity}",
+    )
+
+
+def test_store_replaces_same_attempt_without_recurrence_inflation():
+    store = InMemoryAttemptRecordStore()
+
+    store.upsert_attempt(_record("job-1", 1, completed=10))
+    store.upsert_attempt(_record("job-1", 1, completed=20))
+
+    records = store.records("job-1")
+    assert len(records) == 1
+    assert records[0].progress.last_completed_step == 20
+
+
+def test_store_applies_per_job_then_total_retention():
+    store = InMemoryAttemptRecordStore(max_attempts_per_job=2, max_total_records=3)
+    store.upsert_attempt(_record("job-a", 1))
+    store.upsert_attempt(_record("job-a", 2))
+    store.upsert_attempt(_record("job-a", 3))
+    assert [item.cycle_id for item in store.records("job-a")] == [2, 3]
+
+    store.upsert_attempt(_record("job-b", 1))
+    store.upsert_attempt(_record("job-c", 1))
+
+    assert [(item.job_id, item.cycle_id) for item in store.records()] == [
+        ("job-a", 3),
+        ("job-b", 1),
+        ("job-c", 1),
+    ]
+    assert store.metrics()["eviction_count"] == 2
+
+
+def test_prior_view_is_exact_job_ordered_and_excludes_current_cycle():
+    store = InMemoryAttemptRecordStore()
+    for record in (
+        _record("job-1", 3),
+        _record("job-2", 1),
+        _record("job-1", 1),
+        _record("job-1", 2),
+    ):
+        store.upsert_attempt(record)
+
+    view = store.get_prior_attempts("job-1", 3)
+
+    assert view.available is True
+    assert view.availability_reason == "ready"
+    assert [item.cycle_id for item in view.records] == [1, 2]
+
+
+def test_disabled_store_rejects_explicit_seed():
+    control = AttemptRecordControl(NullAttemptRecordStore())
+
+    with pytest.raises(ValueError, match="history_disabled"):
+        control.seed([_record("job-1", 1)])
+
+
+def test_attempt_record_control_supports_replace_merge_inspect_and_clear():
+    control = AttemptRecordControl(InMemoryAttemptRecordStore())
+
+    control.seed([_record("job-a", 1), _record("job-b", 1)])
+    control.seed([_record("job-a", 2)], mode="merge")
+    assert [(item.job_id, item.cycle_id) for item in control.records()] == [
+        ("job-a", 1),
+        ("job-a", 2),
+        ("job-b", 1),
+    ]
+
+    control.clear("job-a")
+    assert [(item.job_id, item.cycle_id) for item in control.records()] == [("job-b", 1)]
+    control.clear()
+    assert control.records() == ()
+
+
+def test_prior_view_remains_immutable_after_store_replacement():
+    store = InMemoryAttemptRecordStore()
+    store.upsert_attempt(_record("job-1", 1, completed=10))
+    view = store.get_prior_attempts("job-1", 2)
+
+    store.upsert_attempt(_record("job-1", 1, completed=20))
+
+    assert view.records[0].progress.last_completed_step == 10
+    assert store.records("job-1")[0].progress.last_completed_step == 20
+
+
+def test_fixture_normalization_revalidates_typed_records_and_unknown_fields():
+    payload = _record("job-1", 1).to_payload()
+    payload["unexpected"] = True
+
+    with pytest.raises(ValueError, match="unsupported fields"):
+        normalize_attempt_records([payload])
+
+
+def test_attempt_failure_facts_exclude_semantic_failure_class():
+    payload = _record("job-1", 1).to_payload()
+
+    assert "failure_class" not in payload["deterministic"]
+
+    payload["deterministic"]["failure_class"] = "observed_exception"
+    with pytest.raises(ValueError, match="unsupported fields"):
+        normalize_attempt_records([payload])
+
+
+def test_l3_reports_conflicting_positive_progress_dimensions_as_unknown():
+    prior = _record("job-1", 1, completed=10, checkpoint=20)
+    current = _record("job-1", 2, completed=11, checkpoint=19)
+
+    summary = evaluate_history(
+        HistoryEvaluationInput(
+            current_record=current,
+            fact_selector=DETERMINISTIC_FACT_SELECTOR,
+            prior_attempts=PriorAttemptView(
+                records=(prior,),
+                available=True,
+                availability_reason="ready",
+            ),
+        )
+    )
+
+    comparison = summary.comparisons[0]
+    assert comparison.selected_basis == "completed_step_and_checkpoint_step"
+    assert comparison.positive_progress_conflict is True
+    assert comparison.relation == "unknown"
+    assert summary.no_observed_advance_attempts == 0
+
+
+def test_l3_tracks_root_and_exact_affected_entity_recurrence_separately():
+    token_42 = _entity("token:42", kind=AffectedEntityKind.DATA_POSITION)
+    token_43 = _entity("token:43", kind=AffectedEntityKind.DATA_POSITION)
+    current = _record(
+        "job-1",
+        3,
+        completed=10,
+        affected_entity=token_42,
+    )
+    prior_same = _record(
+        "job-1",
+        1,
+        completed=10,
+        affected_entity=token_42,
+    )
+    prior_different = _record(
+        "job-1",
+        2,
+        completed=10,
+        affected_entity=token_43,
+    )
+
+    summary = evaluate_history(
+        HistoryEvaluationInput(
+            current_record=current,
+            fact_selector=DETERMINISTIC_FACT_SELECTOR,
+            prior_attempts=PriorAttemptView(
+                records=(prior_same, prior_different),
+                available=True,
+                availability_reason="ready",
+            ),
+        )
+    )
+
+    assert summary.matching_root_attempts == 2
+    assert summary.same_entity_attempts == 1
+    assert summary.different_entity_attempts == 1
+    assert summary.consecutive_same_root_no_advance_attempts == 2
+    assert summary.consecutive_same_root_and_entity_no_advance_attempts == 0
+    assert [item.affected_entity_relation for item in summary.comparisons] == [
+        "same",
+        "different",
+    ]
+
+
+def test_l3_entity_scoped_progress_ignores_a_different_artifact():
+    current = _record(
+        "job-1",
+        3,
+        completed=20,
+        affected_entity=_entity(
+            "/checkpoints/step-20",
+            kind=AffectedEntityKind.ARTIFACT,
+        ),
+    )
+    prior = _record(
+        "job-1",
+        2,
+        completed=10,
+        affected_entity=_entity(
+            "/checkpoints/step-10",
+            kind=AffectedEntityKind.ARTIFACT,
+        ),
+    )
+
+    summary = evaluate_history(
+        HistoryEvaluationInput(
+            current_record=current,
+            fact_selector=DETERMINISTIC_FACT_SELECTOR,
+            prior_attempts=PriorAttemptView(
+                records=(prior,),
+                available=True,
+                availability_reason="ready",
+            ),
+        )
+    )
+
+    assert summary.advanced_beyond_all_comparable_attempts is True
+    assert summary.advanced_beyond_all_same_entity_comparable_attempts is False
+
+
+def test_l3_uses_deterministic_identity_for_prior_records_in_mvp():
+    assembler = AttemptRecordAssembler()
+    prior = assembler.with_enriched(
+        _record("job-1", 1, root="deterministic:prior", completed=10),
+        route_id="gpt",
+        facts=_facts("enriched:shared", source=AttemptFailureFactsSource.L2_GROUNDED),
+    )
+    current = assembler.with_enriched(
+        _record("job-1", 2, root="deterministic:current", completed=10),
+        route_id="gpt",
+        facts=_facts("enriched:shared", source=AttemptFailureFactsSource.L2_GROUNDED),
+    )
+
+    summary = evaluate_history(
+        HistoryEvaluationInput(
+            current_record=current,
+            fact_selector="gpt",
+            prior_attempts=PriorAttemptView(
+                records=(prior,),
+                available=True,
+                availability_reason="ready",
+            ),
+        )
+    )
+
+    assert summary.same_job_attempts == 1
+    assert summary.matching_root_attempts == 0
+
+
+def test_attempt_record_assembler_replaces_one_enriched_route():
+    record = _record("job-1", 1)
+    assembler = AttemptRecordAssembler()
+    enriched = AttemptFailureFacts(
+        source=AttemptFailureFactsSource.L2_GROUNDED,
+        root_fingerprint="observed:checkpoint:read",
+        root_fingerprint_source="l2_grounded_primary",
+        fault_outcome="terminal",
+    )
+
+    once = assembler.with_enriched(record, route_id="gpt", facts=enriched)
+    twice = assembler.with_enriched(once, route_id="gpt", facts=enriched)
+
+    assert len(twice.enriched) == 1
+    assert twice.enriched[0].route_id == "gpt"
+
+
+def test_runtime_publishes_l0_record_and_reuses_it_as_prior_history(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: CUDA initialization failed\n", encoding="utf-8")
+    store = InMemoryAttemptRecordStore()
+    runtime = RestartAgentRuntime(RestartAgent(), attempt_record_store=store)
+
+    first = runtime.analyze_one(
+        RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1)
+    )
+    second = runtime.analyze_one(
+        RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=2)
+    )
+
+    assert first.trace["runtime_history"]["initial_upserted"] is True
+    assert second.trace["runtime_history"]["prior_attempt_count"] == 1
+    assert second.trace["l3_history"]["matching_root_attempts"] == 1
+    assert second.trace["l3_history"]["unknown_progress_attempts"] == 1
+    assert second.result.retry_policy["general_root_ceiling"]["matching_prior_failures"] == 0
+    assert [item.cycle_id for item in store.records("job-1")] == [1, 2]
+
+
+def test_attempt_progress_is_unknown_without_a_recognized_progress_dialect(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: CUDA initialization failed\n", encoding="utf-8")
+    store = InMemoryAttemptRecordStore()
+    runtime = RestartAgentRuntime(RestartAgent(), attempt_record_store=store)
+
+    runtime.analyze_one(RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1))
+
+    progress = store.records("job-1")[0].progress
+    assert progress.training_progress == "unknown"
+    assert progress.checkpoint_progress == "unknown"
+    assert progress.failure_position == "unknown"
+    assert progress.progress_after_failure == "unknown"
+
+
+def test_attempt_progress_can_prove_absence_for_a_recognized_dialect(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "setting training iterations to 100\n"
+        "loading distributed checkpoint from /tmp/ckpt at iteration 10\n"
+        "RuntimeError: checkpoint read failed\n",
+        encoding="utf-8",
+    )
+    store = InMemoryAttemptRecordStore()
+    runtime = RestartAgentRuntime(RestartAgent(), attempt_record_store=store)
+
+    runtime.analyze_one(RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1))
+
+    progress = store.records("job-1")[0].progress
+    assert progress.training_progress == "not_observed"
+    assert progress.checkpoint_progress == "not_observed"
+    assert progress.failure_position == "before_observed_training_progress"
+
+
+def test_store_rejects_deterministic_history_without_fault_outcome():
+    record = AttemptRecord(
+        job_id="job-1",
+        cycle_id=1,
+        progress=AttemptProgressSummary(),
+        deterministic=AttemptFailureFacts(
+            source=AttemptFailureFactsSource.L0_DETERMINISTIC,
+            root_fingerprint="observed:runtimeerror:test",
+            root_fingerprint_source="test_fixture",
+            fault_outcome=None,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="deterministic fault_outcome is required"):
+        InMemoryAttemptRecordStore().upsert_attempt(record)
+
+
+def test_runtime_reanalysis_replaces_same_cycle_and_clears_old_enrichment(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: CUDA initialization failed\n", encoding="utf-8")
+    store = InMemoryAttemptRecordStore()
+    base = _record("job-1", 1)
+    enriched = AttemptRecordAssembler().with_enriched(
+        base,
+        route_id="old-route",
+        facts=AttemptFailureFacts(
+            source=AttemptFailureFactsSource.L2_GROUNDED,
+            root_fingerprint=base.deterministic.root_fingerprint,
+            root_fingerprint_source="old",
+            fault_outcome="terminal",
+        ),
+    )
+    store.upsert_attempt(enriched)
+    runtime = RestartAgentRuntime(RestartAgent(), attempt_record_store=store)
+
+    runtime.analyze_one(RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1))
+
+    records = store.records("job-1")
+    assert len(records) == 1
+    assert records[0].enriched == ()
+
+
+def test_runtime_aggregates_completed_routes_into_one_attempt_record(tmp_path):
+    line = "RuntimeError: CUDA initialization failed"
+    log_path = tmp_path / "job.log"
+    log_path.write_text(line + "\n", encoding="utf-8")
+    store = InMemoryAttemptRecordStore()
+    runtime = RestartAgentRuntime(RestartAgent(), attempt_record_store=store)
+    routes = (
+        ModelRoute(route_id="fast", evidence_extractor=_EvidenceExtractor(line)),
+        ModelRoute(route_id="deep", evidence_extractor=_EvidenceExtractor(line)),
+    )
+
+    run = runtime.analyze_many(
+        RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1),
+        routes,
+    )
+
+    record = store.records("job-1")[0]
+    assert [entry.route_id for entry in record.enriched] == ["deep", "fast"]
+    assert set(run.trace["runtime_history"]["enriched_route_updates"]) == {"fast", "deep"}
+    assert run.trace["runtime_history"]["store_before"]["record_count"] == 0
+    assert run.trace["runtime_history"]["store_after"]["record_count"] == 1
+
+
+def test_runtime_disabled_history_assembles_but_does_not_persist_record(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: CUDA initialization failed\n", encoding="utf-8")
+    runtime = RestartAgentRuntime(
+        RestartAgent(),
+        attempt_record_store=NullAttemptRecordStore(),
+    )
+
+    run = runtime.analyze_one(
+        RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1)
+    )
+
+    runtime_history = run.trace["runtime_history"]
+    assert runtime_history["upsert_reason"] == "history_disabled"
+    assert runtime_history["initial_upserted"] is False
+    assert runtime_history["current_attempt_record"]["cycle_id"] == 1
+    assert runtime.attempt_record_control.records() == ()
+
+
+@pytest.mark.parametrize(
+    ("request_kwargs", "reason"),
+    (
+        ({"cycle_id": 1}, "missing_job_id"),
+        ({"job_id": "job-1"}, "missing_cycle_id"),
+    ),
+)
+def test_runtime_missing_attempt_identity_is_explicit_and_not_stored(
+    tmp_path,
+    request_kwargs,
+    reason,
+):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("RuntimeError: CUDA initialization failed\n", encoding="utf-8")
+    store = InMemoryAttemptRecordStore()
+    runtime = RestartAgentRuntime(RestartAgent(), attempt_record_store=store)
+
+    run = runtime.analyze_one(RestartAgentRequest(log_path=str(log_path), **request_kwargs))
+
+    runtime_history = run.trace["runtime_history"]
+    assert runtime_history["availability_reason"] == reason
+    assert runtime_history["initial_upserted"] is False
+    assert runtime_history["current_attempt_record"] is None
+    assert store.records() == ()
+
+
+def test_runtime_does_not_store_attempt_without_deterministic_fingerprint(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text("training process exited normally\n", encoding="utf-8")
+    store = InMemoryAttemptRecordStore()
+    runtime = RestartAgentRuntime(RestartAgent(), attempt_record_store=store)
+
+    run = runtime.analyze_one(
+        RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1)
+    )
+
+    runtime_history = run.trace["runtime_history"]
+    assert runtime_history["upsert_reason"] == "missing_root_fingerprint"
+    assert runtime_history["initial_upserted"] is False
+    assert runtime_history["current_attempt_record"] is not None
+    assert store.records() == ()
+
+
+def test_runtime_reports_l0_not_ready_when_log_is_unavailable(tmp_path):
+    log_path = tmp_path / "missing.log"
+    runtime = RestartAgentRuntime(
+        RestartAgent(),
+        attempt_record_store=InMemoryAttemptRecordStore(),
+    )
+
+    run = runtime.analyze_one(
+        RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1)
+    )
+
+    runtime_history = run.trace["runtime_history"]
+    assert runtime_history["availability_reason"] == "ready"
+    assert runtime_history["upsert_reason"] == "l0_not_ready"
+    assert runtime_history["initial_upserted"] is False
+
+
+def test_runtime_does_not_accept_route_enrichment_after_deadline(tmp_path):
+    line = "RuntimeError: CUDA initialization failed"
+    log_path = tmp_path / "job.log"
+    log_path.write_text(line + "\n", encoding="utf-8")
+    store = InMemoryAttemptRecordStore()
+    runtime = RestartAgentRuntime(RestartAgent(), attempt_record_store=store)
+
+    run = runtime.analyze_many(
+        RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1),
+        (ModelRoute(route_id="slow", evidence_extractor=_SlowEvidenceExtractor(line)),),
+        timeout_seconds=0.01,
+    )
+    time.sleep(0.15)
+
+    assert run.result.model_results[0].execution_status == "deadline_exceeded"
+    assert store.records("job-1")[0].enriched == ()
+    assert run.trace["runtime_history"]["enriched_updates"] == 0
+
+
+def test_runtime_serializes_same_attempt_invocations(tmp_path):
+    line = "RuntimeError: CUDA initialization failed"
+    log_path = tmp_path / "job.log"
+    log_path.write_text(line + "\n", encoding="utf-8")
+    extractor = _BlockingFirstEvidenceExtractor(line)
+    runtime = RestartAgentRuntime(
+        RestartAgent(evidence_extractor=extractor),
+        attempt_record_store=InMemoryAttemptRecordStore(),
+    )
+    request = RestartAgentRequest(log_path=str(log_path), job_id="job-1", cycle_id=1)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(runtime.analyze_one, request)
+        assert extractor.first_started.wait(timeout=1)
+        second = pool.submit(runtime.analyze_one, request)
+        assert not extractor.second_started.wait(timeout=0.05)
+        extractor.release_first.set()
+        first.result(timeout=2)
+        assert extractor.second_started.wait(timeout=1)
+        second.result(timeout=2)
+
+    assert len(runtime.attempt_record_control.records("job-1")) == 1
+
+
+def test_config_history_defaults_and_overrides_are_closed():
+    base = {
+        "schema_version": "restart_agent_config.v1",
+        "config_id": "test",
+        "config_version": 1,
+        "enrichment": {"enabled": True},
+        "model_routes": [
+            {
+                "route_id": "one",
+                "model": "test/model",
+                "base_url": "https://example.invalid/v1",
+                "credential_ref": "TEST_KEY_FILE",
+            }
+        ],
+    }
+    environment = {"TEST_KEY_FILE": "/private/tmp/test-key"}
+
+    defaults = parse_restart_agent_config(base, environ=environment)
+    overridden = parse_restart_agent_config(
+        {
+            **base,
+            "runtime": {
+                "history": {
+                    "enabled": False,
+                    "max_attempts_per_job": 4,
+                    "max_total_records": 20,
+                }
+            },
+        },
+        environ=environment,
+    )
+
+    assert defaults.history.enabled is True
+    assert defaults.history.max_attempts_per_job == 10
+    assert defaults.history.max_total_records == 3000
+    assert overridden.history.enabled is False
+    assert overridden.history.max_attempts_per_job == 4
+    assert overridden.history.max_total_records == 20
+    with pytest.raises(ValueError, match="runtime.history has unsupported fields"):
+        parse_restart_agent_config(
+            {**base, "runtime": {"history": {"ttl_seconds": 10}}},
+            environ=environment,
+        )
+
+
+def test_cli_round_trips_plain_attempt_record_fixture(tmp_path, capsys):
+    log_path = tmp_path / "job.log"
+    output_path = tmp_path / "attempts.json"
+    log_path.write_text("RuntimeError: CUDA initialization failed\n", encoding="utf-8")
+
+    assert (
+        cli_main(
+            [
+                str(log_path),
+                "--job-id",
+                "job-1",
+                "--cycle-id",
+                "1",
+                "--disable-l1",
+                "--attempt-records-json-out",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    first_payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert isinstance(first_payload, list)
+    assert first_payload[0]["cycle_id"] == 1
+
+    assert (
+        cli_main(
+            [
+                str(log_path),
+                "--job-id",
+                "job-1",
+                "--cycle-id",
+                "2",
+                "--disable-l1",
+                "--attempt-records-json-in",
+                str(output_path),
+                "--attempt-records-json-out",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert [item["cycle_id"] for item in json.loads(output_path.read_text())] == [1, 2]

--- a/tests/attribution/unit/test_restart_agent_distributed_timeout.py
+++ b/tests/attribution/unit/test_restart_agent_distributed_timeout.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral boundaries for distributed collective-timeout incidents."""
+
+import pytest
+
+from nvidia_resiliency_ext.attribution.restart_agent.infrastructure.log_source import (
+    SOURCE_READ_MODE_SINGLE_SNAPSHOT,
+    ChunkedLogReader,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l0 import (
+    ProgressiveL0Accumulator,
+    build_l0_bundle,
+    canonical_l0a_payload,
+)
+
+
+def _timeout(
+    rank: int,
+    timestamp: str | None,
+    sequence: int,
+    *,
+    timeout_ms: int = 600_000,
+) -> str:
+    timestamp_prefix = f"[E224 {timestamp} ProcessGroupNCCL.cpp:697] " if timestamp else ""
+    return (
+        f"{rank}: [rank{rank}]:{timestamp_prefix}"
+        "Watchdog caught collective operation timeout: "
+        f"WorkNCCL(SeqNum={sequence}, OpType=ALLGATHER, Timeout(ms)={timeout_ms}) "
+        f"ran for {timeout_ms + 1} milliseconds before timing out."
+    )
+
+
+def test_timeout_wave_matches_any_prior_event_across_midnight(tmp_path):
+    # Arrange
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                _timeout(0, "00:00:00.000000000", 1),
+                _timeout(1, "00:01:00.000000000", 2),
+                _timeout(2, "23:59:50.000000000", 3),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    # Act
+    bundle = build_l0_bundle(log_path)
+
+    # Assert
+    assert len(bundle.distributed_failure_incidents) == 1
+    incident = bundle.distributed_failure_incidents[0]
+    assert incident.event_count == 3
+    assert incident.member_event_lines == (1, 2, 3)
+
+
+def test_progress_between_timeout_events_starts_a_new_wave(tmp_path):
+    # Arrange
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                _timeout(0, "19:02:08.000000000", 1),
+                ("0: [2026-02-24 19:02:08.500000] iteration 2/100 | " "consumed samples: 20 |"),
+                _timeout(1, "19:02:09.000000000", 2),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    # Act
+    bundle = build_l0_bundle(log_path)
+
+    # Assert
+    assert [incident.member_event_lines for incident in bundle.distributed_failure_incidents] == [
+        (1,),
+        (3,),
+    ]
+
+
+def test_configured_timeout_change_starts_a_new_wave(tmp_path):
+    # Arrange
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                _timeout(0, "19:02:08.000000000", 1, timeout_ms=600_000),
+                _timeout(1, "19:02:09.000000000", 2, timeout_ms=300_000),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    # Act
+    bundle = build_l0_bundle(log_path)
+
+    # Assert
+    assert [incident.member_event_lines for incident in bundle.distributed_failure_incidents] == [
+        (1,),
+        (2,),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("filler_line_count", "expected_incident_count"),
+    ((999, 1), (1000, 2)),
+)
+def test_timeout_without_timestamp_uses_line_distance_boundary(
+    tmp_path,
+    filler_line_count,
+    expected_incident_count,
+):
+    # Arrange
+    log_path = tmp_path / "job.log"
+    lines = [_timeout(0, None, 1)]
+    lines.extend(f"ordinary output {index}" for index in range(filler_line_count))
+    lines.append(_timeout(1, None, 2))
+    log_path.write_text("\n".join(lines), encoding="utf-8")
+
+    # Act
+    bundle = build_l0_bundle(log_path)
+
+    # Assert
+    assert len(bundle.distributed_failure_incidents) == expected_incident_count
+
+
+def test_collective_timeout_l0a_is_identical_across_read_modes(tmp_path):
+    # Arrange
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "\n".join(_timeout(rank, f"19:02:{rank:02d}.000000000", rank + 1) for rank in range(8)),
+        encoding="utf-8",
+    )
+
+    # Act
+    chunked = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(chunk_bytes=17),
+    ).finalize()
+    single_snapshot = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(read_mode=SOURCE_READ_MODE_SINGLE_SNAPSHOT),
+    ).finalize()
+
+    # Assert
+    assert canonical_l0a_payload(
+        chunked.bundle,
+        chunked.decision_evidence,
+    ) == canonical_l0a_payload(
+        single_snapshot.bundle,
+        single_snapshot.decision_evidence,
+    )
+    assert chunked.canonical_hash == single_snapshot.canonical_hash

--- a/tests/attribution/unit/test_restart_agent_identity.py
+++ b/tests/attribution/unit/test_restart_agent_identity.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable failure-identity normalization behavior."""
+
+import pytest
+
+from nvidia_resiliency_ext.attribution.restart_agent.identity import (
+    normalize_token,
+    normalized_pattern,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    (
+        (
+            "E207 12:34:56.123 rank=7 cuda:3 RuntimeError: boom",
+            "runtimeerror_boom",
+        ),
+        (
+            "rank7:pid42 cuda:3 GPU_9 iteration=15 bucket#2 failure",
+            "failure",
+        ),
+        (
+            "node=worker-a17 device 4 retry 2 attempt 3 line 99",
+            "",
+        ),
+        (
+            "2026-07-25T12:34:56Z loss=inf at 0xdeadbeef",
+            "loss_inf_at",
+        ),
+        (
+            "allocated 16 GiB after 250ms",
+            "allocated_after",
+        ),
+    ),
+)
+def test_normalize_token_removes_volatile_routing_fields(text, expected):
+    assert normalize_token(text) == expected
+
+
+def test_normalized_pattern_retains_stable_words_and_replaces_free_numbers():
+    text = "RuntimeError code 17 on tensor shard 23"
+
+    assert normalized_pattern(text) == "runtimeerror_code_n_on_tensor_shard_n"

--- a/tests/attribution/unit/test_restart_agent_l0_registry.py
+++ b/tests/attribution/unit/test_restart_agent_l0_registry.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral tests for neutral L0 failure-signature classification."""
+
+import pytest
+
+from nvidia_resiliency_ext.attribution.restart_agent.l0.registry import (
+    MVP_SIGNATURES,
+    match_registry,
+    root_fingerprint,
+)
+
+
+@pytest.mark.parametrize(
+    ("line", "expected_registry_ids"),
+    (
+        (
+            "ValueError: invalid config option tensor_model_parallel_size",
+            {"observed_exception", "configuration_validation_failure"},
+        ),
+        (
+            "configuration loader failed: missing key model.hidden_size",
+            {"configuration_validation_failure"},
+        ),
+        (
+            "RuntimeError: invalid argument",
+            {"observed_exception", "argument_validation_failure"},
+        ),
+        (
+            "FileNotFoundError: [Errno 2] No such file or directory",
+            {"observed_exception", "artifact_or_path_not_found"},
+        ),
+        (
+            "checkpoint metadata version mismatch",
+            {"checkpoint_compatibility_mismatch"},
+        ),
+        (
+            "loaded tensor has a shape mismatch",
+            {"shape_mismatch"},
+        ),
+    ),
+)
+def test_registry_emits_observed_mechanisms_without_user_attribution(
+    line,
+    expected_registry_ids,
+):
+    rows = match_registry(line)
+    registry_ids = {row.registry_id for row in rows}
+
+    assert expected_registry_ids <= registry_ids
+    assert "user_config_error" not in registry_ids
+
+
+def test_neutral_structural_signatures_have_stable_family_fingerprints():
+    lines_by_registry_id = {
+        "configuration_validation_failure": "invalid config option hidden_size",
+        "argument_validation_failure": "invalid argument",
+        "artifact_or_path_not_found": "No such file or directory",
+        "checkpoint_compatibility_mismatch": "checkpoint metadata mismatch",
+        "shape_mismatch": "shape mismatch",
+    }
+    rows_by_registry_id = {row.registry_id: row for row in MVP_SIGNATURES}
+
+    for registry_id, line in lines_by_registry_id.items():
+        fingerprint = root_fingerprint(rows_by_registry_id[registry_id], line)
+
+        assert fingerprint is not None
+        assert fingerprint.startswith(f"{registry_id}:")
+
+
+@pytest.mark.parametrize(
+    "line",
+    (
+        "INFO:hypercorn.error: server started",
+        "INFO checkpoint metadata loaded",
+        "information about gradient health",
+    ),
+)
+def test_nonfinite_routing_does_not_index_on_inf_inside_words(line):
+    rows = match_registry(line)
+
+    assert all(row.registry_id != "nan_or_inf" for row in rows)
+
+
+@pytest.mark.parametrize(
+    "line",
+    (
+        "loss: inf",
+        "gradient = NaN",
+        "non-finite activation detected",
+    ),
+)
+def test_nonfinite_routing_preserves_real_numeric_instability(line):
+    rows = match_registry(line)
+
+    assert "nan_or_inf" in {row.registry_id for row in rows}
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    (
+        ("slurmstepd: error: JOB CANCELLED DUE TO TIME LIMIT", True),
+        ("scheduler terminated allocation because wall-time limit expired", True),
+        ("configured wall-time limit is 04:00:00", False),
+        ("training has 30 minutes remaining before the time limit", False),
+    ),
+)
+def test_time_limit_registry_requires_an_observed_termination_event(line, expected):
+    rows = match_registry(line)
+
+    assert ("time_limit" in {row.registry_id for row in rows}) is expected

--- a/tests/attribution/unit/test_restart_agent_progressive.py
+++ b/tests/attribution/unit/test_restart_agent_progressive.py
@@ -1,0 +1,366 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared byte-ingestion behavior for terminal and progressive L0A."""
+
+import pytest
+
+from nvidia_resiliency_ext.attribution.restart_agent.infrastructure.log_source import (
+    SOURCE_READ_MODE_SINGLE_SNAPSHOT,
+    ChunkedLogReader,
+    IncrementalLineDecoder,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.l0 import (
+    ProgressiveL0Accumulator,
+    canonical_l0a_payload,
+)
+from nvidia_resiliency_ext.attribution.restart_agent.models import RestartAgentRequest
+from nvidia_resiliency_ext.attribution.restart_agent.pipeline import RestartAgent
+
+
+def test_chunk_boundaries_preserve_linux_physical_lines_and_unterminated_tail(tmp_path):
+    # Arrange
+    log_path = tmp_path / "mixed-newlines.log"
+    log_path.write_bytes("alpha\r\nbeta\rgamma\nsnowman \N{SNOWMAN}\nlast\r".encode())
+
+    # Act
+    one_byte = ChunkedLogReader(chunk_bytes=1).snapshot(log_path)
+    seven_bytes = ChunkedLogReader(chunk_bytes=7).snapshot(log_path)
+    single_snapshot = ChunkedLogReader(
+        chunk_bytes=7,
+        read_mode=SOURCE_READ_MODE_SINGLE_SNAPSHOT,
+    ).snapshot(log_path)
+
+    # Assert
+    expected = ("alpha", "beta\rgamma", "snowman \N{SNOWMAN}", "last\r")
+    assert one_byte.lines == expected
+    assert seven_bytes.lines == expected
+    assert single_snapshot.lines == expected
+    assert one_byte.line_count == len(expected)
+    assert one_byte.context_before(4, limit=2) == ("beta\rgamma", "snowman \N{SNOWMAN}")
+
+
+def test_incremental_decoder_retains_partial_line_and_split_crlf():
+    # Arrange
+    decoder = IncrementalLineDecoder()
+
+    # Act and assert
+    assert decoder.feed(b"first\r") == ()
+    assert decoder.pending_bytes == len(b"first\r")
+    assert decoder.feed(b"\nRuntimeError: CUDA out of") == ("first",)
+    assert decoder.feed(b" memory\nlast") == ("RuntimeError: CUDA out of memory",)
+    assert decoder.feed(b"", final=True) == ("last",)
+
+
+def test_incremental_decoder_preserves_bare_cr_content_and_source_offsets():
+    # Arrange
+    decoder = IncrementalLineDecoder()
+
+    # Act
+    complete = decoder.feed_records(b"a\rb\r\nc\n")
+    tail = decoder.feed_records(b"last\r", final=True)
+
+    # Assert
+    assert [
+        (record.text, record.start_offset, record.end_offset, record.next_offset)
+        for record in complete
+    ] == [
+        ("a\rb", 0, 3, 5),
+        ("c", 5, 6, 7),
+    ]
+    assert [
+        (record.text, record.start_offset, record.end_offset, record.next_offset) for record in tail
+    ] == [("last\r", 7, 12, 12)]
+
+
+def test_chunked_reader_replaces_invalid_utf8_without_replaying_boundary(tmp_path):
+    # Arrange
+    log_path = tmp_path / "malformed-utf8.log"
+    log_path.write_bytes(b"valid\ninvalid \xde byte\n")
+
+    # Act
+    snapshot = ChunkedLogReader(chunk_bytes=1).snapshot(log_path)
+
+    # Assert
+    assert snapshot.encoding == "utf-8"
+    assert snapshot.lines == ("valid", "invalid \N{REPLACEMENT CHARACTER} byte")
+
+
+@pytest.mark.parametrize("terminal_chunk_bytes", [1, 2, 3, 7, 11, 64 * 1024])
+def test_terminal_progressive_and_single_snapshot_have_identical_l0a(
+    tmp_path,
+    terminal_chunk_bytes,
+):
+    # Arrange
+    log_path = tmp_path / "train.log"
+    prefix = "[2026-01-01 00:00:00] iteration 7 / 100 | consumed samples: 64 |\n"
+    suffix = "RuntimeError: CUDA out of memory\n"
+    log_path.write_text(prefix, encoding="utf-8")
+    progressive = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(chunk_bytes=3),
+    )
+
+    # Act
+    assert progressive.refresh() is True
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(suffix)
+    assert progressive.refresh() is True
+    progressive_final = progressive.finalize()
+    chunked_terminal = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(chunk_bytes=terminal_chunk_bytes),
+    ).finalize()
+    single_snapshot = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(read_mode=SOURCE_READ_MODE_SINGLE_SNAPSHOT),
+    ).finalize()
+
+    # Assert
+    assert progressive_final.precomputed is True
+    assert chunked_terminal.precomputed is False
+    payloads = [
+        canonical_l0a_payload(result.bundle, result.decision_evidence)
+        for result in (progressive_final, chunked_terminal, single_snapshot)
+    ]
+    assert payloads[0] == payloads[1] == payloads[2]
+    assert {
+        progressive_final.canonical_hash,
+        chunked_terminal.canonical_hash,
+        single_snapshot.canonical_hash,
+    } == {progressive_final.canonical_hash}
+
+
+def test_partial_failure_line_is_not_observed_until_completed(tmp_path):
+    # Arrange
+    log_path = tmp_path / "train.log"
+    log_path.write_bytes(b"RuntimeError: CUDA out")
+    accumulator = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(chunk_bytes=2),
+    )
+
+    # Act
+    accumulator.refresh()
+    partial_state = accumulator.state()
+    with log_path.open("ab") as handle:
+        handle.write(b" of memory\n")
+    accumulator.refresh()
+    finalized = accumulator.finalize()
+
+    # Assert
+    assert partial_state.line_count == 0
+    assert partial_state.pending_line_bytes == len(b"RuntimeError: CUDA out")
+    assert finalized.source_log.lines == ("RuntimeError: CUDA out of memory",)
+    assert finalized.bundle.line_count == 1
+    assert finalized.bundle.deterministic_primary_candidate is not None
+    assert finalized.bundle.deterministic_primary_candidate.line == 1
+    assert finalized.source_log.storage_mode == "indexed_file"
+
+
+def test_finalization_can_exclude_an_actively_written_partial_tail(tmp_path):
+    # Arrange
+    log_path = tmp_path / "train.log"
+    log_path.write_bytes(b"iteration 1 completed\nRuntimeError: still being written")
+    accumulator = ProgressiveL0Accumulator(str(log_path))
+    accumulator.refresh(precompute=False)
+
+    # Act
+    finalized = accumulator.finalize(include_incomplete_tail=False)
+
+    # Assert
+    assert finalized.source_log.lines == ("iteration 1 completed",)
+    assert finalized.bundle.line_count == 1
+    assert finalized.progressive_metrics["discarded_incomplete_tail_bytes"] == len(
+        b"RuntimeError: still being written"
+    )
+
+
+def test_late_invalid_utf8_is_replaced_without_replaying_complete_source(tmp_path):
+    # Arrange
+    log_path = tmp_path / "late-malformed-utf8.log"
+    first = "snowman \N{SNOWMAN}\n".encode("utf-8")
+    log_path.write_bytes(first)
+    progressive = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(chunk_bytes=2),
+    )
+    progressive.refresh()
+
+    # Act
+    with log_path.open("ab") as handle:
+        handle.write(b"invalid \xde byte\n")
+    progressive.refresh()
+    progressive_final = progressive.finalize()
+    terminal_final = ProgressiveL0Accumulator(str(log_path)).finalize()
+
+    # Assert
+    assert progressive_final.source_log.encoding == "utf-8"
+    assert progressive_final.source_log.lines == terminal_final.source_log.lines
+    assert progressive_final.canonical_hash == terminal_final.canonical_hash
+    assert progressive_final.progressive_metrics["decode_replacement_count"] == 1
+    assert progressive_final.progressive_metrics["decode_replacement_line_count"] == 1
+    assert progressive_final.progressive_metrics["bytes_reread"] == 0
+
+
+def test_finalize_rebuilds_precomputed_l0a_after_unobserved_late_append(tmp_path):
+    # Arrange
+    log_path = tmp_path / "late-terminal-output.log"
+    log_path.write_text("iteration 7 completed\n", encoding="utf-8")
+    progressive = ProgressiveL0Accumulator(str(log_path))
+    assert progressive.refresh(precompute=True) is True
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write("RuntimeError: CUDA out of memory\n")
+
+    # Act
+    progressive_final = progressive.finalize()
+    terminal_final = ProgressiveL0Accumulator(str(log_path)).finalize()
+
+    # Assert
+    assert progressive_final.precomputed is False
+    assert progressive_final.progressive_metrics["l0a_build_count"] == 2
+    assert progressive_final.source_log.lines == terminal_final.source_log.lines
+    assert progressive_final.canonical_hash == terminal_final.canonical_hash
+    assert progressive_final.bundle.deterministic_primary_candidate is not None
+    assert progressive_final.bundle.deterministic_primary_candidate.line == 2
+
+
+def test_unchanged_refresh_builds_checkpoint_for_exact_current_boundary(tmp_path):
+    # Arrange
+    log_path = tmp_path / "stable-terminal-output.log"
+    log_path.write_text(
+        "iteration 7 completed\nRuntimeError: CUDA out of memory\n",
+        encoding="utf-8",
+    )
+    accumulator = ProgressiveL0Accumulator(str(log_path))
+    assert accumulator.refresh(precompute=False) is True
+    assert accumulator.state().l0a_build_count == 0
+
+    # Act
+    assert accumulator.refresh(precompute=True) is False
+    finalized = accumulator.finalize()
+
+    # Assert
+    assert finalized.precomputed is True
+    assert finalized.progressive_metrics["l0a_build_count"] == 1
+    assert finalized.source_boundary == finalized.source_log.source_boundary
+
+
+def test_repeated_large_reductions_match_fresh_terminal_reduction(tmp_path):
+    # Arrange
+    log_path = tmp_path / "many-high-signal-lines.log"
+    initial_lines = [f"ERROR: repeated failure rendering {index}" for index in range(4_100)]
+    log_path.write_text("\n".join(initial_lines) + "\n", encoding="utf-8")
+    progressive = ProgressiveL0Accumulator(str(log_path))
+    assert progressive.refresh(precompute=True) is True
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write("RuntimeError: terminal failure\n")
+
+    # Act
+    progressive_final = progressive.finalize()
+    terminal_final = ProgressiveL0Accumulator(str(log_path)).finalize()
+
+    # Assert
+    assert progressive_final.progressive_metrics["l0a_build_count"] == 2
+    assert progressive_final.canonical_hash == terminal_final.canonical_hash
+
+
+def test_invalid_utf8_in_unterminated_tail_is_replaced_at_finalization(tmp_path):
+    # Arrange
+    log_path = tmp_path / "unterminated-malformed-utf8.log"
+    log_path.write_bytes(b"first\ninvalid \xde")
+    accumulator = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(chunk_bytes=1),
+    )
+    accumulator.refresh()
+
+    # Act
+    finalized = accumulator.finalize()
+
+    # Assert
+    assert finalized.source_log.encoding == "utf-8"
+    assert finalized.source_log.lines == ("first", "invalid \N{REPLACEMENT CHARACTER}")
+    assert finalized.progressive_metrics["decode_replacement_count"] == 1
+    assert finalized.progressive_metrics["decode_replacement_line_count"] == 1
+    assert finalized.progressive_metrics["bytes_reread"] == 0
+
+
+def test_unchanged_poll_is_metadata_only_and_same_size_rewrite_resets(tmp_path):
+    # Arrange
+    log_path = tmp_path / "train.log"
+    log_path.write_text("RuntimeError: first failure\n", encoding="utf-8")
+    accumulator = ProgressiveL0Accumulator(
+        str(log_path),
+        reader=ChunkedLogReader(chunk_bytes=2),
+    )
+
+    # Act
+    assert accumulator.refresh() is True
+    assert accumulator.refresh() is False
+    log_path.write_text("RuntimeError: other failure\n", encoding="utf-8")
+    assert accumulator.refresh() is True
+
+    # Assert
+    state = accumulator.state()
+    assert state.poll_count == 3
+    assert state.unchanged_poll_count == 1
+    assert state.reset_count == 1
+    assert state.l0a_build_count == 2
+
+
+def test_source_replacement_resets_progressive_state(tmp_path):
+    # Arrange
+    log_path = tmp_path / "train.log"
+    log_path.write_text("RuntimeError: first failure\n", encoding="utf-8")
+    accumulator = ProgressiveL0Accumulator(str(log_path))
+    accumulator.refresh()
+    replacement = tmp_path / "replacement.log"
+    replacement.write_text("RuntimeError: replacement\n", encoding="utf-8")
+
+    # Act
+    replacement.replace(log_path)
+    accumulator.refresh()
+    finalized = accumulator.finalize()
+
+    # Assert
+    assert finalized.source_log.lines == ("RuntimeError: replacement",)
+    assert finalized.progressive_metrics["reset_count"] == 1
+
+
+def test_finalized_snapshot_hides_later_appends(tmp_path):
+    # Arrange
+    log_path = tmp_path / "train.log"
+    log_path.write_text("first\nsecond\n", encoding="utf-8")
+    finalized = ProgressiveL0Accumulator(str(log_path)).finalize()
+
+    # Act
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write("late\n")
+
+    # Assert
+    assert finalized.source_log.lines == ("first", "second")
+    assert finalized.source_log.line(3) is None
+
+
+def test_prepared_runtime_does_not_require_a_second_source_read(tmp_path):
+    # Arrange
+    log_path = tmp_path / "train.log"
+    log_path.write_text("RuntimeError: CUDA out of memory\n", encoding="utf-8")
+    finalized = ProgressiveL0Accumulator(str(log_path)).finalize()
+    log_path.unlink()
+
+    # Act
+    run = RestartAgent().run_prepared(
+        RestartAgentRequest(
+            log_path=str(log_path),
+            job_id="job-1",
+            cycle_id=1,
+        ),
+        finalized,
+    )
+
+    # Assert
+    assert run.bundle == finalized.bundle
+    assert run.trace["l0_source"]["canonical_hash"] == finalized.canonical_hash
+    assert run.trace["l0_source"]["storage_mode"] == "indexed_file"

--- a/tests/attribution/unit/test_restart_agent_recovery_capabilities.py
+++ b/tests/attribution/unit/test_restart_agent_recovery_capabilities.py
@@ -1,0 +1,495 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declared workload recovery capability configuration and L4 behavior."""
+
+import pytest
+
+from nvidia_resiliency_ext.attribution.restart_agent import RestartAgent, RestartAgentRequest
+from nvidia_resiliency_ext.attribution.restart_agent.config import parse_restart_agent_config
+from nvidia_resiliency_ext.attribution.restart_agent.l4 import L4PolicyInput, evaluate_policy
+from nvidia_resiliency_ext.attribution.restart_agent.models import (
+    AffectedEntity,
+    AffectedEntityKind,
+    AssessmentStatus,
+    Decision,
+    DecisionBasis,
+    DeclaredRecoveryCapability,
+    FailureDomain,
+    FailureDomainAssessment,
+    FailureEvidence,
+    HistoryMatchScope,
+    HistorySummary,
+    ModelRecoveryAssessment,
+    RecoveryBehavior,
+    RecoveryCapabilityId,
+    RetryOutlookAssessment,
+    RetryOutlookWithoutWorkloadChange,
+    RetryPolicyRule,
+)
+
+
+def _bad_token_capability(*, allowed_retries: int = 2) -> DeclaredRecoveryCapability:
+    return DeclaredRecoveryCapability(
+        capability_id=RecoveryCapabilityId.BAD_TOKEN_RETRY_THEN_SKIP,
+        behavior=RecoveryBehavior.RETRY_THEN_SKIP,
+        applies_to=("bad_token_or_window",),
+        required_entity_kind=AffectedEntityKind.DATA_POSITION,
+        history_match_scope=HistoryMatchScope.ROOT_AND_ENTITY,
+        allowed_retries=allowed_retries,
+    )
+
+
+def _data_position_entity(identity: str = "token:42") -> AffectedEntity:
+    return AffectedEntity(
+        kind=AffectedEntityKind.DATA_POSITION,
+        identity=identity,
+        fingerprint=f"affected_entity:data_position:{identity}",
+        evidence_line=2,
+    )
+
+
+def _artifact_entity(
+    identity: str = "/checkpoints/model#checkpoint_iteration=42",
+) -> AffectedEntity:
+    return AffectedEntity(
+        kind=AffectedEntityKind.ARTIFACT,
+        identity=identity,
+        fingerprint=f"affected_entity:artifact:{identity}",
+        evidence_line=2,
+    )
+
+
+def _bad_token_primary() -> FailureEvidence:
+    return FailureEvidence(
+        failure_class="bad_token_or_window",
+        signature="bad token detected",
+        root_fingerprint="observed:data:bad_token",
+        fault_outcome="terminal",
+        registry_id="bad_token_or_window",
+        recovery_behavior=RecoveryBehavior.RETRY_THEN_SKIP.value,
+    )
+
+
+def _established_unrecoverable_assessment() -> ModelRecoveryAssessment:
+    return ModelRecoveryAssessment(
+        failure_domain=FailureDomainAssessment(
+            value=FailureDomain.WORKLOAD,
+            status=AssessmentStatus.ESTABLISHED_BY_CURRENT_LOG,
+            confidence=95,
+        ),
+        retry_outlook_without_workload_change=RetryOutlookAssessment(
+            value=RetryOutlookWithoutWorkloadChange.CANNOT_RECOVER,
+            status=AssessmentStatus.ESTABLISHED_BY_CURRENT_LOG,
+            confidence=95,
+        ),
+        rationale="The unchanged workload cannot process this token.",
+    )
+
+
+def test_bad_token_capability_precedes_generic_workload_unrecoverable_rule():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_bad_token_primary(),
+            history=HistorySummary(available=True),
+            current_affected_entity=_data_position_entity(),
+            model_recovery_assessment=_established_unrecoverable_assessment(),
+            assessment_grounded=True,
+            declared_recovery_capabilities=(_bad_token_capability(),),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value
+    assert outcome.general_root_ceiling.allowed_retries == 3
+    assert outcome.selected_rule_budget is not None
+    assert outcome.selected_rule_budget.allowed_retries == 2
+    assert outcome.selected_rule_budget.history_match_scope == (
+        HistoryMatchScope.ROOT_AND_ENTITY.value
+    )
+    assert outcome.decision == Decision.RESTART.value
+    assert outcome.decision_basis == DecisionBasis.WORKLOAD_MANAGED_RECOVERY_AVAILABLE.value
+    assert outcome.current_evidence_qualified is True
+    assert outcome.declared_recovery_capability_ids == (
+        RecoveryCapabilityId.BAD_TOKEN_RETRY_THEN_SKIP.value,
+    )
+    assert outcome.applied_recovery_capability == {
+        "capability_id": RecoveryCapabilityId.BAD_TOKEN_RETRY_THEN_SKIP.value,
+        "behavior": RecoveryBehavior.RETRY_THEN_SKIP.value,
+        "applies_to": ["bad_token_or_window"],
+        "required_entity_kind": AffectedEntityKind.DATA_POSITION.value,
+        "history_match_scope": HistoryMatchScope.ROOT_AND_ENTITY.value,
+        "allowed_retries": 2,
+    }
+
+
+def test_exact_artifact_selects_confirmation_retry():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=FailureEvidence(
+                failure_class="checkpoint_decode",
+                signature="UnicodeDecodeError",
+                root_fingerprint="observed:unicode_decode:tensor_to_object",
+                fault_outcome="terminal",
+            ),
+            history=HistorySummary(available=True),
+            current_affected_entity=_artifact_entity(),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.CONFIRMATION_RETRY.value
+    assert outcome.decision == Decision.RESTART.value
+    assert outcome.decision_basis == DecisionBasis.CONFIRMATION_RETRY_AVAILABLE.value
+    assert outcome.selected_rule_budget is not None
+    assert outcome.selected_rule_budget.allowed_retries == 1
+    assert outcome.selected_rule_budget.history_match_scope == (
+        HistoryMatchScope.ROOT_AND_ENTITY.value
+    )
+
+
+def test_confirmation_retry_stops_on_first_exact_no_progress_recurrence():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=FailureEvidence(
+                failure_class="checkpoint_decode",
+                signature="UnicodeDecodeError",
+                root_fingerprint="observed:unicode_decode:tensor_to_object",
+                fault_outcome="terminal",
+            ),
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_no_advance_attempts=1,
+                consecutive_same_root_and_entity_no_advance_attempts=1,
+            ),
+            current_affected_entity=_artifact_entity(),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.CONFIRMATION_RETRY.value
+    assert outcome.general_root_ceiling.exhausted is False
+    assert outcome.selected_rule_budget is not None
+    assert outcome.selected_rule_budget.exhausted is True
+    assert outcome.exhausted_by == ("selected_rule_budget",)
+    assert outcome.decision == Decision.STOP.value
+
+
+def test_confirmation_retry_does_not_consume_on_different_entity():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=FailureEvidence(
+                failure_class="checkpoint_decode",
+                signature="UnicodeDecodeError",
+                root_fingerprint="observed:unicode_decode:tensor_to_object",
+                fault_outcome="terminal",
+            ),
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_no_advance_attempts=1,
+                consecutive_same_root_and_entity_no_advance_attempts=0,
+            ),
+            current_affected_entity=_artifact_entity("/checkpoints/model#checkpoint_iteration=43"),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.CONFIRMATION_RETRY.value
+    assert outcome.selected_rule_budget is not None
+    assert outcome.selected_rule_budget.exhausted is False
+    assert outcome.decision == Decision.RESTART.value
+
+
+def test_observed_advance_protects_confirmation_retry():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=FailureEvidence(
+                failure_class="checkpoint_decode",
+                signature="UnicodeDecodeError",
+                root_fingerprint="observed:unicode_decode:tensor_to_object",
+                fault_outcome="terminal",
+            ),
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_and_entity_no_advance_attempts=1,
+                advanced_beyond_all_same_entity_comparable_attempts=True,
+            ),
+            current_affected_entity=_artifact_entity(),
+        )
+    ).retry_policy
+
+    assert outcome.selected_rule_budget is not None
+    assert outcome.selected_rule_budget.exhausted is False
+    assert outcome.decision == Decision.RESTART.value
+    assert outcome.decision_basis == DecisionBasis.OBSERVED_ADVANCE.value
+
+
+def test_bad_token_capability_stops_after_its_declared_retry_budget():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_bad_token_primary(),
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_and_entity_no_advance_attempts=2,
+            ),
+            current_affected_entity=_data_position_entity(),
+            declared_recovery_capabilities=(_bad_token_capability(),),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value
+    assert outcome.retry_budget_exhausted is True
+    assert outcome.exhausted_by == ("selected_rule_budget",)
+    assert outcome.decision == Decision.STOP.value
+    assert outcome.decision_basis == DecisionBasis.RETRY_BUDGET_EXHAUSTED.value
+
+
+def test_bad_token_capability_allows_first_matching_recurrence():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_bad_token_primary(),
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_and_entity_no_advance_attempts=1,
+            ),
+            current_affected_entity=_data_position_entity(),
+            declared_recovery_capabilities=(_bad_token_capability(),),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value
+    assert outcome.retry_budget_exhausted is False
+    assert outcome.decision == Decision.RESTART.value
+
+
+def test_observed_advance_protects_exhausted_bad_token_capability_budget():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_bad_token_primary(),
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_and_entity_no_advance_attempts=2,
+                advanced_beyond_all_same_entity_comparable_attempts=True,
+            ),
+            current_affected_entity=_data_position_entity(),
+            declared_recovery_capabilities=(_bad_token_capability(),),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value
+    assert outcome.retry_budget_exhausted is False
+    assert outcome.decision == Decision.RESTART.value
+    assert outcome.decision_basis == DecisionBasis.OBSERVED_ADVANCE.value
+
+
+def test_capability_does_not_apply_without_grounded_bad_token_behavior():
+    primary = FailureEvidence(
+        failure_class="bad_token_or_window",
+        signature="numeric instability",
+        root_fingerprint="observed:data:numeric_instability",
+        fault_outcome="terminal",
+        registry_id="model_selected",
+        recovery_behavior=RecoveryBehavior.NONE.value,
+    )
+
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=primary,
+            history=HistorySummary(available=False),
+            declared_recovery_capabilities=(_bad_token_capability(),),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.GENERAL_RETRY.value
+    assert outcome.applied_recovery_capability is None
+
+
+def test_bad_token_capability_requires_a_data_position_entity():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_bad_token_primary(),
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_no_advance_attempts=3,
+            ),
+            declared_recovery_capabilities=(_bad_token_capability(),),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.GENERAL_RETRY.value
+    assert outcome.applied_recovery_capability is None
+    assert outcome.general_root_ceiling.history_match_scope == (HistoryMatchScope.ROOT_ONLY.value)
+    assert outcome.selected_rule_budget is None
+
+
+def test_restart_agent_threads_declared_capability_to_l4(tmp_path):
+    log_path = tmp_path / "job.log"
+    log_path.write_text(
+        "iteration 418 completed\nbad token detected token_id=42\n",
+        encoding="utf-8",
+    )
+
+    run = RestartAgent(declared_recovery_capabilities=(_bad_token_capability(),)).run(
+        RestartAgentRequest(log_path=str(log_path))
+    )
+    result = run.result
+
+    assert result.decision == Decision.RESTART.value
+    assert result.retry_policy["rule"] == RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value
+    assert result.retry_policy["applied_recovery_capability"]["capability_id"] == (
+        RecoveryCapabilityId.BAD_TOKEN_RETRY_THEN_SKIP.value
+    )
+    assert result.retry_policy["selected_rule_budget"]["history_match_scope"] == (
+        HistoryMatchScope.ROOT_AND_ENTITY.value
+    )
+    assert result.retry_policy["current_affected_entity"]["kind"] == (
+        AffectedEntityKind.DATA_POSITION.value
+    )
+    assert result.retry_policy["current_affected_entity"]["identity"] == "token:42"
+    assert run.trace["layers"]["L0"]["affected_entity"] == (
+        result.retry_policy["current_affected_entity"]
+    )
+    assert run.trace["layers"]["L3"]["current_affected_entity"] == (
+        result.retry_policy["current_affected_entity"]
+    )
+    assert run.trace["layers"]["L4"]["selected_rule_budget"]["history_match_scope"] == (
+        HistoryMatchScope.ROOT_AND_ENTITY.value
+    )
+
+
+def test_general_root_ceiling_still_exhausts_when_entity_budget_does_not():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_bad_token_primary(),
+            history=HistorySummary(
+                available=True,
+                consecutive_same_root_no_advance_attempts=3,
+                consecutive_same_root_and_entity_no_advance_attempts=0,
+            ),
+            current_affected_entity=_data_position_entity(),
+            declared_recovery_capabilities=(_bad_token_capability(),),
+        )
+    ).retry_policy
+
+    assert outcome.rule == RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value
+    assert outcome.general_root_ceiling.exhausted is True
+    assert outcome.selected_rule_budget is not None
+    assert outcome.selected_rule_budget.exhausted is False
+    assert outcome.exhausted_by == ("general_root_ceiling",)
+    assert outcome.decision == Decision.STOP.value
+
+
+def test_restart_agent_config_declares_bad_token_retry_then_skip():
+    config = parse_restart_agent_config(
+        {
+            "schema_version": "restart_agent_config.v1",
+            "config_id": "bad-token-managed-recovery",
+            "config_version": 1,
+            "enrichment": {"enabled": True},
+            "declared_recovery_capabilities": [
+                {
+                    "capability_id": "bad_token_retry_then_skip",
+                    "behavior": "retry_then_skip",
+                    "applies_to": ["bad_token_or_window"],
+                    "required_entity_kind": "data_position",
+                    "history_match_scope": "root_and_entity",
+                    "allowed_retries": 2,
+                }
+            ],
+            "model_routes": [{"route_id": "model-a", "model": "provider/model-a"}],
+        },
+        environ={"LLM_API_KEY_FILE": "/tmp/test-key"},
+    )
+
+    assert config.declared_recovery_capabilities == (_bad_token_capability(),)
+    assert config.effective_config["declared_recovery_capabilities"] == [
+        {
+            "capability_id": "bad_token_retry_then_skip",
+            "behavior": "retry_then_skip",
+            "applies_to": ["bad_token_or_window"],
+            "required_entity_kind": "data_position",
+            "history_match_scope": "root_and_entity",
+            "allowed_retries": 2,
+        }
+    ]
+
+
+def test_restart_environment_guarantees_are_not_configurable():
+    with pytest.raises(ValueError, match="unsupported fields: restart_environment_context"):
+        parse_restart_agent_config(
+            {
+                "schema_version": "restart_agent_config.v1",
+                "config_id": "invalid-restart-guarantee-override",
+                "config_version": 1,
+                "enrichment": {"enabled": True},
+                "restart_environment_context": {
+                    "hardware_allocation_may_change": False,
+                },
+                "model_routes": [{"route_id": "model-a", "model": "provider/model-a"}],
+            },
+            environ={"LLM_API_KEY_FILE": "/tmp/test-key"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("behavior", "fallback", "behavior is unsupported"),
+        ("applies_to", ["numeric_instability"], "applies_to must be"),
+        ("allowed_retries", 0, "allowed_retries must be greater than zero"),
+    ],
+)
+def test_restart_agent_config_rejects_invalid_bad_token_capability(
+    field,
+    value,
+    message,
+):
+    capability = {
+        "capability_id": "bad_token_retry_then_skip",
+        "behavior": "retry_then_skip",
+        "applies_to": ["bad_token_or_window"],
+        "required_entity_kind": "data_position",
+        "history_match_scope": "root_and_entity",
+        "allowed_retries": 2,
+    }
+    capability[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        parse_restart_agent_config(
+            {
+                "schema_version": "restart_agent_config.v1",
+                "config_id": "invalid-capability",
+                "config_version": 1,
+                "enrichment": {"enabled": True},
+                "declared_recovery_capabilities": [capability],
+                "model_routes": [{"route_id": "model-a", "model": "provider/model-a"}],
+            },
+            environ={"LLM_API_KEY_FILE": "/tmp/test-key"},
+        )
+
+
+def test_restart_agent_config_rejects_capability_budget_above_general_ceiling():
+    with pytest.raises(
+        ValueError,
+        match="allowed_retries must not exceed.*general_retry_allowed_retries",
+    ):
+        parse_restart_agent_config(
+            {
+                "schema_version": "restart_agent_config.v1",
+                "config_id": "invalid-capability-budget",
+                "config_version": 1,
+                "retry_policy": {
+                    "bounded_retry_allowed_retries": 1,
+                    "general_retry_allowed_retries": 1,
+                },
+                "enrichment": {"enabled": False},
+                "declared_recovery_capabilities": [
+                    {
+                        "capability_id": "bad_token_retry_then_skip",
+                        "behavior": "retry_then_skip",
+                        "applies_to": ["bad_token_or_window"],
+                        "required_entity_kind": "data_position",
+                        "history_match_scope": "root_and_entity",
+                        "allowed_retries": 2,
+                    }
+                ],
+                "model_routes": [],
+            },
+            environ={},
+        )

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -202,6 +202,19 @@ def test_attribution_config_maps_launcher_args(tmp_path):
     )
 
 
+def test_attribution_config_accepts_lib_analysis_backend(tmp_path):
+    cfg = AttributionConfig.from_args(
+        _args(
+            ft_attribution_endpoint="localhost",
+            ft_attribution_analysis_backend="lib",
+        ),
+        str(tmp_path / "train.log"),
+        FaultToleranceConfig(),
+    )
+
+    assert cfg.analysis_backend == "lib"
+
+
 def test_attribution_stop_action_defaults_to_log_only(tmp_path):
     """Enabling attribution must not implicitly enable acting on its verdicts."""
     cfg = AttributionConfig.from_args(
@@ -241,18 +254,6 @@ def test_attribution_stop_action_rejects_unknown_values(tmp_path, value):
     with pytest.raises(ValueError, match="--ft-attribution-stop-action"):
         AttributionConfig.from_args(
             _args(ft_attribution_endpoint="localhost", ft_attribution_stop_action=value),
-            str(tmp_path / "train.log"),
-            FaultToleranceConfig(),
-        )
-
-
-def test_attribution_config_rejects_lib_analysis_backend(tmp_path):
-    with pytest.raises(ValueError, match="only 'mcp'"):
-        AttributionConfig.from_args(
-            _args(
-                ft_attribution_endpoint="localhost",
-                ft_attribution_analysis_backend="lib",
-            ),
             str(tmp_path / "train.log"),
             FaultToleranceConfig(),
         )

--- a/tests/shared_utils/test_health_check.py
+++ b/tests/shared_utils/test_health_check.py
@@ -1137,9 +1137,14 @@ class TestAttributionService(unittest.TestCase):
         response.json.return_value = {
             "status": "in_flight",
             "recommendation": {
-                "action": "UNKNOWN",
-                "reason": "analysis still running",
-                "source": "log_analyzer",
+                "action": "STOP",
+                "reason": "provisional deterministic result",
+                "source": "deterministic",
+            },
+            "candidate_recommendation": {
+                "action": "STOP",
+                "reason": "provisional deterministic result",
+                "source": "deterministic",
             },
         }
         client.get.return_value = response


### PR DESCRIPTION
Merge `origin/main` into `stable`. Brings the restart-agent runtime and product specs (PR #370) into the stable branch. Fast, conflict-free merge — all additions under `attribution/restart_agent/`, `services/attrsvc/`, and `tests/attribution/unit/`.