### PR TITLE
Exclude unhealthy-group ghost slots from rendezvous close selection

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -1543,12 +1543,26 @@ class _RendezvousBarrierState:
                 )
                 continue
 
+            # Exclude participants that belong to a replacement group already marked
+            # unhealthy this round. This covers the SLURM job-array rack-refill race:
+            # when a task is terminated mid-round and its physical nodes are refilled
+            # into a new array task, the dead task's slots linger in the store with the
+            # current round id (round-fenced, not lifetime-fenced) and are otherwise
+            # indistinguishable from live participants. Their replacement_group_id
+            # (SLURM_ARRAY_TASK_ID) still identifies the dead cohort, so dropping them
+            # here keeps ghost nodes out of segment/replacement-group selection, the
+            # duplicate-addr scan, and the previous-active last-call gate. Filtering by
+            # replacement_group_id never touches co-located launchers from healthy
+            # groups (multi-launcher simulation), and is a no-op when no group is marked.
+            unhealthy_replacement_groups = self._get_unhealthy_replacement_groups()
             current_round_participants = [
-                participant for participant in slot_participants if participant is not None
+                participant
+                for participant in slot_participants
+                if participant is not None
+                and (participant[3] is None or participant[3] not in unhealthy_replacement_groups)
             ]
 
             # Check if the segment/replacement-group constraint is satisfied.
-            unhealthy_replacement_groups = self._get_unhealthy_replacement_groups()
             complete_replacement_group_participants, incomplete_replacement_group_participants = (
                 self._split_by_complete_replacement_groups(current_round_participants)
             )

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -847,6 +847,80 @@ class Step2CompletionTest(BaseRendezvousTest):
         # The dead survivor's slot_3 rank key was never written by the host.
         self.assertFalse(self.store.check([f"{state.prefix}:slot_3_rank"]))
 
+    def test_step2_excludes_unhealthy_group_ghosts_on_rack_refill(self):
+        """SLURM job-array rack refill: dead task's ghost slots must not be selected.
+
+        Task A joins round 0 on two physical nodes, then SLURM terminates it (its
+        slots linger in the store, round-fenced but lifetime-stale). Task A's
+        replacement group is marked unhealthy (the failing node does this on its way
+        out). SLURM refills the SAME physical nodes into task B, which joins the same
+        open round -- so each addr now appears twice (ghost A + live B).
+
+        Without the unhealthy-group filter the duplicate-addr scan would fire and
+        permanently shut the job down. With it, the ghosts are dropped before
+        selection: the round closes on task B, and the ghost slots keep their
+        UNASSIGNED rank (never written by the host).
+        """
+        # Ensure the fatal duplicate-addr guard is active (not the simulation bypass),
+        # so this test proves the filter -- not the bypass -- prevents the shutdown.
+        os.environ.pop("NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE", None)
+        min_nodes = 2
+        max_nodes = 4
+        state = _RendezvousBarrierState(
+            store=self.store,
+            run_id=self.run_id,
+            is_store_host=True,
+            join_timeout_seconds=TEST_JOIN_TIMEOUT_SECS,
+            replacement_group_size=2,
+        )
+        state._compute_step2_poll_interval = lambda min_nodes, segment_check_interval: 0.0
+
+        # Ghost task A (slots 1,2) and refill task B (slots 3,4) share physical nodes:
+        # host0/host1 appear in both cohorts, distinguished only by replacement group.
+        participants = [
+            (_NodeDesc("host0", 100, 0), 0, "none", "A"),  # ghost
+            (_NodeDesc("host1", 101, 0), 1, "none", "A"),  # ghost
+            (_NodeDesc("host0", 200, 1), 2, "none", "B"),  # live refill (same node as slot 1)
+            (_NodeDesc("host1", 201, 1), 3, "none", "B"),  # live refill (same node as slot 2)
+        ]
+        _seed_joined_participants(self.store, state, participants)
+        # Model Step 1: every joiner (ghost and live) writes an UNASSIGNED rank first.
+        for slot in range(1, len(participants) + 1):
+            self.store.set(
+                f"{state.prefix}:slot_{slot}_rank",
+                state._pack_rank_value(GroupRankStatus.UNASSIGNED.value, 0, state._round),
+            )
+
+        # The failing task A node marks its replacement group unhealthy on exit.
+        state._mark_replacement_group_unhealthy("A")
+
+        state._rendezvous_start_time = time.monotonic()
+        state._host_close_round(
+            _NodeDesc("control", 10, 0),
+            min_nodes=min_nodes,
+            max_nodes=max_nodes,
+            segment_check_interval=0.0,
+        )
+
+        # Round closes on task B; the job is NOT shut down.
+        self.assertFalse(state.is_shutdown())
+        self.assertEqual(self.store.get(state.round_done_key).decode("utf-8"), "1")
+
+        # Live task B (slots 3,4) receives the active ranks.
+        live_ranks = [
+            state._unpack_rank_value(self.store.get(f"{state.prefix}:slot_{slot}_rank"))[0]
+            for slot in (3, 4)
+        ]
+        self.assertEqual(sorted(live_ranks), [0, 1])
+
+        # Ghost task A (slots 1,2) keeps its UNASSIGNED rank from Step 1: the host never
+        # reassigns it, so a still-live task-A node reads UNASSIGNED and loops.
+        for slot in (1, 2):
+            ghost_rank = state._unpack_rank_value(
+                self.store.get(f"{state.prefix}:slot_{slot}_rank")
+            )[0]
+            self.assertEqual(ghost_rank, GroupRankStatus.UNASSIGNED.value)
+
     def test_step2_duplicate_addr_is_fatal_misconfiguration(self):
         """Two ft_launchers on one node (same addr) is a fatal misconfiguration."""
         os.environ.pop("NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE", None)


### PR DESCRIPTION
## Problem

SLURM job-array **rack refill** race in the barrier rendezvous. Rendezvous slots are fenced by *round id* only, not by process lifetime. When a task is terminated mid-round (HW failure elsewhere) and SLURM refills its physical nodes into a new array task that joins the *same* open round:

- The dead task's slots linger in the store with the current round id — indistinguishable from live participants.
- The refill lands on the same physical nodes, so ghost and live entries **collide by `addr`**.
- The store host's duplicate-addr scan then fires `set_shutdown(FAILURE)` and **permanently kills the job**; under node-stable infra-rank schemes it instead crashes the host on a duplicate-infra-rank `RuntimeError`. Ghosts can also be selected active, wasting a restart cycle on NCCL-init hangs.

The one field that still distinguishes the dead cohort from the refill is `replacement_group_id` (`SLURM_ARRAY_TASK_ID`), and the failing node already marks its group unhealthy on its way out — but that set was only consumed by the last-call gate, never applied to selection.

## Fix

In `_host_close_round`, hoist `_get_unhealthy_replacement_groups()` and exclude participants whose `replacement_group_id` is in the marked set **before** the constraint / duplicate-addr / last-call checks. Everything downstream inherits the filtered list, so ghosts are dropped instead of shutting the job down.

- No-op when no group is marked (empty set) and for `replacement_group_id is None` (short-circuits) — non-array/no-group configs unchanged.
- Keys on `replacement_group_id`, never on `addr`, so multi-launcher simulation (`NVRX_ENABLE_MULTI_LAUNCHERS_PER_NODE=1`) is unaffected.
- Dropped ghosts keep their Step-1 UNASSIGNED rank; a still-live task-A node reads UNASSIGNED and loops as a late joiner.

## Test

`test_step2_excludes_unhealthy_group_ghosts_on_rack_refill`: ghost task A and refill task B share `addr` host0/host1; group A marked unhealthy; duplicate-addr guard left active (sim bypass unset) so the test proves the *filter* — not the bypass — prevents the shutdown. Asserts no shutdown, round closes on task B (ranks 0/1), ghost slots stay UNASSIGNED. Full `test_barrier_rendezvous.py` green (99 passed).

## Known gap (follow-up)

Marking currently only happens via the failing node's health-check path. SIGKILL / silent node loss leaves ghosts unmarked. A SIGTERM-path marking would cover "SLURM killed my task" generically — deferred to a follow-up.

> Issue tracking to be linked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)