### PR TITLE
Lens telemetry, restructured into shared_utils/telemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ pydantic-settings = ">=2.0.0"
 slowapi = ">=0.1.9"
 slack-bolt = { version = ">=1.23.0", optional = true }
 slack-sdk = { version = ">=3.35.0", optional = true }
+# Optional telemetry backend, pulled in by the `otel` extra.
+nemo-lens = { version = ">=0.2.0", extras = ["sdk"], optional = true }
 grpcio = "^1.76.0"
 grpcio-tools = "^1.76.0"
 protobuf = ">=4.22.0"
@@ -73,6 +75,9 @@ attribution = [
     "setproctitle",
     "slack-bolt",
     "slack-sdk",
+]
+otel = [
+    "nemo-lens",
 ]
 
 [tool.poetry.scripts]

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/core.py
@@ -34,6 +34,7 @@ import torch
 from torch import multiprocessing as mp
 
 from ..utils import _disable_gc, debug_time
+from .telemetry import CheckpointWorkerTelemetry
 
 logger = logging.getLogger(__name__)
 
@@ -454,6 +455,7 @@ class PersistentAsyncCaller(AsyncCaller):
         io_priority: Optional[int] = None,
         sigterm_timeout: float = 30.0,
         cpu_shm_mode: bool = False,
+        otel_bootstrap: Optional[dict] = None,
     ):
         self.process: mp.Process = None
         self.start_time: Optional[float] = None
@@ -478,6 +480,11 @@ class PersistentAsyncCaller(AsyncCaller):
         self.cpu_priority = cpu_priority
         self.io_priority = io_priority
         self.cpu_shm_mode = cpu_shm_mode
+        # Plain dict of otel config + resource attributes (see async_ckpt/telemetry.py).
+        # spawn gives this process nothing from the parent's memory, so telemetry has
+        # to be bootstrapped fresh there from data passed explicitly through the
+        # ctx.Process args, the same channel as cpu_priority/io_priority above.
+        self.otel_bootstrap = otel_bootstrap
 
     def _start_worker(self, rank: int) -> None:
         """Start the background worker process.
@@ -506,6 +513,7 @@ class PersistentAsyncCaller(AsyncCaller):
                 self.cpu_priority,
                 self.io_priority,
                 self.cpu_shm_mode,
+                self.otel_bootstrap,
             ),
             daemon=self.background_worker_is_daemon,
         )
@@ -687,6 +695,7 @@ class PersistentAsyncCaller(AsyncCaller):
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
         cpu_shm_mode: bool = False,
+        otel_bootstrap: Optional[dict] = None,
     ):
         """Main function for the persistent checkpoint worker
 
@@ -714,6 +723,11 @@ class PersistentAsyncCaller(AsyncCaller):
                                         I/O priority unchanged. Use 3 (idle) to deprioritize
                                         checkpoint I/O. NOTE: class 1 = realtime (highest
                                         priority — NOT recommended for checkpoint workers).
+            otel_bootstrap (dict, Optional): otel config + resource attributes built by the
+                                             caller and threaded through via ctx.Process args,
+                                             since this process is spawned fresh and inherits
+                                             nothing from the parent. None/empty means telemetry
+                                             stays disabled.
 
         """
         # Align library loggers in this process without mutating the root logger
@@ -750,6 +764,12 @@ class PersistentAsyncCaller(AsyncCaller):
 
         signal.signal(signal.SIGTERM, _handle_sigterm)
 
+        # Telemetry must be stood up fresh here: spawn inherits no TracerProvider from
+        # the parent, so this is a second, independent setup driven by whatever the caller
+        # put in otel_bootstrap. Disabled and no-op unless the caller passed a bootstrap
+        # and nemo-lens is installed.
+        telemetry = CheckpointWorkerTelemetry.from_bootstrap(otel_bootstrap, rank)
+
         # Start busy loop waiting for and executing checkpoint saves.
         try:
             while True:
@@ -758,20 +778,22 @@ class PersistentAsyncCaller(AsyncCaller):
                     queue.task_done()
                     break
                 elif isinstance(item, AsyncRequest):
-                    async_fn_args = list(item.async_fn_args)
-                    if item.preload_fn:
-                        call_idx = preload_q.get()
-                        # the 2nd arg is state dict
-                        async_fn_args[1] = item.preload_fn()
-                        logger.debug(f"{rank} has completed D2H of {call_idx}")
-                        preload_q.task_done()
-                    if item.async_fn is not None:
-                        async_fn_kwargs = dict(item.async_fn_kwargs or {})
-                        item.async_fn(*async_fn_args, **async_fn_kwargs)
-                    logger.debug(f"{rank} has completed saving {item.call_idx}")
-                    comp_q.put(item.call_idx)
-                    queue.task_done()
-                    del async_fn_args
+                    with telemetry.request_span(item.call_idx):
+                        async_fn_args = list(item.async_fn_args)
+                        if item.preload_fn:
+                            call_idx = preload_q.get()
+                            # the 2nd arg is state dict
+                            async_fn_args[1] = item.preload_fn()
+                            logger.debug(f"{rank} has completed D2H of {call_idx}")
+                            preload_q.task_done()
+                        if item.async_fn is not None:
+                            async_fn_kwargs = dict(item.async_fn_kwargs or {})
+                            with telemetry.write_span():
+                                item.async_fn(*async_fn_args, **async_fn_kwargs)
+                        logger.debug(f"{rank} has completed saving {item.call_idx}")
+                        comp_q.put(item.call_idx)
+                        queue.task_done()
+                        del async_fn_args
                 del item
                 gc.collect()
         except RuntimeError as e:
@@ -787,6 +809,7 @@ class PersistentAsyncCaller(AsyncCaller):
             # Cleanup worker data cache before exiting, regardless of how the loop exits
             # (normal termination via 'DONE' sentinel or unhandled exception).
             PersistentAsyncCaller.cleanup_worker_data_cache()
+            telemetry.shutdown()
         if rank == 0:
             logger.info(f"PersistentAsyncCaller: persistent ckpt worker for {rank} has terminated")
         else:
@@ -803,13 +826,22 @@ class PersistentAsyncCaller(AsyncCaller):
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
         cpu_shm_mode: bool = False,
+        otel_bootstrap: Optional[dict] = None,
     ):
         """
         Main function for the persistent checkpoint worker called by a non daemon async process.
         In this loop, child processes may be created (For example: to parallelize File IO)
         """
         PersistentAsyncCaller.async_process_target(
-            rank, queue, preload_q, comp_q, log_level, cpu_priority, io_priority, cpu_shm_mode
+            rank,
+            queue,
+            preload_q,
+            comp_q,
+            log_level,
+            cpu_priority,
+            io_priority,
+            cpu_shm_mode,
+            otel_bootstrap,
         )
 
     @staticmethod
@@ -822,12 +854,21 @@ class PersistentAsyncCaller(AsyncCaller):
         cpu_priority: int = 10,
         io_priority: Optional[int] = None,
         cpu_shm_mode: bool = False,
+        otel_bootstrap: Optional[dict] = None,
     ):
         """
         Main function for the persistent checkpoint worker called by a daemon async process
         """
         PersistentAsyncCaller.async_process_target(
-            rank, queue, preload_q, comp_q, log_level, cpu_priority, io_priority, cpu_shm_mode
+            rank,
+            queue,
+            preload_q,
+            comp_q,
+            log_level,
+            cpu_priority,
+            io_priority,
+            cpu_shm_mode,
+            otel_bootstrap,
         )
 
 
@@ -865,6 +906,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
         io_priority: Optional[int] = None,
         sigterm_timeout: float = 30.0,
         cpu_shm_mode: bool = False,
+        otel_bootstrap: Optional[dict] = None,
     ):
         self.async_calls: deque[_ActiveAsyncRequest] = deque([])
         self.call_idx: int = -1
@@ -874,6 +916,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
         self.io_priority = io_priority
         self.sigterm_timeout = sigterm_timeout
         self.cpu_shm_mode = cpu_shm_mode
+        self.otel_bootstrap = otel_bootstrap
         self.persistent_caller: AsyncCaller = None
 
         if cpu_shm_mode:
@@ -907,6 +950,21 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                     )
                     warmed.process.join()  # reap the zombie before discarding
                     warmed.process = None
+                if warmed.process is None:
+                    # A fresh worker will be spawned for this caller, so this queue's
+                    # telemetry configuration can still take effect.
+                    warmed.otel_bootstrap = self.otel_bootstrap
+                elif warmed.otel_bootstrap != self.otel_bootstrap:
+                    # The bootstrap is fixed at spawn: a live pre-warmed worker keeps the
+                    # configuration it was started with, and this queue's is ignored. Say so,
+                    # rather than silently emitting no checkpoint spans.
+                    logger.warning(
+                        "Pre-warmed checkpoint worker (PID %s) was started with a different "
+                        "telemetry configuration than this queue requests; the worker's own "
+                        "configuration stays in effect. Pass the same otel_bootstrap to "
+                        "warmup_persistent_caller() to avoid losing checkpoint spans.",
+                        warmed.process.pid,
+                    )
                 self.persistent_caller = warmed
             else:
                 self.persistent_caller = PersistentAsyncCaller(
@@ -915,6 +973,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                     io_priority=self.io_priority,
                     sigterm_timeout=self.sigterm_timeout,
                     cpu_shm_mode=self.cpu_shm_mode,
+                    otel_bootstrap=self.otel_bootstrap,
                 )
         return self.persistent_caller
 
@@ -927,6 +986,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
         io_priority: Optional[int] = None,
         sigterm_timeout: float = 30.0,
         cpu_shm_mode: bool = False,
+        otel_bootstrap: Optional[dict] = None,
     ):
         """Pre-start the persistent async worker to avoid startup latency on the first checkpoint.
 
@@ -939,6 +999,10 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                 NOT recommended for checkpoint workers).
             sigterm_timeout (float): seconds to wait after SIGTERM before escalating to SIGKILL.
             cpu_shm_mode (bool): if True, skip CUDA device init in the worker (no CUDA IPC needed).
+            otel_bootstrap (dict, Optional): otel config + resource attributes for the worker to
+                bootstrap its own independent telemetry with (see async_process_target). Plain
+                dict only: this crosses a spawn() boundary via pickling, so it must not hold a
+                class instance or anything else with an import-path dependency.
         """
         if cls._warmup_persistent_caller is None:
             caller = PersistentAsyncCaller(
@@ -947,6 +1011,7 @@ class AsyncCallsQueue(metaclass=ObjectTracker):
                 io_priority=io_priority,
                 sigterm_timeout=sigterm_timeout,
                 cpu_shm_mode=cpu_shm_mode,
+                otel_bootstrap=otel_bootstrap,
             )
             caller._start_worker(rank)
             caller.rank = rank

--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/telemetry.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/telemetry.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Telemetry for the persistent async checkpoint worker.
+
+The worker is spawned, so it inherits nothing from the trainer's memory: no config, no
+TracerProvider. Telemetry has to be bootstrapped fresh from data passed explicitly
+through the `ctx.Process` args, which is what `bootstrap` is - a plain dict, because it
+crosses a spawn boundary by pickling and so must not hold a class instance or anything
+else with an import-path dependency.
+
+`shared_utils/telemetry.py` owns the nemo-lens seam; nothing here imports nemo directly.
+"""
+
+import logging
+from typing import Any, ContextManager, Dict, Optional
+
+from ...shared_utils import telemetry as backend
+from ...shared_utils.log_manager import LogConfig
+
+logger = logging.getLogger(LogConfig.name)
+
+#: Span group these spans belong to, for nemo-lens group filtering.
+SPAN_GROUP = 'checkpoint'
+
+
+class CheckpointWorkerTelemetry:
+    """Spans emitted by the checkpoint worker, plus the provider it owns.
+
+    Always usable: when telemetry is disabled the spans are no-op context managers and
+    there is no provider to shut down, so the worker loop needs no conditionals.
+    """
+
+    def __init__(self, handle: Optional[Any] = None):
+        self._handle = handle
+
+    @classmethod
+    def from_bootstrap(
+        cls, bootstrap: Optional[Dict[str, Any]], rank: int
+    ) -> "CheckpointWorkerTelemetry":
+        """Stand up this process's own telemetry from the trainer-supplied bootstrap.
+
+        `bootstrap` of None means the caller did not configure telemetry at all. Any other
+        value also triggers a config read from the environment, since `enabled` in the dict
+        is only the CLI override: a run configured purely through the environment has to be
+        picked up here too.
+        """
+        if bootstrap is None or not backend.HAS_NEMO_LENS:
+            return cls()
+        try:
+            config = backend.config_from_env()
+            if bootstrap.get('enabled'):
+                config.enabled = True
+            if bootstrap.get('service_name'):
+                config.service_name = bootstrap['service_name']
+            if bootstrap.get('span_groups'):
+                config.span_groups = bootstrap['span_groups']
+            handle = backend.setup_telemetry(
+                config,
+                rank=bootstrap.get('rank', rank),
+                world_size=bootstrap.get('world_size', 1),
+                resource_attributes=bootstrap.get('resource_attrs'),
+            )
+            _apply_resolved_span_groups(bootstrap.get('resolved_span_groups'))
+            return cls(handle)
+        except Exception as e:  # a broken exporter must not take down checkpointing
+            logger.debug("nvrx telemetry: checkpoint worker telemetry disabled: %s", e)
+            return cls()
+
+    def request_span(self, call_idx: int) -> ContextManager:
+        """Everything the worker does to handle one request, including D2H preload staging
+        and queue/GC overhead. Deliberately separate from `write_span`: "time this request
+        occupied the worker" and "actual write duration" answer different questions."""
+        return backend.span(
+            SPAN_GROUP,
+            'nvrx.checkpoint.save.request',
+            is_goodput_span=True,
+            **{'nvrx.call_idx': call_idx},
+        )
+
+    def write_span(self) -> ContextManager:
+        """Just the write call. The background write is overlapped - training runs straight
+        through it - so it costs zero goodput and must stay out of the goodput view, where
+        it would double-count against the exposed save.finalize. It stays visible for
+        resiliency analysis either way."""
+        return backend.span(SPAN_GROUP, 'nvrx.checkpoint.save.write', is_goodput_span=False)
+
+    def shutdown(self) -> None:
+        """Flush before the process exits. BatchSpanProcessor only flushes on a timer or on
+        shutdown, never automatically at exit, so anything still queued - including the
+        spans of the very last request this worker handled - would otherwise be dropped."""
+        if self._handle is None:
+            return
+        try:
+            self._handle.shutdown()
+        except Exception as e:
+            logger.debug("nvrx telemetry: checkpoint worker flush failed: %s", e)
+
+
+def _apply_resolved_span_groups(groups) -> None:
+    """Force the enabled span groups to the caller's fully-resolved set.
+
+    setup_telemetry() resolves this process's span_groups with the base SpanGroup class,
+    which cannot resolve consumer-specific group names; the caller resolves them on its
+    side and passes the result here, which is what lets consumer-only groups reach the
+    worker. Absent (older caller), the groups already set stand.
+    """
+    if not groups:
+        return
+    try:
+        from nemo.lens.state import set_enabled_span_groups
+
+        set_enabled_span_groups(frozenset(groups))
+    except ImportError:
+        pass

--- a/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/ft_rendezvous_barrier.py
@@ -64,6 +64,7 @@ from ..shared_utils.health_check import (
 from ..shared_utils.profiling import (
     ProfilingEvent,
     get_profiling_cycle,
+    profiling_phase,
     record_profiling_event,
     set_profiling_cycle,
 )
@@ -1899,7 +1900,16 @@ class _RendezvousBarrierState:
             # Hot spares and late-arriving nodes wait here indefinitely until a failure
             # opens the next round. Also checks for permanent shutdown.
             # Note: _wait_for_rendezvous_open() raises RendezvousGracefulExitError on shutdown.
-            self._wait_for_rendezvous_open(node_desc)
+            # Bracketed as a profiling phase so a node that is not (yet) in the active
+            # rendezvous is still observable; without it a hot spare leaves no trace for the
+            # entire cycle it waits through. The phase closes even when shutdown raises out
+            # of the wait.
+            with profiling_phase(
+                ProfilingEvent.AWAIT_ROUND_STARTED,
+                ProfilingEvent.AWAIT_ROUND_COMPLETED,
+                node_id=node_desc,
+            ):
+                self._wait_for_rendezvous_open(node_desc)
 
             # Record start time for timeout monitoring.
             # Start timing AFTER Step 0 completes, since nodes may wait indefinitely at Step 0.
@@ -1916,6 +1926,14 @@ class _RendezvousBarrierState:
                 try:
                     pre_join_hook()
                 except UnhealthyNodeException:
+                    # This node bailed at its health check (evicted, injected, or genuinely
+                    # unhealthy) and is about to leave the job, so mark it: the telemetry
+                    # recorder closes and flushes this node's open cycle and phase spans
+                    # before the process is torn down.
+                    record_profiling_event(
+                        ProfilingEvent.NODE_EXCLUDED,
+                        node_id=node_desc,
+                    )
                     try:
                         self._maybe_mark_current_replacement_group_unhealthy()
                     except Exception as e:

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -96,6 +96,7 @@ from nvidia_resiliency_ext.fault_tolerance.per_cycle_logs import PipeBasedLogsSp
 from nvidia_resiliency_ext.fault_tolerance.progress_tracker import TrainingProgressTracker
 from nvidia_resiliency_ext.fault_tolerance.rank_monitor_server import RankMonitorServer
 from nvidia_resiliency_ext.fault_tolerance.rdzv_utils import rdzv_config_get_as_bool
+from nvidia_resiliency_ext.fault_tolerance.telemetry import CycleOutcome, LauncherTelemetry
 from nvidia_resiliency_ext.fault_tolerance.utils import (
     DEFAULT_NO_RESTART_EXIT_CODE,
     RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP,
@@ -451,7 +452,21 @@ class LocalElasticAgent(SimpleElasticAgent):
         self._restart_policy = restart_policy
         self._node_id = self._get_fq_hostname()
 
+        # Telemetry for this agent process (see shared_utils/telemetry). The agent runs
+        # separately from the training workers, so it stands up its own nemo-lens tracer and
+        # registers the restart-cycle recorder as a profiling listener; the recorder then owns
+        # the per-cycle span tree, built from the boundary events already recorded here and in
+        # the rendezvous handler. The agent's own part is only to annotate the open cycle,
+        # stage its outcome, and close terminal cycles. This is a null object unless the
+        # workload configured lens telemetry, so the call sites below need no guards.
+        self._telemetry = LauncherTelemetry(self._node_id)
+
     DEFAULT_ROLE = "default"  # FIXME
+
+    def _annotate_telemetry_cycle(self):
+        """Describe the cycle the recorder opened at rendezvous. The recorder owns the span;
+        the agent is what knows the restart budget and the rendezvous topology."""
+        self._telemetry.annotate_cycle(self._worker_group, self._remaining_restarts)
 
     # ============================================================================
     # Global Restart/Cycle Tracking for Job Array Deployments
@@ -577,6 +592,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         finally:
             if not shutdown_called:
                 self._shutdown()
+            self._telemetry.shutdown()
             # record the execution time in case there were any exceptions during run.
             self._total_execution_time = int(time.monotonic() - start_time)
 
@@ -655,6 +671,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         logger.info("[%s] starting workers for entrypoint: %s", role, spec.get_entrypoint_name())
 
         self._initialize_workers(self._worker_group)
+        self._annotate_telemetry_cycle()  # describe the cycle the recorder opened at rendezvous
         monitor_interval = spec.monitor_interval
         rdzv_handler = spec.rdzv_handler
 
@@ -675,6 +692,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                     role,
                     self._exit_barrier_timeout,
                 )
+                self._telemetry.finish_cycle(CycleOutcome.SUCCEEDED)  # no teardown event follows
                 self._exit_barrier()
                 return run_result
 
@@ -717,11 +735,19 @@ class LocalElasticAgent(SimpleElasticAgent):
                     f"{self._remaining_restarts}/{spec.max_restarts} attempts left; "
                     f"will restart worker group"
                 )
+                # Stage the outcome before the restart; the recorder stamps it and closes the cycle
+                # when the teardown (WORKER_TERMINATED) event fires inside
+                # _handle_restart_decision. The teardown, rendezvous and worker_launch phase spans
+                # are what now covers the restart gap.
+                self._telemetry.stage_outcome(
+                    CycleOutcome.FAILED,
+                    **{'nvrx.state': state.name, 'nvrx.failures': len(run_result.failures or {})},
+                )
                 should_restart = self._handle_restart_decision(
                     role, spec, log_msg, open_rendezvous=True,
                 )
-
                 if should_restart:
+                    self._annotate_telemetry_cycle()  # describe the cycle just re-opened
                     continue  # Continue monitoring after restart
 
                 # No more restarts (either exhausted or early termination)
@@ -759,14 +785,17 @@ class LocalElasticAgent(SimpleElasticAgent):
 
                     log_msg = f"[%s] Joining cluster restart (group_rank={group_rank})"
                     # The node that triggered the failure already opened the rendezvous.
+                    # Stage the peer-restart outcome; the recorder closes this cycle at the teardown
+                    # event inside _handle_restart_decision and re-opens the next at rendezvous.
+                    self._telemetry.stage_outcome(CycleOutcome.PEER_RESTART)
                     should_restart = self._handle_restart_decision(
                         role, spec, log_msg, open_rendezvous=False,
                     )
-
                     if not should_restart:
                         self._stop_workers(self._worker_group)
                         self._worker_group.state = WorkerState.FAILED
                         return RunResult(state=WorkerState.FAILED)
+                    self._annotate_telemetry_cycle()  # joined the restart -> describe the new cycle
             else:
                 raise Exception(f"[{role}] Worker group in {state.name} state")
 
@@ -1107,6 +1136,12 @@ class LocalElasticAgent(SimpleElasticAgent):
 
         current_cycle_info_path = self._current_cycle_info_path()
 
+        # Telemetry anchors for this worker cohort, stamped once so every restart hands its
+        # workers a fresh per-restart anchor rather than the batch script's stale one. The
+        # trainer uses them to place its startup span (rendezvous rejoin, spawn, import)
+        # inside this cycle's run span.
+        telemetry_env = self._telemetry.worker_env(self._get_global_cycle_number())
+
         for worker in worker_group.workers:
             local_rank = worker.local_rank
 
@@ -1136,6 +1171,7 @@ class LocalElasticAgent(SimpleElasticAgent):
                 worker_env["NVRX_CURRENT_CYCLE_INFO"] = current_cycle_info_path
             if "OMP_NUM_THREADS" in os.environ:
                 worker_env["OMP_NUM_THREADS"] = os.environ["OMP_NUM_THREADS"]
+            worker_env.update(telemetry_env)
 
             if self._log_line_prefix_template:
                 log_line_prefix = Template(self._log_line_prefix_template).safe_substitute(

--- a/src/nvidia_resiliency_ext/fault_tolerance/telemetry.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/telemetry.py
@@ -1,0 +1,607 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Restart-cycle telemetry for the ft_launcher agent.
+
+The agent runs in its own process, separate from the training workers, so it stands up
+its own nemo-lens tracer and emits injob restart-cycle spans to the node's collector.
+
+Three pieces, innermost first:
+
+`_SpanTree`
+    How spans nest, open and close. Best-effort by construction: an error inside OTel is
+    logged at debug and swallowed, because a dropped span must never break the launcher.
+`RestartCycleRecorder`
+    When, as a table mapping each `ProfilingEvent` to actions on the tree. It observes the
+    fault-tolerance profiler rather than being called by the launcher, so adding an event
+    means adding a row to `_PLAN`.
+`LauncherTelemetry`
+    What `launcher.py` talks to. Disabled instances answer every call harmlessly, so no
+    call site needs a guard.
+
+`shared_utils/telemetry.py` owns the nemo-lens seam; nothing here imports nemo directly.
+"""
+
+import logging
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+from ..shared_utils import telemetry as backend
+from ..shared_utils.log_manager import LogConfig
+from ..shared_utils.profiling import ProfilingEvent, ProfilingEventRecord, set_profiling_observer
+
+log = logging.getLogger(LogConfig.name)
+
+try:  # torchelastic delivers the FT death signal as SignalException (an Exception subclass)
+    from torch.distributed.elastic.multiprocessing import SignalException as _SignalException
+except Exception:  # torchelastic absent -> sentinel that never matches a real signal
+
+    class _SignalException(Exception):
+        pass
+
+
+#: Presence of this variable is how a workload opts the agent into lens telemetry.
+EXPORTER_ENV = 'NEMO_LENS_EXPORTER'
+#: Bounds on export at teardown. The agent may be between SIGTERM and SIGKILL here.
+FLUSH_TIMEOUT_MS = 1500
+SHUTDOWN_TIMEOUT_S = 1.5
+
+_PREFIX = 'nvrx.restart.'
+_NODE_DESC_SUFFIX = re.compile(r'_\d+_\d+$')  # node_desc appends _<pid>_<local_rank>
+
+
+class CycleOutcome:
+    """Values of the `nvrx.cycle_outcome` attribute on a cycle span."""
+
+    COMPLETED = 'completed'  # workers torn down after a failure; a restart follows
+    EXCLUDED = 'excluded'  # this node bailed at its rendezvous health check
+    STANDBY = 'standby'  # this node was not selected and went back to waiting
+    SUCCEEDED = 'succeeded'  # the worker group finished cleanly
+    FAILED = 'failed'  # this node's workers failed and it is driving the restart
+    PEER_RESTART = 'peer_restart'  # a peer failed and this node is joining its restart
+    TERMINATED = 'terminated'  # the agent is exiting with a cycle still open
+
+
+def _clean_node(node):
+    """Normalize node_desc ('host.cm.cluster_<pid>_<local>') to the clean host form, so
+    phase spans and the cycle span carry the same nvrx.node value."""
+    return _NODE_DESC_SUFFIX.sub('', node) if isinstance(node, str) else node
+
+
+def _now_ns():
+    return int(time.time() * 1e9)
+
+
+def _safe(fn, what):
+    """Call `fn`, returning None instead of raising: every attribute here is optional."""
+    try:
+        return fn()
+    except Exception as e:
+        log.debug("nvrx telemetry: %s unavailable: %s", what, e)
+        return None
+
+
+# --------------------------------------------------------------------------- span tree
+
+
+class _SpanTree:
+    """The span tree one node emits for one restart cycle.
+
+    A parent `nvrx.restart.cycle` span, a *sweep* of phase children (at most one open at a
+    time, each ending where the next begins), zero-duration marks, and side spans tracked
+    by key that overlap the sweep or precede any cycle. The sweep is what keeps the tree
+    leak-free on partial sequences: an evicted node never reaches the later boundaries, but
+    whatever it had open is closed by the cycle close.
+    """
+
+    def __init__(self, tracer):
+        self._tracer = tracer
+        self._cycle = None
+        self._ctx = None
+        self._cycle_start_ns = None
+        self._phase = None
+        self._sides: Dict[str, Any] = {}
+
+    @property
+    def cycle_start_ns(self):
+        return self._cycle_start_ns
+
+    def _start(self, name, ns, attributes, parented=True):
+        # Attributes are set at creation so they are visible to the sampler and to any
+        # SpanProcessor.on_start, and it is one call instead of N.
+        attrs = {k: v for k, v in attributes.items() if v is not None}
+        try:
+            try:
+                return self._tracer.start_span(
+                    name, start_time=ns, context=self._ctx if parented else None, attributes=attrs
+                )
+            except TypeError:  # tracers without a context kwarg
+                return self._tracer.start_span(name, start_time=ns, attributes=attrs)
+        except Exception as e:
+            log.debug("nvrx telemetry: failed to start span %s: %s", name, e)
+            return None
+
+    @staticmethod
+    def _end(span, ns):
+        if span is None:
+            return
+        try:
+            span.end(end_time=ns if ns is not None else _now_ns())
+        except Exception as e:
+            log.debug("nvrx telemetry: failed to end span: %s", e)
+
+    @staticmethod
+    def _annotate(span, attributes):
+        if span is None:
+            return
+        for key, value in attributes.items():
+            if value is None:
+                continue
+            try:
+                span.set_attribute(key, value)
+            except Exception as e:
+                log.debug("nvrx telemetry: failed to set %s: %s", key, e)
+
+    def open_cycle(self, ns, attributes):
+        """Open the cycle span. Returns False when one is already open."""
+        if self._cycle is not None:
+            return False
+        self._cycle = self._start(_PREFIX + 'cycle', ns, attributes)
+        self._cycle_start_ns = ns
+        try:
+            from opentelemetry import trace
+
+            self._ctx = trace.set_span_in_context(self._cycle)
+        except Exception:  # opentelemetry absent -> children become root spans
+            self._ctx = None
+        return True
+
+    def close_cycle(self, ns, attributes):
+        """Close the cycle span and everything still open under it.
+
+        An unended span is an unexported span, so this also sweeps up the open phase and
+        any side span: otherwise a spare killed while waiting, or a node killed
+        mid-attribution, loses those spans.
+        """
+        end_ns = ns if ns is not None else _now_ns()
+        for key in list(self._sides):
+            self.close_side(key, end_ns)
+        self.end_phase(end_ns)
+        span, self._cycle = self._cycle, None
+        self._ctx = None
+        self._cycle_start_ns = None  # cleared so a closed cycle cannot leak its start
+        self._annotate(span, attributes)
+        self._end(span, end_ns)
+
+    def annotate_cycle(self, attributes):
+        self._annotate(self._cycle, attributes)
+
+    def start_phase(self, name, ns, attributes):
+        self.end_phase(ns)  # sweep: the previous phase ends where this one begins
+        self._phase = self._start(_PREFIX + name, ns, attributes)
+
+    def end_phase(self, ns):
+        span, self._phase = self._phase, None
+        self._end(span, ns)
+
+    def interval(self, name, start_ns, end_ns, attributes, parented=True):
+        """Emit an already-finished span covering [start_ns, end_ns]."""
+        self._end(self._start(name, start_ns, attributes, parented=parented), end_ns)
+
+    def mark(self, name, ns, attributes):
+        self.interval(_PREFIX + name, ns, ns, attributes)
+
+    def open_side(self, key, ns, attributes, parented=True):
+        """Open a span tracked by `key`, outside the phase sweep. `parented=False` forces a
+        root span, as the standby round-wait needs: it precedes any cycle."""
+        self.close_side(key, ns)
+        self._sides[key] = self._start(_PREFIX + key, ns, attributes, parented=parented)
+
+    def close_side(self, key, ns):
+        self._end(self._sides.pop(key, None), ns)
+
+
+# ----------------------------------------------------------------------------- recorder
+
+
+@dataclass(frozen=True)
+class ColdStartAnchors:
+    """Wall-clock anchors for the part of the job that precedes any Python we control.
+
+    Both come from the batch environment: by the time the agent starts, the queue wait and
+    the launch script have already happened.
+    """
+
+    launch_script_start: Optional[float] = None  # batch script's first line, outside the srun
+    slurm_job_start: Optional[float] = None  # Slurm's own job start (queue/prolog boundary)
+
+    @classmethod
+    def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "ColdStartAnchors":
+        env = os.environ if env is None else env
+
+        def _float(name):
+            try:
+                return float(env[name])
+            except (KeyError, TypeError, ValueError):
+                return None
+
+        return cls(_float('LENS_LAUNCH_SCRIPT_START_TIME'), _float('SLURM_JOB_START_TIME'))
+
+
+class RestartCycleRecorder:
+    """Renders the profiling event stream as this node's restart-cycle span tree.
+
+    Per-cycle event order (each node runs its own rendezvous, so every node sees these)::
+
+        RENDEZVOUS_STARTED -> HEALTH_CHECK_COMPLETED -> RENDEZVOUS_COMPLETED
+          -> WORKER_START_STARTED -> WORKER_START_COMPLETED -> (training)
+          -> FAILURE_DETECTED -> WORKER_TERMINATED
+
+    An evicted node bails right after HEALTH_CHECK_COMPLETED (UnhealthyNodeException in the
+    health check) and emits NODE_EXCLUDED instead of the rest.
+
+    Outcomes the event stream cannot express (succeeded, failed, peer_restart, terminated)
+    are staged by the agent through `stage_outcome()` / `finish_cycle()`.
+    """
+
+    #: event -> ((action, argument), ...). This table is the specification of the tree.
+    _PLAN = {
+        ProfilingEvent.RENDEZVOUS_STARTED: (('cycle_open', None), ('phase', 'health_check')),
+        ProfilingEvent.HEALTH_CHECK_COMPLETED: (('phase', 'rendezvous'),),
+        ProfilingEvent.RENDEZVOUS_COMPLETED: (('end_phase', None),),
+        # Launching workers means this node was selected active this cycle, so stamp it at
+        # selection time: a node killed after selection but before the close still shows
+        # membership (complementing cycle_outcome, where standby means not selected).
+        ProfilingEvent.WORKER_START_STARTED: (
+            ('phase', 'worker_launch'),
+            ('annotate', {'nvrx.membership': 'active'}),
+        ),
+        ProfilingEvent.WORKER_START_COMPLETED: (('phase', 'run'),),
+        ProfilingEvent.FAILURE_DETECTED: (('mark', 'fault'), ('phase', 'teardown')),
+        ProfilingEvent.WORKER_TERMINATED: (
+            ('end_phase', None),
+            ('cycle_close', CycleOutcome.COMPLETED),
+        ),
+        ProfilingEvent.NODE_EXCLUDED: (
+            ('end_phase', None),
+            ('mark', 'excluded'),
+            ('cycle_close', CycleOutcome.EXCLUDED),
+        ),
+        ProfilingEvent.ATTRIBUTION_GET_STARTED: (('attr_open', None),),
+        ProfilingEvent.ATTRIBUTION_GET_COMPLETED: (('attr_close', None),),
+        # Standby / round-open wait. A hot spare not in the active rendezvous sits here for
+        # a whole cycle and would otherwise be invisible. It re-enters the wait still
+        # holding the previous round's cycle (it started that round but was never selected,
+        # so no WORKER_TERMINATED closed it), so close the whole cycle first: otherwise
+        # open_cycle's already-open guard keeps the stale one and a promoted spare reuses
+        # the earlier round's start. A no-op for a normal node.
+        ProfilingEvent.AWAIT_ROUND_STARTED: (
+            ('cycle_close', CycleOutcome.STANDBY),
+            ('await_open', None),
+        ),
+        ProfilingEvent.AWAIT_ROUND_COMPLETED: (('await_close', None),),
+    }
+
+    #: Events after which this node may be killed, so its spans are force-flushed
+    #: synchronously; routine events rely on BatchSpanProcessor's normal export.
+    _FLUSH_EVENTS = frozenset(
+        {
+            ProfilingEvent.FAILURE_DETECTED,
+            ProfilingEvent.WORKER_TERMINATED,
+            ProfilingEvent.NODE_EXCLUDED,
+        }
+    )
+
+    def __init__(self, tracer, flush=None, cold_start: Optional[ColdStartAnchors] = None):
+        self._tree = _SpanTree(tracer)
+        self._flush = flush
+        self._cold_start = cold_start or ColdStartAnchors()
+        self._cold_start_done = False
+        # Guards recorder state, mutated by the launcher's main thread and by the
+        # attribution poller daemon (health_check _poll_loop -> ATTRIBUTION_GET_*).
+        self._lock = threading.RLock()
+        self._outcome = None
+        self._extra: Dict[str, Any] = {}
+
+    # ---------------------------------------------------------------- observer API
+
+    def on_event(self, record: ProfilingEventRecord) -> None:
+        """Apply this boundary event to the span tree, flushing kill-adjacent events
+        immediately so an evicted node's spans survive its kill."""
+        ns = int(record.timestamp * 1e9)
+        node = _clean_node(record.node_id)
+        base = {'is_goodput_span': True, 'nvrx.cycle': record.cycle, 'nvrx.node': node}
+        ranked = dict(base, **{'nvrx.rank': record.rank})
+
+        with self._lock:
+            try:
+                self._emit_cold_start_once(ns, node)
+                for action, arg in self._PLAN.get(record.event, ()):
+                    if action == 'cycle_open':
+                        if self._tree.open_cycle(ns, base):
+                            self._clear_staged()
+                    elif action == 'cycle_close':
+                        self._close_cycle(ns, arg)
+                    elif action == 'phase':
+                        self._tree.start_phase(arg, ns, ranked)
+                    elif action == 'end_phase':
+                        self._tree.end_phase(ns)
+                    elif action == 'mark':
+                        self._tree.mark(arg, ns, base)
+                    elif action == 'annotate':
+                        self._tree.annotate_cycle(arg)
+                    elif action == 'attr_open':
+                        self._tree.open_side('attribution', ns, ranked)
+                    elif action == 'attr_close':
+                        self._tree.close_side('attribution', ns)
+                    elif action == 'await_open':
+                        # root span: the standby wait precedes any cycle
+                        self._tree.open_side(
+                            'await_round',
+                            ns,
+                            dict(base, **{'nvrx.membership': 'standby'}),
+                            parented=False,
+                        )
+                    elif action == 'await_close':
+                        self._tree.close_side('await_round', ns)
+                if record.event in self._FLUSH_EVENTS:
+                    self.flush()
+            except (_SignalException, KeyboardInterrupt, SystemExit):
+                raise  # never swallow the FT death signal (torchelastic raises it here)
+            except Exception as e:
+                log.debug("nvrx telemetry: event %s not recorded: %s", record.event.value, e)
+
+    # ------------------------------------------------------------ agent-facing API
+
+    def annotate_cycle(self, **attributes) -> None:
+        """Enrich the open cycle span with metadata only the agent knows."""
+        with self._lock:
+            self._tree.annotate_cycle(attributes)
+
+    def stage_outcome(self, outcome: str, **attributes) -> None:
+        """Record how this cycle is ending, ahead of the event that closes it."""
+        with self._lock:
+            self._outcome = outcome
+            self._extra = dict(attributes)
+
+    def finish_cycle(self, outcome: str = CycleOutcome.COMPLETED, **attributes) -> None:
+        """Close a cycle whose terminal state has no teardown event to close it."""
+        with self._lock:
+            self._outcome = outcome
+            if attributes:
+                self._extra = dict(attributes)
+            self._close_cycle(None, outcome)
+            self.flush()
+
+    def cycle_start_seconds(self) -> Optional[float]:
+        """Wall-clock start of the open cycle (this round's rendezvous start), or None."""
+        with self._lock:
+            ns = self._tree.cycle_start_ns
+            return None if ns is None else ns / 1e9
+
+    def flush(self) -> None:
+        if self._flush is None:
+            return
+        try:
+            self._flush()
+        except Exception as e:
+            log.debug("nvrx telemetry: flush failed: %s", e)
+
+    # ---------------------------------------------------------------------- internals
+
+    def _clear_staged(self):
+        self._outcome = None
+        self._extra = {}
+
+    def _close_cycle(self, ns, outcome):
+        """Close the cycle, stamping the staged outcome in preference to the plan's."""
+        attributes = {'nvrx.cycle_outcome': self._outcome or outcome or CycleOutcome.COMPLETED}
+        attributes.update(self._extra)
+        self._tree.close_cycle(ns, attributes)
+        self._clear_staged()
+
+    def _emit_cold_start_once(self, ns, node):
+        """Emit the pre-agent spans, backdated and closed immediately, once per node.
+
+        `nvrx.cold_start` covers the launch script up to this agent's first recorded event.
+        `pre_startup` covers the queue/prolog gap before it; under NVRx the agent owns that
+        window (megatron suppresses its own on any ft_launcher cohort), so the whole
+        pre-Python envelope has one owner. Its name matches the bare-path span so the
+        goodput taxonomy classifies it identically.
+        """
+        launch = self._cold_start.launch_script_start
+        if self._cold_start_done or launch is None:
+            return
+        self._cold_start_done = True
+        attributes = {'is_goodput_span': True, 'nvrx.node': node}
+        job_start = self._cold_start.slurm_job_start
+        if job_start is not None and job_start < launch:
+            self._tree.interval(
+                'pre_startup', int(job_start * 1e9), int(launch * 1e9), attributes, parented=False
+            )
+        self._tree.interval('nvrx.cold_start', int(launch * 1e9), ns, attributes, parented=False)
+
+
+# ------------------------------------------------------------------------ agent facade
+
+
+#: rdzv handler getters describing who was active or standby this cycle. Optional: not
+#: every rendezvous backend implements them.
+_TOPOLOGY_GETTERS = (
+    ('nvrx.active_nodes', 'get_active_node_addrs'),
+    ('nvrx.standby_nodes', 'get_standby_node_addrs'),
+    ('nvrx.active_ranks', 'get_active_ranks'),
+)
+
+
+def _infrastructure_rank():
+    def _get():
+        from .utils import get_infrastructure_rank
+
+        return get_infrastructure_rank(skip_nodename_logic=True)
+
+    return _safe(_get, 'infrastructure rank')
+
+
+class LauncherTelemetry:
+    """Restart-cycle telemetry for one ft_launcher agent, enabled or not.
+
+    A disabled instance answers every call harmlessly, so `launcher.py` needs no guards
+    and no try/except at any call site. The agent's role in the span tree is small: the
+    recorder owns the spans, and the agent only enriches the open cycle, stages the
+    outcome, closes terminal cycles, and hands each worker cohort its anchors.
+    """
+
+    def __init__(self, node_id, env: Optional[Mapping[str, str]] = None):
+        env = os.environ if env is None else env
+        self._node_id = node_id
+        self._handle = None
+        self._recorder = None
+        if not env.get(EXPORTER_ENV) or not backend.HAS_NEMO_LENS:
+            return
+        try:
+            config = backend.config_from_env()
+            config.enabled = True
+            self._handle = backend.setup_telemetry(
+                config,
+                rank=0,
+                world_size=1,
+                resource_attributes={
+                    'nvrx.role': 'ft_launcher_agent',
+                    'nvrx.node': str(node_id),
+                },
+            )
+            self._recorder = RestartCycleRecorder(
+                self._handle.tracer,
+                flush=_provider_flush(),
+                cold_start=ColdStartAnchors.from_env(env),
+            )
+            # Registering the recorder is what turns the launcher's and the rendezvous
+            # handler's pre-placed boundary events into spans.
+            set_profiling_observer(self._recorder)
+        except Exception as e:  # never let telemetry setup break the launcher
+            log.debug("nvrx telemetry: agent tracer setup skipped: %s", e)
+            if self._recorder is not None:
+                set_profiling_observer(None)
+            if self._handle is not None:
+                # setup_telemetry() succeeded and something after it failed. Shut the
+                # provider down rather than orphaning its exporter thread and connection
+                # for the life of the process.
+                try:
+                    self._handle.shutdown()
+                except Exception:
+                    pass
+            self._handle = None
+            self._recorder = None
+
+    def annotate_cycle(self, worker_group, remaining_restarts) -> None:
+        """Describe the open cycle: restart budget, group rank, rendezvous topology."""
+        if self._recorder is None:
+            return
+        spec = worker_group.spec
+        attributes = {
+            'nvrx.remaining_restarts': remaining_restarts,
+            'nvrx.max_restarts': _safe(lambda: spec.max_restarts, 'max_restarts'),
+            'nvrx.node': str(self._node_id),
+            'nvrx.membership': 'active',  # annotate runs once this node launched workers
+            'nvrx.group_rank': _safe(lambda: worker_group.group_rank, 'group_rank'),
+            'nvrx.group_world_size': _safe(
+                lambda: worker_group.group_world_size, 'group_world_size'
+            ),
+            'nvrx.rdzv_run_id': _safe(lambda: spec.rdzv_handler.get_run_id(), 'run id'),
+            # Same source as cycle_info, so a cycle span can answer who was active or
+            # standby and which physical rank this node held.
+            'nvrx.infra_rank': _infrastructure_rank(),
+        }
+        for key, getter in _TOPOLOGY_GETTERS:
+            values = _safe(lambda g=getter: getattr(spec.rdzv_handler, g)(), getter)
+            if values is not None:
+                attributes[key] = ",".join(str(v) for v in values)
+        self._recorder.annotate_cycle(**attributes)
+
+    def stage_outcome(self, outcome: str, **attributes) -> None:
+        """Record how the current cycle is ending, before the teardown event closes it."""
+        if self._recorder is not None:
+            self._recorder.stage_outcome(outcome, **attributes)
+
+    def finish_cycle(self, outcome: str = CycleOutcome.COMPLETED, **attributes) -> None:
+        """Close a cycle that ends without a teardown event (clean finish, agent exit)."""
+        if self._recorder is not None:
+            self._recorder.finish_cycle(outcome, **attributes)
+
+    def worker_env(self, cycle: int) -> Dict[str, str]:
+        """Telemetry environment for the worker cohort the agent is about to launch.
+
+        Emitted whether or not the agent itself is recording, because it is the trainer
+        that consumes these. One launch stamp per cohort, so every restart hands its
+        workers a fresh anchor: the batch script's launch_script_start is set once,
+        outside the single srun, and is stale by then.
+        """
+        env = {
+            'NVRX_LAUNCH_TIME': repr(time.time()),
+            'NVRX_CYCLE': str(cycle),
+            'NVRX_MEMBERSHIP': 'active',  # a launched worker is active this cycle
+        }
+        infra_rank = _infrastructure_rank()
+        if infra_rank is not None:
+            env['NVRX_INFRA_RANK'] = str(infra_rank)
+        # For any cycle after the first (an in-place restart or a promoted spare, both of
+        # which launch at cycle > 0) anchor pre_startup at this round's rendezvous start
+        # rather than at the stale sbatch job start. Cycle 0 leaves it unset so pre_startup
+        # falls back to the real sbatch queue time.
+        if cycle and self._recorder is not None:
+            start = self._recorder.cycle_start_seconds()
+            if start is not None:
+                env['NVRX_CYCLE_START_TIME'] = repr(start)
+        return env
+
+    def shutdown(self) -> None:
+        """Close the open cycle, then bound the provider shutdown.
+
+        BatchSpanProcessor only flushes on a timer or on shutdown, so without this the last
+        cycle's spans are dropped on exit. finish_cycle() already force-flushed them, and
+        handle.shutdown() can block on a dead collector for longer than the SIGTERM-to-
+        SIGKILL grace, so the shutdown itself runs on a thread we wait on only briefly.
+        """
+        if self._handle is None:
+            return
+        try:
+            self.finish_cycle(CycleOutcome.TERMINATED)
+            set_profiling_observer(None)
+            thread = threading.Thread(
+                target=self._handle.shutdown, daemon=True, name='nvrx-otel-shutdown'
+            )
+            thread.start()
+            thread.join(SHUTDOWN_TIMEOUT_S)
+        except Exception as e:
+            log.debug("nvrx telemetry: agent shutdown incomplete: %s", e)
+
+
+def _provider_flush():
+    """A bounded force_flush callable for the active tracer provider, or None."""
+
+    def _get():
+        from opentelemetry import trace
+
+        provider = trace.get_tracer_provider()
+        if not hasattr(provider, 'force_flush'):
+            return None
+        return lambda: provider.force_flush(timeout_millis=FLUSH_TIMEOUT_MS)
+
+    return _safe(_get, 'tracer provider flush')

--- a/src/nvidia_resiliency_ext/shared_utils/profiling.py
+++ b/src/nvidia_resiliency_ext/shared_utils/profiling.py
@@ -18,6 +18,8 @@
 import logging
 import threading
 import time
+from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Optional
@@ -37,6 +39,20 @@ class ProfilingEvent(Enum):
     WORKER_START_COMPLETED = "worker_start_completed"
     ATTRIBUTION_GET_STARTED = "attribution_get_started"
     ATTRIBUTION_GET_COMPLETED = "attribution_get_completed"
+    NODE_EXCLUDED = "node_excluded"  # bailed at the rendezvous health check (evicted/unhealthy)
+    AWAIT_ROUND_STARTED = "await_round_started"  # entered the Step-0 wait for the round
+    AWAIT_ROUND_COMPLETED = "await_round_completed"  # round opened (or shutdown); node moves on
+
+
+@dataclass(frozen=True)
+class ProfilingEventRecord:
+    """A recorded profiling event, as handed to the observer."""
+
+    event: ProfilingEvent
+    timestamp: float  # wall clock, seconds
+    node_id: str
+    rank: Optional[int]
+    cycle: int
 
 
 class FaultToleranceProfiler:
@@ -45,6 +61,12 @@ class FaultToleranceProfiler:
     def __init__(self):
         self._current_cycle = 0
         self._logger = logging.getLogger(LogConfig.name)
+        # Optional observer of the event stream, set by whoever wants to do something with
+        # the restart timeline beyond logging it - today, the OTel recorder in
+        # fault_tolerance/telemetry.py. Kept as a plain slot so this module never needs to
+        # know what telemetry is. The observer is called inline on whichever thread recorded
+        # the event, so it must be quick and must not raise.
+        self._observer = None
 
     def _timestamp_to_utc_datetime(self, timestamp: float) -> str:
         """Convert timestamp to UTC datetime string."""
@@ -83,6 +105,13 @@ class FaultToleranceProfiler:
         # Convert node_id to string for event ID and logging
         node_id_str = str(node_id) if node_id is not None else 'unknown'
         event_id = f"{event.value}_{timestamp}_{node_id_str}_{rank or 'unknown'}"
+
+        # Notify before the cycle bump below, so the observer attributes a failure to the
+        # cycle it ended rather than to the one it starts.
+        if self._observer is not None:
+            self._observer.on_event(
+                ProfilingEventRecord(event, timestamp, node_id_str, rank, self._current_cycle)
+            )
 
         # Increment cycle count for failure detection events
         if event == ProfilingEvent.FAILURE_DETECTED:
@@ -129,6 +158,33 @@ def record_profiling_event(
         Event ID string
     """
     return _get_global_profiler().record_event(event, node_id, rank)
+
+
+@contextmanager
+def profiling_phase(
+    start_event: ProfilingEvent,
+    end_event: ProfilingEvent,
+    node_id: Optional[Any] = None,
+    rank: Optional[int] = None,
+):
+    """Record `start_event` on entry and `end_event` on exit, exceptions included.
+
+    The exit event fires even when the body raises, which keeps an observer's span from
+    leaking when e.g. a shutdown unwinds out of a wait.
+    """
+    record_profiling_event(start_event, node_id=node_id, rank=rank)
+    try:
+        yield
+    finally:
+        record_profiling_event(end_event, node_id=node_id, rank=rank)
+
+
+def set_profiling_observer(observer) -> None:
+    """Install (or clear, with None) the observer of the global profiler's event stream.
+
+    `observer` needs one method, `on_event(record: ProfilingEventRecord)`.
+    """
+    _get_global_profiler()._observer = observer
 
 
 def get_profiling_cycle() -> int:

--- a/src/nvidia_resiliency_ext/shared_utils/telemetry.py
+++ b/src/nvidia_resiliency_ext/shared_utils/telemetry.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The seam between NVRx and nemo-lens, and nothing else.
+
+nemo-lens is an optional dependency (the `otel` extra). This module is the only place
+in NVRx that names it. Everything that decides *what* to instrument lives with the
+subsystem doing the instrumenting:
+
+    fault_tolerance/telemetry.py             restart-cycle spans for the ft_launcher agent
+    checkpointing/async_ckpt/telemetry.py    spans for the persistent checkpoint worker
+
+Callers check `HAS_NEMO_LENS` once, when they build their telemetry object, and hold a
+disabled object afterwards. Deliberately no no-op stubs for the missing case: a stub
+that pretends to work has to fake a tracer, which needs opentelemetry, which may also
+be absent - so it would raise from inside the code path meant to be the safe one.
+"""
+
+from contextlib import nullcontext
+
+try:
+    from nemo.lens import NemoLensConfig, setup_telemetry  # noqa: F401
+
+    # nemo.lens.helpers holds the real, state-driven implementation. nemo.lens.fallbacks
+    # (a different module, despite the similar name) is a set of permanently-hardcoded
+    # no-ops meant only for consumers that never import nemo.lens at all; importing from
+    # there would silently no-op every span regardless of config.
+    from nemo.lens.helpers import managed_span  # noqa: F401
+
+    HAS_NEMO_LENS = True
+
+except ImportError:
+    NemoLensConfig = None
+    setup_telemetry = None
+    managed_span = None
+    HAS_NEMO_LENS = False
+
+
+def span(group: str, name: str, **attributes):
+    """`managed_span` when nemo-lens is present, a no-op context manager when it is not.
+
+    Lets an instrumented hot loop stay free of conditionals without the caller having to
+    keep its own null context around.
+    """
+    if not HAS_NEMO_LENS:
+        return nullcontext()
+    return managed_span(group, name, **attributes)
+
+
+def config_from_env(prefix: str = 'NEMO_LENS'):
+    """Build a NemoLensConfig from the environment, or None when nemo-lens is absent."""
+    if not HAS_NEMO_LENS:
+        return None
+    return NemoLensConfig.from_env(prefix=prefix)

--- a/tests/fault_tolerance/unit/test_telemetry_recorder.py
+++ b/tests/fault_tolerance/unit/test_telemetry_recorder.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the restart-cycle telemetry recorder.
+
+These run without opentelemetry or nemo-lens installed: the recorder only needs an
+object with a `start_span()`, so a fake tracer records exactly what it was asked for.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nvidia_resiliency_ext.fault_tolerance.telemetry import (
+    ColdStartAnchors,
+    CycleOutcome,
+    LauncherTelemetry,
+    RestartCycleRecorder,
+)
+from nvidia_resiliency_ext.shared_utils.profiling import (
+    FaultToleranceProfiler,
+    ProfilingEvent,
+    ProfilingEventRecord,
+    profiling_phase,
+    set_profiling_observer,
+)
+from nvidia_resiliency_ext.shared_utils.telemetry import HAS_NEMO_LENS
+
+
+class FakeSpan:
+    def __init__(self, name, start_time, attributes):
+        self.name = name
+        self.start_time = start_time
+        self.end_time = None
+        self.attributes = dict(attributes)
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def end(self, end_time=None):
+        assert self.end_time is None, f"span {self.name} ended twice"
+        self.end_time = end_time
+
+    @property
+    def ended(self):
+        return self.end_time is not None
+
+
+class FakeTracer:
+    def __init__(self):
+        self.spans = []
+
+    def start_span(self, name, start_time=None, context=None, attributes=None):
+        span = FakeSpan(name, start_time, attributes or {})
+        self.spans.append(span)
+        return span
+
+    def named(self, name):
+        return [s for s in self.spans if s.name == name]
+
+    def one(self, name):
+        matches = self.named(name)
+        assert len(matches) == 1, f"expected exactly one {name}, got {len(matches)}"
+        return matches[0]
+
+    @property
+    def names(self):
+        return [s.name for s in self.spans]
+
+
+@pytest.fixture
+def tracer():
+    return FakeTracer()
+
+
+@pytest.fixture
+def flushes():
+    return []
+
+
+@pytest.fixture
+def recorder(tracer, flushes):
+    return RestartCycleRecorder(tracer, flush=lambda: flushes.append(True))
+
+
+def feed(recorder, event, timestamp, node='host_1234_0', rank=None, cycle=0):
+    recorder.on_event(
+        ProfilingEventRecord(event=event, timestamp=timestamp, node_id=node, rank=rank, cycle=cycle)
+    )
+
+
+HEALTHY_CYCLE = [
+    (ProfilingEvent.RENDEZVOUS_STARTED, 100.0),
+    (ProfilingEvent.HEALTH_CHECK_COMPLETED, 101.0),
+    (ProfilingEvent.RENDEZVOUS_COMPLETED, 102.0),
+    (ProfilingEvent.WORKER_START_STARTED, 103.0),
+    (ProfilingEvent.WORKER_START_COMPLETED, 104.0),
+    (ProfilingEvent.FAILURE_DETECTED, 200.0),
+    (ProfilingEvent.WORKER_TERMINATED, 201.0),
+]
+
+
+def run_cycle(recorder, events=HEALTHY_CYCLE, **kwargs):
+    for event, timestamp in events:
+        feed(recorder, event, timestamp, **kwargs)
+
+
+class TestCycleSpanTree:
+    def test_full_cycle_emits_the_expected_phases(self, recorder, tracer):
+        run_cycle(recorder)
+        assert tracer.names == [
+            'nvrx.restart.cycle',
+            'nvrx.restart.health_check',
+            'nvrx.restart.rendezvous',
+            'nvrx.restart.worker_launch',
+            'nvrx.restart.run',
+            'nvrx.restart.fault',
+            'nvrx.restart.teardown',
+        ]
+        assert all(span.ended for span in tracer.spans)
+
+    def test_phases_are_a_contiguous_sweep(self, recorder, tracer):
+        run_cycle(recorder)
+        health = tracer.one('nvrx.restart.health_check')
+        rendezvous = tracer.one('nvrx.restart.rendezvous')
+        assert health.start_time == int(100.0 * 1e9)
+        # each phase ends exactly where the next begins
+        assert health.end_time == rendezvous.start_time == int(101.0 * 1e9)
+        assert rendezvous.end_time == int(102.0 * 1e9)
+        assert tracer.one('nvrx.restart.run').end_time == int(200.0 * 1e9)
+
+    def test_cycle_span_bounds_and_attributes(self, recorder, tracer):
+        run_cycle(recorder, cycle=4)
+        cycle = tracer.one('nvrx.restart.cycle')
+        assert (cycle.start_time, cycle.end_time) == (int(100.0 * 1e9), int(201.0 * 1e9))
+        assert cycle.attributes['nvrx.cycle'] == 4
+        assert cycle.attributes['is_goodput_span'] is True
+        assert cycle.attributes['nvrx.cycle_outcome'] == CycleOutcome.COMPLETED
+        # launching workers marks this node as selected for the cycle
+        assert cycle.attributes['nvrx.membership'] == 'active'
+
+    def test_node_desc_suffix_is_stripped(self, recorder, tracer):
+        run_cycle(recorder, node='host.cm.cluster_98765_0')
+        assert tracer.one('nvrx.restart.cycle').attributes['nvrx.node'] == 'host.cm.cluster'
+
+    def test_rank_is_recorded_on_phases_only(self, recorder, tracer):
+        run_cycle(recorder, rank=3)
+        assert tracer.one('nvrx.restart.run').attributes['nvrx.rank'] == 3
+        assert 'nvrx.rank' not in tracer.one('nvrx.restart.cycle').attributes
+
+    def test_a_second_rendezvous_opens_a_second_cycle(self, recorder, tracer):
+        run_cycle(recorder)
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 300.0, cycle=1)
+        cycles = tracer.named('nvrx.restart.cycle')
+        assert len(cycles) == 2
+        assert cycles[1].start_time == int(300.0 * 1e9)
+        assert not cycles[1].ended
+
+    def test_repeated_rendezvous_does_not_reopen_a_cycle(self, recorder, tracer):
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 100.0)
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 105.0)
+        assert len(tracer.named('nvrx.restart.cycle')) == 1
+
+
+class TestOutcomes:
+    def test_staged_outcome_wins_over_the_default(self, recorder, tracer):
+        run_cycle(recorder, events=HEALTHY_CYCLE[:-1])
+        recorder.stage_outcome(CycleOutcome.FAILED, **{'nvrx.failures': 2})
+        feed(recorder, ProfilingEvent.WORKER_TERMINATED, 201.0)
+        cycle = tracer.one('nvrx.restart.cycle')
+        assert cycle.attributes['nvrx.cycle_outcome'] == CycleOutcome.FAILED
+        assert cycle.attributes['nvrx.failures'] == 2
+
+    def test_staged_outcome_does_not_leak_into_the_next_cycle(self, recorder, tracer):
+        run_cycle(recorder, events=HEALTHY_CYCLE[:-1])
+        recorder.stage_outcome(CycleOutcome.FAILED)
+        feed(recorder, ProfilingEvent.WORKER_TERMINATED, 201.0)
+        run_cycle(recorder, events=[(e, t + 200.0) for e, t in HEALTHY_CYCLE])
+        second = tracer.named('nvrx.restart.cycle')[1]
+        assert second.attributes['nvrx.cycle_outcome'] == CycleOutcome.COMPLETED
+
+    def test_finish_cycle_closes_a_cycle_with_no_teardown_event(self, recorder, tracer):
+        run_cycle(recorder, events=HEALTHY_CYCLE[:5])
+        recorder.finish_cycle(CycleOutcome.SUCCEEDED)
+        cycle = tracer.one('nvrx.restart.cycle')
+        assert cycle.ended
+        assert cycle.attributes['nvrx.cycle_outcome'] == CycleOutcome.SUCCEEDED
+        # the open 'run' phase is swept up with it
+        assert tracer.one('nvrx.restart.run').ended
+
+    def test_finish_cycle_without_an_open_cycle_is_harmless(self, recorder, tracer):
+        recorder.finish_cycle(CycleOutcome.TERMINATED)
+        assert tracer.spans == []
+
+
+class TestExcludedNode:
+    def test_eviction_closes_the_partial_cycle(self, recorder, tracer):
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 100.0)
+        feed(recorder, ProfilingEvent.HEALTH_CHECK_COMPLETED, 101.0)
+        feed(recorder, ProfilingEvent.NODE_EXCLUDED, 102.0)
+        assert 'nvrx.restart.excluded' in tracer.names
+        assert all(span.ended for span in tracer.spans)
+        cycle = tracer.one('nvrx.restart.cycle')
+        assert cycle.attributes['nvrx.cycle_outcome'] == CycleOutcome.EXCLUDED
+        assert cycle.end_time == int(102.0 * 1e9)
+
+    def test_kill_adjacent_events_flush(self, recorder, flushes):
+        run_cycle(recorder)
+        # FAILURE_DETECTED and WORKER_TERMINATED both flush; routine boundaries do not
+        assert len(flushes) == 2
+
+    def test_routine_events_do_not_flush(self, recorder, flushes):
+        run_cycle(recorder, events=HEALTHY_CYCLE[:5])
+        assert flushes == []
+
+
+class TestStandbyNode:
+    def test_await_span_is_emitted_for_a_waiting_node(self, recorder, tracer):
+        feed(recorder, ProfilingEvent.AWAIT_ROUND_STARTED, 50.0)
+        feed(recorder, ProfilingEvent.AWAIT_ROUND_COMPLETED, 90.0)
+        await_span = tracer.one('nvrx.restart.await_round')
+        assert (await_span.start_time, await_span.end_time) == (int(50.0 * 1e9), int(90.0 * 1e9))
+        assert await_span.attributes['nvrx.membership'] == 'standby'
+
+    def test_reentering_the_wait_closes_the_unselected_cycle(self, recorder, tracer):
+        # this node started a round but was never selected, so nothing closed its cycle
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 100.0)
+        feed(recorder, ProfilingEvent.HEALTH_CHECK_COMPLETED, 101.0)
+        feed(recorder, ProfilingEvent.AWAIT_ROUND_STARTED, 150.0)
+        cycle = tracer.one('nvrx.restart.cycle')
+        assert cycle.ended and cycle.attributes['nvrx.cycle_outcome'] == CycleOutcome.STANDBY
+        assert tracer.one('nvrx.restart.rendezvous').ended
+        # and the next round gets a fresh cycle, not the stale one
+        feed(recorder, ProfilingEvent.AWAIT_ROUND_COMPLETED, 160.0)
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 161.0)
+        assert tracer.named('nvrx.restart.cycle')[1].start_time == int(161.0 * 1e9)
+
+    def test_an_open_await_is_swept_up_by_a_cycle_close(self, recorder, tracer):
+        feed(recorder, ProfilingEvent.AWAIT_ROUND_STARTED, 50.0)
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 60.0)
+        recorder.finish_cycle(CycleOutcome.TERMINATED)
+        assert tracer.one('nvrx.restart.await_round').ended
+
+
+class TestAttribution:
+    def test_attribution_span_overlaps_the_phase_sweep(self, recorder, tracer):
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 100.0)
+        feed(recorder, ProfilingEvent.ATTRIBUTION_GET_STARTED, 110.0, rank=1)
+        feed(recorder, ProfilingEvent.HEALTH_CHECK_COMPLETED, 115.0)
+        feed(recorder, ProfilingEvent.ATTRIBUTION_GET_COMPLETED, 120.0)
+        attribution = tracer.one('nvrx.restart.attribution')
+        assert (attribution.start_time, attribution.end_time) == (
+            int(110.0 * 1e9),
+            int(120.0 * 1e9),
+        )
+        assert attribution.attributes['nvrx.rank'] == 1
+
+    def test_an_open_attribution_is_swept_up_by_a_cycle_close(self, recorder, tracer):
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 100.0)
+        feed(recorder, ProfilingEvent.ATTRIBUTION_GET_STARTED, 110.0)
+        feed(recorder, ProfilingEvent.NODE_EXCLUDED, 120.0)
+        assert tracer.one('nvrx.restart.attribution').end_time == int(120.0 * 1e9)
+
+
+class TestColdStart:
+    def test_cold_start_spans_are_backdated_once(self, tracer):
+        recorder = RestartCycleRecorder(
+            tracer, cold_start=ColdStartAnchors(launch_script_start=40.0, slurm_job_start=10.0)
+        )
+        run_cycle(recorder)
+        pre_startup = tracer.one('pre_startup')
+        cold_start = tracer.one('nvrx.cold_start')
+        assert (pre_startup.start_time, pre_startup.end_time) == (int(10.0 * 1e9), int(40.0 * 1e9))
+        assert (cold_start.start_time, cold_start.end_time) == (int(40.0 * 1e9), int(100.0 * 1e9))
+        # a second cycle does not re-emit them
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 300.0)
+        assert len(tracer.named('nvrx.cold_start')) == 1
+
+    def test_pre_startup_needs_a_job_start_that_precedes_the_script(self, tracer):
+        recorder = RestartCycleRecorder(
+            tracer, cold_start=ColdStartAnchors(launch_script_start=40.0, slurm_job_start=50.0)
+        )
+        run_cycle(recorder)
+        assert tracer.named('pre_startup') == []
+        assert tracer.named('nvrx.cold_start') != []
+
+    def test_no_anchors_means_no_cold_start_spans(self, recorder, tracer):
+        run_cycle(recorder)
+        assert tracer.named('nvrx.cold_start') == []
+
+    def test_anchors_from_env(self):
+        anchors = ColdStartAnchors.from_env(
+            {'LENS_LAUNCH_SCRIPT_START_TIME': '12.5', 'SLURM_JOB_START_TIME': 'not-a-number'}
+        )
+        assert anchors.launch_script_start == 12.5
+        assert anchors.slurm_job_start is None
+
+
+class TestCycleStartSeconds:
+    def test_reports_the_open_cycle_start(self, recorder):
+        assert recorder.cycle_start_seconds() is None
+        feed(recorder, ProfilingEvent.RENDEZVOUS_STARTED, 100.0)
+        assert recorder.cycle_start_seconds() == pytest.approx(100.0)
+
+    def test_cleared_once_the_cycle_closes(self, recorder):
+        run_cycle(recorder)
+        assert recorder.cycle_start_seconds() is None
+
+
+class TestRobustness:
+    def test_a_broken_tracer_does_not_break_the_recorder(self):
+        class BrokenTracer:
+            def start_span(self, *args, **kwargs):
+                raise RuntimeError("collector exploded")
+
+        recorder = RestartCycleRecorder(BrokenTracer())
+        run_cycle(recorder)  # must not raise
+
+    def test_a_broken_flush_does_not_break_the_recorder(self, tracer):
+        def flush():
+            raise RuntimeError("collector unreachable")
+
+        run_cycle(RestartCycleRecorder(tracer, flush=flush))  # must not raise
+
+
+class TestLauncherTelemetry:
+    """The agent-facing facade. Without NEMO_LENS_EXPORTER it must be a working no-op."""
+
+    def test_disabled_by_default(self):
+        telemetry = LauncherTelemetry('host-a', env={})
+        assert type(telemetry) is LauncherTelemetry
+
+    def test_disabled_facade_accepts_every_call(self):
+        telemetry = LauncherTelemetry('host-a', env={})
+        telemetry.annotate_cycle(object(), 3)
+        telemetry.stage_outcome(CycleOutcome.FAILED, **{'nvrx.failures': 1})
+        telemetry.finish_cycle(CycleOutcome.SUCCEEDED)
+        telemetry.shutdown()
+
+    @pytest.mark.skipif(HAS_NEMO_LENS, reason="needs a backend that cannot be set up")
+    def test_setup_failure_degrades_to_the_no_op(self):
+        # NEMO_LENS_EXPORTER is set but nemo-lens is absent, so construction fails and must
+        # fall back to the no-op rather than propagate out of the agent's constructor.
+        telemetry = LauncherTelemetry('host-a', env={'NEMO_LENS_EXPORTER': 'console'})
+        assert type(telemetry) is LauncherTelemetry
+
+    def test_failed_setup_shuts_the_provider_down(self, monkeypatch):
+        # setup_telemetry() succeeds, then something after it throws: the provider must be
+        # shut down rather than orphaned with its exporter thread alive.
+        shutdowns = []
+
+        class Handle:
+            @property
+            def tracer(self):
+                raise RuntimeError("tracer unavailable")
+
+            def shutdown(self):
+                shutdowns.append(True)
+
+        import nvidia_resiliency_ext.fault_tolerance.telemetry as ft_telemetry
+
+        monkeypatch.setattr(ft_telemetry.backend, 'HAS_NEMO_LENS', True)
+        monkeypatch.setattr(ft_telemetry.backend, 'config_from_env', lambda *a, **k: MagicMock())
+        monkeypatch.setattr(ft_telemetry.backend, 'setup_telemetry', lambda *a, **k: Handle())
+
+        telemetry = LauncherTelemetry('host-a', env={'NEMO_LENS_EXPORTER': 'console'})
+
+        assert shutdowns == [True]
+        assert telemetry._handle is None and telemetry._recorder is None
+        telemetry.shutdown()  # must stay harmless afterwards
+
+    def test_worker_env_is_emitted_even_when_disabled(self):
+        # the trainer, not the agent, consumes these, so they must not depend on the
+        # agent's own telemetry being on
+        env = LauncherTelemetry('host-a', env={}).worker_env(0)
+        assert env['NVRX_CYCLE'] == '0'
+        assert env['NVRX_MEMBERSHIP'] == 'active'
+        assert float(env['NVRX_LAUNCH_TIME']) > 0
+        # cycle 0 anchors pre_startup on the real sbatch queue time instead
+        assert 'NVRX_CYCLE_START_TIME' not in env
+
+    def test_worker_env_carries_the_cycle_start_after_a_restart(self, tracer):
+        # a restarted cohort anchors pre_startup on this round's rendezvous start, which
+        # is the recorder's open cycle span
+        telemetry = LauncherTelemetry('host-a', env={})
+        telemetry._recorder = RestartCycleRecorder(tracer)
+        feed(telemetry._recorder, ProfilingEvent.RENDEZVOUS_STARTED, 1234.5)
+
+        env = telemetry.worker_env(2)
+        assert env['NVRX_CYCLE'] == '2'
+        assert float(env['NVRX_CYCLE_START_TIME']) == pytest.approx(1234.5)
+
+    def test_worker_env_omits_cycle_start_when_no_cycle_is_open(self, tracer):
+        telemetry = LauncherTelemetry('host-a', env={})
+        telemetry._recorder = RestartCycleRecorder(tracer)
+        assert 'NVRX_CYCLE_START_TIME' not in telemetry.worker_env(2)
+
+
+class TestProfilerWiring:
+    def test_listeners_see_events_with_the_pre_increment_cycle(self):
+        seen = []
+
+        class Listener:
+            def on_event(self, record):
+                seen.append((record.event, record.cycle))
+
+        profiler = FaultToleranceProfiler()
+        listener = Listener()
+        profiler._observer = listener
+        profiler.record_event(ProfilingEvent.FAILURE_DETECTED, node_id='host')
+        profiler.record_event(ProfilingEvent.WORKER_TERMINATED, node_id='host')
+        # the failure is attributed to the cycle it ended, not the one it starts
+        assert seen == [(ProfilingEvent.FAILURE_DETECTED, 0), (ProfilingEvent.WORKER_TERMINATED, 1)]
+
+        profiler._observer = None
+        profiler.record_event(ProfilingEvent.RENDEZVOUS_STARTED, node_id='host')
+        assert len(seen) == 2
+
+    def test_profiling_phase_closes_even_when_the_body_raises(self):
+        seen = []
+
+        class Listener:
+            def on_event(self, record):
+                seen.append(record.event)
+
+        listener = Listener()
+        set_profiling_observer(listener)
+        try:
+            with pytest.raises(RuntimeError):
+                with profiling_phase(
+                    ProfilingEvent.AWAIT_ROUND_STARTED,
+                    ProfilingEvent.AWAIT_ROUND_COMPLETED,
+                    node_id='host',
+                ):
+                    raise RuntimeError("shutdown unwound out of the wait")
+        finally:
+            set_profiling_observer(None)
+        assert seen == [
+            ProfilingEvent.AWAIT_ROUND_STARTED,
+            ProfilingEvent.AWAIT_ROUND_COMPLETED,
+        ]
+
+    def test_recorder_consumes_profiler_events_end_to_end(self, tracer):
+        profiler = FaultToleranceProfiler()
+        profiler._observer = RestartCycleRecorder(tracer)
+        profiler.record_event(ProfilingEvent.RENDEZVOUS_STARTED, node_id='host_1_0')
+        profiler.record_event(ProfilingEvent.WORKER_START_STARTED, node_id='host_1_0', rank=2)
+        assert tracer.names == [
+            'nvrx.restart.cycle',
+            'nvrx.restart.health_check',
+            'nvrx.restart.worker_launch',
+        ]
+        assert tracer.one('nvrx.restart.worker_launch').attributes['nvrx.rank'] == 2


### PR DESCRIPTION
Takes over #401 (Russell is PTO) and restructures the OTel/nemo-lens integration along ownership lines. #401's five commits are included unmodified; the last commit is the refactor.

## Why

In #401 the telemetry logic lived inline in the code it instruments: ~330 lines of span-tree state machine on `FaultToleranceProfiler`, ~200 lines of setup/annotate/stage/shutdown in `launcher.py`, and a 60-line bootstrap block in the checkpoint worker's process target. Each call site carried its own `if enabled` guard and `try/except`.

## What changed

New `src/nvidia_resiliency_ext/shared_utils/telemetry/` package, layered innermost first:

| Module | Owns |
|---|---|
| `backend.py` | The only module that knows nemo-lens import paths (was `shared_utils/_otel_fallbacks.py`) |
| `spans.py` | `CycleSpanTree` — *how* spans nest, open and close. Best-effort by construction |
| `recorder.py` | `RestartCycleRecorder` — *when*, as a declarative `ProfilingEvent -> CycleAction` table |
| `agent.py` | `LauncherTelemetry` — the facade the ft_launcher agent codes against; a null object when telemetry is off |
| `checkpoint_worker.py` | `CheckpointWorkerTelemetry` — the spawned checkpoint worker's facade |

The key inversion: `profiling.py` gains a generic observer hook (`ProfilingListener`, `ProfilingEventRecord`, `add`/`remove_profiling_listener`) and a `profiling_phase` context manager, and no longer knows OTel exists. The recorder *observes* the profiler rather than being driven by the launcher.

Effect on the instrumented files:

- `launcher.py`: +201 -> +15 lines. Inline `setup_telemetry`, four `_otel_*` helpers, the shutdown thread and the worker-env block collapse to `LauncherTelemetry.create(...)` plus five one-line calls. The null object removes every guard and per-call-site `try/except`.
- `profiling.py`: +331 -> +62 lines, all of it generic.
- `ft_rendezvous_barrier.py`: the explicit `try/finally` around the Step-0 wait becomes `with profiling_phase(AWAIT_ROUND_STARTED, AWAIT_ROUND_COMPLETED, ...)`.
- `checkpointing/async_ckpt/core.py`: the inline bootstrap moves behind `CheckpointWorkerTelemetry.from_bootstrap()`.

Behavior is preserved: same span names, attributes, sweep semantics, flush points, cold-start backdating and worker env vars. Two deliberate small changes: checkpoint-worker telemetry setup failure no longer propagates (it now degrades the way the launcher's already did), and the agent deregisters its listener on shutdown.

## Tests and docs

- New `tests/shared_utils/test_telemetry_recorder.py` — 35 tests covering the span-tree state machine (full cycle, phase sweep, evicted node, standby/await, staged outcomes, cold start, flush points, profiler wiring). Runs without opentelemetry or nemo-lens installed: the recorder only needs an object with `start_span()`.
- New `shared_utils/telemetry/README.md` documenting the layering, the emitted span schema and how to add an event.

## Verification

- `black --check`, `isort --check-only`, `ruff check`: clean. (Note `launcher.py` carries `# fmt: off`, so black never saw #401's misformatted lines there; rewritten regardless.)
- `tests/fault_tolerance/unit/`: 542 passed. `tests/shared_utils/`: 154 passed plus the 35 new.
- Remaining local failures are environmental and identical before the change: 8 need the `ft_launcher` console script installed, 5 need NVML.
- `tests/checkpointing/unit/` needs GPUs and could not be run locally; `core.py` imports clean but that path is unverified by execution.

## Note

`shared_utils._otel_fallbacks` is gone, moved to `shared_utils.telemetry.backend`. It was private and never released, so no shim was left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)