### PR TITLE
Category-based STOP/RESTART decisions in restart_agent (L1 category selection + L4 gate)

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
@@ -122,6 +122,7 @@ def build_decision_outcome(
             assessment_grounded=l2_result.recovery_assessment_policy_grounded,
             retry_policy=RetryPolicyConfig.from_mapping(execution_context.retry_policy),
             declared_recovery_capabilities=(execution_context.declared_recovery_capabilities),
+            l1_category_selection=l1_result.category_selection(),
         )
     )
     primary = l4_outcome.primary

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
@@ -5,8 +5,28 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any, Mapping
+
+
+def _category_threshold_override() -> int | None:
+    """Read per-model confidence threshold override from env var.
+
+    NVRX_CATEGORY_CONFIDENCE_THRESHOLD is set by the eval harness / caller
+    based on the model target (e.g. 70 for GPT, 80 default). Returns None
+    when unset to keep the module-level default (80).
+    """
+    raw = os.environ.get("NVRX_CATEGORY_CONFIDENCE_THRESHOLD")
+    if not raw:
+        return None
+    try:
+        val = int(raw.strip())
+    except ValueError:
+        return None
+    if 0 <= val <= 100:
+        return val
+    return None
 
 from .attempt_records import AttemptRecordAssembler
 from .causality import build_result_cascades
@@ -123,6 +143,7 @@ def build_decision_outcome(
             retry_policy=RetryPolicyConfig.from_mapping(execution_context.retry_policy),
             declared_recovery_capabilities=(execution_context.declared_recovery_capabilities),
             l1_category_selection=l1_result.category_selection(),
+            category_confidence_threshold=_category_threshold_override(),
         )
     )
     primary = l4_outcome.primary

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
@@ -9,25 +9,6 @@ import os
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-
-def _category_threshold_override() -> int | None:
-    """Read per-model confidence threshold override from env var.
-
-    NVRX_CATEGORY_CONFIDENCE_THRESHOLD is set by the eval harness / caller
-    based on the model target (e.g. 70 for GPT, 80 default). Returns None
-    when unset to keep the module-level default (80).
-    """
-    raw = os.environ.get("NVRX_CATEGORY_CONFIDENCE_THRESHOLD")
-    if not raw:
-        return None
-    try:
-        val = int(raw.strip())
-    except ValueError:
-        return None
-    if 0 <= val <= 100:
-        return val
-    return None
-
 from .attempt_records import AttemptRecordAssembler
 from .causality import build_result_cascades
 from .l1 import L1EvidenceResult, execution_status
@@ -51,6 +32,25 @@ from .models import (
     RetryPolicyConfig,
 )
 from .runtime import SYSTEM_CLOCK, Clock
+
+
+def _category_threshold_override() -> int | None:
+    """Read per-model confidence threshold override from env var.
+
+    NVRX_CATEGORY_CONFIDENCE_THRESHOLD is set by the eval harness / caller
+    based on the model target (e.g. 70 for GPT, 80 default). Returns None
+    when unset to keep the module-level default (80).
+    """
+    raw = os.environ.get("NVRX_CATEGORY_CONFIDENCE_THRESHOLD")
+    if not raw:
+        return None
+    try:
+        val = int(raw.strip())
+    except ValueError:
+        return None
+    if 0 <= val <= 100:
+        return val
+    return None
 
 
 @dataclass(frozen=True)

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l0/assembly.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l0/assembly.py
@@ -1121,14 +1121,15 @@ def _selection_summary(
 
 def _line_numbering_anomaly() -> Mapping[str, str]:
     return {
-        "scheme": "linux_physical_lines",
+        "scheme": "python_text_universal_newlines",
         "line_field": (
-            "1-based physical line split on LF; a preceding CR is removed for "
-            "CRLF, while bare CR remains line content"
+            "1-based logical line after Python text-mode universal-newline "
+            "splitting on LF, CR, or CRLF"
         ),
         "shell_tool_note": (
-            "Line numbers align with Linux tools that count LF-delimited "
-            "records. Rank prefixes may also look like '<rank>:'."
+            "Rank prefixes also look like '<rank>:'. Tools that count only "
+            "LF-delimited records, or render embedded CR-delimited records, "
+            "may show different line numbers for the same text."
         ),
     }
 
@@ -2128,8 +2129,30 @@ def _select_primary_candidate(
         and match.fault_outcome
         not in {FaultOutcome.RECOVERED.value, FaultOutcome.PROGRESSED_AFTER.value}
     ]
-    if root_matches:
-        return sorted(root_matches, key=lambda match: match.line or 0)[0]
+    cascade_matches = [
+        match
+        for match in matches
+        if match.role == RegistryRole.CASCADE_CANDIDATE.value
+        and match.fault_outcome
+        not in {FaultOutcome.RECOVERED.value, FaultOutcome.PROGRESSED_AFTER.value}
+    ]
+    earliest_root = (
+        sorted(root_matches, key=lambda match: match.line or 0)[0] if root_matches else None
+    )
+    earliest_cascade = (
+        sorted(cascade_matches, key=lambda match: match.line or 0)[0] if cascade_matches else None
+    )
+    # If a terminal cascade candidate precedes the earliest root candidate, promote the
+    # cascade to primary. This handles cases where a scheduler cancel (root_candidate)
+    # follows an earlier NCCL watchdog CUDA-launch-failure (cascade_candidate) but no
+    # upstream root is visible in the log - the watchdog termination is genuinely the
+    # first observed failure.
+    if earliest_cascade is not None and (
+        earliest_root is None or (earliest_cascade.line or 0) < (earliest_root.line or 0)
+    ):
+        return earliest_cascade
+    if earliest_root is not None:
+        return earliest_root
 
     progressed_roots = [
         match

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
@@ -162,10 +162,14 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     ),
     CategoryDef(
         id=13,
-        name="Filesystem I/O error / Lustre or node-local FS",
+        name="Filesystem I/O error / Lustre or node-local FS / import visibility",
         description=(
             "Non-checkpoint storage error (Lustre stall, missing generated dataset "
-            "cache); transient storage / node-local FS issue."
+            "cache); transient storage / node-local FS issue. Also covers "
+            "ModuleNotFoundError or ImportError at startup where the failing import "
+            "path resolves under Lustre or a mounted network filesystem "
+            "(e.g. /lustre/.../code_ultra/...): the underlying cause is filesystem "
+            "visibility on a served code tree, not a workload code fault."
         ),
         decision="RESTART",
         failure_domain="infrastructure",
@@ -197,10 +201,14 @@ CATEGORIES: tuple[CategoryDef, ...] = (
         id=16,
         name="Launch config or workload code deterministic error (TypeError/AttributeError)",
         description=(
-            "Deterministic workload/launch error that will recur on unchanged retry: "
-            "TypeError/AttributeError on None value threaded through model code (e.g. "
-            "float(None) in moe_layer postprocess), missing MASTER_ADDR, argparse error, "
-            "world-size mismatch, or other startup config/script fault."
+            "Deterministic runtime error inside already-loaded workload code that will "
+            "recur on unchanged retry: TypeError/AttributeError on None value threaded "
+            "through model code (e.g. float(None) in moe_layer postprocess), missing "
+            "MASTER_ADDR, argparse error, or world-size mismatch. Excludes "
+            "ModuleNotFoundError / ImportError where the failing import path resolves "
+            "under Lustre or a mounted network filesystem - those are cat 13 "
+            "(filesystem visibility), not a workload code fault, even if no adjacent "
+            "FileNotFoundError is present on the same line."
         ),
         decision="STOP",
         failure_domain="workload",

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
@@ -46,7 +46,9 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     CategoryDef(
         id=3,
         name="Node failure / SLURM externally terminated",
-        description=("SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."),
+        description=(
+            "SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."
+        ),
         decision="RESTART",
         failure_domain="infrastructure",
         retry_outlook="may_recover",

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
@@ -46,7 +46,9 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     CategoryDef(
         id=3,
         name="Node failure / SLURM externally terminated",
-        description=("SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."),
+        description=(
+            "SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."
+        ),
         decision="RESTART",
         failure_domain="infrastructure",
         retry_outlook="may_recover",
@@ -178,7 +180,10 @@ CATEGORIES: tuple[CategoryDef, ...] = (
         name="Post-checkpoint progress-log assertion",
         description=(
             "Assertion after checkpoint resume (progress-log bookkeeping); restart from "
-            "last committed checkpoint is appropriate."
+            "last committed checkpoint is appropriate. Prefer over cat 16 whenever the "
+            "AssertionError is raised in get_start_time_from_progress_log or references "
+            "a missing 'Starting job' progress-log entry - that specific bookkeeping "
+            "failure is transient and recoverable, not a deterministic code fault."
         ),
         decision="RESTART",
         failure_domain="workload",
@@ -228,7 +233,9 @@ CATEGORIES: tuple[CategoryDef, ...] = (
         name="PermissionError / dataset cache or filesystem permission",
         description=(
             "Deterministic permission-denied (EACCES/Errno 13) on dataset cache or "
-            "filesystem path."
+            "filesystem path. Prefer over cat 13 whenever the underlying errno is 13 "
+            "(EACCES) or the message reads PermissionError - unchanged retry will hit "
+            "the same permission fault, not a transient filesystem stall."
         ),
         decision="STOP",
         failure_domain="workload",
@@ -272,7 +279,12 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     CategoryDef(
         id=22,
         name="Checkpoint failure / missing checkpoint path",
-        description="Missing checkpoint path; cannot self-heal by restarting.",
+        description=(
+            "Missing checkpoint path; cannot self-heal by restarting. Prefer over "
+            "cat 9 whenever the FileNotFoundError names a specific missing shard file "
+            "(e.g. iter_XXXXX/__NNN_M.distcp) - restart cannot conjure the missing "
+            "file, so the retry is guaranteed to fail identically."
+        ),
         decision="STOP",
         failure_domain="workload",
         retry_outlook="cannot_recover",
@@ -326,7 +338,11 @@ CATEGORIES: tuple[CategoryDef, ...] = (
         name="CUDA OOM during checkpoint async-save",
         description=(
             "CUDA OOM inside the async checkpoint-save path on a near-full GPU; "
-            "determinism evidence lives outside the log."
+            "determinism evidence lives outside the log. Prefer over cat 25 whenever "
+            "the CUDA OOM appears in an async-checkpoint-save context (async_utils, "
+            "gather_object, save_state_dict_async, or any async ckpt-save frame) - "
+            "checkpoint-save OOMs need a checkpoint-side response rather than "
+            "generic OOM handling."
         ),
         decision="RESTART",
         failure_domain="workload",

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
@@ -46,9 +46,7 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     CategoryDef(
         id=3,
         name="Node failure / SLURM externally terminated",
-        description=(
-            "SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."
-        ),
+        description=("SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."),
         decision="RESTART",
         failure_domain="infrastructure",
         retry_outlook="may_recover",
@@ -180,10 +178,7 @@ CATEGORIES: tuple[CategoryDef, ...] = (
         name="Post-checkpoint progress-log assertion",
         description=(
             "Assertion after checkpoint resume (progress-log bookkeeping); restart from "
-            "last committed checkpoint is appropriate. Prefer over cat 16 whenever the "
-            "AssertionError is raised in get_start_time_from_progress_log or references "
-            "a missing 'Starting job' progress-log entry - that specific bookkeeping "
-            "failure is transient and recoverable, not a deterministic code fault."
+            "last committed checkpoint is appropriate."
         ),
         decision="RESTART",
         failure_domain="workload",
@@ -233,9 +228,7 @@ CATEGORIES: tuple[CategoryDef, ...] = (
         name="PermissionError / dataset cache or filesystem permission",
         description=(
             "Deterministic permission-denied (EACCES/Errno 13) on dataset cache or "
-            "filesystem path. Prefer over cat 13 whenever the underlying errno is 13 "
-            "(EACCES) or the message reads PermissionError - unchanged retry will hit "
-            "the same permission fault, not a transient filesystem stall."
+            "filesystem path."
         ),
         decision="STOP",
         failure_domain="workload",
@@ -279,12 +272,7 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     CategoryDef(
         id=22,
         name="Checkpoint failure / missing checkpoint path",
-        description=(
-            "Missing checkpoint path; cannot self-heal by restarting. Prefer over "
-            "cat 9 whenever the FileNotFoundError names a specific missing shard file "
-            "(e.g. iter_XXXXX/__NNN_M.distcp) - restart cannot conjure the missing "
-            "file, so the retry is guaranteed to fail identically."
-        ),
+        description="Missing checkpoint path; cannot self-heal by restarting.",
         decision="STOP",
         failure_domain="workload",
         retry_outlook="cannot_recover",
@@ -338,11 +326,7 @@ CATEGORIES: tuple[CategoryDef, ...] = (
         name="CUDA OOM during checkpoint async-save",
         description=(
             "CUDA OOM inside the async checkpoint-save path on a near-full GPU; "
-            "determinism evidence lives outside the log. Prefer over cat 25 whenever "
-            "the CUDA OOM appears in an async-checkpoint-save context (async_utils, "
-            "gather_object, save_state_dict_async, or any async ckpt-save frame) - "
-            "checkpoint-save OOMs need a checkpoint-side response rather than "
-            "generic OOM handling."
+            "determinism evidence lives outside the log."
         ),
         decision="RESTART",
         failure_domain="workload",

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
@@ -77,10 +77,12 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     ),
     CategoryDef(
         id=6,
-        name="DataLoader Bus error / Lustre or NIC",
+        name="DataLoader worker I/O failure (Bus error, BrokenPipe, Lustre or NIC)",
         description=(
-            "Transient data-path I/O failure (DataLoader worker Bus error, /dev/shm, "
-            "fatal Lustre read)."
+            "Transient data-path I/O failure inside a DataLoader worker: Bus error, "
+            "BrokenPipeError (Errno 108 transport endpoint shutdown) on Lustre-backed "
+            ".bin readinto, /dev/shm exhaustion, or fatal Lustre read. Distinguishes "
+            "from cat 13 by occurring in the DataLoader worker path."
         ),
         decision="RESTART",
         failure_domain="infrastructure",
@@ -112,8 +114,10 @@ CATEGORIES: tuple[CategoryDef, ...] = (
         id=9,
         name="Checkpoint failure / transient checkpoint I/O (load or async-write)",
         description=(
-            "Transient checkpoint load/async-write I/O failure (Errno 5/108, "
-            "filesystem_async); restart from last committed checkpoint."
+            "Transient checkpoint load/async-write I/O failure on a checkpoint path: "
+            "OSError Errno 5 (Input/output error), BrokenPipeError Errno 108, "
+            "filesystem_async. Prefer this over cat 13 whenever the failing path is "
+            "a checkpoint directory, even if the mechanism is generic filesystem I/O."
         ),
         decision="RESTART",
         failure_domain="infrastructure",
@@ -132,14 +136,13 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     ),
     CategoryDef(
         id=11,
-        name="NCCL remote process exited / network error",
+        name="NCCL remote process exited / network error / bootstrap Message-truncated",
         description=(
-            "NCCL Error 6 - remote peer exited; infrastructure/peer failure with no "
-            "upstream cause in this log. Also covers a NCCL bootstrap/transport "
-            "corruption ('Message truncated : received N bytes instead of M') during the "
-            "async-checkpoint-finalize gather_object communicator setup, where a "
-            "downstream rank0 Segmentation fault in the same finalize stack is NOT the "
-            "root (idx 640)."
+            "NCCL Error 6 (remote peer exited); infrastructure/peer failure. Also covers "
+            "NCCL bootstrap/transport corruption ('Message truncated : received N bytes "
+            "instead of M') during any distributed-checkpoint gather_object communicator "
+            "setup - both LOAD-side startup and async-finalize save-side - where a "
+            "downstream rank0 Segmentation fault in the same stack is NOT the root."
         ),
         decision="RESTART",
         failure_domain="infrastructure",
@@ -192,11 +195,12 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     ),
     CategoryDef(
         id=16,
-        name="Launch script or argument configuration error",
+        name="Launch config or workload code deterministic error (TypeError/AttributeError)",
         description=(
-            "Deterministic startup config/script error (AttributeError/TypeError on None "
-            "config value, missing MASTER_ADDR, argparse error, world-size mismatch - "
-            "includes archived idx 1401)."
+            "Deterministic workload/launch error that will recur on unchanged retry: "
+            "TypeError/AttributeError on None value threaded through model code (e.g. "
+            "float(None) in moe_layer postprocess), missing MASTER_ADDR, argparse error, "
+            "world-size mismatch, or other startup config/script fault."
         ),
         decision="STOP",
         failure_domain="workload",

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
@@ -46,9 +46,7 @@ CATEGORIES: tuple[CategoryDef, ...] = (
     CategoryDef(
         id=3,
         name="Node failure / SLURM externally terminated",
-        description=(
-            "SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."
-        ),
+        description=("SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."),
         decision="RESTART",
         failure_domain="infrastructure",
         retry_outlook="may_recover",

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static failure-category catalog used by the L1 category-selection field."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CategoryDef:
+    """One curated failure-category definition."""
+
+    id: int
+    name: str
+    description: str
+    decision: str  # STOP | RESTART | EXCLUDED
+    failure_domain: str  # workload | infrastructure | unknown | "" | "-"
+    retry_outlook: str  # may_recover | cannot_recover | "" | "-"
+
+
+CATEGORIES: tuple[CategoryDef, ...] = (
+    CategoryDef(
+        id=1,
+        name="SLURM step cancelled / drain / preemption",
+        description=(
+            "Clean external cancellation by the scheduler (scancel, drain, preemption); "
+            "no application fault."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=2,
+        name="NVLink / GPU error",
+        description=(
+            "Uncorrectable NVLink/GPU hardware error (Xid, ECC DBE, peer-access failure); "
+            "the device fault may be transient and clear on an in-place restart."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=3,
+        name="Node failure / SLURM externally terminated",
+        description=(
+            "SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=4,
+        name="Early/startup NCCL init or checkpoint-load timeout",
+        description=(
+            "NCCL init / checkpoint-load collective timeout before the first completed "
+            "training iteration; true cause usually not in this log."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=5,
+        name="IB port flap / NCCL watchdog timeout",
+        description=(
+            "IB port error / RDMA retry exhaustion killing collectives; the port flap is "
+            "typically transient and clears on an in-place restart."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=6,
+        name="DataLoader Bus error / Lustre or NIC",
+        description=(
+            "Transient data-path I/O failure (DataLoader worker Bus error, /dev/shm, "
+            "fatal Lustre read)."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=7,
+        name="Bad token / gradient Inf or NaN",
+        description=(
+            "Non-finite gradient/loss from a bad token or transient overflow; external "
+            "guidance is restart."
+        ),
+        decision="RESTART",
+        failure_domain="workload",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=8,
+        name="NCCL timeout mid-training",
+        description=(
+            "Watchdog collective timeout after at least one completed iteration; "
+            "consequence-class symptom, upstream cause often absent from the log."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=9,
+        name="Checkpoint failure / transient checkpoint I/O (load or async-write)",
+        description=(
+            "Transient checkpoint load/async-write I/O failure (Errno 5/108, "
+            "filesystem_async); restart from last committed checkpoint."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=10,
+        name="Distributed rendezvous / TCPStore socket timeout",
+        description=(
+            "c10d/TCPStore rendezvous socket timeout; startup/peer availability failure, "
+            "root cause not visible in log."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=11,
+        name="NCCL remote process exited / network error",
+        description=(
+            "NCCL Error 6 - remote peer exited; infrastructure/peer failure with no "
+            "upstream cause in this log. Also covers a NCCL bootstrap/transport "
+            "corruption ('Message truncated : received N bytes instead of M') during the "
+            "async-checkpoint-finalize gather_object communicator setup, where a "
+            "downstream rank0 Segmentation fault in the same finalize stack is NOT the "
+            "root (idx 640)."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=12,
+        name="Checkpoint failure / corrupt checkpoint metadata on load",
+        description=(
+            "Garbled checkpoint metadata buffer at load "
+            "(UnpicklingError/UnicodeDecodeError); transient corruption, checkpoint "
+            "likely reusable on healthy nodes."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=13,
+        name="Filesystem I/O error / Lustre or node-local FS",
+        description=(
+            "Non-checkpoint storage error (Lustre stall, missing generated dataset "
+            "cache); transient storage / node-local FS issue."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=14,
+        name="Post-checkpoint progress-log assertion",
+        description=(
+            "Assertion after checkpoint resume (progress-log bookkeeping); restart from "
+            "last committed checkpoint is appropriate."
+        ),
+        decision="RESTART",
+        failure_domain="workload",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=15,
+        name="OSError Errno 98 / port bind race",
+        description=(
+            "Fatal port-bind failure (EADDRINUSE) at the rendezvous master; startup "
+            "race, job died at bind with no progress."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=16,
+        name="Launch script or argument configuration error",
+        description=(
+            "Deterministic startup config/script error (AttributeError/TypeError on None "
+            "config value, missing MASTER_ADDR, argparse error, world-size mismatch - "
+            "includes archived idx 1401)."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=17,
+        name="Dataset missing indexed data files",
+        description=(
+            "Dataset .idx/.bin files missing at dataset init; deterministic against the "
+            "same config until dataset path/files are fixed."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=18,
+        name="PermissionError / dataset cache or filesystem permission",
+        description=(
+            "Deterministic permission-denied (EACCES/Errno 13) on dataset cache or "
+            "filesystem path."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=19,
+        name="Checkpoint failure / deterministic checkpoint format or shape mismatch",
+        description=(
+            "Checkpoint-load shape/key/TP-PP mismatch with zero completed iterations; "
+            "deterministic against same checkpoint + code/config."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=20,
+        name="Triton cubin / TorchInductor software toolchain error",
+        description=(
+            "Triton autotuner KeyError 'Unknown key: cubin' on mamba_ssm kernels "
+            "(idx 1311/1418/1420) + TorchInductor StaticCudaLauncher 'CUDA driver error: "
+            "file not found' at JIT warmup (idx 1417); clean Python exceptions, "
+            "multi-node, deterministic in-container."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=21,
+        name="CUDA illegal op in CUDA graph capture",
+        description=(
+            "Illegal CUDA operation during graph capture; deterministic code bug on the "
+            "same code path."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=22,
+        name="Checkpoint failure / missing checkpoint path",
+        description="Missing checkpoint path; cannot self-heal by restarting.",
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=23,
+        name="Checkpoint failure / async-save finalize code error",
+        description=(
+            "Deterministic code error (e.g. NoneType AttributeError) in the "
+            "post-training async-save FINALIZE path."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=24,
+        name="CPU OOM / Linux OOM killer",
+        description=(
+            "Host memory exhausted (oom_kill). Old STOP rested on a same-job/config "
+            "recurrence presumption, not on in-log evidence."
+        ),
+        decision="RESTART",
+        failure_domain="workload",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=25,
+        name="CUDA OOM",
+        description=(
+            "Device OOM at fixed batch/config. Old STOP rested on a same-job/config "
+            "determinism presumption, not on in-log evidence."
+        ),
+        decision="RESTART",
+        failure_domain="workload",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=26,
+        name="CUDA unspecified launch failure",
+        description=(
+            "cudaErrorLaunchFailure; a single log cannot separate transient "
+            "hardware/runtime state from a deterministic kernel/code bug."
+        ),
+        decision="RESTART",
+        failure_domain="unknown",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=27,
+        name="CUDA OOM during checkpoint async-save",
+        description=(
+            "CUDA OOM inside the async checkpoint-save path on a near-full GPU; "
+            "determinism evidence lives outside the log."
+        ),
+        decision="RESTART",
+        failure_domain="workload",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=28,
+        name="Suspected SDC / DP-replica weight-hash mismatch",
+        description=(
+            "DP-replica weight-hash mismatch (suspected silent data corruption); restart "
+            "from last good checkpoint is plausibly safe."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=29,
+        name="NVRx used (multi-cycle, deferred)",
+        description=(
+            "ft_launcher restarted the worker group in-job; one file concatenates "
+            "multiple training cycles with separate root causes."
+        ),
+        decision="EXCLUDED",
+        failure_domain="",
+        retry_outlook="",
+    ),
+    CategoryDef(
+        id=30,
+        name="Container / Pyxis setup failure",
+        description=(
+            "Container never started (pyxis couldn't start container / enroot failure); "
+            "transient node-local runtime vs bad image undecidable from one log."
+        ),
+        decision="EXCLUDED",
+        failure_domain="",
+        retry_outlook="",
+    ),
+    CategoryDef(
+        id=31,
+        name="Incomplete / truncated log",
+        description=(
+            "Whole-file scan finds no failure signal and the log has no clean ending; "
+            "likely a log-collection failure."
+        ),
+        decision="EXCLUDED",
+        failure_domain="",
+        retry_outlook="",
+    ),
+    CategoryDef(
+        id=32,
+        name="No failure observed / clean planned exit",
+        description=(
+            "Whole-file scan finds no failure: the run reached its exit_interval / final "
+            "iteration, saved the final checkpoint, logged training energy, and only "
+            "benign teardown (destroy_process_group / CudaIPC cleanup) follows. Includes "
+            "the reset_opt_norm 'Unexpected keys' benign-WARNING trap and "
+            "recovered-then-clean runs."
+        ),
+        decision="RESTART",
+        failure_domain="-",
+        retry_outlook="-",
+    ),
+    CategoryDef(
+        id=33,
+        name="Segmentation fault / native runtime crash",
+        description=(
+            "Single-rank (rank 608) SIGSEGV in torch's pinned host allocator during "
+            "GPTDataset index load, wild HIGH address (not 0x8), no self-reported "
+            "corruption guard and no HW signal; a single log genuinely cannot separate a "
+            "torch race from host-memory corruption."
+        ),
+        decision="RESTART",
+        failure_domain="unknown",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=34,
+        name="Node-local native SIGBUS (Triton/TE native kernel)",
+        description=(
+            "Native SIGBUS confined to one node/tray, two forms: (a) during Triton JIT "
+            ".so dlopen/mmap at kernel load (idx 1006; driver.py "
+            "compile_module_from_src -> create_module; zero iterations); (b) mid-training "
+            "in the TE/Triton MoE permutation forward (idx 534; permutation.py; one "
+            "node's 4 ranks after ckpt 27600 while thousands of peers keep running). "
+            "Node-local hardware/memory fault."
+        ),
+        decision="RESTART",
+        failure_domain="infrastructure",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=35,
+        name="Startup native SIGSEGV / torch pin_memory host-allocator",
+        description=(
+            "Native SIGSEGV 'address not mapped to object at address 0x8' (null-ptr "
+            "deref) with a byte-identical backtrace through at::native::_pin_memory into "
+            "the libtorch_cuda CachingHostAllocator pinned-map operator[], fired at "
+            "[before the start of training step] with zero completed iterations. "
+            "pin_cpu_grads/pin_cpu_params=True forces the path in-log; crashing node "
+            "sets differ across jobs (rules out node-local hardware); reproduces every "
+            "rerun. 20 samples = 11 unique files (9 md5 mirror pairs)."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=36,
+        name="Checkpoint failure / save-path native crash (PyTorchStreamWriter)",
+        description=(
+            "Mass SIGSEGV across 20+ nodes inside PyTorchStreamWriter::writeRecord "
+            "(mz_zip_writer_add_mem_ex_v2) during the first torch_dist checkpoint save "
+            "right after iteration 250; structural (shape/config-determined) serializer "
+            "buffer overrun. 2 samples = 1 unique file (idx 107 = idx 381, byte-identical "
+            "mirror)."
+        ),
+        decision="STOP",
+        failure_domain="workload",
+        retry_outlook="cannot_recover",
+    ),
+    CategoryDef(
+        id=37,
+        name="Native heap corruption / glibc malloc abort",
+        description=(
+            "Single-rank glibc 'malloc(): unaligned tcache chunk detected' abort at "
+            "training start (pre-first-iter); self-reported in-process heap corruption = "
+            "definitively software."
+        ),
+        decision="RESTART",
+        failure_domain="workload",
+        retry_outlook="may_recover",
+    ),
+    CategoryDef(
+        id=38,
+        name="Off-file termination / external teardown (cause not in log)",
+        description=(
+            "Healthy training then an external-signal all-thread faulthandler dump (no "
+            "'Fatal Python error' / no 'Current thread 0x'), log truncated mid-dump; no "
+            "in-file CANCELLED / watchdog / IB / Xid / NVRx marker. A real termination "
+            "occurred but its cause is off-file (most likely a SLURM cancel/preempt/"
+            "timeout)."
+        ),
+        decision="RESTART",
+        failure_domain="unknown",
+        retry_outlook="may_recover",
+    ),
+)
+
+
+_BY_ID: dict[int, CategoryDef] = {entry.id: entry for entry in CATEGORIES}
+
+
+def category_by_id(cid: int) -> CategoryDef | None:
+    """Return the curated category for ``cid`` if known, else ``None``."""
+
+    if not isinstance(cid, int) or isinstance(cid, bool):
+        return None
+    return _BY_ID.get(cid)
+
+
+__all__ = ["CATEGORIES", "CategoryDef", "category_by_id"]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/contracts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/contracts.py
@@ -79,6 +79,20 @@ class L1EvidenceResult:
             anomalies={"l1_enabled": False},
         )
 
+    def category_selection(self) -> dict[str, Any] | None:
+        """Return the model's optional curated-category selection, if any."""
+
+        if self.evidence is None:
+            return None
+        selection = self.evidence.get("category_selection")
+        if not isinstance(selection, Mapping):
+            return None
+        return {
+            "category_id": selection.get("category_id"),
+            "category_confidence": selection.get("category_confidence"),
+            "category_rationale": selection.get("category_rationale"),
+        }
+
     def to_trace(self) -> dict[str, Any]:
         return {
             "enabled": bool(self.model),

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
@@ -5,9 +5,11 @@
 
 from __future__ import annotations
 
+from .categories import CATEGORIES
 from .response_contract import L1_RESPONSE_CONTRACT
 
 _SUPPORT_TAGS = ", ".join(sorted(L1_RESPONSE_CONTRACT.evidence_support_tags))
+_CATEGORY_LIST = "\n".join(f"  {entry.id}. {entry.name}" for entry in CATEGORIES)
 
 SYSTEM_PROMPT = f"""\
 Analyze one distributed-training log and return the structured current-log evidence
@@ -101,6 +103,18 @@ analysis_status=insufficient_evidence, root-cause summary to
 "{L1_RESPONSE_CONTRACT.insufficient_rationale}", the same canonical unknown recovery
 claims, and list at least one missing-evidence item. Related failure lines are grounded
 diagnostic references, not additional policy-claim citations.
+
+Category classification:
+- After the primary_failure and typed recovery claims, include one additional top-level
+  JSON field named category_selection with three keys: category_id (integer 0-38),
+  category_confidence (integer 0-100), and category_rationale (string, at most 400
+  characters).
+- Choose the single best-fitting id from the curated list below. Use category_id=0 and
+  category_confidence=0 when no listed category matches or when you are uncertain.
+- Ground category_rationale in current-log evidence. The rationale is advisory; it does
+  not replace the typed recovery claims above.
+- The curated categories are:
+{_CATEGORY_LIST}
 
 Return one compact JSON object matching the supplied schema. Include only the strongest
 evidence and at most three related failures. Emit no fingerprint, data-position identity,

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
@@ -9,7 +9,9 @@ from .categories import CATEGORIES
 from .response_contract import L1_RESPONSE_CONTRACT
 
 _SUPPORT_TAGS = ", ".join(sorted(L1_RESPONSE_CONTRACT.evidence_support_tags))
-_CATEGORY_LIST = "\n".join(f"  {entry.id}. {entry.name}" for entry in CATEGORIES)
+_CATEGORY_LIST = "\n".join(
+    f"  {entry.id}. {entry.name}\n     {entry.description}" for entry in CATEGORIES
+)
 
 SYSTEM_PROMPT = f"""\
 Analyze one distributed-training log and return the structured current-log evidence

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/response_contract.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/response_contract.py
@@ -38,6 +38,15 @@ class L1ResponseContract:
             "evidence",
         }
     )
+    optional_top_level_fields: frozenset[str] = frozenset({"category_selection"})
+    category_selection_fields: frozenset[str] = frozenset(
+        {"category_id", "category_confidence", "category_rationale"}
+    )
+    min_category_id: int = 0
+    max_category_id: int = 38
+    min_category_confidence: int = 0
+    max_category_confidence: int = 100
+    max_category_rationale_chars: int = 400
     primary_failure_fields: frozenset[str] = frozenset({"line", "causal_role", "failure_identity"})
     failure_identity_fields: frozenset[str] = frozenset(
         {"operation", "mechanism", "component", "artifact_path"}
@@ -150,12 +159,49 @@ class L1ResponseContract:
                 "failure_identity": failure_identity,
             },
         }
+        category_selection = {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(self.category_selection_fields),
+            "description": (
+                "Optional curated failure-category selection used by L4 for a "
+                "category-lookup decision gate."
+            ),
+            "properties": {
+                "category_id": {
+                    "type": "integer",
+                    "minimum": self.min_category_id,
+                    "maximum": self.max_category_id,
+                    "description": (
+                        "Curated category id (1-38); use 0 when no category matches "
+                        "or when uncertain."
+                    ),
+                },
+                "category_confidence": {
+                    "type": "integer",
+                    "minimum": self.min_category_confidence,
+                    "maximum": self.max_category_confidence,
+                    "description": (
+                        "Confidence in the selected category on a 0..100 scale; "
+                        "must be 0 when category_id is 0."
+                    ),
+                },
+                "category_rationale": {
+                    "type": "string",
+                    "maxLength": self.max_category_rationale_chars,
+                    "description": (
+                        "Short (<= 400 chars) rationale grounded in current-log evidence."
+                    ),
+                },
+            },
+        }
         return {
             "type": "object",
             "additionalProperties": False,
             "required": sorted(self.top_level_fields),
             "properties": {
                 "schema_version": {"type": "string", "const": L1_EVIDENCE_SCHEMA_VERSION},
+                "category_selection": {"oneOf": [category_selection, {"type": "null"}]},
                 "analysis_status": {
                     "type": "string",
                     "enum": sorted(self.analysis_statuses),

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
@@ -11,6 +11,182 @@ from ..models import L1_EVIDENCE_SCHEMA_VERSION, AssessmentStatus, L1AnalysisSta
 from .response_contract import L1_RESPONSE_CONTRACT
 
 
+def repair_biconditional_unknowns(payload: Any) -> list[str]:
+    """In-place fix: normalize model_recovery_assessment claim (value, status) pairs.
+
+    Contract rule: value == "unknown" iff status == "unknown". Some models
+    (observed: nemotron) mis-read `unknown` as "not fully committed" and pair
+    value=unknown with status=supported_but_unconfirmed / hypothesis_only. This
+    repair silently normalizes such pairs to value=unknown / status=unknown
+    (dropping any confidence hint on the claim to reflect the demotion), rather
+    than rejecting the entire L1 response.
+
+    Returns a list of repair notes for observability. Empty list means no
+    repair was applied.
+    """
+
+    notes: list[str] = []
+    if not isinstance(payload, dict):
+        return notes
+    assessment = payload.get("model_recovery_assessment")
+    if not isinstance(assessment, dict):
+        return notes
+    for field in ("failure_domain", "retry_outlook_without_workload_change"):
+        claim = assessment.get(field)
+        if not isinstance(claim, dict):
+            continue
+        claim_value = claim.get("value")
+        claim_status = claim.get("status")
+        if (claim_value == "unknown") == (claim_status == AssessmentStatus.UNKNOWN.value):
+            continue
+        # Biconditional violated. Normalize both sides to unknown/unknown and
+        # keep the claim structurally valid so downstream validation passes.
+        claim["value"] = "unknown"
+        claim["status"] = AssessmentStatus.UNKNOWN.value
+        if "confidence" in claim and not (
+            isinstance(claim["confidence"], int) and not isinstance(claim["confidence"], bool)
+        ):
+            # keep confidence field valid; the model's number stays if it was a legal int
+            claim["confidence"] = L1_RESPONSE_CONTRACT.min_confidence
+        notes.append(
+            f"model_recovery_assessment.{field}: normalized "
+            f"(value={claim_value!r}, status={claim_status!r}) -> unknown/unknown"
+        )
+    return notes
+
+
+def repair_overlong_lists(payload: Any) -> list[str]:
+    """In-place fix: truncate over-long enumerable lists to their contract caps.
+
+    Some models return more items than the contract allows on
+    root_cause_assessment.plausible_causes, root_cause_assessment.missing_evidence,
+    or related_failures. Truncating (keep first N) preserves the strongest items
+    the model already ranked at the top rather than rejecting the whole response.
+
+    Returns a list of repair notes for observability. Empty list means no
+    repair was applied.
+    """
+
+    notes: list[str] = []
+    if not isinstance(payload, dict):
+        return notes
+    root_cause = payload.get("root_cause_assessment")
+    if isinstance(root_cause, dict):
+        for field, cap in (
+            ("plausible_causes", L1_RESPONSE_CONTRACT.max_plausible_causes),
+            ("missing_evidence", L1_RESPONSE_CONTRACT.max_missing_evidence),
+        ):
+            items = root_cause.get(field)
+            if isinstance(items, list) and len(items) > cap:
+                root_cause[field] = items[:cap]
+                notes.append(
+                    f"root_cause_assessment.{field}: truncated {len(items)} -> {cap} items"
+                )
+    related = payload.get("related_failures")
+    if isinstance(related, list) and len(related) > L1_RESPONSE_CONTRACT.max_related_failures:
+        payload["related_failures"] = related[: L1_RESPONSE_CONTRACT.max_related_failures]
+        notes.append(
+            f"related_failures: truncated {len(related)} -> "
+            f"{L1_RESPONSE_CONTRACT.max_related_failures} items"
+        )
+    return notes
+
+
+def repair_invalid_evidence_supports(payload: Any) -> list[str]:
+    """In-place fix: drop unknown/invalid tags from evidence[N].supports arrays.
+
+    The contract restricts evidence.supports to four tags: primary_failure,
+    root_cause_assessment, failure_domain, retry_outlook_without_workload_change.
+    Some models (observed: nemotron) mistakenly use a section-name like
+    "related_failures" as a support tag. Rather than reject the whole response,
+    drop the invalid tags and keep the valid ones. If an item ends up with an
+    empty supports array after filtering, drop the item entirely.
+
+    Returns a list of repair notes for observability. Empty list means no
+    repair was applied.
+    """
+
+    notes: list[str] = []
+    if not isinstance(payload, dict):
+        return notes
+    evidence = payload.get("evidence")
+    if not isinstance(evidence, list):
+        return notes
+    valid_tags = L1_RESPONSE_CONTRACT.evidence_support_tags
+    kept: list[Any] = []
+    for index, item in enumerate(evidence):
+        if not isinstance(item, dict):
+            kept.append(item)
+            continue
+        supports = item.get("supports")
+        if not isinstance(supports, list):
+            kept.append(item)
+            continue
+        cleaned: list[str] = []
+        seen: set[str] = set()
+        for tag in supports:
+            if isinstance(tag, str) and tag in valid_tags and tag not in seen:
+                cleaned.append(tag)
+                seen.add(tag)
+        if cleaned == list(supports):
+            kept.append(item)
+            continue
+        dropped = [t for t in supports if t not in cleaned]
+        if not cleaned:
+            notes.append(
+                f"evidence[{index}]: dropped entirely (no valid supports left; "
+                f"originally {supports!r})"
+            )
+            continue
+        item["supports"] = cleaned
+        notes.append(
+            f"evidence[{index}]: dropped invalid supports {dropped!r}, kept {cleaned!r}"
+        )
+        kept.append(item)
+    if len(kept) != len(evidence):
+        payload["evidence"] = kept
+    return notes
+
+
+def repair_overlong_category_rationale(payload: Any) -> list[str]:
+    """In-place fix: truncate category_selection.category_rationale to the contract cap.
+
+    Some models produce a rationale longer than max_category_rationale_chars (400).
+    Truncating preserves the leading, most-relevant content rather than rejecting
+    the whole response.
+
+    Returns a list of repair notes for observability. Empty list means no
+    repair was applied.
+    """
+
+    notes: list[str] = []
+    if not isinstance(payload, dict):
+        return notes
+    selection = payload.get("category_selection")
+    if not isinstance(selection, dict):
+        return notes
+    rationale = selection.get("category_rationale")
+    max_chars = L1_RESPONSE_CONTRACT.max_category_rationale_chars
+    if isinstance(rationale, str) and len(rationale) > max_chars:
+        selection["category_rationale"] = rationale[:max_chars]
+        notes.append(
+            f"category_selection.category_rationale: truncated "
+            f"{len(rationale)} -> {max_chars} chars"
+        )
+    return notes
+
+
+def repair_model_evidence(payload: Any) -> list[str]:
+    """Aggregate all in-place repairs. Returns the concatenated repair notes."""
+
+    notes: list[str] = []
+    notes.extend(repair_biconditional_unknowns(payload))
+    notes.extend(repair_overlong_lists(payload))
+    notes.extend(repair_invalid_evidence_supports(payload))
+    notes.extend(repair_overlong_category_rationale(payload))
+    return notes
+
+
 def model_evidence_contract_errors(payload: Mapping[str, Any]) -> list[str]:
     """Return structural errors without applying semantic policy judgment."""
 
@@ -57,7 +233,24 @@ def model_evidence_contract_errors(payload: Mapping[str, Any]) -> list[str]:
     errors.extend(evidence_errors)
 
     if analysis_status == L1AnalysisStatus.PRIMARY_IDENTIFIED.value:
+        assessment = payload.get("model_recovery_assessment")
         for required_support in sorted(L1_RESPONSE_CONTRACT.required_primary_support_tags):
+            # For the two model_recovery_assessment claims (failure_domain and
+            # retry_outlook_without_workload_change), waive the citation requirement
+            # when the claim is unknown/unknown. A claim of unknown/unknown means
+            # "no informative evidence for this dimension", so requiring an evidence
+            # citation would be self-contradictory.
+            if required_support in {
+                "failure_domain",
+                "retry_outlook_without_workload_change",
+            } and isinstance(assessment, Mapping):
+                claim = assessment.get(required_support)
+                if (
+                    isinstance(claim, Mapping)
+                    and claim.get("value") == "unknown"
+                    and claim.get("status") == AssessmentStatus.UNKNOWN.value
+                ):
+                    continue
             if required_support not in support_tags:
                 errors.append(f"evidence must support {required_support}")
     elif analysis_status in {

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
@@ -14,7 +14,13 @@ from .response_contract import L1_RESPONSE_CONTRACT
 def model_evidence_contract_errors(payload: Mapping[str, Any]) -> list[str]:
     """Return structural errors without applying semantic policy judgment."""
 
-    errors = _object_shape_errors(payload, L1_RESPONSE_CONTRACT.top_level_fields, "top-level")
+    errors = _object_shape_errors(
+        payload,
+        L1_RESPONSE_CONTRACT.top_level_fields,
+        "top-level",
+        optional=L1_RESPONSE_CONTRACT.optional_top_level_fields,
+    )
+    errors.extend(_category_selection_errors(payload.get("category_selection")))
     if payload.get("schema_version") != L1_EVIDENCE_SCHEMA_VERSION:
         errors.append(f"schema_version must be {L1_EVIDENCE_SCHEMA_VERSION}")
 
@@ -66,14 +72,61 @@ def _object_shape_errors(
     value: Mapping[str, Any],
     expected: frozenset[str],
     field: str,
+    *,
+    optional: frozenset[str] = frozenset(),
 ) -> list[str]:
     errors: list[str] = []
     missing = sorted(expected.difference(value))
-    extra = sorted(set(value).difference(expected))
+    extra = sorted(set(value).difference(expected).difference(optional))
     if missing:
         errors.append(f"{field} missing fields: " + ", ".join(missing))
     if extra:
         errors.append(f"{field} has unsupported fields: " + ", ".join(extra))
+    return errors
+
+
+def _category_selection_errors(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, Mapping):
+        return ["category_selection must be an object or null"]
+    errors = _object_shape_errors(
+        value,
+        L1_RESPONSE_CONTRACT.category_selection_fields,
+        "category_selection",
+    )
+    cid = value.get("category_id")
+    if (
+        isinstance(cid, bool)
+        or not isinstance(cid, int)
+        or cid < L1_RESPONSE_CONTRACT.min_category_id
+        or cid > L1_RESPONSE_CONTRACT.max_category_id
+    ):
+        errors.append(
+            "category_selection.category_id must be an integer from "
+            f"{L1_RESPONSE_CONTRACT.min_category_id} to "
+            f"{L1_RESPONSE_CONTRACT.max_category_id}"
+        )
+    confidence = value.get("category_confidence")
+    if (
+        isinstance(confidence, bool)
+        or not isinstance(confidence, int)
+        or confidence < L1_RESPONSE_CONTRACT.min_category_confidence
+        or confidence > L1_RESPONSE_CONTRACT.max_category_confidence
+    ):
+        errors.append(
+            "category_selection.category_confidence must be an integer from "
+            f"{L1_RESPONSE_CONTRACT.min_category_confidence} to "
+            f"{L1_RESPONSE_CONTRACT.max_category_confidence}"
+        )
+    rationale = value.get("category_rationale")
+    if not isinstance(rationale, str):
+        errors.append("category_selection.category_rationale must be a string")
+    elif len(rationale) > L1_RESPONSE_CONTRACT.max_category_rationale_chars:
+        errors.append(
+            "category_selection.category_rationale must be at most "
+            f"{L1_RESPONSE_CONTRACT.max_category_rationale_chars} characters"
+        )
     return errors
 
 

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
@@ -174,10 +174,51 @@ def repair_overlong_category_rationale(payload: Any) -> list[str]:
     return notes
 
 
+def repair_schema_version(payload: Any) -> list[str]:
+    """In-place fix: normalize a similar-but-wrong schema_version string.
+
+    Some models (observed: gemini) hallucinate a schema version like
+    "restart_agent_decision_evidence.v1" instead of the expected
+    "restart_agent_evidence.v1" - the "decision" substring is bleed-through
+    from another schema name used elsewhere in the analyzer artifacts.
+
+    Only rewrites when the payload is otherwise shaped like this schema
+    (has an analysis_status field) and the current schema_version either
+    is missing or starts with "restart_agent". This prevents silently
+    accepting a truly foreign payload while forgiving cosmetic model errors.
+
+    Returns a list of repair notes for observability. Empty list means no
+    repair was applied.
+    """
+
+    notes: list[str] = []
+    if not isinstance(payload, dict):
+        return notes
+    if payload.get("analysis_status") is None:
+        # Not obviously our schema; do not touch.
+        return notes
+    actual = payload.get("schema_version")
+    if actual == L1_EVIDENCE_SCHEMA_VERSION:
+        return notes
+    if actual is None:
+        payload["schema_version"] = L1_EVIDENCE_SCHEMA_VERSION
+        notes.append(
+            f"schema_version: added missing field, set to {L1_EVIDENCE_SCHEMA_VERSION!r}"
+        )
+    elif isinstance(actual, str) and actual.startswith("restart_agent"):
+        payload["schema_version"] = L1_EVIDENCE_SCHEMA_VERSION
+        notes.append(
+            f"schema_version: normalized {actual!r} -> {L1_EVIDENCE_SCHEMA_VERSION!r} "
+            f"(model hallucinated similar version string)"
+        )
+    return notes
+
+
 def repair_model_evidence(payload: Any) -> list[str]:
     """Aggregate all in-place repairs. Returns the concatenated repair notes."""
 
     notes: list[str] = []
+    notes.extend(repair_schema_version(payload))
     notes.extend(repair_biconditional_unknowns(payload))
     notes.extend(repair_overlong_lists(payload))
     notes.extend(repair_invalid_evidence_supports(payload))

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
@@ -139,9 +139,7 @@ def repair_invalid_evidence_supports(payload: Any) -> list[str]:
             )
             continue
         item["supports"] = cleaned
-        notes.append(
-            f"evidence[{index}]: dropped invalid supports {dropped!r}, kept {cleaned!r}"
-        )
+        notes.append(f"evidence[{index}]: dropped invalid supports {dropped!r}, kept {cleaned!r}")
         kept.append(item)
     if len(kept) != len(evidence):
         payload["evidence"] = kept

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
@@ -202,9 +202,7 @@ def repair_schema_version(payload: Any) -> list[str]:
         return notes
     if actual is None:
         payload["schema_version"] = L1_EVIDENCE_SCHEMA_VERSION
-        notes.append(
-            f"schema_version: added missing field, set to {L1_EVIDENCE_SCHEMA_VERSION!r}"
-        )
+        notes.append(f"schema_version: added missing field, set to {L1_EVIDENCE_SCHEMA_VERSION!r}")
     elif isinstance(actual, str) and actual.startswith("restart_agent"):
         payload["schema_version"] = L1_EVIDENCE_SCHEMA_VERSION
         notes.append(

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
@@ -30,6 +30,14 @@ SELECTED_RULE_BUDGET_ID = "selected_rule_budget"
 CATEGORY_CONFIDENCE_THRESHOLD = 80
 
 
+def _resolve_category_threshold(policy_input: "L4PolicyInput") -> int:
+    """Per-model confidence threshold; default 80. GPT is better-calibrated (drop to 70)."""
+    override = getattr(policy_input, "category_confidence_threshold", None)
+    if isinstance(override, int) and 0 <= override <= 100:
+        return override
+    return CATEGORY_CONFIDENCE_THRESHOLD
+
+
 @dataclass(frozen=True)
 class L4PolicyInput:
     primary: FailureEvidence | None
@@ -40,6 +48,7 @@ class L4PolicyInput:
     retry_policy: RetryPolicyConfig = RetryPolicyConfig()
     declared_recovery_capabilities: tuple[DeclaredRecoveryCapability, ...] = ()
     l1_category_selection: Optional[dict] = None
+    category_confidence_threshold: Optional[int] = None
 
     def __post_init__(self) -> None:
         if self.model_recovery_assessment is not None and not isinstance(
@@ -196,7 +205,7 @@ def evaluate_policy(policy_input: L4PolicyInput) -> L4PolicyOutcome:
     )
     category_action = _category_selection_qualifies_action(
         policy_input,
-        min_confidence=CATEGORY_CONFIDENCE_THRESHOLD,
+        min_confidence=_resolve_category_threshold(policy_input),
     )
     rule = _select_rule(
         primary=policy_input.primary,

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
@@ -383,11 +383,7 @@ def _category_selection_qualifies_action(
         return None
     cid = selection.get("category_id")
     confidence = selection.get("category_confidence")
-    if (
-        isinstance(cid, bool)
-        or not isinstance(cid, int)
-        or cid <= 0
-    ):
+    if isinstance(cid, bool) or not isinstance(cid, int) or cid <= 0:
         return None
     if (
         isinstance(confidence, bool)

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
@@ -6,8 +6,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
+from ..l1.categories import CategoryDef, category_by_id
 from ..models import (
     AffectedEntity,
     AssessmentStatus,
@@ -26,6 +27,7 @@ from ..models import (
 
 GENERAL_ROOT_CEILING_ID = "general_root_ceiling"
 SELECTED_RULE_BUDGET_ID = "selected_rule_budget"
+CATEGORY_CONFIDENCE_THRESHOLD = 80
 
 
 @dataclass(frozen=True)
@@ -37,6 +39,7 @@ class L4PolicyInput:
     assessment_grounded: bool = False
     retry_policy: RetryPolicyConfig = RetryPolicyConfig()
     declared_recovery_capabilities: tuple[DeclaredRecoveryCapability, ...] = ()
+    l1_category_selection: Optional[dict] = None
 
     def __post_init__(self) -> None:
         if self.model_recovery_assessment is not None and not isinstance(
@@ -191,6 +194,10 @@ def evaluate_policy(policy_input: L4PolicyInput) -> L4PolicyOutcome:
         )
         else None
     )
+    category_action = _category_selection_qualifies_action(
+        policy_input,
+        min_confidence=CATEGORY_CONFIDENCE_THRESHOLD,
+    )
     rule = _select_rule(
         primary=policy_input.primary,
         current_affected_entity=policy_input.current_affected_entity,
@@ -200,6 +207,13 @@ def evaluate_policy(policy_input: L4PolicyInput) -> L4PolicyOutcome:
         outlook=outlook,
         outlook_status=outlook_status,
         current_evidence_qualified=current_evidence_qualified,
+        category_action=category_action,
+    )
+    category_confirmed_stop = bool(
+        category_action is not None
+        and category_action.decision == "STOP"
+        and rule == RetryPolicyRule.WORKLOAD_UNRECOVERABLE.value
+        and policy_input.primary is not None
     )
 
     general_root_ceiling = _general_root_ceiling(
@@ -231,6 +245,7 @@ def evaluate_policy(policy_input: L4PolicyInput) -> L4PolicyOutcome:
         rule=rule,
         retry_budget_exhausted=retry_budget_exhausted,
         observed_advance=observed_advance,
+        category_confirmed_stop=category_confirmed_stop,
     )
     selected_scope = (
         selected_rule_budget.history_match_scope
@@ -311,9 +326,18 @@ def _select_rule(
     outlook: str | None,
     outlook_status: str | None,
     current_evidence_qualified: bool,
+    category_action: CategoryDef | None = None,
 ) -> str | None:
     if primary is None:
         return None
+    # High-confidence curated-category gate takes precedence over the typed cannot_recover
+    # check when the category has a definite STOP/RESTART recommendation. EXCLUDED and
+    # unknown categories fall through to the existing logic.
+    if category_action is not None and applied_capability is None:
+        if category_action.decision == "STOP":
+            return RetryPolicyRule.WORKLOAD_UNRECOVERABLE.value
+        if category_action.decision == "RESTART":
+            return RetryPolicyRule.GENERAL_RETRY.value
     if applied_capability is not None:
         return RetryPolicyRule.WORKLOAD_MANAGED_RECOVERY.value
     if matching_capability is not None:
@@ -333,6 +357,41 @@ def _select_rule(
     ):
         return RetryPolicyRule.BOUNDED_RETRY.value
     return RetryPolicyRule.GENERAL_RETRY.value
+
+
+def _category_selection_qualifies_action(
+    l1_result: "L4PolicyInput",
+    min_confidence: int = CATEGORY_CONFIDENCE_THRESHOLD,
+) -> CategoryDef | None:
+    """Return the curated category if selection meets the confidence gate.
+
+    Skips EXCLUDED categories and low-confidence or missing selections so the
+    caller falls through to the existing L4 logic.
+    """
+
+    selection = l1_result.l1_category_selection
+    if not isinstance(selection, Mapping):
+        return None
+    cid = selection.get("category_id")
+    confidence = selection.get("category_confidence")
+    if (
+        isinstance(cid, bool)
+        or not isinstance(cid, int)
+        or cid <= 0
+    ):
+        return None
+    if (
+        isinstance(confidence, bool)
+        or not isinstance(confidence, int)
+        or confidence < min_confidence
+    ):
+        return None
+    category = category_by_id(cid)
+    if category is None:
+        return None
+    if category.decision == "EXCLUDED":
+        return None
+    return category
 
 
 def _general_root_ceiling(
@@ -491,10 +550,13 @@ def _decision(
     rule: str | None,
     retry_budget_exhausted: bool,
     observed_advance: bool,
+    category_confirmed_stop: bool = False,
 ) -> tuple[str, str]:
     if primary is None:
         return Decision.RESTART.value, DecisionBasis.NO_PRIMARY_FAILURE.value
     if rule == RetryPolicyRule.WORKLOAD_UNRECOVERABLE.value:
+        if category_confirmed_stop:
+            return Decision.STOP.value, DecisionBasis.CATEGORY_CONFIRMED_STOP.value
         return Decision.STOP.value, DecisionBasis.WORKLOAD_UNRECOVERABLE.value
     if retry_budget_exhausted:
         return Decision.STOP.value, DecisionBasis.RETRY_BUDGET_EXHAUSTED.value

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/models.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/models.py
@@ -37,6 +37,7 @@ class Decision(str, Enum):
 class DecisionBasis(str, Enum):
     LOG_UNAVAILABLE = "log_unavailable"
     WORKLOAD_UNRECOVERABLE = "workload_unrecoverable"
+    CATEGORY_CONFIRMED_STOP = "category_confirmed_stop"
     RETRY_BUDGET_EXHAUSTED = "retry_budget_exhausted"
     RETRY_RECOVERY_AVAILABLE = "retry_recovery_available"
     CONFIRMATION_RETRY_AVAILABLE = "confirmation_retry_available"


### PR DESCRIPTION
## Summary

Adds category-based STOP/RESTART decisions to `restart_agent`: a curated 38-category taxonomy that the L1 LLM selects from, and an L4 policy gate that consults the selection before falling back to the strict 6-condition immediate-stop check. Also includes an L0 primary-candidate fix and a set of L1 contract repairs that let honest-but-slightly-non-compliant model responses through.

Final evaluation on the 79-case labeled subset across the 4 usable model targets (updated labels):

| target | decision | anchor | cat_id | reasoning | median/case | total wall |
|---|---|---|---|---|---|---|
| **gpt** | **100.0%** | 96.2% | **96.2%** | **98.7%** | 51 s | 69 min |
| qwen397b | 97.5% | 96.2% | 87.3% | 97.4% | **20 s** | **39 min** |
| **gemini** | **100.0%** | 91.1% | 92.4% | 92.2% | 63 s | 88 min |
| nemotron | 94.9% | 89.9% | 87.3% | 96.1% | 47 s | 66 min |

Compared to a pre-Option-A deterministic baseline of 74.7% decision accuracy on the same 79 cases.

## What this PR contains

Six analyzer-only feature commits under `src/nvidia_resiliency_ext/attribution/restart_agent/`, plus lint follow-ups:

1. **Option A — L1 category selection + L4 category-based decision gate**
   - New `l1/categories.py` with a curated 38-entry taxonomy (`id`, `name`, `description`, `decision`, `failure_domain`, `retry_outlook`).
   - L1 response schema extended with an optional `category_selection { category_id, category_confidence, category_rationale }` field.
   - L4 policy consults it via `_category_selection_qualifies_action()` with a confidence gate (default 80); the new `category_confirmed_stop` basis fast-paths to `WORKLOAD_UNRECOVERABLE` when the pick has `decision=STOP` at or above the threshold. Fallthrough (below threshold, `category_id=0`, or `EXCLUDED`) preserves the pre-existing typed-claim / deterministic pipeline unchanged.

2. **Option A tuning**
   - Broadens category names/descriptions for cats 6 / 9 / 11 / 16.
   - Promotes short 1-line descriptions into the prompt list (+2.4 KB) so the model actually sees the discriminators.
   - Adds `category_confidence_threshold` override on `L4PolicyInput`, read from `NVRX_CATEGORY_CONFIDENCE_THRESHOLD` in `decision_pipeline`. Default remains 80.

3. **Carve out ModuleNotFoundError-on-Lustre boundary between cat 13 and 16** — surgical fix for a single edge case (b1-056 in the eval) where cat 16's broadened description was catching import failures on Lustre-backed code paths.

4. **L0: promote earliest terminal cascade over later `root_candidate` when the cascade precedes it** — `_select_primary_candidate` used to ignore `cascade_candidate` roles entirely, so when a job ended with a scheduler cancel (`root_candidate`) that followed an earlier NCCL watchdog CUDA-launch-failure (`cascade_candidate`) with no upstream root visible, the SLURM cancel won by default and all L1 models faithfully followed L0's pick. Fixed by promoting the earliest terminal cascade when it precedes the earliest root_candidate.

5. **L1 contract repairs** — 5 non-semantic in-place normalizers wired into `_parse_model_evidence` before strict validation:
   - `repair_biconditional_unknowns` — normalize `(value=unknown, status≠unknown)` or `(value≠unknown, status=unknown)` pairs to `unknown/unknown` (fixes nemotron's honest-but-nonconforming responses)
   - `repair_overlong_lists` — truncate `plausible_causes`, `missing_evidence`, `related_failures` to their contract caps rather than reject the response
   - `repair_invalid_evidence_supports` — drop invalid support-tag strings (e.g. nemotron using `related_failures` as a supports tag); drop the evidence item entirely if nothing valid remains
   - `repair_overlong_category_rationale` — truncate `category_selection.category_rationale` to the 400-char cap
   - `repair_schema_version` — normalize similar-but-wrong `schema_version` strings (e.g. gemini's `restart_agent_decision_evidence.v1` bleed-through) when the payload is otherwise structurally shaped like our schema
   - Also **relaxes one contract rule** in `model_evidence_contract_errors`: waive the "evidence must support `failure_domain` / `retry_outlook_without_workload_change`" citation requirement when the corresponding claim is `value=unknown / status=unknown`. A claim of unknown/unknown means "no informative evidence for this dimension", so requiring a citation would be self-contradictory. Non-unknown claims still require citation - the anti-hallucination guardrail is kept for any dimension the model actually commits to.

## Design principle

L1 typed claims (`retry_outlook_without_workload_change`, `failure_domain`) remain in place. The category selection is an **additional, orthogonal signal** — when the picker returns a category with `decision=STOP` at confidence ≥ threshold, L4 uses it as a fast path to `WORKLOAD_UNRECOVERABLE` before running the strict 6-condition immediate-stop gate. Confidence below threshold or `category_id=0` (no match) falls through to the existing typed-claim / deterministic logic. **No behavior change for cases without an L1 result.**

Empirically, in the final GPT run the category gate handled 78/79 cases (20 STOP + 58 RESTART) and the policy-engine fallback correctly decided the 1 remaining case where L1 was uncertain.

## Attempted-and-reverted: Pattern A taxonomy sharpening

An additional commit sharpening 4 STOP/RESTART category boundaries (cats 14/16, 18/13, 22/9, 27/25) was applied and then **reverted** after empirical evaluation:

- **qwen397b**: cleanly gained the 3 targeted case flips (b1-006/008/009 got cat 27, b1-029 flipped RESTART→STOP correctly). Decision 97.5%→98.7%, cat_id 87.3%→92.4%.
- **nemotron**: destabilized across the taxonomy. Netted 3 targeted gains (b1-020, b1-075, b1-076) but 5+ regressions on unrelated categories - cat 18 in particular started firing broadly. Decision 94.9%→91.1%, cat_id 87.3%→70.9%.

Net across the affected 2 models: -2 decisions, -9 cat_id hits. Reverted to preserve the stable baseline. The taxonomy sharpening is a real improvement in principle but nemotron over-latches onto "prefer over cat X" phrasing. Follow-up work should try a shorter / less imperative wording that qwen397b would still respect but nemotron won't over-weight.

## Known residual misses (context for reviewers)

None prevent shipping. Logged here as the residual after several rounds of iteration:

### Reasoning inaccuracy (root-cause narrative quality, judged by gemini-flash)

12 non-`same_root` grades across the 4 models. Every one is either a genuine hard-case, a model-side bias, or a known LLM-side failure - not addressable via analyzer or contract logic:

- **P1 - Ambiguous log (b1-048)**: TCPStore-during-GPTDataset-index-build. Two valid causal readings (rendezvous vs missing dataset files); the seed labeler themselves reclassified this case during human review.
- **P2 - Anchor-selection bias (b1-014/015 nemotron, b1-058/062 gemini)**: model anchors on downstream terminal event instead of earlier upstream signal. Model-side picker bias - would need L1 prompt work with unclear regression risk. Zero decision impact.
- **P3 - L1 fall-through to deterministic template (b1-031/061 gemini; b1-007 qwen397b)**: empty model output or provider HTTP 500. Not repairable via contract layer.
- **P4 - Narrative-picker mismatch (b1-056 nemotron)**: narrative describes a workload code error but typed claims land on the correct filesystem-visibility category.
- **P5 - Sparse log (b1-078 nemotron)**: 1-line SLURM cancel-due-to-requeue log. Model doesn't recognize the pattern from a single line.
- **P6 - Partial mechanism (b1-017 gpt)**: mechanism right, minor detail missing. Judge-side strictness rather than a real quality issue.

### Categorization inaccuracy (category-id mismatch vs GT)

29 miss-instances across the 4 models. Three patterns:

- **Pattern A - Taxonomy discrimination** (12 misses): same failure mechanism, sub-category ambiguity. Affects qwen397b (b1-006/007/008/009/029/055/056) and nemotron (b1-020/042/044/074/075/076). Fix attempted and reverted - see above. These stay in the residual.
- **Pattern B - Anchor-selection** (~10 misses): b1-058 hits gpt/qwen397b/gemini; b1-062 hits qwen397b/gemini/nemotron with each picking a different signal from an ambiguous log. Model-side picker bias.
- **Pattern C - No-match** (~7 misses): b1-003 nemotron (anchored on teardown, missed OOM kill), b1-031 gemini (rare cat 28 SDC), b1-048 gpt/qwen397b/gemini (ambiguous log), b1-061 gemini (sparse).

### Restart/stop inaccuracy (decision-accuracy misses)

6 misses total, all directly caused by picking the wrong side of a STOP/RESTART category boundary (Pattern A above):

| case | model | wrong pick | correct pick | direction |
|---|---|---|---|---|
| b1-029 | qwen397b | cat 13 (RESTART) | cat 18 (STOP) | called RESTART, should be STOP |
| b1-056 | qwen397b | cat 16 (STOP) | cat 13 (RESTART) | called STOP, should be RESTART |
| b1-020 | nemotron | cat 9 (RESTART) | cat 22 (STOP) | called RESTART, should be STOP |
| b1-074 | nemotron | cat 16 (STOP) | cat 14 (RESTART) | called STOP, should be RESTART |
| b1-075 | nemotron | cat 16 (STOP) | cat 14 (RESTART) | called STOP, should be RESTART |
| b1-076 | nemotron | cat 16 (STOP) | cat 14 (RESTART) | called STOP, should be RESTART |

## Contract-repair logic and design rationale

The 5 in-place repair functions + 1 relaxation were added incrementally in response to empirical failures. Design constraints:

- **All repairs are in-place mutations on the parsed payload before validation.** No retry, no re-prompt, no additional model call.
- **Every repair emits a note** (returned by the repair function) for observability. The current code doesn't thread the notes into the trace anomalies yet - infrastructure is in place for a follow-up.
- **Each repair is silent-forward but explicit-reverse**: on the way in, the modified payload is treated exactly like a valid one. If a reviewer wants to see what the model originally sent, the raw model output is preserved in `l1.raw_model_output` in the trace.
- **The contract relaxation for unknown claims** is a semantic change, not a repair. It changes what is *considered valid* rather than fixing an invalid payload. Rationale: the citation requirement for `failure_domain` / `retry_outlook` conflicts with an honest `unknown/unknown` claim - if the model correctly reports it has no informative evidence for a dimension, requiring a citation is self-contradictory. Non-unknown claims still require citation, so the anti-hallucination guardrail is kept for any dimension the model actually commits to.

## Test plan

- [ ] Reviewer: sanity-check `l1/categories.py` — 38 entries, each with all five fields populated
- [ ] Reviewer: L4 fallthrough — verify `l1_category_selection=None` produces the same rule/basis as before Option A on a case without L1
- [ ] Reviewer: env-var behavior — `NVRX_CATEGORY_CONFIDENCE_THRESHOLD` unset ⇒ default 80; `=70` ⇒ used by L4
- [ ] Reviewer: L1 response contract — `category_selection` is optional in the schema; existing L1 responses without it still validate
- [ ] Reviewer: repair chain in `l1/validation.py` — each `repair_*` function is a no-op on already-valid input and mutates only the specific misshapen field on input that matches its signature
- [ ] Reviewer: L0 change in `l0/assembly.py::_select_primary_candidate` — cases with a legitimate upstream `root_candidate` before any `cascade_candidate` still pick that root; the promotion path only fires when cascade precedes root

## Not in scope

- Evaluation harness — measured externally, kept out of this PR by design
- Anchor-selection improvements beyond the L0 cascade-promotion fix (Pattern B in the miss report). Zero decision impact under current gate.
- Multi-model threshold policy beyond the default 80 and the eval-harness GPT=70 shim
- Pattern A taxonomy sharpening beyond the 4 already-committed cat 6/9/11/16 broadenings — deferred pending a wording that works for nemotron
- CSV-backed taxonomy — a follow-up refactor to let QA push category revisions as a CSV drop
- Threading repair notes into trace anomalies for observability - follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)