### PR TITLE
ft_launcher injob restart-cycle telemetry

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/_otel_fallbacks.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/_otel_fallbacks.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""No-op fallbacks for when nemo-lens is not installed.
+
+nemo-lens is an optional dependency (the `otel` extra) -- most consumers of
+this package don't need it. When it IS installed, the real implementations
+are used. When it is NOT, everything here degrades to a no-op so the
+persistent checkpoint worker's hot path never has to check "is telemetry
+available" itself.
+"""
+
+try:
+    from nemo.lens import NemoLensConfig, setup_telemetry  # noqa: F401
+
+    # nemo.lens.state / nemo.lens.helpers hold the REAL, state-driven
+    # implementations -- nemo.lens.fallbacks (a different module, despite the
+    # similar name) is a set of permanently-hardcoded no-ops meant only for
+    # consumers that never import nemo.lens at all. Importing from the wrong
+    # one here would silently no-op every span regardless of config.
+    from nemo.lens.helpers import (  # noqa: F401
+        managed_span,
+        safe_set_span_attributes,
+        span_cm,
+        trace_fn,
+    )
+    from nemo.lens.state import is_span_group_enabled  # noqa: F401
+
+    HAS_NEMO_LENS = True
+except ImportError:
+    from contextlib import contextmanager
+
+    HAS_NEMO_LENS = False
+
+    class NemoLensConfig:  # noqa: D101
+        pass
+
+    def setup_telemetry(*args, **kwargs):
+        """No-op -- returns a handle whose .tracer/.meter are no-ops and .shutdown() does nothing."""
+        return _NoOpTelemetryHandle()
+
+    class _NoOpTelemetryHandle:
+        is_exporting = False
+
+        @property
+        def tracer(self):
+            from opentelemetry import trace
+
+            return trace.get_tracer(__name__)
+
+        @property
+        def meter(self):
+            from opentelemetry import metrics
+
+            return metrics.get_meter(__name__)
+
+        def shutdown(self, timeout_ms=5000):
+            pass
+
+    def trace_fn(group, name, tracer=None):
+        """No-op decorator -- returns the function unchanged."""
+        def decorator(func):
+            return func
+        return decorator
+
+    @contextmanager
+    def managed_span(group, name, tracer=None, **attributes):
+        """No-op context manager -- yields None."""
+        yield None
+
+    def is_span_group_enabled(group):
+        """Always returns False when nemo-lens is not installed."""
+        return False
+
+    def safe_set_span_attributes(span, attributes, redact_keys=None):
+        """No-op."""
+        pass
+
+    @contextmanager
+    def span_cm(name, tracer=None, record_exception=True, **attributes):
+        """No-op context manager -- yields None."""
+        yield None

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -1885,7 +1885,14 @@ class _RendezvousBarrierState:
             # Hot spares and late-arriving nodes wait here indefinitely until a failure
             # opens the next round. Also checks for permanent shutdown.
             # Note: _wait_for_rendezvous_open() raises RendezvousGracefulExitError on shutdown.
-            self._wait_for_rendezvous_open(node_desc)
+            # Instrument this wait so a node that is NOT (yet) in the active rendezvous still emits a
+            # span -- without it, a hot spare is invisible for the entire cycle it waits through. The
+            # finally guarantees the close (and export) even when shutdown raises out of the wait.
+            record_profiling_event(ProfilingEvent.AWAIT_ROUND_STARTED, node_id=node_desc)
+            try:
+                self._wait_for_rendezvous_open(node_desc)
+            finally:
+                record_profiling_event(ProfilingEvent.AWAIT_ROUND_COMPLETED, node_id=node_desc)
 
             # Record start time for timeout monitoring.
             # Start timing AFTER Step 0 completes, since nodes may wait indefinitely at Step 0.
@@ -1902,6 +1909,13 @@ class _RendezvousBarrierState:
                 try:
                     pre_join_hook()
                 except UnhealthyNodeException:
+                    # This node bailed at its health check (evicted / injected / genuinely unhealthy)
+                    # and is about to leave the job -- mark it so the telemetry recorder closes and
+                    # flushes this node's open cycle/phase spans BEFORE the process is torn down.
+                    record_profiling_event(
+                        ProfilingEvent.NODE_EXCLUDED,
+                        node_id=node_desc,
+                    )
                     try:
                         self._maybe_mark_current_replacement_group_unhealthy()
                     except Exception as e:

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -86,6 +86,7 @@ from nvidia_resiliency_ext.fault_tolerance.cli_args import (
     add_rendezvous_args,
 )
 from nvidia_resiliency_ext.fault_tolerance.config import FaultToleranceConfig
+from nvidia_resiliency_ext.fault_tolerance import _otel_fallbacks
 from nvidia_resiliency_ext.fault_tolerance.cycle_info_writer import CycleInfoReporter
 from nvidia_resiliency_ext.fault_tolerance.data import (
     FT_LAUNCHER_IPC_SOCKET_ENV_VAR,
@@ -451,7 +452,139 @@ class LocalElasticAgent(SimpleElasticAgent):
         self._restart_policy = restart_policy
         self._node_id = self._get_fq_hostname()
 
+        # OTel: the ft_launcher AGENT runs in its OWN process (separate from the training workers),
+        # so it stands up its own nemo-lens tracer to emit injob restart-cycle spans to the node's
+        # collector at localhost:4317 -- mirroring the async checkpoint worker's independent
+        # setup_telemetry(). No-op if nemo-lens isn't installed or telemetry env isn't set; wrapped
+        # so telemetry can NEVER break the launcher. The per-cycle span TREE is owned by the
+        # ProfilingEvent recorder; the agent only annotates/stages/closes via _otel_* helpers below.
+        self._otel_handle = None
+        # Only stand up the agent tracer when the workload configured lens telemetry (the injob
+        # launcher exports NEMO_LENS_EXPORTER / MEGATRON_OTEL_*). Otherwise stay fully no-op.
+        if os.environ.get('NEMO_LENS_EXPORTER') or os.environ.get('MEGATRON_OTEL_EXPORTER'):
+            try:
+                _otel_cfg = _otel_fallbacks.NemoLensConfig.from_env(
+                    prefix='MEGATRON_OTEL', fallback_prefix='NEMO_LENS'
+                )
+                _otel_cfg.enabled = True  # force on (mirrors the async ckpt worker bootstrap)
+                self._otel_handle = _otel_fallbacks.setup_telemetry(
+                    _otel_cfg,
+                    rank=0,
+                    world_size=1,
+                    resource_attributes={
+                        'nvrx.role': 'ft_launcher_agent',
+                        'nvrx.node': str(self._node_id),
+                    },
+                )
+            except Exception as _otel_e:  # never let telemetry setup break the launcher
+                logger.debug("OTel agent tracer setup skipped: %s", _otel_e)
+                self._otel_handle = None
+            # Register the agent tracer with the ProfilingEvent recorder so its pre-placed boundary
+            # events (rendezvous/health_check/worker_launch/run/teardown/attribution -- fired from
+            # here AND the rendezvous handler) become phase spans with IMMEDIATE flush. That is what
+            # lets an evicted node's short, completed phase spans reach the collector before its kill.
+            if self._otel_handle is not None:
+                try:
+                    from opentelemetry import trace as _ot_trace
+                    from nvidia_resiliency_ext.shared_utils.profiling import _get_global_profiler
+                    _prov = _ot_trace.get_tracer_provider()
+                    _flush = (lambda: _prov.force_flush(timeout_millis=1500)) \
+                        if hasattr(_prov, 'force_flush') else None
+                    _prof = _get_global_profiler()
+                    _prof.attach_otel(self._otel_handle.tracer, flush=_flush)
+                    # batch launch_script_start (outside the single srun) -> one-time cold-start span
+                    _ls = os.environ.get('LENS_LAUNCH_SCRIPT_START_TIME')
+                    if _ls:
+                        try:
+                            _prof.otel_set_launch_start(float(_ls))
+                        except (TypeError, ValueError):
+                            pass
+                except Exception as _e:
+                    logger.debug("otel recorder attach skipped: %s", _e)
+
     DEFAULT_ROLE = "default"  # FIXME
+
+    # ---- OTel injob restart-cycle spans (agent process) ------------------------------------------
+    # The per-cycle span TREE is owned by the ProfilingEvent recorder (shared_utils/profiling.py):
+    # it opens 'nvrx.restart.cycle' at RENDEZVOUS_STARTED and nests the phase children
+    # (health_check / rendezvous / worker_launch / run / teardown, + attribution) as a SWEEP, closing
+    # the cycle at WORKER_TERMINATED or NODE_EXCLUDED. The agent's job is only to (a) enrich the open
+    # cycle span with restart-budget metadata, (b) stage the outcome (failed/peer_restart) before the
+    # teardown event closes it, and (c) close terminal cycles (success/terminated) that have no
+    # teardown event. All of this delegates to the global recorder; telemetry can NEVER break the FT.
+    def _otel_profiler(self):
+        if self._otel_handle is None:
+            return None
+        try:
+            from nvidia_resiliency_ext.shared_utils.profiling import _get_global_profiler
+            return _get_global_profiler()
+        except Exception as _e:
+            logger.debug("otel profiler lookup skipped: %s", _e)
+            return None
+
+    def _otel_annotate_cycle(self):
+        """Enrich the recorder's currently-open cycle span with this agent's restart-budget and
+        rendezvous metadata (the recorder opened the cycle at rendezvous; the agent knows the budget)."""
+        prof = self._otel_profiler()
+        if prof is None:
+            return
+        try:
+            spec = self._worker_group.spec
+            wg = self._worker_group
+            attrs = {
+                'nvrx.remaining_restarts': self._remaining_restarts,
+                'nvrx.max_restarts': spec.max_restarts,
+                'nvrx.node': str(self._node_id),
+                'nvrx.membership': 'active',   # annotate runs after this node launched workers
+            }
+            try:
+                attrs['nvrx.group_rank'] = wg.group_rank
+                attrs['nvrx.group_world_size'] = wg.group_world_size
+            except Exception:
+                pass
+            try:
+                attrs['nvrx.rdzv_run_id'] = spec.rdzv_handler.get_run_id()
+            except Exception:
+                pass
+            # cluster TOPOLOGY for this cycle (same source as cycle_info: rdzv-handler getters +
+            # infra_rank). Lets a cycle span answer "who was active/standby + my physical rank".
+            try:
+                from nvidia_resiliency_ext.fault_tolerance.utils import get_infrastructure_rank
+                attrs['nvrx.infra_rank'] = get_infrastructure_rank(skip_nodename_logic=True)
+            except Exception:
+                pass
+            for _key, _getter in (('nvrx.active_nodes', 'get_active_node_addrs'),
+                                  ('nvrx.standby_nodes', 'get_standby_node_addrs'),
+                                  ('nvrx.active_ranks', 'get_active_ranks')):
+                try:
+                    _v = getattr(spec.rdzv_handler, _getter)()
+                    if _v is not None:
+                        attrs[_key] = ",".join(str(x) for x in _v)
+                except Exception:
+                    pass
+            prof.otel_annotate_cycle(**attrs)
+        except Exception as _e:
+            logger.debug("otel annotate_cycle skipped: %s", _e)
+
+    def _otel_stage_outcome(self, outcome, **attrs):
+        """Stage the cycle outcome (failed/peer_restart) BEFORE the teardown event closes the cycle."""
+        prof = self._otel_profiler()
+        if prof is None:
+            return
+        try:
+            prof.otel_stage_outcome(outcome, **attrs)
+        except Exception as _e:
+            logger.debug("otel stage_outcome skipped: %s", _e)
+
+    def _otel_end_cycle(self, outcome, **attrs):
+        """Close a TERMINAL cycle (success/terminated) that has no teardown event to auto-close it."""
+        prof = self._otel_profiler()
+        if prof is None:
+            return
+        try:
+            prof.otel_finish_cycle(outcome, **attrs)
+        except Exception as _e:
+            logger.debug("otel end_cycle skipped: %s", _e)
 
     # ============================================================================
     # Global Restart/Cycle Tracking for Job Array Deployments
@@ -577,6 +710,14 @@ class LocalElasticAgent(SimpleElasticAgent):
         finally:
             if not shutdown_called:
                 self._shutdown()
+            # OTel: close any still-open cycle span + flush the agent tracer. BatchSpanProcessor only
+            # flushes on shutdown, so without this the last cycle's spans would be dropped on exit.
+            if getattr(self, '_otel_handle', None) is not None:
+                try:
+                    self._otel_end_cycle('terminated')
+                    self._otel_handle.shutdown()
+                except Exception:
+                    pass
             # record the execution time in case there were any exceptions during run.
             self._total_execution_time = int(time.monotonic() - start_time)
 
@@ -655,6 +796,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         logger.info("[%s] starting workers for entrypoint: %s", role, spec.get_entrypoint_name())
 
         self._initialize_workers(self._worker_group)
+        self._otel_annotate_cycle()  # OTel: enrich the cycle the recorder opened at rendezvous
         monitor_interval = spec.monitor_interval
         rdzv_handler = spec.rdzv_handler
 
@@ -675,6 +817,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                     role,
                     self._exit_barrier_timeout,
                 )
+                self._otel_end_cycle('succeeded')  # OTel: close the cycle span (clean finish)
                 self._exit_barrier()
                 return run_result
 
@@ -717,11 +860,18 @@ class LocalElasticAgent(SimpleElasticAgent):
                     f"{self._remaining_restarts}/{spec.max_restarts} attempts left; "
                     f"will restart worker group"
                 )
+                # OTel: stage the outcome BEFORE the restart; the recorder stamps it and closes the
+                # cycle when the teardown (WORKER_TERMINATED) event fires inside _handle_restart_decision.
+                # The teardown/rendezvous/worker_launch phase spans ARE the restart gap now.
+                self._otel_stage_outcome(
+                    'failed',
+                    **{'nvrx.state': state.name, 'nvrx.failures': len(run_result.failures or {})},
+                )
                 should_restart = self._handle_restart_decision(
                     role, spec, log_msg, open_rendezvous=True,
                 )
-
                 if should_restart:
+                    self._otel_annotate_cycle()  # enrich the cycle the recorder just re-opened
                     continue  # Continue monitoring after restart
 
                 # No more restarts (either exhausted or early termination)
@@ -759,14 +909,17 @@ class LocalElasticAgent(SimpleElasticAgent):
 
                     log_msg = f"[%s] Joining cluster restart (group_rank={group_rank})"
                     # The node that triggered the failure already opened the rendezvous.
+                    # OTel: stage the peer-restart outcome; the recorder closes this cycle at the
+                    # teardown event inside _handle_restart_decision and re-opens the next at rendezvous.
+                    self._otel_stage_outcome('peer_restart')
                     should_restart = self._handle_restart_decision(
                         role, spec, log_msg, open_rendezvous=False,
                     )
-
                     if not should_restart:
                         self._stop_workers(self._worker_group)
                         self._worker_group.state = WorkerState.FAILED
                         return RunResult(state=WorkerState.FAILED)
+                    self._otel_annotate_cycle()  # joined the restart -> enrich the new cycle
             else:
                 raise Exception(f"[{role}] Worker group in {state.name} state")
 
@@ -1107,6 +1260,19 @@ class LocalElasticAgent(SimpleElasticAgent):
 
         current_cycle_info_path = self._current_cycle_info_path()
 
+        # One launch stamp for THIS worker cohort, so every restart hands its workers a FRESH
+        # per-restart anchor. The batch script's launch_script_start is set once (outside the single
+        # srun) and is stale for restarts; NVRX_LAUNCH_TIME is the in-srun equivalent each cohort
+        # actually needs. Megatron uses it as its per-restart 'launch_script_start' so workload.startup
+        # measures THIS relaunch (rendezvous rejoin + spawn + import), nested in this cycle's run span.
+        _nvrx_cohort_launch = repr(time.time())
+        _nvrx_cycle = str(self._get_global_cycle_number())
+        try:
+            from nvidia_resiliency_ext.fault_tolerance.utils import get_infrastructure_rank
+            _nvrx_infra = str(get_infrastructure_rank(skip_nodename_logic=True))
+        except Exception:
+            _nvrx_infra = None
+
         for worker in worker_group.workers:
             local_rank = worker.local_rank
 
@@ -1136,6 +1302,24 @@ class LocalElasticAgent(SimpleElasticAgent):
                 worker_env["NVRX_CURRENT_CYCLE_INFO"] = current_cycle_info_path
             if "OMP_NUM_THREADS" in os.environ:
                 worker_env["OMP_NUM_THREADS"] = os.environ["OMP_NUM_THREADS"]
+            # per-restart startup anchor + cycle number for the worker's own telemetry
+            worker_env["NVRX_LAUNCH_TIME"] = _nvrx_cohort_launch
+            worker_env["NVRX_CYCLE"] = _nvrx_cycle
+            worker_env["NVRX_MEMBERSHIP"] = "active"   # a launched worker is active this cycle
+            if _nvrx_infra is not None:
+                worker_env["NVRX_INFRA_RANK"] = _nvrx_infra
+            # For any cycle AFTER the first -- an in-place restart OR a promoted spare (both launch
+            # at cycle > 0) -- anchor pre_startup at THIS round's rendezvous start (the recorder's
+            # cycle-span start), not the stale sbatch job start. Cycle 0 leaves it unset so
+            # pre_startup falls back to the real sbatch queue.
+            if _nvrx_cycle and _nvrx_cycle != "0":
+                try:
+                    from nvidia_resiliency_ext.shared_utils.profiling import _get_global_profiler
+                    _cs = _get_global_profiler().otel_cycle_start_seconds()
+                    if _cs is not None:
+                        worker_env["NVRX_CYCLE_START_TIME"] = repr(_cs)
+                except Exception:
+                    pass
 
             if self._log_line_prefix_template:
                 log_line_prefix = Template(self._log_line_prefix_template).safe_substitute(

--- a/src/nvidia_resiliency_ext/shared_utils/profiling.py
+++ b/src/nvidia_resiliency_ext/shared_utils/profiling.py
@@ -16,6 +16,7 @@
 # This file adds time profiling capabilities for fault tolerance (cycle and event logging).
 
 import logging
+import re
 import threading
 import time
 from datetime import datetime, timezone
@@ -23,6 +24,15 @@ from enum import Enum
 from typing import Any, Optional
 
 from ..shared_utils.log_manager import LogConfig
+
+
+_NODE_DESC_SUFFIX = re.compile(r'_\d+_\d+$')  # node_desc appends _<pid>_<local_rank>
+
+
+def _clean_node(n):
+    """Normalize node_desc ('host.cm.cluster_<pid>_<local>') to the clean host form, so phase spans
+    and the cycle span carry the SAME nvrx.node value."""
+    return _NODE_DESC_SUFFIX.sub('', n) if isinstance(n, str) else n
 
 
 class ProfilingEvent(Enum):
@@ -37,6 +47,9 @@ class ProfilingEvent(Enum):
     WORKER_START_COMPLETED = "worker_start_completed"
     ATTRIBUTION_GET_STARTED = "attribution_get_started"
     ATTRIBUTION_GET_COMPLETED = "attribution_get_completed"
+    NODE_EXCLUDED = "node_excluded"  # this node bailed at its rendezvous health-check (evicted/unhealthy)
+    AWAIT_ROUND_STARTED = "await_round_started"      # node entered the Step-0 wait for the round to open
+    AWAIT_ROUND_COMPLETED = "await_round_completed"   # round opened (or shutdown) -> node proceeds/exits
 
 
 class FaultToleranceProfiler:
@@ -45,6 +58,225 @@ class FaultToleranceProfiler:
     def __init__(self):
         self._current_cycle = 0
         self._logger = logging.getLogger(LogConfig.name)
+        # OTel per-cycle span TREE state (set by the ft_launcher agent via attach_otel, its process).
+        self._otel_tracer = None
+        self._otel_flush = None
+        self._otel_cycle_span = None   # per-cycle PARENT span ('nvrx.restart.cycle')
+        self._otel_cycle_ctx = None    # parent context, so phase spans nest as CHILDREN (one trace/cycle)
+        self._otel_phase = None        # (name, span) of the single currently-open phase (sweep model)
+        self._otel_attr = None         # attribution span (a nested lookup, tracked off the sweep)
+        self._otel_await = None        # standby / round-open wait span (root; makes a spare visible)
+        self._otel_launch_start = None  # batch launch_script_start (outside srun) for the cold-start
+        self._otel_cycle_start_ns = None  # current cycle span start (this round's rendezvous start)
+        self._otel_cold_done = False    # nvrx.cold_start emitted (once per agent = once per node)
+        self._otel_outcome = None      # outcome the agent staged for the current cycle
+        self._otel_extra = {}          # extra attrs the agent staged for the current cycle
+
+    # Per-cycle event order (each node runs its OWN rendezvous, so every node sees these):
+    #   RENDEZVOUS_STARTED -> HEALTH_CHECK_COMPLETED -> RENDEZVOUS_COMPLETED -> WORKER_START_STARTED
+    #   -> WORKER_START_COMPLETED -> (training) -> FAILURE_DETECTED -> WORKER_TERMINATED.
+    # An EVICTED node bails right after HEALTH_CHECK_COMPLETED (UnhealthyNodeException in the health
+    # check), so the exclusion catch also emits NODE_EXCLUDED. Phases are a SWEEP -- ONE open phase at
+    # a time, each boundary ENDS the prior phase and STARTS the next -- so nothing leaks OPEN even on
+    # the partial evicted-node sequence, and every phase is a CHILD of the cycle span (one trace per
+    # cycle). health_check opens at RENDEZVOUS_STARTED (it is the first join step) and closes at
+    # HEALTH_CHECK_COMPLETED, so the evicted node ALWAYS gets a closed, flushed health_check span.
+    #   value -> list of (action, arg): 'cycle_open' | 'cycle_close'(outcome) | 'phase'(name)
+    #            | 'end' | 'mark'(name) | 'attr_open' | 'attr_close'
+    _OTEL_SEQ = {
+        'rendezvous_started':        [('cycle_open', None), ('phase', 'health_check')],
+        'health_check_completed':    [('phase', 'rendezvous')],
+        'rendezvous_completed':      [('end', None)],
+        'worker_start_started':      [('phase', 'worker_launch')],
+        'worker_start_completed':    [('phase', 'run')],
+        'failure_detected':          [('mark', 'fault'), ('phase', 'teardown')],
+        'worker_terminated':         [('end', None), ('cycle_close', 'completed')],
+        'node_excluded':             [('end', None), ('mark', 'excluded'), ('cycle_close', 'excluded')],
+        'attribution_get_started':   [('attr_open', None)],
+        'attribution_get_completed': [('attr_close', None)],
+        # standby / round-open wait -- a hot spare (or late node) NOT in the active rendezvous sits
+        # here for the whole cycle. Emitted as a ROOT span so the node shows up even though it never
+        # joined the round; long for a spare, short for an active node just joining.
+        'await_round_started':       [('await_open', None)],
+        'await_round_completed':     [('await_close', None)],
+    }
+
+    def attach_otel(self, tracer, flush=None):
+        """Register the ft_launcher agent's nemo-lens tracer so profiling events become a per-cycle
+        span TREE with immediate flush. Called once, from the agent process, after setup_telemetry()."""
+        self._otel_tracer = tracer
+        self._otel_flush = flush
+
+    def otel_set_launch_start(self, ts):
+        """Batch-script launch_script_start (captured OUTSIDE the single srun). Used ONCE to emit the
+        nvrx.cold_start span [launch_script_start -> this node's first nvrx event]."""
+        self._otel_launch_start = ts
+
+    def otel_cycle_start_seconds(self):
+        """Wall-clock start of the CURRENT cycle span (this round's rendezvous start), or None. The
+        agent stamps it as NVRX_CYCLE_START_TIME on a restart/promotion so pre_startup anchors here."""
+        return None if self._otel_cycle_start_ns is None else self._otel_cycle_start_ns / 1e9
+
+    def otel_annotate_cycle(self, **attrs):
+        """Agent enriches the currently-open cycle span with restart-budget/rendezvous metadata
+        (the recorder opens the cycle at rendezvous; the agent is who knows the budget)."""
+        sp = self._otel_cycle_span
+        if sp is None:
+            return
+        try:
+            for k, v in attrs.items():
+                if v is not None:
+                    sp.set_attribute(k, v)
+        except Exception:
+            pass
+
+    def otel_stage_outcome(self, outcome, **attrs):
+        """Agent stages the cycle outcome (failed/peer_restart) BEFORE teardown; the recorder stamps
+        it on the cycle span when WORKER_TERMINATED closes the cycle."""
+        self._otel_outcome = outcome
+        self._otel_extra = attrs or {}
+
+    def otel_finish_cycle(self, outcome='completed', **attrs):
+        """Agent closes the cycle on a terminal state that has NO teardown event (success/terminated)."""
+        self._otel_outcome = outcome
+        if attrs:
+            self._otel_extra = attrs
+        self._otel_cycle_close(None, outcome)
+        if self._otel_flush is not None:
+            try:
+                self._otel_flush()
+            except Exception:
+                pass
+
+    def _otel_span(self, name, ns, node_id_str, rank=None, parent=True):
+        """Start a span, parented to the current cycle span (child) when one is open. parent=False
+        forces a ROOT span (used by the standby wait, which happens BEFORE any cycle opens)."""
+        tr = self._otel_tracer
+        ctx = self._otel_cycle_ctx if parent else None
+        try:
+            sp = tr.start_span(name, start_time=ns, context=ctx)
+        except TypeError:
+            sp = tr.start_span(name, start_time=ns)
+        try:
+            sp.set_attribute('lens.group', 'restart')
+            sp.set_attribute('lens.span_category', 'goodput')
+            sp.set_attribute('nvrx.cycle', self._current_cycle)
+            if node_id_str is not None:
+                sp.set_attribute('nvrx.node', node_id_str)
+            if rank is not None:
+                sp.set_attribute('nvrx.rank', rank)
+        except Exception:
+            pass
+        return sp
+
+    def _otel_cycle_open(self, ns, node_id_str):
+        if self._otel_cycle_span is not None:
+            return  # cycle already open
+        self._otel_outcome = None
+        self._otel_extra = {}
+        sp = self._otel_span('nvrx.restart.cycle', ns, node_id_str)
+        self._otel_cycle_span = sp
+        self._otel_cycle_start_ns = ns
+        try:
+            from opentelemetry import trace as _t
+            self._otel_cycle_ctx = _t.set_span_in_context(sp)
+        except Exception:
+            self._otel_cycle_ctx = None
+
+    def _otel_cycle_close(self, ns, outcome):
+        self._otel_end_phase(ns)
+        sp = self._otel_cycle_span
+        if sp is not None:
+            try:
+                sp.set_attribute('nvrx.cycle_outcome', self._otel_outcome or outcome or 'completed')
+                for k, v in (self._otel_extra or {}).items():
+                    if v is not None:
+                        sp.set_attribute(k, v)
+                sp.end(end_time=ns if ns is not None else int(time.time() * 1e9))
+            except Exception:
+                pass
+        self._otel_cycle_span = None
+        self._otel_cycle_ctx = None
+        self._otel_outcome = None
+        self._otel_extra = {}
+
+    def _otel_start_phase(self, name, ns, node_id_str, rank):
+        self._otel_end_phase(ns)  # sweep: close the prior phase before opening the next
+        sp = self._otel_span('nvrx.restart.' + name, ns, node_id_str, rank)
+        self._otel_phase = (name, sp)
+
+    def _otel_end_phase(self, ns):
+        if self._otel_phase is not None:
+            _, sp = self._otel_phase
+            self._otel_phase = None
+            try:
+                sp.end(end_time=ns if ns is not None else int(time.time() * 1e9))
+            except Exception:
+                pass
+
+    def _otel_mark(self, name, ns, node_id_str):
+        sp = self._otel_span('nvrx.restart.' + name, ns, node_id_str)
+        try:
+            sp.end(end_time=ns)  # instant marker (zero-duration)
+        except Exception:
+            pass
+
+    def _otel_on_event(self, event, timestamp, node_id_str, rank):
+        """Drive the per-cycle span tree from this boundary event, then flush immediately so an
+        evicted node's spans survive its kill. Never raises -- telemetry can't break FT."""
+        if self._otel_tracer is None:
+            return
+        node_id_str = _clean_node(node_id_str)
+        ns = int(timestamp * 1e9)
+        try:
+            # One-time "outside srun -> first nvrx" cold start: batch launch_script_start -> this
+            # agent's FIRST recorded event. Backdated, closed immediately; per node, exactly once.
+            if not self._otel_cold_done and self._otel_launch_start is not None:
+                self._otel_cold_done = True
+                cs = self._otel_tracer.start_span('nvrx.cold_start',
+                                                  start_time=int(self._otel_launch_start * 1e9))
+                cs.set_attribute('lens.group', 'restart')
+                cs.set_attribute('lens.span_category', 'goodput')
+                cs.set_attribute('nvrx.node', node_id_str)
+                cs.end(end_time=ns)
+            for action, arg in self._OTEL_SEQ.get(event.value, ()):
+                if action == 'cycle_open':
+                    self._otel_cycle_open(ns, node_id_str)
+                elif action == 'cycle_close':
+                    self._otel_cycle_close(ns, arg)
+                elif action == 'phase':
+                    self._otel_start_phase(arg, ns, node_id_str, rank)
+                elif action == 'end':
+                    self._otel_end_phase(ns)
+                elif action == 'mark':
+                    self._otel_mark(arg, ns, node_id_str)
+                elif action == 'attr_open':
+                    self._otel_attr = self._otel_span('nvrx.restart.attribution', ns, node_id_str, rank)
+                elif action == 'attr_close':
+                    if self._otel_attr is not None:
+                        try:
+                            self._otel_attr.end(end_time=ns)
+                        except Exception:
+                            pass
+                        self._otel_attr = None
+                elif action == 'await_open':
+                    # a standby node loops RENDEZVOUS_STARTED->health_check without RENDEZVOUS_COMPLETED,
+                    # so close any phase it left open before we start waiting -- otherwise the open
+                    # 'rendezvous' phase would span the whole standby wait and double-count await_round.
+                    self._otel_end_phase(ns)
+                    self._otel_await = self._otel_span('nvrx.restart.await_round', ns, node_id_str,
+                                                       parent=False)  # ROOT: precedes any cycle
+                elif action == 'await_close':
+                    if self._otel_await is not None:
+                        try:
+                            self._otel_await.end(end_time=ns)
+                        except Exception:
+                            pass
+                        self._otel_await = None
+            if self._otel_flush is not None:
+                self._otel_flush()
+        except Exception:
+            pass  # telemetry must never break the launcher
 
     def _timestamp_to_utc_datetime(self, timestamp: float) -> str:
         """Convert timestamp to UTC datetime string."""
@@ -83,6 +315,11 @@ class FaultToleranceProfiler:
         # Convert node_id to string for event ID and logging
         node_id_str = str(node_id) if node_id is not None else 'unknown'
         event_id = f"{event.value}_{timestamp}_{node_id_str}_{rank or 'unknown'}"
+
+        # OTel: turn this pre-placed boundary event into a nemo-lens PHASE span (rendezvous /
+        # health_check / worker_launch / run / teardown / attribution), flushed immediately so the
+        # EVICTED node's restart sequence survives its kill. No-op unless the agent attached a tracer.
+        self._otel_on_event(event, timestamp, node_id_str, rank)
 
         # Increment cycle count for failure detection events
         if event == ProfilingEvent.FAILURE_DETECTED:


### PR DESCRIPTION
Per-cycle span TREE (cycle parent + sweep phase children) via a hook in the ProfilingEvent recorder: rendezvous/health_check/worker_launch/run/teardown, + NODE_EXCLUDED (evicted node), await_round (standby/spare visibility), one-time cold_start, immediate flush so an evicted node's spans survive its kill. Agent stamps cycle metadata (budget, topology: infra_rank/active/standby/ active_ranks/membership) and per-restart launch stamps (NVRX_LAUNCH_TIME/NVRX_CYCLE/ NVRX_CYCLE_START_TIME/NVRX_INFRA_RANK/NVRX_MEMBERSHIP) into the worker env. Normalized nvrx.node.