### PR TITLE
Consume scheduler exclusions in FT rendezvous

### DIFF
--- a/docs/design/segment_health_check_ft_spec.md
+++ b/docs/design/segment_health_check_ft_spec.md
@@ -1,0 +1,73 @@
+# Segment Health Check: FT Consumer Design
+
+## Purpose
+
+NVRx consumes a shared segment health decision before joining rendezvous.
+The restart path performs filesystem I/O only; it does not query Slurm or call
+an external service. The
+[integration guide](../source/fault_tolerance/integration/segment_health_check.rst)
+owns the user-facing configuration, artifact contract, and supported launch
+shape.
+
+## Internal Flow
+
+```text
+FtRendezvousBarrierHandler initialization
+  -> get_segment_health_check()
+       -> ineligible launcher: no check installed
+       `-> eligible allocation-unit process 0: SegmentHealthCheck(directory, job_id, task_id)
+
+pre_join_hook
+  -> ensure_node_is_healthy()
+       -> SegmentHealthCheck._perform_health_check()
+       -> existing local node checks
+       `-> _run_health_check() converts failure to UnhealthyNodeException
+            -> array path marks replacement group unhealthy
+            `-> regular-job path exits the workload step
+```
+
+### Installation Guard
+
+`get_segment_health_check()` installs the check only on the launcher with
+`SLURM_PROCID=0`. Arrays use `SLURM_ARRAY_JOB_ID` and `SLURM_ARRAY_TASK_ID`;
+regular jobs use `SLURM_JOB_ID` as both the artifact scope and exclusion token.
+Missing job identity leaves the check uninstalled; other launchers return
+without logging. Successful installation emits one INFO record.
+
+### Decision Evaluation
+
+The concrete `SegmentHealthCheck` in
+`fault_tolerance/segment_health_check.py` owns the configured directory and
+Slurm job/task IDs. Its `_perform_health_check()`:
+
+1. derives `segment_health_check.<job_id>.<task_id>` from the configured
+   directory;
+2. performs one metadata check; and
+3. returns unhealthy only when the path is a non-empty regular file.
+
+The file content is producer-owned diagnostic context and is not read by the
+consumer. A missing or zero-byte file is healthy and quiet. An unreadable path
+or unexpected file type logs a warning and fails open.
+
+### Rendezvous Handoff
+
+A matching allocation ID returns unhealthy through `_run_health_check()`, which
+raises `UnhealthyNodeException`. For arrays, the existing pre-join exception
+path uses `SLURM_ARRAY_TASK_ID` as the replacement-group token and adds it to
+`unhealthy_replacement_groups_<round>`. A regular job has no replacement-group
+token; process 0 exits nonzero and `srun --kill-on-bad-exit=1` terminates its
+workload step. Segment Health Check adds no host-side selection path.
+
+## Implementation Map
+
+| Area | Responsibility |
+| --- | --- |
+| `fault_tolerance/segment_health_check.py` | Identify eligible process-0 launchers and implement `SegmentHealthCheck`. |
+| `fault_tolerance/config.py` and launcher plumbing | Validate and pass the decision directory into rendezvous settings. |
+| `fault_tolerance/ft_rendezvous_barrier.py` | Install the check and reuse the existing health-check exception path. |
+| `tests/fault_tolerance/unit/` | Cover installation, per-task file state, failure handling, and rendezvous propagation. |
+
+## Verification
+
+Environment-specific E2E scenarios, commands, and result analysis live with
+the deployment validation harness rather than this product design.

--- a/docs/source/fault_tolerance/integration.rst
+++ b/docs/source/fault_tolerance/integration.rst
@@ -9,4 +9,4 @@ Integration Guides
    integration/sections
    integration/ptl
    integration/inprocess
-
+   integration/segment_health_check

--- a/docs/source/fault_tolerance/integration/segment_health_check.rst
+++ b/docs/source/fault_tolerance/integration/segment_health_check.rst
@@ -1,0 +1,91 @@
+Segment Health Check
+====================
+
+The segment health check prevents NVRx from reusing a Slurm allocation unit
+after it is marked unavailable. The unit is an array task for a job array or
+the job itself for a regular Slurm job. The FT consumer reads a decision
+artifact from shared storage before joining rendezvous; it does not require
+Slurm access inside the workload environment. The decision publisher is
+independent of this consumer as long as it satisfies the artifact contract
+below.
+
+Configuration
+-------------
+
+Pass the shared decision directory to ``ft_launcher``:
+
+.. code-block:: bash
+
+   ft_launcher \
+     --ft-segment-health-check-dir /shared/job/segment-health-check \
+     <other-options> train.py
+
+The path must be absolute and accessible to every launcher. Omitting the option
+disables consumption. The equivalent YAML field is
+``fault_tolerance.segment_health_check_dir``.
+
+Supported Launch Shape
+----------------------
+
+The FT consumer supports Slurm job arrays and regular jobs. Both require one
+``ft_launcher`` process per allocated node and ``srun --kill-on-bad-exit=1``, so
+an excluded process 0 terminates the workload step. Job arrays additionally
+require ``--no-requeue`` for the initial deployment artifact lifecycle.
+
+Only the launcher with ``SLURM_PROCID=0`` in each allocation unit reads the
+artifact.
+
+Artifact Contract
+-----------------
+
+The consumer derives the following path in the configured directory:
+
+.. code-block:: text
+
+   segment_health_check.<job_id>.<task_id>
+
+For an array, ``job_id`` is ``SLURM_ARRAY_JOB_ID`` and ``task_id`` is
+``SLURM_ARRAY_TASK_ID``. For a regular job, both values are ``SLURM_JOB_ID``.
+
+A non-empty regular file marks the allocation unit unhealthy. A missing or
+zero-byte file proceeds normally. The file content is diagnostic context owned
+by the producer; the consumer performs one metadata check and does not read or
+parse it. Unreadable paths and unexpected file types emit a warning and fail
+open.
+
+Runtime Behavior
+----------------
+
+Only allocation-unit process 0 reads the artifact before rendezvous. A clean or
+fail-open result joins normally. A match raises ``UnhealthyNodeException``
+through the existing health-check path and exits nonzero. For an array, the
+same path also marks its replacement group unhealthy; the rendezvous host
+already ignores unhealthy replacement groups. A regular job has no array-task
+replacement group, so process-0 failure terminates its workload step through
+``srun --kill-on-bad-exit=1``.
+
+Other participants from that array task may join before process 0 publishes the
+unhealthy marker. Slurm then terminates the task after process 0 exits, which
+can require one additional rendezvous before eligible spares are selected.
+
+With enough eligible spares, rendezvous proceeds without the excluded task. If
+quorum cannot be formed, the existing rendezvous timeout applies; NVRx does not
+weaken the exclusion to create quorum.
+
+A scheduler state such as Slurm ``DRAIN`` does not evict a task that is already
+running. NVRx consumes the corresponding decision at the next rendezvous
+health-check boundary.
+
+Observability
+-------------
+
+An eligible allocation-unit process 0 logs once when the check is installed:
+
+.. code-block:: text
+
+   Segment health check installed directory=/shared/nvrx job_id=123 task_id=7
+
+A missing decision fails open quietly because the producer may not be running.
+An unreadable path or unexpected file type emits a warning. An exclusion is
+reported by the existing health-check error path. Other launchers do not
+install the segment check or inspect the artifact.

--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -199,6 +199,17 @@ Validation behavior:
   - Other existing types (e.g., devices/symlinks): performs ``stat`` access
 
 
+Segment Health Check
+^^^^^^^^^^^^^^^^^^^^
+
+Set ``--ft-segment-health-check-dir <ABSOLUTE_PATH>`` or
+``fault_tolerance.segment_health_check_dir`` to consume segment health
+decisions before rendezvous. Omitting the setting disables the check.
+
+See the :doc:`Segment Health Check integration guide
+<integration/segment_health_check>` for the consumer contract.
+
+
 Attribution service integration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/config.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/config.py
@@ -107,6 +107,9 @@ class FaultToleranceConfig:
       the cycle_info.<job_id>.current symlink there. The workload receives the path
       to the current cycle file via NVRX_CURRENT_CYCLE_INFO.
       Default: None (disabled).
+    * `segment_health_check_dir` [str|None] Shared directory containing per-task
+      segment health decision artifacts. Allocation-unit process 0 checks its artifact
+      before joining a rendezvous. Default: None (disabled).
 
     If any timeout is None, it has no effect (as if it was +INF).
     All timeouts can be deduced and set during runtime.
@@ -155,6 +158,9 @@ class FaultToleranceConfig:
 
     # NVRx cycle info: base directory for cycle_info JSON files
     cycle_info_dir: Optional[str] = None
+
+    # Segment health check: shared directory containing per-task decision artifacts
+    segment_health_check_dir: Optional[str] = None
 
     @property
     def is_progress_tracking_enabled(self) -> bool:

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -71,6 +71,7 @@ from .cycle_info_writer import CycleInfoReporter, CycleInfoRoundSnapshot, cycle_
 from .data import WorkloadAction
 from .ipc_connector import IpcConnector
 from .launcher import FT_LAUNCHER_IPC_SOCKET, UnhealthyNodeException, get_node_health_check
+from .segment_health_check import get_segment_health_check
 
 # Conditionally import failure injector (only active when NVRX_INJECT_GPU_FAILURE is set)
 if os.environ.get("NVRX_INJECT_GPU_FAILURE"):
@@ -220,6 +221,8 @@ class RendezvousSettings:
         nproc_per_node:
             Number of processes per node (local_world_size). Used to restore local_world_size
             when a standby node becomes active.
+        segment_health_check_dir:
+            Shared directory containing segment health decision artifacts.
     """
 
     run_id: str
@@ -231,6 +234,7 @@ class RendezvousSettings:
     segment: Optional[int] = None
     replacement_group_size: Optional[int] = None
     nproc_per_node: int = 1  # Default to 1 if not specified
+    segment_health_check_dir: Optional[str] = None
 
 
 @dataclass(eq=True, order=True, frozen=True)
@@ -2346,6 +2350,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         attribution_enforce_stop: bool = False,
         cycle_info_dir: Optional[str] = None,
         cycle_log_prefix: Optional[str] = None,
+        segment_health_check_dir: Optional[str] = None,
     ):
         """Create a new :py:class:`FtRendezvousBarrierHandler`.
 
@@ -2396,6 +2401,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             segment=segment,
             replacement_group_size=replacement_group_size,
             nproc_per_node=nproc_per_node,
+            segment_health_check_dir=segment_health_check_dir,
         )
 
         return cls(
@@ -2451,6 +2457,10 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             )
         if settings.replacement_group_size is not None and settings.replacement_group_size < 1:
             raise ValueError("replacement_group_size must be a positive integer when configured.")
+        if settings.segment_health_check_dir and not os.path.isabs(
+            settings.segment_health_check_dir
+        ):
+            raise ValueError("segment_health_check_dir must be an absolute path.")
 
         self._this_node = node
         self._settings = settings
@@ -2500,6 +2510,7 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
         self._storage_path_checker = (
             StoragePathHealthCheck(storage_healthcheck_paths) if storage_healthcheck_paths else None
         )
+        self._segment_health_checker = get_segment_health_check(settings.segment_health_check_dir)
 
         # Attribution service client (optional, only on master node)
         if is_store_host and attribution_endpoint:
@@ -2625,10 +2636,17 @@ class FtRendezvousBarrierHandler(RendezvousHandler):
             raise UnhealthyNodeException(str(e)) from e
 
     def ensure_node_is_healthy(self) -> None:
-        """Perform GPU, NIC link state, and Node health checks for this node."""
-        # Record the health check message
+        """Perform configured segment- and node-level health checks in order."""
+        # Record the health check before any configured check can raise.
         msg = f"Checking health status of {self._this_node}."
         self._record(message=msg)
+
+        if self._segment_health_checker is not None:
+            self._run_health_check(
+                self._segment_health_checker,
+                "Segment health check",
+                "The current Slurm array task segment is excluded by scheduler state.",
+            )
 
         # Perform GPU health check
         self._run_health_check(
@@ -3088,6 +3106,7 @@ def create_handler(
         )
         cycle_info_dir = params.config.get('cycle_info_dir', None)
         cycle_log_prefix = params.config.get('cycle_log_prefix', None)
+        segment_health_check_dir = params.config.get('segment_health_check_dir', None)
 
         return FtRendezvousBarrierHandler.from_backend(
             params.run_id,
@@ -3109,6 +3128,7 @@ def create_handler(
             attribution_enforce_stop=attribution_enforce_stop,
             cycle_info_dir=cycle_info_dir,
             cycle_log_prefix=cycle_log_prefix,
+            segment_health_check_dir=segment_health_check_dir,
         )
     except Exception as e:
         construct_and_record_rdzv_event(

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -2556,6 +2556,16 @@ def get_args_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--ft-segment-health-check-dir",
+        "--ft_segment_health_check_dir",
+        type=str,
+        default=None,
+        dest="ft_segment_health_check_dir",
+        help="Shared directory containing per-task decisions consumed by the segment health check. "
+        "The feature is disabled when omitted.",
+    )
+
+    parser.add_argument(
         "--ft-skip-section-response",
         "--ft-skip_section_response",
         type=lambda x: str(x).lower() in ["true", "1", "yes"],
@@ -2960,6 +2970,14 @@ def config_from_args(args, launcher_pipe_read_fd=None, launcher_log_file=None) -
 
     fault_tol_cfg = FaultToleranceConfig.from_args(args)
     _validate_attribution_requires_per_cycle_applog(args, fault_tol_cfg)
+
+    if fault_tol_cfg.segment_health_check_dir:
+        if not os.path.isabs(fault_tol_cfg.segment_health_check_dir):
+            raise ValueError(
+                "--ft-segment-health-check-dir must be an absolute path, got: "
+                f"{fault_tol_cfg.segment_health_check_dir}"
+            )
+        rdzv_configs['segment_health_check_dir'] = fault_tol_cfg.segment_health_check_dir
 
     # Pass segment-related configs to rendezvous config
     rdzv_configs['segment'] = fault_tol_cfg.segment

--- a/src/nvidia_resiliency_ext/fault_tolerance/segment_health_check.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/segment_health_check.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Consume segment health decisions before joining rendezvous."""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from pathlib import Path
+from typing import Optional
+
+from nvidia_resiliency_ext.shared_utils.log_manager import LogConfig
+
+log = logging.getLogger(LogConfig.name)
+
+
+class SegmentHealthCheck:
+    """Check whether a Slurm allocation unit remains eligible for rendezvous."""
+
+    def __init__(self, directory: str, job_id: str, task_id: str) -> None:
+        self.directory = directory
+        self.job_id = job_id
+        self.task_id = task_id
+        self._path = Path(directory) / f"segment_health_check.{job_id}.{task_id}"
+
+    def __call__(self) -> bool:
+        return self._perform_health_check()
+
+    def _perform_health_check(self) -> bool:
+        """Evaluate the current segment health artifact, failing open."""
+        try:
+            artifact = self._path.stat()
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            log.warning("Ignoring segment health decision: %s", exc)
+            return True
+
+        if not stat.S_ISREG(artifact.st_mode):
+            log.warning("Ignoring segment health decision: not a regular file: %s", self._path)
+            return True
+
+        return artifact.st_size == 0
+
+
+def get_segment_health_check(directory: Optional[str]) -> Optional[SegmentHealthCheck]:
+    """Return the segment health check for this launcher, when eligible."""
+    if not directory or os.environ.get("SLURM_PROCID") != "0":
+        return None
+
+    job_id = os.environ.get("SLURM_ARRAY_JOB_ID") or os.environ.get("SLURM_JOB_ID")
+    if not job_id:
+        return None
+
+    task_id = os.environ.get("SLURM_ARRAY_TASK_ID") or job_id
+
+    log.info(
+        "Segment health check installed directory=%s job_id=%s task_id=%s",
+        directory,
+        job_id,
+        task_id,
+    )
+    return SegmentHealthCheck(directory, job_id, task_id)

--- a/tests/fault_tolerance/unit/test_barrier_rendezvous.py
+++ b/tests/fault_tolerance/unit/test_barrier_rendezvous.py
@@ -60,6 +60,7 @@ from nvidia_resiliency_ext.fault_tolerance.ft_rendezvous_barrier import (
     _RendezvousBarrierState,
     _StaleRendezvousRoundError,
 )
+from nvidia_resiliency_ext.fault_tolerance.segment_health_check import SegmentHealthCheck
 
 # Test timeout configuration - use short timeouts to make tests run faster
 TEST_SEGMENT_CHECK_INTERVAL_SECS = 0.1  # seconds - for segment constraint check interval
@@ -444,8 +445,8 @@ class BarrierStateBasicTest(BaseRendezvousTest):
 
         self.assertEqual(_RendezvousBarrierState._current_replacement_group_id(), "external-rg")
 
-    def test_current_replacement_group_id_uses_slurm_array_id(self):
-        """SLURM job arrays use the array task id as the replacement group id."""
+    def test_current_replacement_group_id_uses_slurm_array_task_id(self):
+        """SLURM job arrays use their task ID as the replacement group."""
         os.environ["SLURM_ARRAY_TASK_ID"] = "7"
 
         self.assertEqual(_RendezvousBarrierState._current_replacement_group_id(), "7")
@@ -542,7 +543,12 @@ class BarrierStateBasicTest(BaseRendezvousTest):
             self.assertEqual(state._get_unhealthy_replacement_groups(), {"4"})
             self.assertFalse(self.store.check([state.join_count_key]))
         finally:
-            for var in ("SLURM_ARRAY_TASK_ID", "SLURM_PROCID", "SLURM_NNODES", "SLURM_JOB_ID"):
+            for var in (
+                "SLURM_ARRAY_TASK_ID",
+                "SLURM_PROCID",
+                "SLURM_NNODES",
+                "SLURM_JOB_ID",
+            ):
                 os.environ.pop(var, None)
 
     def test_get_all_participants_incremental_fetch(self):
@@ -2937,6 +2943,7 @@ class HandlerProfilingTest(TestCase):
         settings = MagicMock()
         settings.min_nodes = 1
         settings.max_nodes = 1
+        settings.segment_health_check_dir = None
         handler._settings = settings
 
         barrier_state = MagicMock()
@@ -2989,6 +2996,33 @@ class HandlerProfilingTest(TestCase):
         )
         handler.ensure_node_is_healthy.assert_called_once_with()
         handler.handle_control_requests_from_rank.assert_not_called()
+
+    def test_segment_health_check_runs_before_node_health_checks(self):
+        """An unhealthy task segment leaves before node checks."""
+        handler = object.__new__(FtRendezvousBarrierHandler)
+        handler._this_node = _NodeDesc("node0", 100, 0)
+        handler._record = MagicMock()
+
+        def fail_after_event():
+            handler._record.assert_called_once_with(
+                message=f"Checking health status of {handler._this_node}."
+            )
+            return False
+
+        handler._segment_health_checker = MagicMock(side_effect=fail_after_event)
+        handler._maybe_increment_unhealthy_count = MagicMock()
+
+        with self.assertRaisesRegex(
+            ft_rendezvous_barrier_module.UnhealthyNodeException,
+            "Slurm array task segment",
+        ):
+            handler.ensure_node_is_healthy()
+
+        handler._segment_health_checker.assert_called_once_with()
+        handler._maybe_increment_unhealthy_count.assert_called_once_with()
+        handler._record.assert_called_once_with(
+            message=f"Checking health status of {handler._this_node}."
+        )
 
 
 class HandlerIntegrationTest(BaseRendezvousTest):
@@ -3048,6 +3082,104 @@ class HandlerIntegrationTest(BaseRendezvousTest):
 
         self.assertEqual(handler.settings.replacement_group_size, 2)
         self.assertEqual(handler._barrier_state.replacement_group_size, 2)
+
+    def test_handler_installs_segment_health_check_only_on_array_task_process_zero(self):
+        with patch.dict(
+            os.environ,
+            {
+                "SLURM_ARRAY_JOB_ID": "123",
+                "SLURM_ARRAY_TASK_ID": "7",
+                "SLURM_NODEID": "0",
+                "SLURM_PROCID": "0",
+                "SLURM_JOB_NUM_NODES": "2",
+            },
+            clear=False,
+        ):
+            with self.assertLogs(level="INFO") as logs:
+                handler = FtRendezvousBarrierHandler.from_backend(
+                    run_id=self.run_id,
+                    store=self.store,
+                    backend=None,
+                    min_nodes=2,
+                    max_nodes=4,
+                    timeout=RendezvousTimeout(),
+                    is_store_host=True,
+                    replacement_group_size=2,
+                    segment_health_check_dir="/shared/nvrx",
+                )
+
+        self.assertEqual(handler.settings.segment_health_check_dir, "/shared/nvrx")
+        self.assertIsInstance(
+            handler._segment_health_checker,
+            SegmentHealthCheck,
+        )
+        self.assertEqual(handler._segment_health_checker.directory, "/shared/nvrx")
+        self.assertEqual(handler._segment_health_checker.job_id, "123")
+        self.assertEqual(handler._segment_health_checker.task_id, "7")
+        self.assertTrue(
+            any(
+                "Segment health check installed directory=/shared/nvrx job_id=123 task_id=7"
+                in message
+                for message in logs.output
+            )
+        )
+        with patch.object(
+            handler._segment_health_checker,
+            "_perform_health_check",
+            return_value=True,
+        ) as check:
+            self.assertTrue(handler._segment_health_checker())
+        check.assert_called_once_with()
+
+    def test_handler_does_not_install_segment_health_check_on_other_processes(self):
+        with patch.dict(
+            os.environ,
+            {
+                "SLURM_ARRAY_JOB_ID": "123",
+                "SLURM_ARRAY_TASK_ID": "7",
+                "SLURM_NODEID": "1",
+                "SLURM_PROCID": "1",
+                "SLURM_NNODES": "2",
+            },
+            clear=False,
+        ):
+            handler = FtRendezvousBarrierHandler.from_backend(
+                run_id=self.run_id,
+                store=self.store,
+                backend=None,
+                min_nodes=2,
+                max_nodes=4,
+                timeout=RendezvousTimeout(),
+                is_store_host=True,
+                replacement_group_size=2,
+                segment_health_check_dir="/shared/nvrx",
+            )
+
+        self.assertIsNone(handler._segment_health_checker)
+
+    def test_handler_installs_segment_health_check_for_regular_job_process_zero(self):
+        with patch.dict(
+            os.environ,
+            {
+                "SLURM_JOB_ID": "456",
+                "SLURM_PROCID": "0",
+            },
+            clear=True,
+        ):
+            handler = FtRendezvousBarrierHandler.from_backend(
+                run_id=self.run_id,
+                store=self.store,
+                backend=None,
+                min_nodes=2,
+                max_nodes=4,
+                timeout=RendezvousTimeout(),
+                is_store_host=True,
+                segment_health_check_dir="/shared/nvrx",
+            )
+
+        self.assertIsInstance(handler._segment_health_checker, SegmentHealthCheck)
+        self.assertEqual(handler._segment_health_checker.job_id, "456")
+        self.assertEqual(handler._segment_health_checker.task_id, "456")
 
     def test_create_handler_derives_replacement_group_size_for_slurm_array(self):
         """SLURM job arrays derive replacement_group_size from the per-array node count."""

--- a/tests/fault_tolerance/unit/test_config.py
+++ b/tests/fault_tolerance/unit/test_config.py
@@ -66,6 +66,8 @@ def test_from_args():
         "custom1:111.1,custom2:222.2",
         "--ft-attribution-export-url",
         "https://dataflow.example.test/dataflow2/example-index/posting",
+        "--ft-segment-health-check-dir",
+        "/shared/nvrx",
     ]
 
     # Add a the dummy training script required by the torchrun argparser
@@ -82,6 +84,7 @@ def test_from_args():
     assert (
         ft.attribution_export_url == "https://dataflow.example.test/dataflow2/example-index/posting"
     )
+    assert ft.segment_health_check_dir == "/shared/nvrx"
 
 
 def test_signal_field_with_valid_values():

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -979,6 +979,32 @@ def test_cli_cycle_info_dir_does_not_require_per_cycle_applog():
     _validate_args(args)
 
 
+def test_segment_health_check_dir_is_passed_to_rendezvous(tmp_path):
+    from nvidia_resiliency_ext.fault_tolerance.launcher import config_from_args, get_args_parser
+
+    parser = get_args_parser()
+    args = parser.parse_args(["--ft-segment-health-check-dir", str(tmp_path), "train.py"])
+
+    with patch(
+        "nvidia_resiliency_ext.fault_tolerance.launcher.LocalElasticAgent.setup_rank_monitors_early",
+        return_value={},
+    ):
+        config, _, _ = config_from_args(args)
+
+    assert config.fault_tol_cfg.segment_health_check_dir == str(tmp_path)
+    assert config.rdzv_configs["segment_health_check_dir"] == str(tmp_path)
+
+
+def test_segment_health_check_dir_must_be_absolute():
+    from nvidia_resiliency_ext.fault_tolerance.launcher import config_from_args, get_args_parser
+
+    parser = get_args_parser()
+    args = parser.parse_args(["--ft-segment-health-check-dir", "relative/path", "train.py"])
+
+    with pytest.raises(ValueError, match="must be an absolute path"):
+        config_from_args(args)
+
+
 def test_cli_attribution_endpoint_requires_per_cycle_applog():
     from nvidia_resiliency_ext.fault_tolerance.launcher import (
         _validate_attribution_requires_per_cycle_applog,

--- a/tests/fault_tolerance/unit/test_segment_health_check.py
+++ b/tests/fault_tolerance/unit/test_segment_health_check.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+from nvidia_resiliency_ext.fault_tolerance.segment_health_check import (
+    SegmentHealthCheck,
+    get_segment_health_check,
+)
+
+
+def _environment(**overrides):
+    values = {
+        "SLURM_ARRAY_JOB_ID": "123",
+        "SLURM_ARRAY_TASK_ID": "7",
+        "SLURM_NODEID": "0",
+        "SLURM_PROCID": "0",
+    }
+    values.update(overrides)
+    return values
+
+
+def _write_decision(tmp_path, task_id="7", *, nodes="node03", modified_at=None):
+    path = tmp_path / f"segment_health_check.123.{task_id}"
+    path.write_text(nodes, encoding="utf-8")
+    if modified_at is not None:
+        os.utime(path, (modified_at, modified_at))
+    return path
+
+
+def _is_segment_healthy(directory, *, task_id="7"):
+    return SegmentHealthCheck(str(directory), "123", task_id)()
+
+
+def test_segment_health_check_is_installed_only_on_array_task_process_zero():
+    with patch.dict(os.environ, _environment(SLURM_JOB_ID="123_7"), clear=True):
+        check = get_segment_health_check("/shared/nvrx")
+    assert check is not None
+    assert check.job_id == "123"
+    assert check.task_id == "7"
+
+    with patch.dict(os.environ, _environment(SLURM_PROCID="1"), clear=True):
+        assert get_segment_health_check("/shared/nvrx") is None
+
+    with patch.dict(os.environ, _environment(SLURM_NODEID="1"), clear=True):
+        assert get_segment_health_check("/shared/nvrx") is not None
+
+    env = _environment()
+    del env["SLURM_PROCID"]
+    with patch.dict(os.environ, env, clear=True):
+        assert get_segment_health_check("/shared/nvrx") is None
+
+
+def test_segment_health_check_is_installed_for_regular_job_process_zero(tmp_path):
+    path = tmp_path / "segment_health_check.456.456"
+    path.write_text("node03", encoding="utf-8")
+
+    with patch.dict(
+        os.environ,
+        {"SLURM_JOB_ID": "456", "SLURM_PROCID": "0"},
+        clear=True,
+    ):
+        check = get_segment_health_check(str(tmp_path))
+
+    assert check is not None
+    assert check.job_id == "456"
+    assert check.task_id == "456"
+    assert not check()
+
+    path.write_text("", encoding="utf-8")
+    assert check()
+
+
+def test_segment_health_check_is_not_installed_without_job_metadata():
+    env = _environment()
+    del env["SLURM_ARRAY_JOB_ID"]
+    del env["SLURM_ARRAY_TASK_ID"]
+
+    with patch.dict(os.environ, env, clear=True):
+        assert get_segment_health_check("/shared/nvrx") is None
+
+
+def test_nonempty_task_decision_is_excluded(tmp_path):
+    _write_decision(tmp_path)
+
+    assert not _is_segment_healthy(tmp_path)
+
+
+def test_consumer_checks_only_its_task_file(tmp_path):
+    _write_decision(tmp_path, task_id="17")
+
+    assert _is_segment_healthy(tmp_path, task_id="7")
+
+
+def test_zero_byte_decision_is_healthy(tmp_path):
+    _write_decision(tmp_path, nodes="")
+
+    assert _is_segment_healthy(tmp_path)
+
+
+@pytest.mark.parametrize("nodes", ["node03", "not,csv", "x" * (128 * 1024)])
+def test_nonempty_content_is_excluded_without_parsing(tmp_path, nodes):
+    _write_decision(tmp_path, nodes=nodes)
+
+    with patch(
+        "nvidia_resiliency_ext.fault_tolerance.segment_health_check.Path.open",
+        side_effect=AssertionError("consumer must not read the artifact"),
+    ):
+        assert not _is_segment_healthy(tmp_path)
+
+
+def test_old_decision_remains_authoritative(tmp_path):
+    _write_decision(tmp_path, modified_at=100.0)
+
+    assert not _is_segment_healthy(tmp_path)
+
+
+def test_missing_decision_fails_open_quietly(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING):
+        assert _is_segment_healthy(tmp_path)
+    assert not caplog.text
+
+
+def test_io_failure_is_observable_and_fails_open(tmp_path, caplog):
+    with (
+        caplog.at_level(logging.INFO),
+        patch(
+            "nvidia_resiliency_ext.fault_tolerance.segment_health_check.Path.stat",
+            side_effect=OSError("storage unavailable"),
+        ),
+    ):
+        assert _is_segment_healthy(tmp_path)
+
+    assert "Ignoring segment health decision: storage unavailable" in caplog.text
+
+
+def test_non_regular_decision_is_observable_and_fails_open(tmp_path, caplog):
+    path = tmp_path / "segment_health_check.123.7"
+    path.mkdir()
+
+    with caplog.at_level(logging.WARNING):
+        assert _is_segment_healthy(tmp_path)
+
+    assert f"Ignoring segment health decision: not a regular file: {path}" in caplog.text


### PR DESCRIPTION
## Summary

Consumes Scheduler Exclusion decisions in the FT rendezvous path.

- adds `--ft-scheduler-exclusion-dir` and its YAML equivalent
- adds `SegmentHealthCheck` for task- or segment-scoped health predicates
- lets only array-task Node0 read the compact first JSONL record
- validates exact task IDs, bounded input size, and artifact freshness while failing open on missing or invalid data
- raises the existing `UnhealthyNodeException` and reuses `unhealthy_replacement_groups_<round>`
- makes replacement-group identity generation-aware
- documents and provides the combined Slurm array lifecycle

Depends on #358, which owns the producer service and shared decision-artifact contract. After #358 merges, this PR can be retargeted to `main`.

## Validation

- Black, isort, shell syntax, and `git diff --check` passed
- focused FT, health-check, and scheduler-decision unit coverage is included
- prior PDX E2E covered baseline, exclusion without spares, replacement with a spare, stale/missing/malformed fail-open behavior, and typical decision-read overhead of about 2-3 ms
