### PR TITLE
Skip split-log detection for progressive submissions

### DIFF
--- a/docs/source/attribution/features/progressive-ft-launcher-attribution.rst
+++ b/docs/source/attribution/features/progressive-ft-launcher-attribution.rst
@@ -264,9 +264,10 @@ Compatibility
 -------------
 
 Existing attrsvc callers must continue to work without sending new fields.
-Service-mode ``POST`` calls with ``job_id`` continue to support splitlog
-detection and tracking. Single-file ``POST`` calls from older clients remain
-track-only.
+Track-only and terminal service-mode ``POST`` calls with ``job_id`` continue to
+support splitlog detection and tracking. Progressive submissions identify NVRx
+per-cycle files and register them directly. Single-file ``POST`` calls from
+older clients remain track-only.
 
 The final ``GET`` result must remain semantically compatible with the current
 terminal analysis result. A progressive implementation may improve latency, but

--- a/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
+++ b/src/nvidia_resiliency_ext/attribution/analyzer/engine.py
@@ -330,7 +330,12 @@ class Analyzer:
             return LogAnalyzerError(error_code=ErrorCode.INVALID_PARAMETER, message=str(e))
 
         del cycle_id
-        result = await self._log.submit(log_path, user=user, job_id=job_id)
+        result = await self._log.submit(
+            log_path,
+            user=user,
+            job_id=job_id,
+            detect_splitlog=intent != ANALYSIS_INTENT_PROGRESSIVE,
+        )
         if isinstance(result, LogAnalyzerError):
             return result
 

--- a/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
@@ -718,6 +718,8 @@ class LogAnalyzer:
         log_path: str,
         user: str = "unknown",
         job_id: Optional[str] = None,
+        *,
+        detect_splitlog: bool = True,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
         """Submit a log path for tracking (splitlog / pending / single)."""
         if not log_path:
@@ -739,4 +741,9 @@ class LogAnalyzer:
         if existing_job:
             return self._tracked.handle_existing_job(existing_job, validated)
 
-        return await self._tracked.create_new_job(validated, user, job_id)
+        return await self._tracked.create_new_job(
+            validated,
+            user,
+            job_id,
+            detect_splitlog=detect_splitlog,
+        )

--- a/src/nvidia_resiliency_ext/attribution/orchestration/tracked_jobs.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/tracked_jobs.py
@@ -126,9 +126,14 @@ class TrackedJobs:
         )
 
     async def create_new_job(
-        self, validated: str, user: str, job_id: Optional[str]
+        self,
+        validated: str,
+        user: str,
+        job_id: Optional[str],
+        *,
+        detect_splitlog: bool = True,
     ) -> LogAnalyzerSubmitResult | LogAnalyzerError:
-        if job_id:
+        if job_id and detect_splitlog:
             logger.debug("create_new_job: job_id=%s, checking for splitlog mode", job_id)
             info = read_and_parse_slurm_output(validated)
             logger.debug(
@@ -192,10 +197,20 @@ class TrackedJobs:
             )
 
         self._total_single += 1
-        job = Job(path=validated, user=user, mode=JobMode.SINGLE)
+        job = Job(
+            path=validated,
+            user=user,
+            mode=JobMode.SINGLE,
+            job_id=job_id,
+        )
         with self._jobs_lock:
             self._jobs[validated] = job
-        logger.debug("Created SINGLE job (no job_id): path=%s", validated)
+        logger.debug(
+            "Created SINGLE job: path=%s, job_id=%s, splitlog_detection=%s",
+            validated,
+            job_id,
+            detect_splitlog,
+        )
         await self._track_submission(validated)
         return LogAnalyzerSubmitResult(
             submitted=True,

--- a/tests/attribution/unit/test_progressive_plumbing.py
+++ b/tests/attribution/unit/test_progressive_plumbing.py
@@ -20,6 +20,7 @@ from nvidia_resiliency_ext.attribution.orchestration.progressive import (
     ProgressiveLogAnalysisStartTool,
     ProgressiveStartResult,
 )
+from nvidia_resiliency_ext.attribution.orchestration.tracked_jobs import TrackedJobs
 from nvidia_resiliency_ext.attribution.orchestration.types import (
     LogAnalyzerError,
     LogAnalyzerSubmitResult,
@@ -116,6 +117,7 @@ def _import_analyzer_with_optional_dependency_stubs(monkeypatch):
 class FakeLogAnalyzer:
     def __init__(self) -> None:
         self.submissions: list[tuple[str, str, str | None]] = []
+        self.splitlog_detection: list[bool] = []
         self.progressive_starts: list[tuple[str, str, str | None]] = []
         self.progressive_started: asyncio.Event | None = None
         self.progressive_release: asyncio.Event | None = None
@@ -151,8 +153,11 @@ class FakeLogAnalyzer:
         log_path: str,
         user: str = "unknown",
         job_id: str | None = None,
+        *,
+        detect_splitlog: bool = True,
     ) -> LogAnalyzerSubmitResult:
         self.submissions.append((log_path, user, job_id))
+        self.splitlog_detection.append(detect_splitlog)
         self.jobs[log_path] = types.SimpleNamespace(
             mode=JobMode.SINGLE,
             user=user,
@@ -253,6 +258,7 @@ def test_progressive_submit_starts_backend_when_enabled(monkeypatch, tmp_path):
     asyncio.run(run())
 
     assert log_analyzer.submissions == [(str(tmp_path / "train_cycle0.log"), "alice", None)]
+    assert log_analyzer.splitlog_detection == [False]
     assert log_analyzer.progressive_starts == [(str(tmp_path / "train_cycle0.log"), "alice", None)]
 
 
@@ -274,6 +280,61 @@ def test_progressive_submit_is_ignored_when_feature_gate_disabled(monkeypatch, t
     asyncio.run(run())
 
     assert log_analyzer.progressive_starts == []
+    assert log_analyzer.splitlog_detection == [False]
+
+
+def test_progressive_registration_skips_splitlog_detection(monkeypatch, tmp_path):
+    log_path = tmp_path / "train_cycle0.log"
+    log_path.write_text("LOGS_DIR=/should/not/be/discovered\n")
+    tracked_paths: list[str] = []
+
+    async def track_submission(path: str) -> None:
+        tracked_paths.append(path)
+
+    def unexpected_detection(_path: str):
+        raise AssertionError("progressive submission attempted split-log detection")
+
+    monkeypatch.setattr(
+        "nvidia_resiliency_ext.attribution.orchestration.tracked_jobs."
+        "read_and_parse_slurm_output",
+        unexpected_detection,
+    )
+    tracked = TrackedJobs(track_submission=track_submission)
+
+    result = asyncio.run(
+        tracked.create_new_job(
+            str(log_path),
+            "alice",
+            "123",
+            detect_splitlog=False,
+        )
+    )
+
+    assert result.mode == JobMode.SINGLE.value
+    assert tracked.get_job(str(log_path)).job_id == "123"
+    assert tracked_paths == [str(log_path)]
+
+
+def test_non_progressive_registration_retains_splitlog_detection(tmp_path):
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_path = tmp_path / "slurm.out"
+    log_path.write_text(f"<< START PATHS >>\nLOGS_DIR={logs_dir}\n<< END PATHS >>\n")
+
+    async def track_submission(_path: str) -> None:
+        raise AssertionError("split-log registration should not track a single file")
+
+    tracked = TrackedJobs(track_submission=track_submission)
+    result = asyncio.run(
+        tracked.create_new_job(
+            str(log_path),
+            "alice",
+            "123",
+        )
+    )
+
+    assert result.mode == JobMode.SPLITLOG.value
+    assert result.logs_dir == str(logs_dir)
 
 
 def test_terminal_submit_starts_final_analysis_that_get_can_join(monkeypatch, tmp_path):
@@ -313,6 +374,7 @@ def test_terminal_submit_starts_final_analysis_that_get_can_join(monkeypatch, tm
     asyncio.run(run())
 
     assert log_analyzer.terminal_runs == [(log_path, "alice", "123")]
+    assert log_analyzer.splitlog_detection == [True]
 
 
 def test_terminal_get_nonblocking_reports_in_flight_without_joining(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Progressive NVRx submissions provide a concrete per-cycle log path and a
`job_id`. Attrsvc previously treated every submission with a `job_id` as a
possible Slurm wrapper log, scanned it for `LOGS_DIR`, and registered it as
pending when no split-log metadata was found.

This change:

- skips split-log detection for `analysis_intent="progressive"`
- registers the submitted per-cycle path directly as a single log
- retains `job_id` for attribution and observability
- preserves existing split-log detection for track-only and terminal submissions
- adds coverage for progressive and legacy split-log registration

No HTTP API shape changes are introduced.

## Validation

- `12 passed` in `tests/attribution/unit/test_progressive_plumbing.py`
- Black passed
- isort passed