### PR TITLE
Keep attribution logs under NVRx directory

### DIFF
--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -231,9 +231,12 @@ a launcher-managed attribution service:
   - ``--ft-attribution-export-url <URL>`` (alias: ``--ft_attribution_export_url``)
 
   The managed attribution app-log directory is derived from
-  ``dirname(realpath(--ft-per-cycle-applog-prefix))``. Its stdout/stderr log is derived
-  from ``--ft-per-cycle-applog-prefix`` as ``*_attribution.log``. The managed service listens on
-  ``127.0.0.1:50050`` and is exposed to the in-job client as ``http://localhost:50050``.
+  ``dirname(realpath(--ft-per-cycle-applog-prefix))``. When ``--ft-nvrx-logfile`` is set, the
+  managed service stdout/stderr log is derived from it as ``*_attribution.log`` and written
+  beside it. Without ``--ft-nvrx-logfile``, the log is named from the application prefix and
+  written under an ``nvrx/`` subdirectory of the application-log directory. The managed service
+  listens on ``127.0.0.1:50050`` and is exposed to the in-job client as
+  ``http://localhost:50050``.
 
   The managed attribution API key must come from ``--ft-attribution-llm-api-key-file`` or inherited
   ``LLM_API_KEY_FILE``. If neither points to a readable file, the TCPStore-host launcher fails

--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -159,7 +159,10 @@ class AttributionConfig:
                 f"{applog_dir!r} does not contain {base_real!r}"
             )
 
-        log_file = _attribution_log_path(base_log_file)
+        log_file = _attribution_log_path(
+            base_log_file,
+            nvrx_log_file=getattr(args, "ft_nvrx_logfile", None),
+        )
         log_file = os.path.realpath(os.path.abspath(os.path.expanduser(log_file)))
         log_parent = os.path.dirname(log_file) or "."
         os.makedirs(log_parent, exist_ok=True)
@@ -354,10 +357,16 @@ def _attribution_command() -> list[str]:
     return [sys.executable, "-m", "nvidia_resiliency_ext.services.attrsvc"]
 
 
-def _attribution_log_path(base_log_file: str) -> str:
-    if base_log_file.endswith(".log"):
-        return base_log_file[:-4] + "_attribution.log"
-    return base_log_file + "_attribution.log"
+def _attribution_log_path(base_log_file: str, *, nvrx_log_file: Optional[str] = None) -> str:
+    name_source = nvrx_log_file or base_log_file
+    base_name = os.path.basename(name_source)
+    if base_name.endswith(".log"):
+        base_name = base_name[:-4]
+    attribution_name = base_name + "_attribution.log"
+
+    if nvrx_log_file:
+        return os.path.join(os.path.dirname(nvrx_log_file), attribution_name)
+    return os.path.join(os.path.dirname(base_log_file), "nvrx", attribution_name)
 
 
 def _validate_attribution_endpoint(endpoint: str) -> None:

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -26,6 +26,7 @@ def _args(**overrides):
         "ft_attribution_stop_action": None,
         "ft_attribution_log_level": None,
         "ft_attribution_export_url": None,
+        "ft_nvrx_logfile": None,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -94,9 +95,25 @@ def test_managed_attribution_config_derives_applog_dir_and_log_file(tmp_path):
     assert cfg.endpoint == "localhost"
     assert cfg.client_endpoint.endpoint == f"http://127.0.0.1:{DEFAULT_ATTRIBUTION_PORT}"
     assert cfg.applog_dir == str(tmp_path / "logs")
-    assert cfg.log_file == str(tmp_path / "logs" / "train_attribution.log")
+    assert cfg.log_file == str(tmp_path / "logs" / "nvrx" / "train_attribution.log")
     assert cfg.is_enabled
     assert cfg.is_managed
+
+
+def test_managed_attribution_log_uses_nvrx_log_stem_and_directory(tmp_path):
+    base_log = tmp_path / "application" / "train.log"
+    nvrx_log = tmp_path / "nvrx" / "job" / "logs" / "launcher.log"
+    cfg = AttributionConfig.from_args(
+        _args(
+            ft_attribution_endpoint="localhost",
+            ft_nvrx_logfile=str(nvrx_log),
+        ),
+        str(base_log),
+        FaultToleranceConfig(),
+    )
+
+    assert cfg.applog_dir == str(tmp_path / "application")
+    assert cfg.log_file == str(nvrx_log.parent / "launcher_attribution.log")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- write launcher-managed attrsvc stdout/stderr beside `--ft-nvrx-logfile`
- fall back to an `nvrx/` subdirectory when no NVRx logfile is configured
- keep per-cycle application-log directories free of NVRx control-process logs

## Why

The attribution service analyzes application logs, but its own process log is NVRx operational data. It should follow the NVRx log location instead of being written beside user application logs.

## Validation

- `tests/fault_tolerance/unit/test_attribution_manager.py` (46 passed)
- Black and isort checks for changed Python files
- `git diff --check`
