### PR TITLE
examples/ft: carry no-restart verdict in a file

### DIFF
--- a/examples/fault_tolerance/deployment/slurm/README.md
+++ b/examples/fault_tolerance/deployment/slurm/README.md
@@ -93,9 +93,10 @@ ClusterUUID, e.g. H100), `NVRX_GPUS_PER_NUMA` (2), `NVRX_LOG_DEBUG` (true),
 
 `NVRX_STORE_CONNECT_WAIT` and `NVRX_RDZV_HOST_WAIT` share a default on purpose. A cold
 spare that starts in the window between task 0's `srun` exiting and its `EXIT` trap
-writing `RDZV_CLOSED` escapes both the flag and `cancel_pending_spares`, and will hold
-its node until one of these two expires — the gate wait if it started before task 0
-published `rdzv_host`, the store wait if after. That drain is on the critical path:
+writing `RDZV_CLOSED` escapes the flag, and holds its node until `cancel_generation`
+collects it — or, if that `scancel` failed, until one of these two expires: the gate wait
+if it started before task 0 published `rdzv_host`, the store wait if after. That drain is
+on the critical path:
 `--dependency=singleton` holds the successor generation until the array's last task
 exits. Raise `NVRX_STORE_CONNECT_WAIT` where task 0's startup can exceed it (container
 pull, cold shared filesystem) — set too tight, no generation ever forms.
@@ -143,6 +144,13 @@ restart a few times before giving up) and `NVRX_FAULT_DELAY` (60).
 init + `NVRX_FAULT_DELAY` + the progress check; lower `NVRX_FAULT_DELAY` to speed it up).
 Watch for `ft_launcher` exit `93`, then `cancel_chain` in task 0's stdout; the watcher
 then reports `chain_exhausted` (and, if `cancel_chain` had failed, `chain_not_cancelled`).
+At the demo's `NODES_PER_TASK=1` task 0 records 93 itself: one task per step, no peer to
+trigger a teardown. At `NODES_PER_TASK>1` on a site with `KillOnBadExit=1` it will not — a
+peer exits 93 first, the step comes down, and task 0 is signalled during its store-host
+grace wait, so `srun` returns 143. That is why the trap reads `control/no_restart` rather
+than `$?`. `chain_not_cancelled` keys on sacct's code, so it cannot see that case either; a
+`cancel_chain` that fails there shows up as `chain_exhausted` or in `squeue`, not in that
+detector.
 
 ### Hot spares vs cold spares
 
@@ -181,10 +189,21 @@ neither the job nor `squeue` will tell you about.
 3. **`ft_launcher` runs.** Sections bound each phase — `setup:900,step:60,
    checkpointing:300` — and out-of-section code gets 90s. NVRx restarts in place, up to
    `--max-restarts`, promoting standby nodes as needed.
-4. **Teardown.** Task 0's trap writes `RDZV_CLOSED` and releases the pool. On exit
-   code 93 (NVRx: do not restart) it cancels the queued chain instead, because
-   otherwise the singleton dependency would start the next generation and reproduce
-   the same failure.
+4. **Teardown.** Task 0's trap writes `RDZV_CLOSED`, cancels the queued chain if NVRx
+   returned the no-restart verdict (otherwise the singleton dependency would start the
+   next generation and reproduce the same failure), and finally `scancel`s this array
+   outright — every task, any state, so a cold spare that escaped the gate does not hold
+   a node for the length of `NVRX_STORE_CONNECT_WAIT`.
+
+   The verdict is read from a **file**, not from task 0's exit code. Where the site sets
+   `KillOnBadExit=1` and `NODES_PER_TASK>1`, the first peer to exit 93 takes the step down,
+   and the store host — last alive by design, since it waits ~3s after closing the
+   rendezvous so peers can read the final TCPStore state — is signalled mid-wait, leaving
+   `srun` to hand the batch script 143. So each task's `sh` writes
+   `control/no_restart` before exiting 93; SLURM's task is that `sh`, so the write always
+   precedes the exit that triggers the teardown, and any node that exited cleanly is a
+   better witness than task 0's own code. The flag is per-generation and needs no cleanup;
+   `cancel_chain` remains the one mechanism that stops the successors.
 
 ---
 

--- a/examples/fault_tolerance/deployment/slurm/nvrx_singleton_array.sbatch
+++ b/examples/fault_tolerance/deployment/slurm/nvrx_singleton_array.sbatch
@@ -184,6 +184,27 @@ mkdir -p "${NVRX_JOB_DIR}"/{control,cycle_infos,logs}
 RDZV_FILE=${NVRX_JOB_DIR}/control/rdzv_host
 RDZV_CLOSED=${NVRX_JOB_DIR}/control/rdzv_closed
 
+# The no-restart verdict as a file, because $? on task 0 cannot carry it wherever the site
+# sets KillOnBadExit=1 (srun's default source; slurm.conf defaults it to 0, and this script
+# does not override either way). There, at NODES_PER_TASK>1, the first peer to exit
+# NO_RESTART_EXIT_CODE tears the step down while the store host is by design the last one
+# alive -- it sleeps ~3s after closing the rendezvous so peers can read the final TCPStore
+# state -- so it is signalled mid-wait and srun hands this script 143. task0_exit would then
+# read the ordinary branch and the chain would restart a job NVRx said must not restart.
+# Measured, not deduced: srun returns 143 with the peer's 93 already on disk.
+#
+# Race-free because SLURM's task is the `sh` below, not ft_launcher: the step teardown
+# cannot begin until an `sh` exits, and the touch precedes that exit. Whichever node fires
+# the kill has already written the flag.
+#
+# Generation-scoped on purpose. A chain-scoped twin would make cancel_chain durable --
+# level-triggered, so a successor that escaped the scancel would stop itself -- but only if
+# something reliably clears it when a new chain starts, and the sbatch is submittable
+# without submit_chain.sh. A stale flag would then refuse every later run into the same
+# NVRX_WORK_DIR, which is a worse failure than the one it prevents. cancel_chain stays the
+# mechanism; nvrx-watch is the out-of-band backstop for a scancel that failed.
+NO_RESTART_FLAG=${NVRX_JOB_DIR}/control/no_restart
+
 # The file the progress tracker watches. Normally Megatron's live iteration file, which
 # advances every checkpoint. In the no-restart demo it is a static file seeded once by
 # task 0 and never touched again, so every restart cycle reads the same number -> no
@@ -349,15 +370,27 @@ options=" \
 # ---------------------------------------------------------------------------------
 # Generation teardown
 # ---------------------------------------------------------------------------------
-# Release this generation's queued cold spares; without it each is allocated a node
-# only to hit the gate below and exit. --state=PENDING leaves RUNNING tasks their NVRx
-# teardown, and $SLURM_ARRAY_JOB_ID scopes it to this generation.
-cancel_pending_spares() {
-    echo "Releasing pending cold spares of array ${SLURM_ARRAY_JOB_ID}."
-    if ! scancel --state=PENDING "${SLURM_ARRAY_JOB_ID}"; then
+# End this generation outright -- every task, any state, scoped to this array by
+# $SLURM_ARRAY_JOB_ID. Deliberately not --state=PENDING: that filter is evaluated once, so
+# it cannot touch a cold spare that already left PENDING, and such a spare then reads a
+# published rdzv_host, probes a store host that is gone, and waits out
+# store_connect_wait_seconds (300s) holding a node. --dependency=singleton holds the
+# successor generation until this array fully exits, so that drain is on the chain's
+# critical path. Cancelling the array job itself is also level-triggered: no remaining task
+# of it can start afterwards, which no state filter can promise.
+#
+# The cost is that RUNNING peers lose the tail of their NVRx teardown. Bounded, not abrupt:
+# SLURM sends SIGTERM first and waits KillWait before SIGKILL, and ft_launcher handles
+# SIGTERM by stopping its ranks (see --ft-* termination intervals). Confirm KillWait
+# exceeds those intervals for the site, or the tail is cut anyway.
+#
+# Includes task 0, i.e. this script: nothing may follow the call in the EXIT trap.
+cancel_generation() {
+    echo "Cancelling all remaining tasks of array ${SLURM_ARRAY_JOB_ID}."
+    if ! scancel "${SLURM_ARRAY_JOB_ID}"; then
         # Not fatal and not silent: nvrx-watch corrects this state from outside, on a
         # retrying loop. Swallowing the status here is what made it undiagnosable.
-        echo "WARNING: scancel of pending spares failed; nvrx-watch should reconcile."
+        echo "WARNING: scancel of this generation failed; nvrx-watch should reconcile."
     fi
 }
 
@@ -387,15 +420,20 @@ cancel_chain() {
 # $? must be read first -- any command here would overwrite it. Bash saves the pending
 # exit status before running an EXIT trap and restores it after, so nothing below can
 # change the code SLURM records.
+#
+# The flag is tested before rc and not merely alongside it: rc is the code that survived
+# ft_launcher -> sh -c -> srun, and under kill-on-bad-exit task 0's own launcher is the one
+# whose code the teardown rewrites (see NO_RESTART_FLAG). A flag written by any node that
+# did exit cleanly is the more trustworthy witness.
 task0_exit() {
     local rc=$?
     echo "Task 0 exiting (rc=${rc}), creating RDZV_CLOSED file"
     touch "$RDZV_CLOSED"
-    if (( rc == NO_RESTART_EXIT_CODE )); then
+    if [[ -f "$NO_RESTART_FLAG" ]] || (( rc == NO_RESTART_EXIT_CODE )); then
         cancel_chain "$rc"
-    else
-        cancel_pending_spares
     fi
+    # Last: this cancels task 0 too, so nothing after it is guaranteed to run.
+    cancel_generation
 }
 
 # ---------------------------------------------------------------------------------
@@ -464,14 +502,16 @@ OPTIONAL_ARGS=""
 [[ -n "$NVRX_MAX_NO_PROGRESS_CYCLES" ]] && \
     OPTIONAL_ARGS+=" --ft-max-no-progress-cycles ${NVRX_MAX_NO_PROGRESS_CYCLES}"
 
-# store_connect_wait_seconds bounds the dead-generation drain, and bounding it is the
-# whole mechanism: a cold spare that reaches CONFIGURING/RUNNING after task 0's srun
-# exits but before its EXIT trap writes RDZV_CLOSED cannot be stopped by the flag (not
-# written yet) or by cancel_pending_spares (no longer PENDING). It reads a published
+# store_connect_wait_seconds bounds the dead-generation drain: a cold spare that reaches
+# CONFIGURING/RUNNING after task 0's srun exits but before its EXIT trap writes
+# RDZV_CLOSED cannot be stopped by the flag (not written yet). It reads a published
 # rdzv_host, breaks the gate above on its first iteration, and probes a host that is
 # gone. Nothing upstream closes that race -- a task-0 liveness check does not either,
-# since task 0 is still RUNNING while its own trap executes -- so the cost is capped
-# here rather than prevented.
+# since task 0 is still RUNNING while its own trap executes.
+#
+# cancel_generation is what normally collects such a spare, seconds later and whatever
+# state it is in; this bound is the backstop for the case where that scancel failed, so
+# it stays sized for a spare nobody cancels.
 #
 # 300 matches NVRX_RDZV_HOST_WAIT, so both escape paths cost the same: a spare that
 # starts before publication waits out the gate, one that starts after waits out this.
@@ -494,7 +534,13 @@ LAUNCHER_ARGS=" \
     --ft-rank-out-of-section-timeout 90 \
     ${OPTIONAL_ARGS} "
 
-run_cmd="ft_launcher ${LAUNCHER_ARGS} ${MEGATRON_PATH}/pretrain_gpt.py ${options}"
+# The trailing shell is what carries the no-restart verdict out of the step teardown: the
+# launcher's own exit code does not survive it on the store host (see NO_RESTART_FLAG).
+# Every \$ is escaped so the outer bash leaves it for the `sh -c` that srun runs.
+run_cmd="ft_launcher ${LAUNCHER_ARGS} ${MEGATRON_PATH}/pretrain_gpt.py ${options}
+rc=\$?
+if [ \"\$rc\" -eq ${NO_RESTART_EXIT_CODE} ]; then touch '${NO_RESTART_FLAG}'; fi
+exit \$rc"
 
 # Names of host env vars to forward into the container. NVRX_GPUS_PER_NUMA (rank-to-NUMA
 # binding) and NVRX_INJECT_GPU_FAILURE (the HW-failure injector) must reach the ranks;

--- a/examples/fault_tolerance/deployment/slurm/submit_chain.sh
+++ b/examples/fault_tolerance/deployment/slurm/submit_chain.sh
@@ -22,9 +22,9 @@ SBATCH_SCRIPT="${SCRIPT_DIR}/nvrx_singleton_array.sbatch"
 # spare + 1 cold spare. Scale up for real training (see the README).
 export NVRX_TRAIN_TASKS="${NVRX_TRAIN_TASKS:-1}"     # tasks the model is sized for
 export NVRX_HOT_SPARES="${NVRX_HOT_SPARES:-1}"       # running, standby, absorb a failure
-NVRX_COLD_SPARES="${NVRX_COLD_SPARES:-3}"            # queued; several so the pending-task
-                                                    # cancellation (cancel_chain /
-                                                    # cancel_pending_spares) is visible
+NVRX_COLD_SPARES="${NVRX_COLD_SPARES:-3}"            # queued; several so the teardown
+                                                    # (cancel_chain / cancel_generation)
+                                                    # is visible
 NODES_PER_TASK="${NODES_PER_TASK:-1}"
 export GPUS_PER_NODE="${GPUS_PER_NODE:-4}"   # GB200 tray default; 8 for HGX/DGX
 


### PR DESCRIPTION
## Problem

In `nvrx_singleton_array.sbatch`, `task0_exit` decides whether to cancel the queued chain by testing `$?` against the no-restart exit code (93). That code does not survive the step teardown.

Where the site sets `KillOnBadExit=1` and `NODES_PER_TASK>1`:

1. NVRx returns a no-restart verdict; the store host closes the rendezvous and sleeps ~3s so peers can read the final TCPStore state.
2. Peers read the close key and exit 93 during that window.
3. The first 93 tears the step down; the store host — last alive by design — is signalled mid-wait.
4. `srun` hands the batch script **143**, so `(( rc == 93 ))` is false, `cancel_chain` never runs, and `--dependency=singleton` starts the successor generation that reproduces the failure NVRx asked to stop.

`chain_not_cancelled` in nvrx-watch cannot catch this: it keys on the same rewritten sacct code.

## Fix

Each task's `sh` wrapper touches `control/no_restart` before exiting 93, and `task0_exit` tests that flag before `$?`. Race-free: SLURM's task is the `sh`, not `ft_launcher`, so the step teardown cannot begin until an `sh` exits, and the write precedes that exit — whichever node fires the kill has already written the flag.

The flag is generation-scoped (`${NVRX_JOB_DIR}/control/`, already fresh per `SLURM_ARRAY_JOB_ID`), so nothing has to clean it up. A chain-scoped variant was considered and rejected: it would need a guaranteed clear point, and the sbatch is submittable without `submit_chain.sh`.

Also in this change: `cancel_pending_spares` → `cancel_generation`, an unfiltered `scancel "$SLURM_ARRAY_JOB_ID"`. `--state=PENDING` is evaluated once, so it cannot collect a cold spare that already left PENDING — such a spare holds a node for `store_connect_wait_seconds` (300s) on the chain's critical path. `cancel_chain` keeps its `--state=PENDING`, because its selector is `--name` + `--user` and the filter is what bounds the blast radius on a job-name collision.

## Verification

Synthetic 2-node reproducer on an `KillOnBadExit=1` cluster (AGA), mirroring the structure with no NVRx or Megatron — peer exits 93 first, store host sleeps in its grace wait:

```
1: [procid=1] read close key, exiting 93
1: [procid=1] wrote flag
srun: error: task 1: Exited with exit code 93
srun: Terminating StepId=...
srun: error: task 0: Terminated
=== srun returned 143
RESULT rc=143 flag=present
RESULT old_logic=ordinary_branch  <-- chain would restart a doomed job
RESULT new_logic=cancel_chain
```

The signature is visible in real runs too: production 16-node array tasks record batch `143:0` while the `sh` step exits `1` (torch's `SignalException` path), with no 93 surviving anywhere.

Also checked: `bash -n` on both scripts; the generated `run_cmd` executed under `sh` (quoting survives, 93 propagates, flag lands); trap branch logic across `rc` ∈ {0, 1, 93, 143} × flag present/absent.

## Notes

- No tracked issue yet — happy to file one and re-title per the `#<Issue> - <Title>` convention.
- Not included, and worth deciding separately: on the launcher side, a `SignalException` raised during the store host's grace wait (`launcher.py:1759-1776`) replaces the pending `NoRestartRequested`, so the head node's own exit reads as a generic failure. Cosmetic once the flag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)