### PR TITLE
Add Bash Scheduler Segment Health producer

### DIFF
--- a/examples/fault_tolerance/deployment/slurm/README.md
+++ b/examples/fault_tolerance/deployment/slurm/README.md
@@ -7,6 +7,7 @@ training rank and the rendezvous host. See [../README.md](../README.md) for why.
 ```
 nvrx_singleton_array.sbatch   one generation: rendezvous, gate, ft_launcher, teardown
 submit_chain.sh               computes the array shape and enqueues K generations
+scheduler_segment_health.sh    optional: publishes scheduler-unavailable array tasks
 ```
 
 ## Requirements
@@ -203,3 +204,88 @@ neither the job nor `squeue` will tell you about.
    precedes the exit that triggers the teardown, and any node that exited cleanly is a
    better witness than task 0's own code. The flag is per-generation and needs no cleanup;
    `cancel_chain` remains the one mechanism that stops the successors.
+---
+
+## Scheduler segment-health producer
+
+`scheduler_segment_health.sh` exposes a sourceable interface:
+`scheduler_segment_health_configure` validates and initializes configuration
+without querying Slurm, `scheduler_segment_health_poll_once` performs one poll,
+and `scheduler_segment_health_cleanup` releases producer-owned temporary state
+at caller exit. The producer publishes non-empty per-task control markers
+consumed by `SegmentHealthCheck`. The caller owns cadence and handles a failed
+pass:
+
+```bash
+if [[ "${SLURM_ARRAY_TASK_ID}" == "0" ]]; then
+  export NVRX_SEGMENT_HEALTH_CHECK_DIR="<shared-dir>/${SLURM_ARRAY_JOB_ID}/scheduler-segment-health"
+  export SLURM_JOB_PARTITION
+  source scheduler_segment_health.sh
+
+  scheduler_segment_health_configure || exit 1
+  scheduler_segment_health_poll_once || \
+    echo "scheduler segment-health poll failed; prior decision preserved" >&2
+fi
+```
+
+`nvrx_singleton_array.sbatch` integrates this lifecycle directly. Setting
+`NVRX_SEGMENT_HEALTH_CHECK_DIR` enables the feature; leaving it empty preserves
+the existing launch path. `submit_chain.sh` copies the producer into the run
+directory, and the example's host-side control loop invokes
+`scheduler_segment_health_poll_once` and performs best-effort cleanup when that
+loop exits. The producer itself is a one-shot function: it does not create a
+loop or background process. Every task receives the same
+`--ft-segment-health-check-dir` value:
+
+```bash
+NVRX_SEGMENT_HEALTH_CHECK_DIR=/lustre/run/segment-health ./submit_chain.sh
+```
+
+The example control-loop interval is 600 seconds and can be changed with
+`NVRX_CONTROL_LOOP_INTERVAL_SECONDS`. A direct `sbatch` submission must
+place `scheduler_segment_health.sh` under `NVRX_WORK_DIR` or set
+`NVRX_SEGMENT_HEALTH_CHECK_PRODUCER` to its readable path.
+
+### Poll and publication behavior
+
+Every poll performs one partition-filtered `sinfo`. When unavailable nodes or
+existing active decisions exist, one array-wide `squeue` builds the complete
+running task-to-node map. Local `scontrol show hostnames` expansion does not
+query `slurmctld` for ordinary bracket hostlists.
+
+The producer maps nodes in `DRAIN`, `DOWN`, `FAIL`, or `NO_RESPOND` state and
+publishes:
+
+```text
+segment_health_check.<array_job_id>.<task_id>
+segment_health_check.<array_job_id>.<task_id>.inactive
+segment_health_check_history.<array_job_id>.log
+```
+
+A non-empty current task file excludes its task; zero bytes or absence means no
+current exclusion. Its canonical unavailable-node CSV is diagnostic context.
+When a tracked task is absent from two consecutive complete `squeue` results,
+its unsuffixed file is renamed to `.inactive`. One omitted result preserves the
+current decision, guarding against a transiently incomplete scheduler response.
+The producer keeps a process-local set of tasks missing from the prior complete
+poll. Current absence is derived from the new running-task map: a task already
+in the prior set moves inactive, while a first miss becomes the set used by the
+next poll. A producer restart resets this one-poll memory.
+The centralized `.log` is best-effort JSONL audit history.
+
+Each poll reconstructs prior task state from the unsuffixed task files, then changes
+them only after deriving a complete scheduler result. Failed polls preserve
+prior decisions until 30 minutes have elapsed since the last complete poll;
+the producer then clears non-empty current task files and fails open. Per-task
+publication errors do not block other tasks and are reconciled by the next
+invocation's filesystem scan. `sinfo` and `squeue` have 30-second timeouts. The
+surrounding `sbatch` control flow owns invocation cadence.
+
+The clean path performs only `sinfo`: when there are no unavailable nodes and
+no prior decisions, it skips `squeue` and hostlist expansion. Reconciliation
+queries all running array tasks and expands their hostlists locally, so that
+path scales with the number of running tasks and their total allocated nodes.
+
+The initial deployment requires an explicitly non-requeued array and an output
+directory scoped to `SLURM_ARRAY_JOB_ID`. Producer logs remain in batch
+stdout/stderr.

--- a/examples/fault_tolerance/deployment/slurm/nvrx_singleton_array.sbatch
+++ b/examples/fault_tolerance/deployment/slurm/nvrx_singleton_array.sbatch
@@ -69,6 +69,11 @@ NVRX_MODEL_PROFILE="${NVRX_MODEL_PROFILE:-small}"
 
 # Optional. Endpoint of the node health check daemon; omitted when empty.
 NVRX_HEALTH_CHECK_ENDPOINT="${NVRX_HEALTH_CHECK_ENDPOINT:-}"
+# Optional. A shared artifact directory enables Scheduler Segment Health for
+# both the task-0 producer and every ft_launcher consumer. Empty disables it.
+NVRX_SEGMENT_HEALTH_CHECK_DIR="${NVRX_SEGMENT_HEALTH_CHECK_DIR:-}"
+NVRX_CONTROL_LOOP_INTERVAL_SECONDS="${NVRX_CONTROL_LOOP_INTERVAL_SECONDS:-600}"
+NVRX_SEGMENT_HEALTH_CHECK_PRODUCER="${NVRX_SEGMENT_HEALTH_CHECK_PRODUCER:-${NVRX_WORK_DIR}/scheduler_segment_health.sh}"
 # Minimum nodes per NVLink domain, identified by GPU ClusterUUID -- a restart cycle then
 # only ever selects complete segments. 1 suits GB200 NVL72 and other NVLink-domain
 # systems (DGX H200, HGX B200). Set empty on systems with no ClusterUUID (e.g. H100),
@@ -399,6 +404,97 @@ cancel_generation() {
 # Matches DEFAULT_NO_RESTART_EXIT_CODE in fault_tolerance/utils.py.
 NO_RESTART_EXIT_CODE="${NVRX_NO_RESTART_EXIT_CODE:-93}"
 
+CONTROL_LOOP_PID=""
+CONTROL_LOOP_CONFIGURED=0
+SEGMENT_HEALTH_CONFIGURED=0
+
+configure_segment_health() {
+    if [[ ! -r "${NVRX_SEGMENT_HEALTH_CHECK_PRODUCER}" ]]; then
+        echo "Scheduler Segment Health producer is not readable: ${NVRX_SEGMENT_HEALTH_CHECK_PRODUCER}" >&2
+        return 1
+    fi
+    if ! source "${NVRX_SEGMENT_HEALTH_CHECK_PRODUCER}"; then
+        echo "Could not load Scheduler Segment Health producer: ${NVRX_SEGMENT_HEALTH_CHECK_PRODUCER}" >&2
+        return 1
+    fi
+    if ! declare -F scheduler_segment_health_configure >/dev/null || \
+       ! declare -F scheduler_segment_health_poll_once >/dev/null || \
+       ! declare -F scheduler_segment_health_cleanup >/dev/null; then
+        echo "Scheduler Segment Health producer does not implement the required interface." >&2
+        return 1
+    fi
+
+    if ! scheduler_segment_health_configure; then
+        echo "Scheduler Segment Health producer configuration failed." >&2
+        return 1
+    fi
+
+    SEGMENT_HEALTH_CONFIGURED=1
+    echo "Scheduler Segment Health configured: dir=${NVRX_SEGMENT_HEALTH_CHECK_DIR}"
+}
+
+# This loop belongs to the example sbatch, not to Scheduler Segment Health. Other
+# host-side periodic controls can be added here without changing the producer API.
+run_control_loop_once() {
+    if (( SEGMENT_HEALTH_CONFIGURED )); then
+        scheduler_segment_health_poll_once || \
+            echo "Scheduler Segment Health poll failed; prior decision preserved." >&2
+    fi
+}
+
+configure_control_loop() {
+    [[ -n "${NVRX_SEGMENT_HEALTH_CHECK_DIR}" ]] || return 0
+
+    if ! configure_segment_health; then
+        return 1
+    fi
+
+    if [[ ! "${NVRX_CONTROL_LOOP_INTERVAL_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "NVRX_CONTROL_LOOP_INTERVAL_SECONDS must be a positive integer." >&2
+        return 1
+    fi
+    CONTROL_LOOP_CONFIGURED=1
+    return 0
+}
+
+start_control_loop() {
+    (( CONTROL_LOOP_CONFIGURED )) || return 0
+
+    (
+        # Keep the control loop readable even though this demo enables xtrace.
+        set +x
+        sleep_pid=""
+        control_loop_cleanup() {
+            [[ -z "${sleep_pid:-}" ]] || kill "${sleep_pid}" 2>/dev/null
+            scheduler_segment_health_cleanup || \
+                echo "Scheduler Segment Health cleanup failed." >&2
+        }
+        trap control_loop_cleanup EXIT
+        trap 'exit 0' TERM INT
+
+        while true; do
+            run_control_loop_once
+            sleep "${NVRX_CONTROL_LOOP_INTERVAL_SECONDS}" &
+            sleep_pid=$!
+            wait "${sleep_pid}" || true
+            sleep_pid=""
+        done
+    ) &
+    CONTROL_LOOP_PID=$!
+    echo "Host control loop started: pid=${CONTROL_LOOP_PID}"
+}
+
+stop_control_loop() {
+    [[ -n "${CONTROL_LOOP_PID}" ]] || return 0
+
+    # Do not wait here. Bash defers the child's TERM trap while a foreground Slurm
+    # command is running; generation teardown must not inherit that command's timeout.
+    # The EXIT path below immediately cancels the Slurm generation, which owns final
+    # cleanup of the batch script and any child still unwinding.
+    kill "${CONTROL_LOOP_PID}" 2>/dev/null || true
+    CONTROL_LOOP_PID=""
+}
+
 # On that verdict the queued successor generations have to go too, or the singleton
 # chain simply starts the next one and reproduces the same failure. Matched by job
 # name, so this also covers the current array's own pending spares. Blast radius is
@@ -429,6 +525,7 @@ task0_exit() {
     local rc=$?
     echo "Task 0 exiting (rc=${rc}), creating RDZV_CLOSED file"
     touch "$RDZV_CLOSED"
+    stop_control_loop
     if [[ -f "$NO_RESTART_FLAG" ]] || (( rc == NO_RESTART_EXIT_CODE )); then
         cancel_chain "$rc"
     fi
@@ -445,6 +542,10 @@ if [[ "${SLURM_ARRAY_TASK_ID:-0}" == "0" ]]; then
     # naive "validate, then exit 1" placed above this line would cause. Primary path:
     # covers every orderly exit, but not a hard node death.
     trap task0_exit EXIT
+    if ! configure_control_loop; then
+        exit 1
+    fi
+    start_control_loop
     # The batch script's own node, which SLURM guarantees is the first node of the
     # allocation -- the same value scontrol yields, but needing no SLURM, no env var
     # and no PATH.
@@ -498,6 +599,8 @@ NVRX_LOGFILE=${NVRX_JOB_DIR}/logs/nvrx_${SLURM_ARRAY_JOB_ID:-${SLURM_JOB_ID}}_${
 OPTIONAL_ARGS=""
 [[ -n "$NVRX_HEALTH_CHECK_ENDPOINT" ]] && \
     OPTIONAL_ARGS+=" --ft-node-health-check-endpoint=${NVRX_HEALTH_CHECK_ENDPOINT}"
+[[ -n "$NVRX_SEGMENT_HEALTH_CHECK_DIR" ]] && \
+    OPTIONAL_ARGS+=" --ft-segment-health-check-dir=${NVRX_SEGMENT_HEALTH_CHECK_DIR}"
 [[ -n "$NVRX_SEGMENT" ]] && OPTIONAL_ARGS+=" --ft-segment ${NVRX_SEGMENT}"
 [[ -n "$NVRX_MAX_NO_PROGRESS_CYCLES" ]] && \
     OPTIONAL_ARGS+=" --ft-max-no-progress-cycles ${NVRX_MAX_NO_PROGRESS_CYCLES}"

--- a/examples/fault_tolerance/deployment/slurm/scheduler_segment_health.sh
+++ b/examples/fault_tolerance/deployment/slurm/scheduler_segment_health.sh
@@ -1,0 +1,611 @@
+#!/bin/bash
+# Publish scheduler-unavailable Slurm array tasks for SegmentHealthCheck.
+#
+# Source this file from array task 0's sbatch control flow, outside the workload
+# environment, call scheduler_segment_health_configure once, call
+# scheduler_segment_health_poll_once periodically, and call
+# scheduler_segment_health_cleanup on exit. The caller owns cadence; direct
+# execution performs the complete lifecycle for testing and manual validation.
+#
+# The producer publishes one per-task control file and a centralized best-effort
+# JSONL history:
+#
+#   segment_health_check.<array_job_id>.<task_id>
+#   segment_health_check.<array_job_id>.<task_id>.inactive
+#   segment_health_check_history.<array_job_id>.log
+#
+# A non-empty current file excludes that task. A missing or zero-byte current
+# file does not. Its canonical CSV content is diagnostic context; consumers use
+# only file size.
+#
+# Environment:
+#   SLURM_ARRAY_JOB_ID           Required numeric Slurm array parent job ID.
+#   NVRX_SEGMENT_HEALTH_CHECK_DIR Required absolute shared artifact directory.
+#   SLURM_JOB_PARTITION          Required partition containing the array job.
+#   NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS
+#                                Clear exclusions after this long without a
+#                                complete poll. Default: 1800 seconds.
+#   NVRX_SEGMENT_HEALTH_SLURM_CMD_TIMEOUT
+#                                sinfo/squeue timeout. Default: 30 seconds.
+
+# Hostlist expansion is local, repeated per task, and should finish quickly.
+_SCHEDULER_SEGMENT_HEALTH_HOSTLIST_EXPANSION_TIMEOUT=5
+
+_scheduler_segment_health_validate_positive_integer() {
+    local name="$1"
+    local value="$2"
+
+    if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
+        printf 'scheduler_segment_health: %s must be a positive integer: %s\n' \
+            "${name}" "${value}" >&2
+        return 2
+    fi
+}
+
+_scheduler_segment_health_log() {
+    printf '[scheduler_segment_health %s] %s\n' "$(date +'%H:%M:%S')" "$*" >&2
+}
+
+_scheduler_segment_health_trim_whitespace() {
+    local value="$1"
+
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "${value}"
+}
+
+_scheduler_segment_health_timestamp_utc() {
+    date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+scheduler_segment_health_configure() {
+    if [[ -n "${_SCHEDULER_SEGMENT_HEALTH_CONFIGURED:-}" ]]; then
+        return 0
+    fi
+    if [[ -z "${SLURM_ARRAY_JOB_ID:-}" ]]; then
+        printf 'scheduler_segment_health: set SLURM_ARRAY_JOB_ID\n' >&2
+        return 2
+    fi
+    if [[ -z "${NVRX_SEGMENT_HEALTH_CHECK_DIR:-}" ]]; then
+        printf 'scheduler_segment_health: set NVRX_SEGMENT_HEALTH_CHECK_DIR\n' >&2
+        return 2
+    fi
+    if [[ -z "${SLURM_JOB_PARTITION:-}" ]]; then
+        printf 'scheduler_segment_health: set SLURM_JOB_PARTITION\n' >&2
+        return 2
+    fi
+    if [[ "${NVRX_SEGMENT_HEALTH_CHECK_DIR}" != /* ]]; then
+        printf 'scheduler_segment_health: NVRX_SEGMENT_HEALTH_CHECK_DIR must be absolute: %s\n' \
+            "${NVRX_SEGMENT_HEALTH_CHECK_DIR}" >&2
+        return 2
+    fi
+    if [[ ! "${SLURM_ARRAY_JOB_ID}" =~ ^[0-9]+$ ]]; then
+        printf 'scheduler_segment_health: SLURM_ARRAY_JOB_ID must be numeric: %s\n' \
+            "${SLURM_ARRAY_JOB_ID}" >&2
+        return 2
+    fi
+
+    NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS="${NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS:-1800}"
+    NVRX_SEGMENT_HEALTH_SLURM_CMD_TIMEOUT="${NVRX_SEGMENT_HEALTH_SLURM_CMD_TIMEOUT:-30}"
+    _scheduler_segment_health_validate_positive_integer \
+        NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS "${NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS}" || return $?
+    _scheduler_segment_health_validate_positive_integer \
+        NVRX_SEGMENT_HEALTH_SLURM_CMD_TIMEOUT "${NVRX_SEGMENT_HEALTH_SLURM_CMD_TIMEOUT}" || return $?
+
+    mkdir -p "${NVRX_SEGMENT_HEALTH_CHECK_DIR}" || return 1
+    _SCHEDULER_SEGMENT_HEALTH_WORK=$(mktemp -d \
+        "${TMPDIR:-/tmp}/scheduler_segment_health.${SLURM_ARRAY_JOB_ID}.XXXXXX") || return 1
+    _SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE="${_SCHEDULER_SEGMENT_HEALTH_WORK}/published-task-state.map"
+    _SEGMENT_HEALTH_UNAVAILABLE_NODES_FILE="${_SCHEDULER_SEGMENT_HEALTH_WORK}/unavailable.nodes"
+    _SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE="${_SCHEDULER_SEGMENT_HEALTH_WORK}/desired-task-state.map"
+    _SCHEDULER_SEGMENT_HEALTH_UNAVAILABLE_STATES="drain,down,fail,no_respond"
+    _SCHEDULER_SEGMENT_HEALTH_LEDGER_PATH="${NVRX_SEGMENT_HEALTH_CHECK_DIR}/segment_health_check_history.${SLURM_ARRAY_JOB_ID}.log"
+    _SCHEDULER_SEGMENT_HEALTH_LAST_COMPLETE_POLL_AT="${SECONDS}"
+    _SCHEDULER_SEGMENT_HEALTH_MISSING_TASK_IDS="|"
+    _scheduler_segment_health_log \
+        "configured array=${SLURM_ARRAY_JOB_ID} partition=${SLURM_JOB_PARTITION} output_dir=${NVRX_SEGMENT_HEALTH_CHECK_DIR}"
+    _scheduler_segment_health_log \
+        "stale_decision=${NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS}s states=${_SCHEDULER_SEGMENT_HEALTH_UNAVAILABLE_STATES}"
+    _SCHEDULER_SEGMENT_HEALTH_CONFIGURED=1
+}
+
+scheduler_segment_health_cleanup() {
+    local work="${_SCHEDULER_SEGMENT_HEALTH_WORK:-}"
+
+    # Best-effort process-lifetime cleanup. An unexpected exit may leave this
+    # one small directory for the node's normal /tmp cleanup policy.
+    [[ -n "${work}" ]] || return 0
+    if ! rm -rf -- "${work}"; then
+        _scheduler_segment_health_log "could not remove temporary workspace ${work}"
+        return 1
+    fi
+    unset _SCHEDULER_SEGMENT_HEALTH_WORK
+    unset _SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE
+    unset _SEGMENT_HEALTH_UNAVAILABLE_NODES_FILE
+    unset _SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE
+    unset _SCHEDULER_SEGMENT_HEALTH_CONFIGURED
+}
+
+_scheduler_segment_health_read_file_exact() {
+    local path="$1"
+    local captured
+
+    # Command substitution strips trailing newlines; the sentinel preserves
+    # the exact file value, including an empty marker.
+    captured=$(
+        cat -- "${path}"
+        status=$?
+        printf '\036'
+        exit "${status}"
+    ) || return 1
+    _SCHEDULER_SEGMENT_HEALTH_FILE_VALUE="${captured%$'\036'}"
+}
+
+_scheduler_segment_health_has_complete_lines() {
+    local path="$1"
+    local last_byte
+
+    [[ -s "${path}" ]] || return 0
+    # Command substitution strips a final newline, yielding an empty value.
+    last_byte=$(tail -c 1 "${path}") || return 1
+    [[ -z "${last_byte}" ]]
+}
+
+_scheduler_segment_health_current_path() {
+    printf '%s/segment_health_check.%s.%s' \
+        "${NVRX_SEGMENT_HEALTH_CHECK_DIR}" "${SLURM_ARRAY_JOB_ID}" "$1"
+}
+
+_scheduler_segment_health_inactive_path() {
+    printf '%s/segment_health_check.%s.%s.inactive' \
+        "${NVRX_SEGMENT_HEALTH_CHECK_DIR}" "${SLURM_ARRAY_JOB_ID}" "$1"
+}
+
+_scheduler_segment_health_state_lookup() {
+    local source="$1"
+    local task_id="$2"
+    local line
+    local rest
+
+    # Read task|status|value and expose the status and value to the caller.
+    # K means known canonical state; U means unreadable or noncanonical state.
+    line=$(grep -m 1 "^${task_id}|" "${source}" 2>/dev/null) || return 1
+    rest="${line#*|}"
+    _SCHEDULER_SEGMENT_HEALTH_STATE_STATUS="${rest%%|*}"
+    _SCHEDULER_SEGMENT_HEALTH_STATE_VALUE="${rest#*|}"
+    return 0
+}
+
+_scheduler_segment_health_snapshot_published_state() {
+    local path
+    local name
+    local task_id
+    local value
+
+    # Per-task files are the source of truth. Read each once into a temporary
+    # task|status|value snapshot that remains stable for this poll. K marks a
+    # readable canonical value; U marks state that must be reconciled.
+    : >"${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}" || return 1
+    for path in "${NVRX_SEGMENT_HEALTH_CHECK_DIR}/segment_health_check.${SLURM_ARRAY_JOB_ID}."*; do
+        [[ -e "${path}" || -L "${path}" ]] || continue
+        name="${path##*/}"
+        task_id="${name#segment_health_check.${SLURM_ARRAY_JOB_ID}.}"
+        if [[ ! "${task_id}" =~ ^[0-9]+$ ]]; then
+            continue
+        fi
+        if _scheduler_segment_health_read_file_exact "${path}"; then
+            value="${_SCHEDULER_SEGMENT_HEALTH_FILE_VALUE}"
+            if [[ -z "${value}" || "${value}" =~ ^[A-Za-z0-9._-]+(,[A-Za-z0-9._-]+)*$ ]]; then
+                printf '%s|K|%s\n' "${task_id}" "${value}" >>"${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}" || return 1
+            else
+                _scheduler_segment_health_log "current artifact has a noncanonical value task=${task_id}; marking it unknown"
+                printf '%s|U|\n' "${task_id}" >>"${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}" || return 1
+            fi
+        else
+            _scheduler_segment_health_log "could not read current artifact ${path}; marking it unknown"
+            printf '%s|U|\n' "${task_id}" >>"${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}" || return 1
+        fi
+    done
+    LC_ALL=C sort -t '|' -k1,1n -o "${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}" \
+        "${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}"
+}
+
+_scheduler_segment_health_append_audit() {
+    local event="$1"
+    local task_id="$2"
+    local nodes="$3"
+    local reason="$4"
+    local observed_at="$5"
+    local observed_at_json="null"
+    local detail=""
+
+    if [[ -z "${observed_at}" ]]; then
+        _scheduler_segment_health_log \
+            "history timestamp unavailable task=${task_id} event=${event}"
+    else
+        printf -v observed_at_json '"%s"' "${observed_at}"
+    fi
+
+    if [[ -n "${nodes}" ]]; then
+        printf -v detail ',"nodes":"%s"' "${nodes}"
+    elif [[ -n "${reason}" ]]; then
+        printf -v detail ',"reason":"%s"' "${reason}"
+    fi
+
+    if ! printf '{"event":"%s","task_id":%s%s,"observed_at":%s}\n' \
+        "${event}" "${task_id}" "${detail}" "${observed_at_json}" \
+        >>"${_SCHEDULER_SEGMENT_HEALTH_LEDGER_PATH}"; then
+        _scheduler_segment_health_log "could not append history event task=${task_id} event=${event}"
+    fi
+    return 0
+}
+
+_scheduler_segment_health_set_current_value() (
+    local task_id="$1"
+    local value="$2"
+    local path
+
+    path=$(_scheduler_segment_health_current_path "${task_id}") || return 1
+    if [[ -z "${value}" ]]; then
+        : >"${path}"
+        return $?
+    fi
+
+    # FD 9 is an arbitrary non-standard descriptor scoped to this subshell.
+    # Keep the file open without truncating so readers never observe an empty
+    # marker during replacement.
+    if [[ -e "${path}" ]]; then
+        exec 9<>"${path}" || return 1
+    else
+        exec 9>"${path}" || return 1
+    fi
+    if ! printf '%s' "${value}" >&9; then
+        exec 9>&-
+        return 1
+    fi
+    # Remove any suffix left by a longer prior value.
+    if ! truncate -s "${#value}" "${path}"; then
+        exec 9>&-
+        return 1
+    fi
+    exec 9>&-
+    return 0
+)
+
+_scheduler_segment_health_reconcile_after_write_failure() {
+    local task_id="$1"
+    local desired="$2"
+    local path
+    local actual
+
+    path=$(_scheduler_segment_health_current_path "${task_id}") || return 1
+    if [[ -f "${path}" ]] && _scheduler_segment_health_read_file_exact "${path}"; then
+        actual="${_SCHEDULER_SEGMENT_HEALTH_FILE_VALUE}"
+        [[ "${actual}" == "${desired}" ]]
+        return $?
+    fi
+    return 1
+}
+
+_scheduler_segment_health_publish_current_value() {
+    local task_id="$1"
+    local desired="$2"
+
+    if _scheduler_segment_health_set_current_value "${task_id}" "${desired}"; then
+        return 0
+    fi
+
+    _scheduler_segment_health_log "could not publish current artifact task=${task_id}; reconciling its actual value"
+    _scheduler_segment_health_reconcile_after_write_failure "${task_id}" "${desired}"
+}
+
+_scheduler_segment_health_move_task_inactive() {
+    local task_id="$1"
+    local source
+    local destination
+
+    source=$(_scheduler_segment_health_current_path "${task_id}") || return 1
+    destination=$(_scheduler_segment_health_inactive_path "${task_id}") || return 1
+    if [[ ! -e "${source}" && ! -L "${source}" ]]; then
+        return 0
+    fi
+    if [[ -e "${destination}" ]]; then
+        _scheduler_segment_health_log "replacing prior inactive artifact task=${task_id}"
+    fi
+    # Leave the active control namespace while retaining the last observation.
+    if mv -f "${source}" "${destination}"; then
+        return 0
+    fi
+
+    _scheduler_segment_health_log "could not move task artifact inactive task=${task_id}"
+    return 1
+}
+
+_scheduler_segment_health_derive_desired_state() {
+    # Build an all-or-nothing decision snapshot without modifying published
+    # task artifacts. First query unavailable nodes in the job partition. If
+    # unavailable nodes or prior exclusions exist, query running array tasks,
+    # expand each task's hostlist, and intersect it with the unavailable set.
+    # On success, stage two deterministic poll outputs:
+    #   unavailable.nodes       one scheduler-unavailable node per line
+    #   desired-task-state.map  task_id|comma-separated-unavailable-nodes;
+    #                           an empty value means the running task is healthy
+    # This function does not modify persistent per-task artifacts; the
+    # reconciliation phase consumes these snapshots to set, clear, or retire them.
+    # Any incomplete query or malformed row aborts the derivation so the caller
+    # can preserve the prior published decision.
+    local unavailable_raw="${_SCHEDULER_SEGMENT_HEALTH_WORK}/unavailable.raw"
+    local unavailable_staged="${_SCHEDULER_SEGMENT_HEALTH_WORK}/unavailable.staged"
+    local taskmap="${_SCHEDULER_SEGMENT_HEALTH_WORK}/taskmap.raw"
+    local expanded_raw="${_SCHEDULER_SEGMENT_HEALTH_WORK}/expanded.raw"
+    local expanded="${_SCHEDULER_SEGMENT_HEALTH_WORK}/expanded.nodes"
+    local matched="${_SCHEDULER_SEGMENT_HEALTH_WORK}/matched.nodes"
+    local node
+    local row
+    local task_id
+    local hostlist
+    local csv
+
+    : >"${_SEGMENT_HEALTH_UNAVAILABLE_NODES_FILE}"
+    : >"${_SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE}"
+
+    # First collect the partition-wide unavailable-node set.
+    if ! timeout --kill-after=5s "${NVRX_SEGMENT_HEALTH_SLURM_CMD_TIMEOUT}" \
+        sinfo --partition="${SLURM_JOB_PARTITION}" \
+        --states="${_SCHEDULER_SEGMENT_HEALTH_UNAVAILABLE_STATES}" --Node --noheader --format='%N' \
+        >"${unavailable_raw}"; then
+        _scheduler_segment_health_log "sinfo failed or timed out; preserving the previous decision"
+        return 1
+    fi
+    if ! _scheduler_segment_health_has_complete_lines "${unavailable_raw}"; then
+        _scheduler_segment_health_log "sinfo returned an incomplete row; preserving the previous decision"
+        return 1
+    fi
+
+    : >"${unavailable_staged}"
+    while IFS= read -r node; do
+        node=$(_scheduler_segment_health_trim_whitespace "${node}")
+        [[ -n "${node}" ]] || continue
+        if [[ ! "${node}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            _scheduler_segment_health_log "invalid sinfo node '${node}'; preserving the previous decision"
+            return 1
+        fi
+        printf '%s\n' "${node}" >>"${unavailable_staged}" || return 1
+    done <"${unavailable_raw}"
+    LC_ALL=C sort -u "${unavailable_staged}" >"${_SEGMENT_HEALTH_UNAVAILABLE_NODES_FILE}" || return 1
+
+    # No unavailable nodes and no prior decisions means no task-map query.
+    if [[ ! -s "${_SEGMENT_HEALTH_UNAVAILABLE_NODES_FILE}" && ! -s "${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}" ]]; then
+        return 0
+    fi
+
+    # Map running array tasks to their nodes only when a decision may change.
+    if ! timeout --kill-after=5s "${NVRX_SEGMENT_HEALTH_SLURM_CMD_TIMEOUT}" \
+        squeue --jobs="${SLURM_ARRAY_JOB_ID}" --states=RUNNING --array --noheader \
+        --format='%K|%N' >"${taskmap}"; then
+        _scheduler_segment_health_log "squeue failed or timed out; preserving the previous decision"
+        return 1
+    fi
+    if ! _scheduler_segment_health_has_complete_lines "${taskmap}"; then
+        _scheduler_segment_health_log "squeue returned an incomplete row; preserving the previous decision"
+        return 1
+    fi
+
+    while IFS= read -r row; do
+        # Validate and split the squeue task-to-hostlist mapping. Any malformed
+        # or duplicate task makes the poll incomplete, so preserve prior state.
+        row=$(_scheduler_segment_health_trim_whitespace "${row}")
+        [[ -n "${row}" ]] || continue
+        if [[ "${row}" != *"|"* || "${row#*|}" == *"|"* ]]; then
+            _scheduler_segment_health_log "invalid squeue task row '${row}'; preserving the previous decision"
+            return 1
+        fi
+        task_id=$(_scheduler_segment_health_trim_whitespace "${row%%|*}")
+        hostlist=$(_scheduler_segment_health_trim_whitespace "${row#*|}")
+        if [[ ! "${task_id}" =~ ^[0-9]+$ || -z "${hostlist}" || "${hostlist}" == *"{"* ]]; then
+            _scheduler_segment_health_log "invalid squeue task row '${row}'; preserving the previous decision"
+            return 1
+        fi
+        if grep -q "^${task_id}|" "${_SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE}"; then
+            _scheduler_segment_health_log "duplicate squeue task '${task_id}'; preserving the previous decision"
+            return 1
+        fi
+
+        # Expand Slurm's compressed hostlist for this task, then normalize it
+        # into a sorted node set suitable for comm(1).
+        if ! timeout --kill-after=5s "${_SCHEDULER_SEGMENT_HEALTH_HOSTLIST_EXPANSION_TIMEOUT}" \
+            scontrol show hostnames "${hostlist}" >"${expanded_raw}"; then
+            _scheduler_segment_health_log "hostlist expansion failed or timed out for task=${task_id}; preserving prior state"
+            return 1
+        fi
+        if ! _scheduler_segment_health_has_complete_lines "${expanded_raw}"; then
+            _scheduler_segment_health_log "hostlist expansion returned an incomplete row for task=${task_id}; preserving prior state"
+            return 1
+        fi
+        : >"${expanded}"
+        while IFS= read -r node; do
+            node=$(_scheduler_segment_health_trim_whitespace "${node}")
+            [[ -n "${node}" ]] || continue
+            if [[ ! "${node}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+                _scheduler_segment_health_log "invalid expanded node '${node}'; preserving the previous decision"
+                return 1
+            fi
+            printf '%s\n' "${node}" >>"${expanded}" || return 1
+        done <"${expanded_raw}"
+        if [[ ! -s "${expanded}" ]]; then
+            _scheduler_segment_health_log "empty hostlist expansion for task=${task_id}; preserving the previous decision"
+            return 1
+        fi
+        LC_ALL=C sort -u -o "${expanded}" "${expanded}" || return 1
+
+        # The intersection is both the task's exclusion decision and its
+        # diagnostic node payload. An empty value records a healthy task.
+        csv=""
+        if [[ -s "${_SEGMENT_HEALTH_UNAVAILABLE_NODES_FILE}" ]]; then
+            LC_ALL=C comm -12 "${_SEGMENT_HEALTH_UNAVAILABLE_NODES_FILE}" "${expanded}" >"${matched}" || return 1
+            if [[ -s "${matched}" ]]; then
+                csv=$(paste -s -d ',' "${matched}") || return 1
+            fi
+        fi
+        printf '%s|%s\n' "${task_id}" "${csv}" >>"${_SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE}" || return 1
+    done <"${taskmap}"
+
+    # Produce a deterministic snapshot for publication and reconciliation.
+    LC_ALL=C sort -t '|' -k1,1n -o "${_SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE}" "${_SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE}" || return 1
+    return 0
+}
+
+_scheduler_segment_health_reconcile_published_state() {
+    local observed_at="$1"
+    local task_id
+    local desired
+    local prior_status
+    local prior_value
+    local event
+    # The process-global set records first misses from the prior complete poll.
+    # Reaching the absent-task branch below proves the task is missing now: a
+    # prior-set match is therefore its second consecutive miss. First misses
+    # accumulate here and replace the prior set after every complete poll.
+    local missing_next="|"
+    local publication_failed=0
+
+    # Reconcile every running task. Healthy tasks without an existing artifact
+    # are skipped so files are created only after a task is first excluded.
+    while IFS='|' read -r task_id desired; do
+        [[ -n "${task_id}" ]] || continue
+        event=excluded
+        if _scheduler_segment_health_state_lookup "${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}" "${task_id}"; then
+            prior_status="${_SCHEDULER_SEGMENT_HEALTH_STATE_STATUS}"
+            prior_value="${_SCHEDULER_SEGMENT_HEALTH_STATE_VALUE}"
+            if [[ "${prior_status}" == K && "${prior_value}" == "${desired}" ]]; then
+                continue
+            fi
+            if [[ -z "${desired}" ]]; then
+                if _scheduler_segment_health_publish_current_value "${task_id}" ""; then
+                    if [[ "${prior_status}" == K && -n "${prior_value}" ]]; then
+                        _scheduler_segment_health_append_audit cleared "${task_id}" "" "" "${observed_at}"
+                    fi
+                else
+                    publication_failed=1
+                fi
+                continue
+            fi
+            if [[ "${prior_status}" != K || -n "${prior_value}" ]]; then
+                event=updated
+            fi
+        elif [[ -z "${desired}" ]]; then
+            continue
+        fi
+        if _scheduler_segment_health_publish_current_value "${task_id}" "${desired}"; then
+            _scheduler_segment_health_append_audit "${event}" "${task_id}" "${desired}" "" "${observed_at}"
+        else
+            publication_failed=1
+        fi
+    done <"${_SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE}"
+
+    # Reconcile prior control files absent from the desired-state snapshot. Move
+    # one inactive only after it is missing from two complete task maps.
+    while IFS='|' read -r task_id prior_status prior_value; do
+        [[ -n "${task_id}" ]] || continue
+        if grep -q "^${task_id}|" "${_SEGMENT_HEALTH_DESIRED_TASK_STATE_FILE}"; then
+            continue
+        fi
+        if [[ "${_SCHEDULER_SEGMENT_HEALTH_MISSING_TASK_IDS:-|}" == *"|${task_id}|"* ]]; then
+            if _scheduler_segment_health_move_task_inactive "${task_id}"; then
+                if [[ "${prior_status}" == K && -n "${prior_value}" ]]; then
+                    _scheduler_segment_health_append_audit \
+                        cleared "${task_id}" "" task_inactive "${observed_at}"
+                fi
+            else
+                publication_failed=1
+                missing_next+="${task_id}|"
+            fi
+        else
+            missing_next+="${task_id}|"
+            _scheduler_segment_health_log \
+                "task absent from one complete squeue result; deferring inactive transition task=${task_id}"
+        fi
+    done <"${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}"
+
+    _SCHEDULER_SEGMENT_HEALTH_MISSING_TASK_IDS="${missing_next}"
+    return "${publication_failed}"
+}
+
+_scheduler_segment_health_clear_stale_decisions() {
+    local observed_at="$1"
+    local task_id
+    local status
+    local value
+
+    # Fail open when Slurm has not produced a complete desired-state snapshot
+    # within the TTL. Reuse this poll's validated published-state snapshot and
+    # clear every non-empty or untrusted active task artifact to zero bytes;
+    # healthy empty artifacts need no write. A later successful poll can
+    # publish fresh exclusions again.
+    while IFS='|' read -r task_id status value; do
+        [[ -n "${task_id}" ]] || continue
+        if [[ "${status}" == K && -z "${value}" ]]; then
+            continue
+        fi
+        if _scheduler_segment_health_publish_current_value "${task_id}" ""; then
+            _scheduler_segment_health_append_audit cleared "${task_id}" "" stale_decision_expired "${observed_at}"
+        fi
+    done <"${_SEGMENT_HEALTH_PUBLISHED_TASK_STATE_FILE}"
+}
+
+scheduler_segment_health_poll_once() {
+    local last_status=0
+    local observed_at
+    local stale_seconds
+
+    scheduler_segment_health_configure || return $?
+    if [[ ! -d "${NVRX_SEGMENT_HEALTH_CHECK_DIR}" ]]; then
+        _scheduler_segment_health_log \
+            "artifact directory is unavailable: ${NVRX_SEGMENT_HEALTH_CHECK_DIR}"
+        return 1
+    fi
+    if [[ ! -d "${_SCHEDULER_SEGMENT_HEALTH_WORK}" ]]; then
+        _scheduler_segment_health_log \
+            "temporary workspace is unavailable: ${_SCHEDULER_SEGMENT_HEALTH_WORK}"
+        return 1
+    fi
+
+    # Each poll follows three phases:
+    #   1. Read the currently published per-task state from the filesystem.
+    #   2. Query Slurm and derive the desired state for every running task.
+    #   3. Reconcile current with desired: set, update, clear, or retire files.
+    # A failure before reconciliation preserves the previously published state.
+    if _scheduler_segment_health_snapshot_published_state; then
+        if _scheduler_segment_health_derive_desired_state; then
+            _SCHEDULER_SEGMENT_HEALTH_LAST_COMPLETE_POLL_AT="${SECONDS}"
+            observed_at=$(_scheduler_segment_health_timestamp_utc 2>/dev/null) || observed_at=""
+            if _scheduler_segment_health_reconcile_published_state "${observed_at}"; then
+                last_status=0
+            else
+                last_status=1
+                _scheduler_segment_health_log "one or more artifact operations failed; continuing with other tasks"
+            fi
+        else
+            last_status=1
+            stale_seconds=$((SECONDS - _SCHEDULER_SEGMENT_HEALTH_LAST_COMPLETE_POLL_AT))
+            _scheduler_segment_health_log "scheduler poll failed stale_seconds=${stale_seconds}/${NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS}"
+            if (( stale_seconds >= NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS )); then
+                observed_at=$(_scheduler_segment_health_timestamp_utc 2>/dev/null) || observed_at=""
+                _scheduler_segment_health_clear_stale_decisions "${observed_at}" || true
+            fi
+        fi
+    else
+        last_status=1
+        _scheduler_segment_health_log "could not snapshot current artifacts; preserving the previous decision"
+    fi
+
+    return "${last_status}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    set -uo pipefail
+    scheduler_segment_health_poll_once
+    status=$?
+    scheduler_segment_health_cleanup || true
+    exit "${status}"
+fi

--- a/examples/fault_tolerance/deployment/slurm/submit_chain.sh
+++ b/examples/fault_tolerance/deployment/slurm/submit_chain.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SBATCH_SCRIPT="${SCRIPT_DIR}/nvrx_singleton_array.sbatch"
+SEGMENT_HEALTH_PRODUCER="${SCRIPT_DIR}/scheduler_segment_health.sh"
 
 # Shape. Defaults form the smallest run that shows a hand-off: 1 training node + 1 hot
 # spare + 1 cold spare. Scale up for real training (see the README).
@@ -43,6 +44,8 @@ export NVRX_CONTAINER_IMAGE="${NVRX_CONTAINER_IMAGE:-}"
 # nothing". This export is what the sbatch actually sees, so the colon here would defeat
 # the matching fix in nvrx_singleton_array.sbatch no matter what that line says.
 export NVRX_CONTAINER_MOUNTS="${NVRX_CONTAINER_MOUNTS-/lustre:/lustre}"
+export NVRX_SEGMENT_HEALTH_CHECK_DIR="${NVRX_SEGMENT_HEALTH_CHECK_DIR:-}"
+export NVRX_CONTROL_LOOP_INTERVAL_SECONDS="${NVRX_CONTROL_LOOP_INTERVAL_SECONDS:-600}"
 
 ACTIVE_TASKS=$(( NVRX_TRAIN_TASKS + NVRX_HOT_SPARES ))
 TOTAL_TASKS=$(( ACTIVE_TASKS + NVRX_COLD_SPARES ))
@@ -96,6 +99,10 @@ RUN_SBATCH="${NVRX_WORK_DIR}/nvrx_singleton_array.sbatch"
 if [[ "${NVRX_DRY_RUN:-0}" != "1" ]]; then
     sed "s#^NVRX_WORK_DIR=.*#NVRX_WORK_DIR=\"${NVRX_WORK_DIR}\"#" "${SBATCH_SCRIPT}" > "${RUN_SBATCH}"
     chmod +x "${RUN_SBATCH}"
+    if [[ -n "${NVRX_SEGMENT_HEALTH_CHECK_DIR}" ]]; then
+        cp "${SEGMENT_HEALTH_PRODUCER}" "${NVRX_WORK_DIR}/scheduler_segment_health.sh"
+        chmod +x "${NVRX_WORK_DIR}/scheduler_segment_health.sh"
+    fi
 fi
 
 SBATCH_ARGS=(

--- a/tests/fault_tolerance/unit/test_scheduler_segment_health.py
+++ b/tests/fault_tolerance/unit/test_scheduler_segment_health.py
@@ -1,0 +1,697 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).parents[3]
+    / "examples/fault_tolerance/deployment/slurm/scheduler_segment_health.sh"
+)
+
+
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture
+def poller_environment(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    sinfo_output = tmp_path / "sinfo.out"
+    squeue_output = tmp_path / "squeue.out"
+    scontrol_map = tmp_path / "scontrol.map"
+    sinfo_output.write_text("", encoding="utf-8")
+    squeue_output.write_text("", encoding="utf-8")
+    scontrol_map.write_text("", encoding="utf-8")
+
+    _write_executable(
+        fake_bin / "timeout",
+        """#!/bin/bash
+[[ "$1" == "--kill-after=5s" ]] || exit 98
+shift
+shift
+exec "$@"
+""",
+    )
+    _write_executable(
+        fake_bin / "sinfo",
+        """#!/bin/bash
+if [[ -n "${FAKE_SINFO_FAIL:-}" ]]; then echo "fake sinfo error" >&2; exit 1; fi
+printf '%s\n' "$*" >"${FAKE_SINFO_ARGS}"
+cat "${FAKE_SINFO_OUTPUT}"
+""",
+    )
+    _write_executable(
+        fake_bin / "squeue",
+        """#!/bin/bash
+if [[ -n "${FAKE_SQUEUE_FAIL:-}" ]]; then echo "fake squeue error" >&2; exit 1; fi
+printf '%s\n' "$*" >"${FAKE_SQUEUE_ARGS}"
+cat "${FAKE_SQUEUE_OUTPUT}"
+""",
+    )
+    _write_executable(
+        fake_bin / "scontrol",
+        """#!/bin/bash
+printf '%s\n' "$*" >>"${FAKE_SCONTROL_ARGS}"
+hostlist=""
+for argument in "$@"; do hostlist="${argument}"; done
+while IFS='|' read -r expected nodes; do
+    if [[ "${expected}" == "${hostlist}" ]]; then
+        [[ "${nodes}" != "__FAIL__" ]] || exit 1
+        printf '%s\n' "${nodes}" | tr ',' '\n'
+        exit 0
+    fi
+done <"${FAKE_SCONTROL_MAP}"
+echo "unknown fake hostlist: ${hostlist}" >&2
+exit 1
+""",
+    )
+    output_dir = tmp_path / "decisions"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "SLURM_ARRAY_JOB_ID": "123",
+            "FAKE_SCONTROL_ARGS": str(tmp_path / "scontrol.args"),
+            "FAKE_SCONTROL_MAP": str(scontrol_map),
+            "FAKE_SINFO_ARGS": str(tmp_path / "sinfo.args"),
+            "FAKE_SINFO_OUTPUT": str(sinfo_output),
+            "FAKE_SQUEUE_ARGS": str(tmp_path / "squeue.args"),
+            "FAKE_SQUEUE_OUTPUT": str(squeue_output),
+            "NVRX_SEGMENT_HEALTH_CHECK_DIR": str(output_dir),
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "SLURM_JOB_PARTITION": "batch",
+            "TMPDIR": str(tmp_path),
+        }
+    )
+    return environment, output_dir, sinfo_output, squeue_output, scontrol_map
+
+
+def _run_poller(environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/bin/bash", str(_SCRIPT)],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+        timeout=10,
+    )
+
+
+def _run_two_sourced_polls(
+    environment: dict[str, str], between_polls: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                f'source "{_SCRIPT}"\n'
+                "scheduler_segment_health_poll_once || true\n"
+                f"{between_polls}\n"
+                "scheduler_segment_health_poll_once"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+        timeout=10,
+    )
+
+
+def _current_path(output_dir: Path, task_id: str = "7") -> Path:
+    return output_dir / f"segment_health_check.123.{task_id}"
+
+
+def _inactive_path(output_dir: Path, task_id: str = "7") -> Path:
+    return output_dir / f"segment_health_check.123.{task_id}.inactive"
+
+
+def _ledger_path(output_dir: Path) -> Path:
+    return output_dir / "segment_health_check_history.123.log"
+
+
+def _read_ledger(output_dir: Path) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in _ledger_path(output_dir).read_text(encoding="utf-8").splitlines()
+    ]
+
+
+def _set_scontrol_map(path: Path, mappings: dict[str, list[str]]) -> None:
+    path.write_text(
+        "".join(f"{hostlist}|{','.join(nodes)}\n" for hostlist, nodes in mappings.items()),
+        encoding="utf-8",
+    )
+
+
+def _configure_two_excluded_tasks(sinfo_output, squeue_output, scontrol_map):
+    sinfo_output.write_text("node18\nnode03\n", encoding="utf-8")
+    squeue_output.write_text("12|node[17-20]\n7|node[01-04]\n", encoding="utf-8")
+    _set_scontrol_map(
+        scontrol_map,
+        {
+            "node[01-04]": ["node01", "node02", "node03", "node04"],
+            "node[17-20]": ["node17", "node18", "node19", "node20"],
+        },
+    )
+
+
+def test_publishes_per_task_decisions_and_audit(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    _configure_two_excluded_tasks(sinfo_output, squeue_output, scontrol_map)
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 0, result.stderr
+    assert _current_path(output_dir, "7").read_text(encoding="utf-8") == "node03"
+    assert _current_path(output_dir, "12").read_text(encoding="utf-8") == "node18"
+    records = _read_ledger(output_dir)
+    assert [(record["event"], record["task_id"], record["nodes"]) for record in records] == [
+        ("excluded", 7, "node03"),
+        ("excluded", 12, "node18"),
+    ]
+    assert all(record["observed_at"].endswith("Z") for record in records)
+
+    sinfo_args = Path(environment["FAKE_SINFO_ARGS"]).read_text(encoding="utf-8")
+    assert "--partition=batch" in sinfo_args
+    assert "--states=drain,down,fail,no_respond" in sinfo_args
+    assert "--format=%N" in sinfo_args
+    squeue_args = Path(environment["FAKE_SQUEUE_ARGS"]).read_text(encoding="utf-8")
+    assert "--jobs=123" in squeue_args
+    assert "--states=RUNNING" in squeue_args
+    assert "--array" in squeue_args
+    assert "--format=%K|%N" in squeue_args
+    assert "--nodelist" not in squeue_args
+
+
+def test_timestamp_failure_retains_audit_event(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    sinfo_output.write_text("node03\n", encoding="utf-8")
+    squeue_output.write_text("7|node03\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node03": ["node03"]})
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                f'source "{_SCRIPT}"\n'
+                "_scheduler_segment_health_timestamp_utc() { return 1; }\n"
+                "scheduler_segment_health_poll_once"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _current_path(output_dir).read_text(encoding="utf-8") == "node03"
+    assert _read_ledger(output_dir)[0]["observed_at"] is None
+    assert "history timestamp unavailable task=7 event=excluded" in result.stderr
+
+
+def test_trims_scheduler_field_padding(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    sinfo_output.write_text("  node03  \n", encoding="utf-8")
+    squeue_output.write_text(" 7 | node[01-04] \n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node[01-04]": ["node01", "node03"]})
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 0, result.stderr
+    assert _current_path(output_dir).read_text(encoding="utf-8") == "node03"
+
+
+def test_clean_poll_without_prior_state_avoids_squeue_and_artifacts(poller_environment):
+    environment, output_dir, _, _, _ = poller_environment
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 0, result.stderr
+    assert not Path(environment["FAKE_SQUEUE_ARGS"]).exists()
+    assert not list(output_dir.glob("segment_health_check.*"))
+
+
+def test_sourcing_defines_interface_without_polling(poller_environment):
+    environment, output_dir, _, _, _ = poller_environment
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                f'source "{_SCRIPT}" && '
+                "declare -F scheduler_segment_health_configure >/dev/null && "
+                "declare -F scheduler_segment_health_poll_once >/dev/null && "
+                "declare -F scheduler_segment_health_cleanup >/dev/null"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not Path(environment["FAKE_SINFO_ARGS"]).exists()
+    assert not output_dir.exists()
+
+
+def test_configure_initializes_without_polling(poller_environment):
+    environment, output_dir, _, _, _ = poller_environment
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            f'source "{_SCRIPT}" && scheduler_segment_health_configure',
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output_dir.is_dir()
+    assert not Path(environment["FAKE_SINFO_ARGS"]).exists()
+
+
+def test_reuses_workspace_until_explicit_cleanup(poller_environment):
+    environment, _, _, _, _ = poller_environment
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                f'source "{_SCRIPT}"\n'
+                "scheduler_segment_health_configure || exit $?\n"
+                'work="${_SCHEDULER_SEGMENT_HEALTH_WORK}"\n'
+                'test -d "${work}" || exit 91\n'
+                "scheduler_segment_health_poll_once || exit $?\n"
+                'test "${work}" = "${_SCHEDULER_SEGMENT_HEALTH_WORK}" || exit 92\n'
+                "scheduler_segment_health_poll_once || exit $?\n"
+                'test "${work}" = "${_SCHEDULER_SEGMENT_HEALTH_WORK}" || exit 93\n'
+                "scheduler_segment_health_cleanup || exit $?\n"
+                'test ! -e "${work}" || exit 94\n'
+                'test -z "${_SCHEDULER_SEGMENT_HEALTH_WORK:-}" || exit 95'
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_artifact_directory_loss_fails_before_scheduler_query(poller_environment):
+    environment, output_dir, _, _, _ = poller_environment
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                f'source "{_SCRIPT}"\n'
+                "scheduler_segment_health_poll_once || exit $?\n"
+                'rm -f "${FAKE_SINFO_ARGS}"\n'
+                'rmdir "${NVRX_SEGMENT_HEALTH_CHECK_DIR}"\n'
+                "scheduler_segment_health_poll_once"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode != 0
+    assert not output_dir.exists()
+    assert "artifact directory is unavailable" in result.stderr
+    assert not Path(environment["FAKE_SINFO_ARGS"]).exists()
+
+
+def test_relative_artifact_directory_is_rejected(poller_environment):
+    environment, _, _, _, _ = poller_environment
+    environment["NVRX_SEGMENT_HEALTH_CHECK_DIR"] = "relative/decisions"
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 2
+
+
+def test_unavailable_nodes_outside_job_publish_no_exclusion(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    sinfo_output.write_text("other-node\n", encoding="utf-8")
+    squeue_output.write_text("7|node[01-02]\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node[01-02]": ["node01", "node02"]})
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 0, result.stderr
+    assert not _current_path(output_dir).exists()
+    assert not _ledger_path(output_dir).exists()
+
+
+def test_running_task_recovery_clears_current_file(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    sinfo_output.write_text("node03\n", encoding="utf-8")
+    squeue_output.write_text("7|node[01-04]\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node[01-04]": ["node01", "node03"]})
+    first = _run_poller(environment)
+    assert first.returncode == 0, first.stderr
+
+    sinfo_output.write_text("", encoding="utf-8")
+    second = _run_poller(environment)
+
+    assert second.returncode == 0, second.stderr
+    assert _current_path(output_dir).exists()
+    assert _current_path(output_dir).stat().st_size == 0
+    assert [record["event"] for record in _read_ledger(output_dir)] == ["excluded", "cleared"]
+
+
+def test_each_poll_reconstructs_state_from_current_files(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    sinfo_output.write_text("node03\n", encoding="utf-8")
+    squeue_output.write_text("7|node03\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node03": ["node03"]})
+    result = _run_two_sourced_polls(
+        environment,
+        f': >"{environment["FAKE_SINFO_OUTPUT"]}"',
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _current_path(output_dir).exists()
+    assert _current_path(output_dir).stat().st_size == 0
+    assert [record["event"] for record in _read_ledger(output_dir)] == ["excluded", "cleared"]
+
+
+def test_inactive_task_preserves_last_observation_outside_control(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    sinfo_output.write_text("node03\n", encoding="utf-8")
+    squeue_output.write_text("7|node[01-04]\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node[01-04]": ["node01", "node03"]})
+    first = _run_poller(environment)
+    assert first.returncode == 0, first.stderr
+
+    sinfo_output.write_text("", encoding="utf-8")
+    squeue_output.write_text("", encoding="utf-8")
+    second = _run_two_sourced_polls(
+        environment,
+        (
+            f'test -f "{_current_path(output_dir)}" '
+            f'&& test ! -e "{_inactive_path(output_dir)}" || exit 91'
+        ),
+    )
+
+    assert second.returncode == 0, second.stderr
+    assert not _current_path(output_dir).exists()
+    assert _inactive_path(output_dir).read_text(encoding="utf-8") == "node03"
+    assert _read_ledger(output_dir)[-1]["reason"] == "task_inactive"
+
+
+def test_transient_missing_task_does_not_move_current_file_inactive(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    sinfo_output.write_text("node03\n", encoding="utf-8")
+    squeue_output.write_text("7|node[01-04]\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node[01-04]": ["node01", "node03"]})
+    first = _run_poller(environment)
+    assert first.returncode == 0, first.stderr
+
+    sinfo_output.write_text("", encoding="utf-8")
+    squeue_output.write_text("", encoding="utf-8")
+    result = _run_two_sourced_polls(
+        environment,
+        f'printf "%s\\n" "7|node[01-04]" >"{squeue_output}"',
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _current_path(output_dir).exists()
+    assert _current_path(output_dir).stat().st_size == 0
+    assert not _inactive_path(output_dir).exists()
+    records = _read_ledger(output_dir)
+    assert [record["event"] for record in records] == ["excluded", "cleared"]
+    assert "reason" not in records[-1]
+
+
+def test_current_state_scan_ignores_inactive_and_nonmatching_files(poller_environment):
+    environment, output_dir, _, _, _ = poller_environment
+    output_dir.mkdir()
+    inactive = _inactive_path(output_dir)
+    inactive.write_text("node03", encoding="utf-8")
+    unrelated = output_dir / "segment_health_check.123.7.temporary"
+    unrelated.write_text("node04", encoding="utf-8")
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 0, result.stderr
+    assert not Path(environment["FAKE_SQUEUE_ARGS"]).exists()
+    assert inactive.read_text(encoding="utf-8") == "node03"
+    assert unrelated.read_text(encoding="utf-8") == "node04"
+
+
+def test_changed_unavailable_nodes_update_state_and_audit(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    squeue_output.write_text("7|node[01-04]\n", encoding="utf-8")
+    _set_scontrol_map(
+        scontrol_map,
+        {"node[01-04]": ["node01", "node03", "node04"]},
+    )
+    sinfo_output.write_text("node03\n", encoding="utf-8")
+    first = _run_poller(environment)
+    assert first.returncode == 0, first.stderr
+
+    sinfo_output.write_text("node04\nnode03\n", encoding="utf-8")
+    second = _run_poller(environment)
+
+    assert second.returncode == 0, second.stderr
+    assert _current_path(output_dir).read_text(encoding="utf-8") == "node03,node04"
+    records = _read_ledger(output_dir)
+    assert [record["event"] for record in records] == ["excluded", "updated"]
+    assert records[-1]["nodes"] == "node03,node04"
+
+
+def test_unchanged_exclusion_does_not_duplicate_audit(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    sinfo_output.write_text("node03\n", encoding="utf-8")
+    squeue_output.write_text("7|node03\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node03": ["node03"]})
+
+    assert _run_poller(environment).returncode == 0
+    assert _run_poller(environment).returncode == 0
+
+    assert [record["event"] for record in _read_ledger(output_dir)] == ["excluded"]
+
+
+@pytest.mark.parametrize("failure", ["sinfo", "squeue", "scontrol"])
+def test_failed_pass_preserves_previous_decision(poller_environment, failure):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    output_dir.mkdir()
+    decision = _current_path(output_dir)
+    decision.write_text("node03", encoding="utf-8")
+
+    if failure == "sinfo":
+        environment["FAKE_SINFO_FAIL"] = "1"
+    else:
+        sinfo_output.write_text("node03\n", encoding="utf-8")
+        if failure == "squeue":
+            environment["FAKE_SQUEUE_FAIL"] = "1"
+        else:
+            squeue_output.write_text("7|node[01-04]\n", encoding="utf-8")
+            _set_scontrol_map(scontrol_map, {"node[01-04]": ["__FAIL__"]})
+
+    result = _run_poller(environment)
+
+    assert result.returncode != 0
+    assert decision.read_text(encoding="utf-8") == "node03"
+
+
+def test_one_publication_failure_does_not_block_other_tasks(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    _configure_two_excluded_tasks(sinfo_output, squeue_output, scontrol_map)
+    output_dir.mkdir()
+    failed_task = _current_path(output_dir, "7")
+    successful_task = _current_path(output_dir, "12")
+    failed_task.write_text("node01", encoding="utf-8")
+
+    first = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                f'source "{_SCRIPT}"\n'
+                "eval \"$(declare -f _scheduler_segment_health_set_current_value "
+                "| sed '1s/_scheduler_segment_health_set_current_value/'"
+                "'_scheduler_segment_health_set_current_value_real/')\"\n"
+                "_scheduler_segment_health_set_current_value() {\n"
+                '    [[ "$1" != "7" ]] || return 1\n'
+                '    _scheduler_segment_health_set_current_value_real "$@"\n'
+                "}\n"
+                "scheduler_segment_health_poll_once"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        env=environment,
+        text=True,
+        timeout=10,
+    )
+
+    assert first.returncode != 0
+    assert failed_task.read_text(encoding="utf-8") == "node01"
+    assert successful_task.read_text(encoding="utf-8") == "node18"
+    assert [(record["event"], record["task_id"]) for record in _read_ledger(output_dir)] == [
+        ("excluded", 12)
+    ]
+
+    second = _run_poller(environment)
+
+    assert second.returncode == 0, second.stderr
+    assert failed_task.read_text(encoding="utf-8") == "node03"
+    assert successful_task.read_text(encoding="utf-8") == "node18"
+    assert [(record["event"], record["task_id"]) for record in _read_ledger(output_dir)] == [
+        ("excluded", 12),
+        ("updated", 7),
+    ]
+
+
+def test_stale_poll_deadline_clears_exclusion(poller_environment):
+    environment, output_dir, _, _, _ = poller_environment
+    output_dir.mkdir()
+    decision = _current_path(output_dir)
+    decision.write_text("node03", encoding="utf-8")
+    environment["FAKE_SINFO_FAIL"] = "1"
+    environment["NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS"] = "1"
+
+    result = _run_two_sourced_polls(environment, "/bin/sleep 1")
+
+    assert result.returncode != 0
+    assert decision.stat().st_size == 0
+    record = _read_ledger(output_dir)[-1]
+    assert record["event"] == "cleared"
+    assert record["task_id"] == 7
+    assert record["reason"] == "stale_decision_expired"
+
+
+def test_noncanonical_current_value_cannot_inject_poll_snapshot_rows(poller_environment):
+    environment, output_dir, _, squeue_output, scontrol_map = poller_environment
+    output_dir.mkdir()
+    decision = _current_path(output_dir)
+    decision.write_text("node03\n999|K|rogue", encoding="utf-8")
+    squeue_output.write_text("7|node03\n999|node99\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node03": ["node03"], "node99": ["node99"]})
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 0, result.stderr
+    assert decision.stat().st_size == 0
+    assert not _current_path(output_dir, "999").exists()
+    assert not _ledger_path(output_dir).exists()
+
+
+def test_trailing_newline_is_not_normalized_as_canonical_state(poller_environment):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    output_dir.mkdir()
+    decision = _current_path(output_dir)
+    decision.write_text("node03\n", encoding="utf-8")
+    sinfo_output.write_text("node03\n", encoding="utf-8")
+    squeue_output.write_text("7|node03\n", encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node03": ["node03"]})
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 0, result.stderr
+    assert decision.read_bytes() == b"node03"
+    assert [record["event"] for record in _read_ledger(output_dir)] == ["updated"]
+
+
+@pytest.mark.parametrize(
+    "taskmap",
+    [
+        "not-a-task|node01\n",
+        "7|node01|extra\n",
+        "7|node{01,02}\n",
+        "7|node01\n7|node02\n",
+    ],
+)
+def test_malformed_task_mapping_preserves_previous_decision(poller_environment, taskmap):
+    environment, output_dir, sinfo_output, squeue_output, scontrol_map = poller_environment
+    output_dir.mkdir()
+    decision = _current_path(output_dir)
+    decision.write_text("node03", encoding="utf-8")
+    sinfo_output.write_text("node01\n", encoding="utf-8")
+    squeue_output.write_text(taskmap, encoding="utf-8")
+    _set_scontrol_map(scontrol_map, {"node01": ["node01"], "node02": ["node02"]})
+
+    result = _run_poller(environment)
+
+    assert result.returncode != 0
+    assert decision.read_text(encoding="utf-8") == "node03"
+
+
+def test_malformed_scheduler_node_preserves_previous_decision(poller_environment):
+    environment, output_dir, sinfo_output, _, _ = poller_environment
+    output_dir.mkdir()
+    decision = _current_path(output_dir)
+    decision.write_text("node03", encoding="utf-8")
+    sinfo_output.write_text("node01|unexpected\n", encoding="utf-8")
+
+    result = _run_poller(environment)
+
+    assert result.returncode != 0
+    assert decision.read_text(encoding="utf-8") == "node03"
+
+
+def test_array_job_id_must_be_numeric(poller_environment):
+    environment, output_dir, _, _, _ = poller_environment
+    environment["SLURM_ARRAY_JOB_ID"] = "../../wrong"
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 2
+    assert not output_dir.exists()
+
+
+def test_partition_is_required(poller_environment):
+    environment, output_dir, _, _, _ = poller_environment
+    del environment["SLURM_JOB_PARTITION"]
+
+    result = _run_poller(environment)
+
+    assert result.returncode != 0
+    assert not output_dir.exists()
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("NVRX_SEGMENT_HEALTH_STALE_DECISION_SECONDS", "0"),
+        ("NVRX_SEGMENT_HEALTH_SLURM_CMD_TIMEOUT", "0"),
+    ],
+)
+def test_numeric_settings_must_be_positive_integers(poller_environment, name, value):
+    environment, output_dir, _, _, _ = poller_environment
+    environment[name] = value
+
+    result = _run_poller(environment)
+
+    assert result.returncode == 2
+    assert f"{name} must be a positive integer: {value}" in result.stderr
+    assert not output_dir.exists()


### PR DESCRIPTION
## Summary

- add one sourceable Bash Scheduler Segment Health producer for Slurm array task 0
- query scheduler-unavailable nodes with partition-filtered `sinfo`
- skip `squeue` entirely when there are no unavailable nodes and no prior decisions
- otherwise query all running array tasks, expand each compressed hostlist locally, and map unavailable nodes to exact task IDs
- publish per-task CSV control markers, `.inactive` last-observation artifacts, and centralized best-effort JSONL history
- preserve prior decisions after incomplete scheduler results or publication failures; clear stale decisions after the configured freshness window
- integrate the producer lifecycle into the singleton-array deployment example without creating a daemon or supervising the workload

## Motivation

The producer runs in the host-side sbatch control flow where Slurm commands are available. The NVRx workload can remain inside its container and consume the resulting per-task files from shared storage through `SegmentHealthCheck`.

The producer is one sourceable Bash file with three operations: `scheduler_segment_health_configure`, `scheduler_segment_health_poll_once`, and `scheduler_segment_health_cleanup`. The surrounding sbatch control loop owns cadence and lifecycle.

## Algorithm

1. A partition-filtered `sinfo` query produces the canonical unavailable-node set for `DRAIN`, `DOWN`, `FAIL`, and `NO_RESPOND` states.
2. If that set and prior published state are both empty, the poll completes without calling `squeue`.
3. Otherwise, one array-wide `squeue` returns `%K|%N` for every running task.
4. Each compressed hostlist is expanded locally with `scontrol show hostnames`, normalized, and intersected with the unavailable-node set.
5. Only after a complete result is derived does reconciliation set, update, clear, or retire individual task artifacts.
6. A tracked task absent from two consecutive complete `squeue` results moves from the current namespace to `.inactive`; one missing result preserves its current decision.

The reconciliation path scales with the number of running array tasks and their total allocated nodes. For `R` running tasks, `U` unavailable nodes, and `N_i` nodes in task `i`, its local set-processing work is approximately `O(U log U + sum_i(N_i log N_i + U))`. It is not independent of total allocated nodes. The healthy fast path performs only `sinfo`.

## Contract

```text
segment_health_check.<array_job_id>.<task_id>
segment_health_check.<array_job_id>.<task_id>.inactive
segment_health_check_history.<array_job_id>.log
```

A non-empty current task file excludes that task. Its sorted unavailable-node CSV is diagnostic context; the consumer checks only that the file is a non-empty regular file. A missing or zero-byte current file means no current exclusion. The centralized log records `excluded`, `updated`, and `cleared` transitions as JSONL.

The deployment uses `--no-requeue` and scopes the artifact directory to `SLURM_ARRAY_JOB_ID`.

## Validation

- local producer unit suite: 33 passed
- exact pushed commit `a73e2bb` on Linux/PDX: 33 passed, Slurm job `3551`
- dev FT baseline: passed, job `3552`
- exclusion without spare: passed, job `3554`
- rendezvous-host exclusion: passed, job `3556`
- recovery and marker clear: passed, job `3558`
- complete-spare replacement: passed, job `3560`
- state reconstruction, update, clear, and two-poll inactive transition: passed, job `3563`
- all mutated nodes restored to `idle`; no qualification jobs remain
- `bash -n`, `black --check`, `isort --check-only`, and `git diff --check` passed
