### PR TITLE
Move optional attribution deps behind attribution extra

### DIFF
--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -225,7 +225,7 @@ a launcher-managed attribution service:
   - ``--ft-attribution-llm-api-key-file <PATH>`` (alias: ``--ft_attribution_llm_api_key_file``)
   - ``--ft-attribution-llm-base-url <URL>`` (alias: ``--ft_attribution_llm_base_url``)
   - ``--ft-attribution-llm-model <MODEL>`` (alias: ``--ft_attribution_llm_model``)
-  - ``--ft-attribution-analysis-backend {lib,mcp}`` (alias: ``--ft_attribution_analysis_backend``)
+  - ``--ft-attribution-analysis-backend {lib}`` (alias: ``--ft_attribution_analysis_backend``)
   - ``--ft-attribution-stop-action {log,no-restart}`` (alias: ``--ft_attribution_stop_action``), default ``log``
   - ``--ft-attribution-startup-timeout <SECONDS>`` (alias: ``--ft_attribution_startup_timeout``), default ``20``
   - ``--ft-attribution-export-url <URL>`` (alias: ``--ft_attribution_export_url``)
@@ -247,7 +247,8 @@ a launcher-managed attribution service:
 
   Launcher-managed attribution defaults to the ``lib`` backend, which runs the Restart Agent
   directly in the attrsvc process. The backend flag may be left unset to use that default or set
-  explicitly to ``lib``. Set it to ``mcp`` only for the legacy LogSage/Flight Recorder path.
+  explicitly to ``lib``. The optional MCP/LogSage analysis path is no longer selectable from
+  launcher-managed attribution.
 
   Attribution never delays a restart. When a cycle ends, the rendezvous host requests
   terminal analysis and immediately closes the next round, so the workload restarts while

--- a/examples/attribution/README.md
+++ b/examples/attribution/README.md
@@ -3,11 +3,11 @@
 These examples cover the existing attribution MCP integration and the Restart
 Agent CLI configuration.
 
-Install NVIDIA Resiliency Extension, then run the examples from the repository
-root:
+Install NVIDIA Resiliency Extension with the optional attribution dependencies
+when running the MCP example, then run the examples from the repository root:
 
 ```bash
-pip install nvidia-resiliency-ext
+pip install 'nvidia-resiliency-ext[attribution]'
 ```
 
 | File | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,26 +48,36 @@ numpy = ">=1.26"
 nvidia-ml-py = ">=12.570.86"
 defusedxml = "*"
 httpx = ">=0.24.0"
-langchain-core = ">=0.3.51,<0.4.0"
-langchain-openai = ">=0.3.0,<1.0.0"
-mcp = ">=1.15.0,<2.0.0"
-setproctitle = ">=1.3.0"
-logsage = ">=0.1.8"
+langchain-core = { version = ">=0.3.51,<0.4.0", optional = true }
+langchain-openai = { version = ">=0.3.0,<1.0.0", optional = true }
+mcp = { version = ">=1.15.0,<2.0.0", optional = true }
+setproctitle = { version = ">=1.3.0", optional = true }
+logsage = { version = ">=0.1.8", optional = true }
 fastapi = ">=0.100.0"
 uvicorn = { version = ">=0.20.0", extras = ["standard"] }
 pydantic = ">=2.0.0"
 pydantic-settings = ">=2.0.0"
 slowapi = ">=0.1.9"
-slack-bolt = ">=1.23.0"
-slack-sdk = ">=3.35.0"
+slack-bolt = { version = ">=1.23.0", optional = true }
+slack-sdk = { version = ">=3.35.0", optional = true }
 grpcio = "^1.76.0"
 grpcio-tools = "^1.76.0"
 protobuf = ">=4.22.0"
 
+[tool.poetry.extras]
+attribution = [
+    "langchain-core",
+    "langchain-openai",
+    "logsage",
+    "mcp",
+    "setproctitle",
+    "slack-bolt",
+    "slack-sdk",
+]
+
 [tool.poetry.scripts]
 ft_launcher = "nvidia_resiliency_ext.fault_tolerance.launcher:main"
 nvrx-control = "nvidia_resiliency_ext.fault_tolerance.control_plane:main"
-nvrx-mcp-analysis = "nvidia_resiliency_ext.attribution.mcp_integration.server_launcher:main"
 nvrx-attrsvc = "nvidia_resiliency_ext.services.attrsvc.__main__:main"
 nvrx-smonsvc = "nvidia_resiliency_ext.services.smonsvc.__main__:main"
 

--- a/services/attrsvc/ATTRSVC_SPEC.md
+++ b/services/attrsvc/ATTRSVC_SPEC.md
@@ -96,12 +96,11 @@ Two layers: **library** (`nvidia_resiliency_ext.attribution`) and **service**
 Summary:
 - Prefix **`NVRX_ATTRSVC_`** for service settings (see README for exceptions: LLM
   API key, Slack tokens, optional `LLM_API_KEY_FILE` / file paths in `api_keys.py`).
-- The default direct backend requires **`LLM_API_KEY_FILE`**, or the key-file
-  environment reference named by an explicit Restart Agent config. The legacy
-  backend retains the older `LLM_API_KEY` / file lookup behavior. Slack is
-  optional and legacy-only in the first direct integration.
-- LLM-related env vars are optional; unset values use the selected backend's
-  defaults.
+- The direct backend requires **`LLM_API_KEY_FILE`**, the default key-file paths,
+  or the key-file environment reference named by an explicit Restart Agent config.
+  The retained library path keeps the older `LLM_API_KEY` / file lookup behavior
+  for manual use.
+- LLM-related env vars are optional; unset values use the direct backend defaults.
 - Rate limits: slowapi, `RATE_LIMIT_SUBMIT` / `RATE_LIMIT_ANALYZE` / `RATE_LIMIT_PREVIEW`.
 
 **3.2 Constants** (library `orchestration/config.py` — single source)
@@ -111,7 +110,7 @@ Summary:
 | TTL | `TTL_PENDING_SECONDS`, `TTL_TERMINATED_SECONDS`, `TTL_MAX_JOB_AGE_SECONDS` |
 | Intervals | `POLL_INTERVAL_SECONDS`, `DEFAULT_COMPUTE_TIMEOUT_SECONDS` |
 | Limits | `MAX_JOBS`, `MIN_FILE_SIZE_KB` |
-| Health thresholds | ~20% degraded, ~50% fail (compute / dataflow error rates in health) |
+| Health thresholds | ~20% degraded, ~50% fail (compute error rates in health) |
 
 **3.3 Markers** (mode detection)
 
@@ -133,7 +132,7 @@ Summary:
 Patterns tried in order (scheduler-agnostic where possible): `_(\d+)_date_`,
 `job_(\d+)`, `slurm-(\d+)\.(out|err|log)`, etc. User: often `"unknown"`.
 
-**3.7 Processed-files ledger (legacy `mcp` backend only)**
+**3.7 Processed-files ledger (controller path, not exposed by `nvrx-attrsvc`)**
 
 - Env: `NVRX_ATTRSVC_CACHE_FILE`, `NVRX_ATTRSVC_CACHE_GRACE_PERIOD_SECONDS` (see README).
 - Purpose: avoid duplicate LLM/analysis work after restarts when clients resubmit.
@@ -148,15 +147,15 @@ Patterns tried in order (scheduler-agnostic where possible): `_(\d+)_date_`,
 
 **Startup (conceptual)**  
 Load `Settings` → configure logging → construct `AttributionHttpAdapter`. The
-default `lib` branch resolves `RestartAgentConfig` and constructs
-`RestartAgentRuntime`; the `mcp` branch constructs `AttributionController` and
-`Analyzer`. Then start Uvicorn. Legacy-only startup may also restore cache and
-start controller dependencies.
+direct `lib` backend resolves `RestartAgentConfig` and constructs
+`RestartAgentRuntime`. Then start Uvicorn. The controller/MCP flow remains
+available as lower-level library code for manual use, not as a selectable
+`nvrx-attrsvc` backend.
 
 **Shutdown**  
 Drain HTTP and stop backend-owned workers. The direct backend drops its bounded
-execution registry and current-lifetime history. The legacy backend may export
-its configured cache; see the coalescer documentation.
+execution registry and current-lifetime history. Controller cache export
+is documented with the lower-level coalescer path.
 
 ================================================================================
 
@@ -216,14 +215,14 @@ mitigates abuse.
 | GET | /logs | Analyze / return results (`log_path`, optional `file`, `wl_restart`) |
 
 **GET /healthz**  
-Uses cumulative compute stats (errors + timeouts vs total) and dataflow failure rate
-when dataflow posting is active. Thresholds: ~20% → degraded, ~50% → fail (see service
-implementation). Worst issue wins. MCP connectivity may add issues when backend is `mcp`.
+Uses cumulative compute stats (errors + timeouts vs total). Thresholds:
+~20% → degraded, ~50% → fail (see service implementation). Worst issue wins.
 
 **GET /stats**  
-Merges `Analyzer.get_stats()` (coalescer, splitlog folder stats, detection,
-deferred, permission errors, …) with **dataflow** counters and **Slack** stats.
-**`dataflow`** holds `total_posts`, `total_successful`, `total_failed`.
+Returns direct Restart Agent backend stats: execution-state counts, route and
+fallback counters, errors, evictions, config fingerprint, and history-record
+count. `Analyzer.get_stats()` / dataflow / Slack counters are available
+only on the retained controller path.
 
 **POST /logs** body
 
@@ -269,7 +268,8 @@ POST terminal -> bounded log drain -> RestartAgentRuntime in background
 GET wait=false -> pending | in_flight with optional fallback | completed
 ```
 
-The following diagram describes only the legacy `mcp` backend:
+The following diagram describes the retained controller/MCP path; it is
+not exposed as a selectable `nvrx-attrsvc` backend:
 
 ```mermaid
 flowchart TD
@@ -306,10 +306,11 @@ flowchart TD
 
 Notes: `ANALYSIS_BACKEND` (`NVRX_ATTRSVC_ANALYSIS_BACKEND`) defaults to `lib`,
 which runs the Restart Agent directly and does not use `RequestCoalescer`.
-The `mcp` backend preserves the diagrammed legacy flow, where the coalescer key
-is the normalized path and splitlog `file=` selects a per-file key. See
-`docs/design/attribution/restart_agent/ATTRSVC_INTEGRATION.md` for the direct
-contract and **ARCHITECTURE.md §7** for the legacy path.
+The controller/MCP flow preserves the diagrammed coalescer behavior for
+manual library use, where the coalescer key is the normalized path and splitlog
+`file=` selects a per-file key. See
+`docs/design/attribution/restart_agent/ATTRSVC_INTEGRATION.md` for the service
+contract and **ARCHITECTURE.md §7** for the controller path.
 
 **curl / examples** — **README.md** (avoid duplicating here).
 
@@ -358,17 +359,16 @@ diagram.
 10. GET FLOW
 --------------------------------------------------------------------------------
 
-For `lib`, GET only projects a registered attempt's pending, in-flight, or
-completed result; terminal POST starts analysis. For `mcp`, validate → locate
-job → trigger analysis via the legacy coalescer → serialize result. Legacy
-coalescing details are in **ARCHITECTURE.md**.
+GET only projects a registered attempt's pending, in-flight, or completed
+result; terminal POST starts analysis. Coalescing details for the manual
+controller path are in **ARCHITECTURE.md**.
 
 11. BACKGROUND POLL
 --------------------------------------------------------------------------------
 
-Legacy `mcp` only: pending promotion, splitlog discovery, cleanup, and stuck
-in-flight handling. The direct backend uses its bounded execution registry and
-background terminal futures instead of this poll loop.
+The direct backend uses its bounded execution registry and background terminal
+futures instead of the controller pending-promotion/splitlog/coalescer poll loop.
+Those details remain documented in **ARCHITECTURE.md**.
 
 ================================================================================
                          LIBRARY TOPICS (POINTERS ONLY)
@@ -376,7 +376,7 @@ background terminal futures instead of this poll loop.
 
 12. LLM ANALYSIS  
 Direct Restart Agent behavior — `docs/design/attribution/restart_agent/`.
-Legacy availability, retries, timeouts, and MCP behavior —
+Controller/MCP availability, retries, timeouts, and behavior —
 **ARCHITECTURE.md §7–9**, `LogAnalyzerConfig`, and
 `RequestCoalescer.compute_timeout`.
 
@@ -400,7 +400,7 @@ workload chunk within that file.
 --------------------------------------------------------------------------------
 
 The direct backend evicts the oldest completed execution when its bounded
-registry is full. Legacy TTL-based job cleanup and coalescer eviction use the
+registry is full. Controller TTL-based job cleanup and coalescer eviction use the
 constants in **§3.2**.
 
 ================================================================================
@@ -409,7 +409,7 @@ constants in **§3.2**.
 --------------------------------------------------------------------------------
 
 The direct backend schedules terminal runs on a bounded thread pool and guards
-its execution registry independently of `RestartAgentRuntime` history. Legacy
+its execution registry independently of `RestartAgentRuntime` history. Controller
 poll-thread, asyncio, and coalescer behavior remains documented in
 **ARCHITECTURE.md** and the `Analyzer` / `RequestCoalescer` source.
 
@@ -422,10 +422,10 @@ poll-thread, asyncio, and coalescer behavior remains documented in
 
 - **Direct `lib`**: Restart Agent config fingerprint, execution-state counts,
   fallback/route completion counts, errors, evictions, and history-record count.
-- **Legacy library** (`Analyzer.get_stats`): coalescer stats (hits/misses, compute,
+- **Analyzer library** (`Analyzer.get_stats`): coalescer stats (hits/misses, compute,
   submissions, …), splitlog folder stats under the `splitlog` key, `detection`,
   `deferred`, `permission_errors`, poll gauges, etc. — **exact keys per implementation**.
-- **Legacy controller/adapter** (`AttributionController.get_stats`, exposed by
+- **Controller/adapter** (`AttributionController.get_stats`, exposed by
   `AttributionHttpAdapter.get_stats`): adds **`dataflow`** (direct HTTP post
   attempts) and **`slack`** (attempts, successes, failures, user lookup stats when enabled).
 
@@ -436,13 +436,12 @@ Refer to live **`GET /stats`** response or OpenAPI for the current JSON shape.
 21. DATAFLOW & SLACK (OPTIONAL)
 --------------------------------------------------------------------------------
 
-Legacy `mcp` postprocessing posts results when `EXPORT_URL` is configured with the
-complete posting URI. No endpoint is built into the package. Slack posts when
-`SLACK_BOT_TOKEN` set or token fallback files are present. Wiring:
-`Settings` → `AttributionControllerConfig` → `AttributionController`. Record build:
-`build_dataflow_record`; backend: `postprocessing/post_backend.py`. Retry behavior in
-implementation. The first direct Restart Agent integration does not invoke
-legacy dataflow or Slack postprocessing.
+The direct backend does not invoke controller dataflow or Slack postprocessing.
+Those integrations remain on the retained controller/manual path: `EXPORT_URL`
+configures complete-result posting, Slack posts when `SLACK_BOT_TOKEN` is set or
+token fallback files are present, and the controller wiring is
+`AttributionControllerConfig` → `AttributionController`. Record build:
+`build_dataflow_record`; backend: `postprocessing/post_backend.py`.
 
 ================================================================================
                          OPERATIONS & DEVELOPMENT (POINTERS)

--- a/services/attrsvc/README.md
+++ b/services/attrsvc/README.md
@@ -1,9 +1,9 @@
 # NVRX Attribution Service (nvrx-attrsvc)
 
-FastAPI server that exposes log analysis over HTTP. The default `lib` backend
-runs `RestartAgentRuntime` directly. The legacy `mcp` backend retains
-`AttributionController`, `Analyzer`, LogSage, Flight Recorder, coalescing, and
-postprocessing. Both use the same HTTP routes and pydantic `Settings` boundary.
+FastAPI server that exposes log analysis over HTTP. The service runs
+`RestartAgentRuntime` directly through the `lib` backend. The lower-level
+attribution package still retains the MCP/controller implementation for
+manual use, but `nvrx-attrsvc` no longer exposes it as a backend selection.
 
 ---
 
@@ -11,11 +11,11 @@ postprocessing. Both use the same HTTP routes and pydantic `Settings` boundary.
 
 | | **Library** (`nvidia_resiliency_ext.attribution`) | **This package** (`nvidia_resiliency_ext.services.attrsvc`) |
 |---|--------------------------------------------------|-----------------------------------|
-| **Role** | **`RestartAgentRuntime`** for direct analysis; **`AttributionController`** for the legacy MCP path | HTTP API, backend selection, env-based `Settings`, and rate limits |
-| **Docs** | [`restart_agent/README.md`](../../docs/design/attribution/restart_agent/README.md), [`ARCHITECTURE.md`](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md) for legacy analysis | This file, [`ATTRSVC_SPEC.md`](ATTRSVC_SPEC.md) |
+| **Role** | **`RestartAgentRuntime`** for direct analysis; **`AttributionController`** for manual MCP use | HTTP API, env-based `Settings`, and rate limits |
+| **Docs** | [`restart_agent/README.md`](../../docs/design/attribution/restart_agent/README.md), [`ARCHITECTURE.md`](../../src/nvidia_resiliency_ext/attribution/ARCHITECTURE.md) for the MCP/controller analysis path | This file, [`ATTRSVC_SPEC.md`](ATTRSVC_SPEC.md) |
 
-The Restart Agent design directory is the source of truth for the direct
-backend. **ARCHITECTURE.md** remains the source of truth for the legacy
+The Restart Agent design directory is the source of truth for the service
+backend. **ARCHITECTURE.md** remains the source of truth for the manual
 controller/LogSage/Flight Recorder path.
 
 ---
@@ -25,7 +25,7 @@ controller/LogSage/Flight Recorder path.
 ```bash
 # Install
 cd services
-pip install -e .
+pip install -e ..
 
 # Run
 export NVRX_ATTRSVC_ALLOWED_ROOT=/path/to/logs
@@ -45,18 +45,18 @@ Environment variables (prefix: `NVRX_ATTRSVC_`):
 | `ENDPOINT` | `""` | Unified bind endpoint. Supports `http://host:port`, `host:port`, `unix:///absolute/path.sock`, or an absolute socket path. Overrides `HOST`/`PORT`. |
 | `HOST` | `127.0.0.1` | Listen address. Deployments that need remote access should set `NVRX_ATTRSVC_HOST=0.0.0.0` explicitly. |
 | `PORT` | `8000` | Listen port |
-| `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, or `WARNING` for root logging and MCP; FastAPI `debug` when set to `DEBUG`. |
-| `CLUSTER_NAME` | `""` | Cluster name for dataflow posting |
-| `EXPORT_URL` | `""` | Complete result export URI. Empty disables result export. |
-| `DATAFLOW_QUEUE` | `""` | Optional queue parameter for dataflow HTTP posting |
-| `DATAFLOW_TIMEOUT_SECONDS` | `10.0` | Dataflow HTTP request timeout |
+| `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, or `WARNING` for root logging; FastAPI `debug` when set to `DEBUG`. |
+| `CLUSTER_NAME` | `""` | Cluster name retained for controller dataflow configuration |
+| `EXPORT_URL` | `""` | Controller complete result export URI. The direct backend does not post results. |
+| `DATAFLOW_QUEUE` | `""` | Controller queue parameter for dataflow HTTP posting |
+| `DATAFLOW_TIMEOUT_SECONDS` | `10.0` | Controller dataflow HTTP request timeout |
 | `RATE_LIMIT_SUBMIT` | `1200/minute` | Rate limit for POST /logs |
 | `RATE_LIMIT_ANALYZE` | `60/minute` | Rate limit for GET /logs |
 | `RATE_LIMIT_PREVIEW` | `120/minute` | Rate limit for GET /print |
 
 **LLM / analysis** (optional — unset vars keep library defaults).
-`AttributionHttpAdapter` resolves these into `RestartAgentConfig` for `lib`, or
-the legacy `AttributionControllerConfig` for `mcp`.
+`AttributionHttpAdapter` resolves these into `RestartAgentConfig` for the direct
+Restart Agent backend.
 
 | Variable (with prefix)          | Description                                                                                                                                                                                                   |
 |---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -66,7 +66,7 @@ the legacy `AttributionControllerConfig` for `mcp`.
 | `NVRX_ATTRSVC_LLM_TOP_P`        | Top-p for nucleus sampling                                                                                                                                                                                    |
 | `NVRX_ATTRSVC_LLM_MAX_TOKENS`   | Max tokens for response                                                                                                                                                                                       |
 | `NVRX_ATTRSVC_COMPUTE_TIMEOUT`  | Timeout for analysis in seconds                                                                                                                                                                               |
-| `NVRX_ATTRSVC_ANALYSIS_BACKEND` | `lib` (direct Restart Agent, default) or `mcp` (legacy LogSage/Flight Recorder path). |
+| `NVRX_ATTRSVC_ANALYSIS_BACKEND` | `lib` (direct Restart Agent backend). |
 | `NVRX_ATTRSVC_RESTART_AGENT_CONFIG` | Optional authoritative `restart_agent_config.v1` JSON file for `lib`; the first attrsvc integration requires exactly one route. |
 | `NVRX_ATTRSVC_RESTART_AGENT_LOG_QUIET_SECONDS` | Required unchanged-log interval after the internal 10-second minimum live observation period; default `5`. |
 | `NVRX_ATTRSVC_RESTART_AGENT_LOG_MAX_WAIT_SECONDS` | Maximum live terminal observation period before the source freezes; default `40`. |
@@ -74,51 +74,28 @@ the legacy `AttributionControllerConfig` for `mcp`.
 
 **LLM API Key**: the default `lib` route requires `LLM_API_KEY_FILE`. A supplied
 Restart Agent config may name another key-file environment variable through its
-`credential_ref`. The legacy `mcp` path retains the older lookup order:
-1. `LLM_API_KEY` environment variable
-2. `LLM_API_KEY_FILE` environment variable (path to file)
-3. `~/.llm_api_key` file
-4. `~/.config/nvrx/llm_api_key` file
+`credential_ref`.
 
 **Slack Notifications** (optional; no `NVRX_ATTRSVC_` prefix):
 
+These settings are retained for the controller/manual path. The current
+`nvrx-attrsvc` direct backend does not send Slack notifications.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SLACK_BOT_TOKEN` | `""` | Bot token (empty = controller tries file fallbacks below) |
+| `SLACK_BOT_TOKEN` | `""` | Bot token (empty = controller path tries file fallbacks below) |
 | `SLACK_BOT_TOKEN_FILE` | — | Path to a file containing the token (checked before `~/.slack_bot_token` / `~/.slack_token`) |
 | `SLACK_CHANNEL` | `""` | Channel ID or name (e.g. `#trng-alerts`). In `.env`, quote values that start with `#`: `SLACK_CHANNEL="#trng-alerts"` |
 
-When configured, sends alerts to Slack for results whose normalized `recommendation.action` is `STOP`.
-
 **Processed Files Ledger** (optional cache persistence):
+
+These settings are retained for the controller cache path. The current
+direct backend uses an in-memory attempt registry and does not persist a ledger.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CACHE_FILE` | `""` | Path to ledger file for persistence (empty = disabled) |
-| `CACHE_GRACE_PERIOD_SECONDS` | `600` | Grace period before validating file on cache hit (10 min) |
-
-The cache acts as a **processed files ledger** - tracking which files have been analyzed
-and posted to the configured dataflow HTTP endpoint. This prevents duplicate processing after service restarts.
-
-**Why needed:** When the service restarts, smonsvc resubmits recently completed jobs.
-Without the ledger, all files would be re-analyzed and re-posted. The ledger
-allows the service to recognize "I've already processed this file" and skip it.
-
-**What's stored:** `(path, mtime, size, result)` for each processed file.
-
-**Validation strategy:**
-
-| Phase | Behavior |
-|-------|----------|
-| **Grace period** (first 10 min) | Serve from cache without file validation |
-| **After grace period** | `stat()` file on each hit; if `(mtime, size)` changed, invalidate and re-analyze |
-| **Eviction** | Remove entries when file mtime > 14 days (safeguard against unbounded growth) |
-| **On import** | Validate `(mtime, size)`; skip if file changed or > 14 days old |
-
-The grace period absorbs straggling writes at end of file, preventing unnecessary re-analysis.
-
-**Note:** Ledger is saved only on graceful shutdown (SIGTERM). If the service crashes or is
-killed (SIGKILL), in-memory entries are lost. Use a process manager with adequate stop timeout.
+| `CACHE_FILE` | `""` | Controller ledger file path (ignored by the direct backend) |
+| `CACHE_GRACE_PERIOD_SECONDS` | `600` | Controller cache grace period (ignored by the direct backend) |
 
 Example: `NVRX_ATTRSVC_CACHE_FILE=/var/lib/nvrx/attrsvc_cache.json`
 
@@ -282,7 +259,7 @@ For combined deployment with monitor, see `../scripts/nvrx_services.sbatch`
 **Embedding the direct analyzer** (no HTTP): use `build_restart_agent_runtime()`
 and `RestartAgentRuntime.analyze()`, or the `restart-agent` CLI. See the
 **[Restart Agent design](../../docs/design/attribution/restart_agent/README.md)**.
-For the legacy analysis stack, use `AttributionController`, `Analyzer`, or
+For the MCP/controller analysis stack, use `AttributionController`, `Analyzer`, or
 `LogAnalyzer`; see the **[attribution README](../../src/nvidia_resiliency_ext/attribution/README.md)**.
 
 **In-process HTTP adapter** (same repo, after `pip install`):
@@ -329,6 +306,6 @@ asyncio.run(main())
 - **Service config** is in `config.py` (`Settings` from env with prefix `NVRX_ATTRSVC_`).
 - **`setup()`** in `config.py` loads settings and configures logging only.
 - **`AttributionHttpAdapter`** translates `Settings` into `RestartAgentConfig`
-  for `lib`, or `AttributionControllerConfig` for `mcp`.
-- Dataflow and Slack postprocessing remain on the legacy controller path in the
-  first direct integration and do not gate responses there.
+  for the direct Restart Agent backend.
+- Dataflow and Slack postprocessing remain on the controller/manual path;
+  the direct backend does not invoke them.

--- a/services/attrsvc/deploy/nvrx-attrsvc.service
+++ b/services/attrsvc/deploy/nvrx-attrsvc.service
@@ -5,13 +5,14 @@
 #   sudo ./setup_systemd.sh
 #
 # Manual installation:
-#   1. Create venv:     python3 -m venv /opt/nvrx/venv
-#   2. Install:         /opt/nvrx/venv/bin/pip install -e services
-#   3. Create API key:  echo "your-llm-api-key-here" | sudo tee /etc/nvrx/llm_api_key
-#   4. Copy service:    sudo cp nvrx-attrsvc.service /etc/systemd/system/
-#   5. Reload:          sudo systemctl daemon-reload
-#   6. Enable:          sudo systemctl enable nvrx-attrsvc
-#   7. Start:           sudo systemctl start nvrx-attrsvc
+#   1. Set repo root:   export NVRX_REPO_DIR=/path/to/nvidia-resiliency-ext
+#   2. Create venv:     python3 -m venv /opt/nvrx/venv
+#   3. Install:         /opt/nvrx/venv/bin/pip install -e "$NVRX_REPO_DIR"
+#   4. Create API key:  echo "your-llm-api-key-here" | sudo tee /etc/nvrx/llm_api_key
+#   5. Copy service:    sudo cp nvrx-attrsvc.service /etc/systemd/system/
+#   6. Reload:          sudo systemctl daemon-reload
+#   7. Enable:          sudo systemctl enable nvrx-attrsvc
+#   8. Start:           sudo systemctl start nvrx-attrsvc
 #
 # Logging:
 #   Default: File-based with timestamps

--- a/services/scripts/README.md
+++ b/services/scripts/README.md
@@ -50,8 +50,7 @@ sudo ./scripts/setup_systemd.sh start
 
 The default direct backend accepts `LLM_API_KEY_FILE`, an explicit Restart
 Agent config with its own credential reference, or the default key-file paths
-`~/.llm_api_key` and `~/.config/nvrx/llm_api_key`. A raw `LLM_API_KEY` is
-accepted only by the legacy `mcp` backend.
+`~/.llm_api_key` and `~/.config/nvrx/llm_api_key`.
 
 **Output files** (in `~/nvrx_logs/` by default):
 - `<timestamp>_attrsvc.log` - Attribution service stdout/stderr

--- a/services/scripts/build_enroot_image.sh
+++ b/services/scripts/build_enroot_image.sh
@@ -97,7 +97,7 @@ enroot start --rw --root --mount "${REPO_ROOT}:/tmp/repo" "${CONTAINER_NAME}" ba
     set -e
     cd /tmp/repo
     
-    # Install the root package, which owns both nvrx-attrsvc and nvrx-smonsvc entry points.
+    # Install the root package, which owns both service entry points.
     echo "  Installing nvidia-resiliency-ext..."
     STRAGGLER_DET_SKIP_CUPTI_EXT_BUILD=1 pip install --no-cache-dir .
     

--- a/services/scripts/common.sh
+++ b/services/scripts/common.sh
@@ -5,9 +5,14 @@
 # Get the directory where this script lives
 COMMON_SETUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Setup the key contract for the selected attrsvc backend.
+# Setup the key contract for the attrsvc Restart Agent backend.
 setup_llm_api_key() {
     local backend="${NVRX_ATTRSVC_ANALYSIS_BACKEND:-lib}"
+
+    if [[ "${backend}" != "lib" ]]; then
+        echo "ERROR: NVRX_ATTRSVC_ANALYSIS_BACKEND only supports lib"
+        return 1
+    fi
 
     if [[ "${backend}" == "lib" && -n "${NVRX_ATTRSVC_RESTART_AGENT_CONFIG:-}" ]]; then
         if [[ ! -f "${NVRX_ATTRSVC_RESTART_AGENT_CONFIG}" ]]; then
@@ -15,11 +20,6 @@ setup_llm_api_key() {
             return 1
         fi
         echo "Using Restart Agent config credentials: ${NVRX_ATTRSVC_RESTART_AGENT_CONFIG}"
-        return 0
-    fi
-
-    if [[ "${backend}" == "mcp" && -n "${LLM_API_KEY:-}" ]]; then
-        echo "Using LLM_API_KEY from environment"
         return 0
     fi
 
@@ -45,11 +45,7 @@ setup_llm_api_key() {
     done
 
     echo "WARNING: LLM API key not found - LLM analysis may fail"
-    if [[ "${backend}" == "lib" ]]; then
-        echo "  Set LLM_API_KEY_FILE, provide NVRX_ATTRSVC_RESTART_AGENT_CONFIG, or create ~/.llm_api_key"
-    else
-        echo "  Set LLM_API_KEY, LLM_API_KEY_FILE, or create ~/.llm_api_key"
-    fi
+    echo "  Set LLM_API_KEY_FILE, provide NVRX_ATTRSVC_RESTART_AGENT_CONFIG, or create ~/.llm_api_key"
     return 1
 }
 

--- a/services/scripts/run_services.sh
+++ b/services/scripts/run_services.sh
@@ -19,7 +19,7 @@
 #
 # Optional environment variables:
 #   NVRX_LOGS_DIR             - Output directory for logs (default: ~/nvrx_logs)
-#   NVRX_ATTRSVC_ANALYSIS_BACKEND - lib Restart Agent (default) or legacy mcp
+#   NVRX_ATTRSVC_ANALYSIS_BACKEND - lib Restart Agent backend
 #   NVRX_SMONSVC_PARTITIONS   - SLURM partitions to monitor (default: "batch batch_long")
 #   NVRX_ATTRSVC_ENDPOINT     - Unified attrsvc endpoint: http://host:port or unix:///path.sock
 #   NVRX_ATTRSVC_PORT         - TCP port fallback when endpoint is unset (default: 8000)

--- a/services/smonsvc/README.md
+++ b/services/smonsvc/README.md
@@ -7,7 +7,7 @@ SLURM job monitor that automatically submits completed job logs to the Attributi
 ```bash
 # Install
 cd services
-pip install -e .
+pip install -e ..
 
 # Run (requires nvrx-attrsvc running)
 export NVRX_ATTRSVC_ENDPOINT=http://localhost:8000

--- a/services/smonsvc/deploy/nvrx-smonsvc.service
+++ b/services/smonsvc/deploy/nvrx-smonsvc.service
@@ -5,12 +5,13 @@
 #   sudo ./setup_systemd.sh
 #
 # Manual installation:
-#   1. Create venv:     python3 -m venv /opt/nvrx/venv
-#   2. Install:         /opt/nvrx/venv/bin/pip install -e services
-#   3. Copy service:    sudo cp nvrx-smonsvc.service /etc/systemd/system/
-#   4. Reload:          sudo systemctl daemon-reload
-#   5. Enable:          sudo systemctl enable nvrx-smonsvc
-#   6. Start:           sudo systemctl start nvrx-smonsvc
+#   1. Set repo root:   export NVRX_REPO_DIR=/path/to/nvidia-resiliency-ext
+#   2. Create venv:     python3 -m venv /opt/nvrx/venv
+#   3. Install:         /opt/nvrx/venv/bin/pip install -e "$NVRX_REPO_DIR"
+#   4. Copy service:    sudo cp nvrx-smonsvc.service /etc/systemd/system/
+#   5. Reload:          sudo systemctl daemon-reload
+#   6. Enable:          sudo systemctl enable nvrx-smonsvc
+#   7. Start:           sudo systemctl start nvrx-smonsvc
 #
 # Logging:
 #   Default: File-based with timestamps

--- a/src/nvidia_resiliency_ext/attribution/README.md
+++ b/src/nvidia_resiliency_ext/attribution/README.md
@@ -2,10 +2,10 @@
 
 Python library for **failure attribution** on job logs: LogSage (LLM over logs), optional **NCCL flight-recorder** analysis, optional **LLM merge** of log + trace, **request coalescing**, SLURM-oriented **splitlog** tracking, and best-effort observability hooks (direct dataflow HTTP posting and Slack).
 
-Install NVIDIA Resiliency Extension with:
+Install NVIDIA Resiliency Extension with the optional attribution dependencies:
 
 ```bash
-pip install nvidia-resiliency-ext
+pip install 'nvidia-resiliency-ext[attribution]'
 ```
 
 **How it is structured (subsystems, diagrams, `AttributionController`, `Analyzer` / `LogAnalyzerConfig`, MCP vs in-process LogSage, pipeline modes):**

--- a/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
+++ b/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
@@ -9,33 +9,6 @@ import time
 from collections import deque
 from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.runnables import RunnablePassthrough
-from langchain_openai import ChatOpenAI
-from logsage.auto_resume_policy.attribution_classes import (
-    ApplicationData,
-    Attribution,
-    AutoResumeAction,
-    ErrorAttribution,
-    FinishedStatus,
-    LRUCache,
-)
-from logsage.auto_resume_policy.error_attribution import (
-    CONTEXT_SIZE,
-    get_attribution,
-    get_auto_resume,
-    get_proposed_solution_cat,
-)
-from logsage.auto_resume_policy.error_extraction import (
-    finished_validation,
-    return_application_errors,
-    return_application_errors_rt,
-)
-from logsage.auto_resume_policy.prompts import template_post_error_check
-from logsage.auto_resume_policy.util_postprocessing import get_auto_resume_postprocessing
-from logsage.auto_resume_policy.utils import chunk_indices
-
 from nvidia_resiliency_ext.attribution.base import (
     AttributionState,
     NVRxAttribution,
@@ -64,6 +37,46 @@ from nvidia_resiliency_ext.attribution.orchestration.types import (
     LogSageAnalysisResult,
     RawAnalysisResultItem,
 )
+
+_ATTRIBUTION_EXTRA_MESSAGE = (
+    "LogSage attribution dependencies are not installed. "
+    "Install with: pip install 'nvidia-resiliency-ext[attribution]'"
+)
+
+try:
+    from langchain_core.output_parsers import StrOutputParser
+    from langchain_core.prompts import ChatPromptTemplate
+    from langchain_core.runnables import RunnablePassthrough
+    from langchain_openai import ChatOpenAI
+    from logsage.auto_resume_policy.attribution_classes import (
+        ApplicationData,
+        Attribution,
+        AutoResumeAction,
+        ErrorAttribution,
+        FinishedStatus,
+        LRUCache,
+    )
+    from logsage.auto_resume_policy.error_attribution import (
+        CONTEXT_SIZE,
+        get_attribution,
+        get_auto_resume,
+        get_proposed_solution_cat,
+    )
+    from logsage.auto_resume_policy.error_extraction import (
+        finished_validation,
+        return_application_errors,
+        return_application_errors_rt,
+    )
+    from logsage.auto_resume_policy.prompts import template_post_error_check
+    from logsage.auto_resume_policy.util_postprocessing import get_auto_resume_postprocessing
+    from logsage.auto_resume_policy.utils import chunk_indices
+except ModuleNotFoundError as exc:
+    if exc.name and (
+        exc.name in {"langchain_core", "langchain_openai", "logsage"}
+        or exc.name.startswith("logsage.")
+    ):
+        raise ModuleNotFoundError(_ATTRIBUTION_EXTRA_MESSAGE) from exc
+    raise
 
 logger = logging.getLogger(__name__)
 

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/README.md
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/README.md
@@ -4,6 +4,10 @@
 
 This document describes the architecture and design decisions behind the MCP integration for NVIDIA Resiliency Extension (NVRX) Attribution modules.
 
+MCP support is optional and is not installed by the default NVRx wheel. Install
+`nvidia-resiliency-ext[attribution]` before launching the MCP server or
+using the MCP client transport.
+
 ## Design Goals
 
 1. **Modularity**: Each attribution module operates independently

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_client.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/mcp_client.py
@@ -10,7 +10,7 @@ This client allows:
 import asyncio
 import json
 import logging
-import shutil
+import sys
 from contextlib import AsyncExitStack
 from importlib.resources import files as pkg_files
 from typing import Any, Dict, List
@@ -61,8 +61,9 @@ def get_server_command(*, log_level: str = "INFO") -> List[str]:
     """
     Resolve and return the server launcher command for the MCP client.
 
-    Prefers the ``nvrx-mcp-analysis`` console script when on PATH (clearer in ``ps``);
-    falls back to ``python path/to/server_launcher.py`` for editable installs.
+    Uses the current Python executable and packaged ``server_launcher.py`` so MCP
+    remains available to explicit callers without installing a default NVRx
+    console entry point.
 
     Args:
         log_level: Subprocess logging level (same names as ``server_launcher --log-level``).
@@ -72,10 +73,6 @@ def get_server_command(*, log_level: str = "INFO") -> List[str]:
         Command list to launch the MCP server subprocess.
     """
     lvl = normalize_mcp_server_log_level(log_level)
-    script = shutil.which("nvrx-mcp-analysis")
-    if script:
-        return [script, "--log-level", lvl]
-
     pkg = "nvidia_resiliency_ext.attribution.mcp_integration"
     try:
         resource = pkg_files(pkg).joinpath("server_launcher.py")
@@ -83,7 +80,7 @@ def get_server_command(*, log_level: str = "INFO") -> List[str]:
         raise FileNotFoundError(f"failed to locate server_launcher.py in package {pkg}: {e}")
     if not resource.exists():
         raise FileNotFoundError(f"server launcher not found in package: {pkg}/server_launcher.py")
-    return ["python", str(resource), "--log-level", lvl]
+    return [sys.executable, str(resource), "--log-level", lvl]
 
 
 def create_mcp_client(*, mcp_server_log_level: str = "INFO") -> "NVRxMCPClient":

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/server_launcher.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/server_launcher.py
@@ -3,19 +3,21 @@
 Launcher for the NVRX Attribution MCP server (tool-agnostic: clients call ``log_analyzer``,
 ``fr_analyzer``, etc. by MCP tool name).
 
-Installed as ``nvrx-mcp-analysis`` for a short ``ps`` name; process title matches via
-``setproctitle`` when available.
+MCP dependencies are optional and are not installed by the default NVRx wheel.
+Install ``nvidia-resiliency-ext[attribution]`` before launching this server.
+The process title is set to ``nvrx-mcp-analysis`` via ``setproctitle`` when available.
 
 Usage:
     # Launch server with all modules
-    nvrx-mcp-analysis
-    python server_launcher.py
+    python -m nvidia_resiliency_ext.attribution.mcp_integration.server_launcher
 
     # Launch with specific modules only
-    nvrx-mcp-analysis --modules log_analyzer fr_analyzer
+    python -m nvidia_resiliency_ext.attribution.mcp_integration.server_launcher \
+        --modules log_analyzer fr_analyzer
 
     # Launch with custom server name
-    nvrx-mcp-analysis --server-name my-attribution-server
+    python -m nvidia_resiliency_ext.attribution.mcp_integration.server_launcher \
+        --server-name my-attribution-server
 """
 
 import argparse
@@ -37,16 +39,42 @@ def _set_process_title(title: str) -> None:
 
 logger = logging.getLogger(__name__)
 
+_ATTRIBUTION_EXTRA_MESSAGE = (
+    "Attribution MCP/LogSage dependencies are not installed. "
+    "Install with: pip install 'nvidia-resiliency-ext[attribution]'"
+)
+
+
+def _is_attribution_extra_dependency(exc: ModuleNotFoundError) -> bool:
+    return bool(
+        exc.name
+        and (
+            exc.name in {"langchain_core", "langchain_openai", "logsage", "mcp"}
+            or exc.name.startswith("logsage.")
+        )
+    )
+
 
 def main():
     """Main entry point for the MCP server."""
     _set_process_title(_PROC_TITLE)
 
-    from nvidia_resiliency_ext.attribution.mcp_integration.mcp_server import NVRxMCPServer
-    from nvidia_resiliency_ext.attribution.mcp_integration.module_definitions import (
-        register_all_modules,
-    )
-    from nvidia_resiliency_ext.attribution.mcp_integration.registry import global_registry
+    try:
+        from nvidia_resiliency_ext.attribution.mcp_integration.mcp_server import NVRxMCPServer
+    except ModuleNotFoundError as exc:
+        if not _is_attribution_extra_dependency(exc):
+            raise
+        raise SystemExit(_ATTRIBUTION_EXTRA_MESSAGE) from exc
+
+    try:
+        from nvidia_resiliency_ext.attribution.mcp_integration.module_definitions import (
+            register_all_modules,
+        )
+        from nvidia_resiliency_ext.attribution.mcp_integration.registry import global_registry
+    except ModuleNotFoundError as exc:
+        if not _is_attribution_extra_dependency(exc):
+            raise
+        raise SystemExit(_ATTRIBUTION_EXTRA_MESSAGE) from exc
 
     parser = argparse.ArgumentParser(description='Launch NVRX Attribution MCP Server')
     parser.add_argument(

--- a/src/nvidia_resiliency_ext/attribution/trace_analyzer/fr_attribution.py
+++ b/src/nvidia_resiliency_ext/attribution/trace_analyzer/fr_attribution.py
@@ -376,7 +376,7 @@ class CollectiveAnalyzer(NVRxAttribution):
                 return result
             except ImportError:
                 eprint("LangChain is not installed. Please install it with:")
-                eprint("pip install langchain langchain-nvidia-ai-endpoints")
+                eprint("pip install 'nvidia-resiliency-ext[attribution]'")
             except Exception as e:
                 eprint(f"\nError using LangChain: {e}")
                 eprint(llm_api_key_help_text())

--- a/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/attribution_manager.py
@@ -443,8 +443,11 @@ def _normalize_analysis_backend(value: Optional[str]) -> Optional[str]:
     normalized = str(value).strip().lower()
     if not normalized:
         return None
-    if normalized not in {"lib", "mcp"}:
-        raise ValueError(f"--ft-attribution-analysis-backend must be 'lib' or 'mcp', got {value!r}")
+    if normalized != "lib":
+        raise ValueError(
+            "--ft-attribution-analysis-backend only supports 'lib' for launcher-managed "
+            f"attribution, got {value!r}"
+        )
     return normalized
 
 

--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -410,12 +410,12 @@ def _add_attribution_args(parser: argparse.ArgumentParser) -> None:
         type=str.lower,
         default=None,
         dest="ft_attribution_analysis_backend",
-        choices=("lib", "mcp"),
-        metavar="{lib,mcp}",
+        choices=("lib",),
+        metavar="{lib}",
         help=(
             "Analysis backend for launcher-managed attribution service. "
-            "lib runs the Restart Agent directly and is the attrsvc default; "
-            "mcp selects the legacy LogSage/Flight Recorder path."
+            "Only lib is supported; it runs the Restart Agent directly and is the "
+            "attrsvc default."
         ),
     )
     parser.add_argument(

--- a/src/nvidia_resiliency_ext/services/attrsvc/app.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/app.py
@@ -137,7 +137,7 @@ def create_app(cfg: Settings) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        """Startup and shutdown for controller-owned runtime dependencies."""
+        """Startup and shutdown for backend-owned runtime dependencies."""
         # Startup
         started = await app.state.attribution.start(asyncio.get_running_loop())
         loaded = started.get("cache_entries_loaded", 0)
@@ -209,7 +209,7 @@ def create_app(cfg: Settings) -> FastAPI:
         """
         Health check endpoint.
 
-        Returns status based on controller dependency health:
+        Returns status based on backend health:
         - "ok": All systems healthy
         - "degraded": Some issues but service is functional (20-50% error rate)
         - "fail": Critical issues (>50% error rate)
@@ -226,7 +226,7 @@ def create_app(cfg: Settings) -> FastAPI:
             default=None, description="Indentation level (overrides pretty)"
         ),
     ) -> Response:
-        """Get cache and request coalescing statistics. See spec Section 20."""
+        """Get backend statistics. See spec Section 20."""
         adapter: AttributionHttpAdapter = request.app.state.attribution
         stats = await adapter.get_stats()
         return json_response(stats, pretty=pretty, indent=indent)

--- a/src/nvidia_resiliency_ext/services/attrsvc/config.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/config.py
@@ -122,11 +122,10 @@ class Settings(BaseSettings):
     Attribution fields are translated into either a direct Restart Agent config
     or the legacy controller config by
     :class:`~nvidia_resiliency_ext.services.attrsvc.service.AttributionHttpAdapter`;
-    unset fields keep the selected implementation's defaults.
+    unset fields keep direct Restart Agent defaults.
 
-    ``LOG_LEVEL`` sets the root log level, FastAPI ``debug`` (when ``LOG_LEVEL`` is ``DEBUG``), MCP
-    subprocess ``--log-level``, and verbosity for in-process MCP client loggers. Allowed values:
-    ``DEBUG``, ``INFO``, ``WARNING`` (default ``INFO``).
+    ``LOG_LEVEL`` sets the root log level and FastAPI ``debug`` (when ``LOG_LEVEL`` is ``DEBUG``).
+    Allowed values: ``DEBUG``, ``INFO``, ``WARNING`` (default ``INFO``).
     """
 
     FAST_API_ROOT_PATH: str = Field(default="", description="FastAPI root path")
@@ -145,15 +144,15 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = Field(
         default="INFO",
         description=(
-            "Service log level: DEBUG, INFO, or WARNING. Drives logging.basicConfig, MCP "
-            "``nvrx-mcp-analysis --log-level``, and FastAPI debug when set to DEBUG."
+            "Service log level: DEBUG, INFO, or WARNING. Drives logging.basicConfig "
+            "and FastAPI debug when set to DEBUG."
         ),
     )
     COMPUTE_TIMEOUT: float | None = Field(
         default=None, description="Timeout for compute_fn in seconds (None = library default)"
     )
 
-    # LLM overrides resolved by the selected backend (see AttributionHttpAdapter).
+    # LLM overrides resolved by the direct Restart Agent backend.
     LLM_MODEL: str | None = Field(default=None, description="LLM model override")
     LLM_BASE_URL: str | None = Field(default=None, description="LLM base url override")
     LLM_TEMPERATURE: float | None = Field(
@@ -166,8 +165,8 @@ class Settings(BaseSettings):
     ANALYSIS_BACKEND: str = Field(
         default="lib",
         description=(
-            "Analysis implementation: 'lib' runs the Restart Agent directly in attrsvc "
-            "(default); 'mcp' preserves the legacy LogSage/flight-recorder MCP path."
+            "Analysis implementation. Only 'lib' is supported; it runs the Restart Agent "
+            "directly in attrsvc."
         ),
     )
     RESTART_AGENT_CONFIG: str | None = Field(
@@ -276,10 +275,9 @@ class Settings(BaseSettings):
     @field_validator("ANALYSIS_BACKEND")
     @classmethod
     def validate_analysis_backend(cls, v: str) -> str:
-        allowed = ("lib", "mcp")
         v_lower = v.strip().lower()
-        if v_lower not in allowed:
-            raise ValueError(f"ANALYSIS_BACKEND must be one of {allowed}, got '{v}'")
+        if v_lower != "lib":
+            raise ValueError(f"ANALYSIS_BACKEND only supports 'lib', got '{v}'")
         return v_lower
 
     @field_validator("RESTART_AGENT_CONFIG", mode="before")
@@ -477,8 +475,6 @@ def setup() -> Settings:
     # Suppress verbose logs from dependencies
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
-    logging.getLogger("mcp").setLevel(_root_lvl)
-    logging.getLogger("nvidia_resiliency_ext.attribution.mcp_integration").setLevel(_root_lvl)
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
 
     return cfg

--- a/src/nvidia_resiliency_ext/services/attrsvc/service.py
+++ b/src/nvidia_resiliency_ext/services/attrsvc/service.py
@@ -1,17 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""HTTP adapter selecting the direct Restart Agent or legacy controller.
+"""HTTP adapter selecting the direct Restart Agent backend.
 
 This module keeps FastAPI-facing concerns in ``services/attrsvc``. The default
-``lib`` backend owns a direct Restart Agent runtime. ``mcp`` keeps
-the pre-existing LogSage/flight-recorder controller path during migration.
+``lib`` backend owns a direct Restart Agent runtime.
 """
 
 import asyncio
 import logging
 from functools import partial
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import Any, Protocol
 
 from nvidia_resiliency_ext.attribution.coalescing import (
     CacheResult,
@@ -43,10 +42,6 @@ from .restart_agent_backend import (
 from .restart_agent_config import restart_agent_config_from_settings
 
 logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from nvidia_resiliency_ext.attribution.controller import AttributionControllerConfig
-
 
 # Re-export result types for convenience
 __all__ = [
@@ -118,50 +113,12 @@ class AttributionServiceBackend(Protocol):
     async def status(self) -> dict[str, Any]: ...
 
 
-def _controller_config_from_settings(cfg: Settings) -> "AttributionControllerConfig":
-    """Translate HTTP service settings into controller startup config."""
-    from nvidia_resiliency_ext.attribution.controller import (
-        AttributionAnalysisConfig,
-        AttributionCacheConfig,
-        AttributionControllerConfig,
-        AttributionPostprocessingConfig,
-        AttributionProgressiveConfig,
-    )
-
-    return AttributionControllerConfig(
-        allowed_root=cfg.ALLOWED_ROOT,
-        analysis=AttributionAnalysisConfig(
-            engine_backend=cfg.ANALYSIS_BACKEND,
-            mcp_server_log_level=cfg.LOG_LEVEL,
-            llm_model=cfg.LLM_MODEL,
-            llm_base_url=cfg.LLM_BASE_URL,
-            llm_temperature=cfg.LLM_TEMPERATURE,
-            llm_top_p=cfg.LLM_TOP_P,
-            llm_max_tokens=cfg.LLM_MAX_TOKENS,
-        ),
-        cache=AttributionCacheConfig(
-            compute_timeout=cfg.COMPUTE_TIMEOUT,
-            grace_period_seconds=(
-                cfg.CACHE_GRACE_PERIOD_SECONDS if cfg.CACHE_GRACE_PERIOD_SECONDS else None
-            ),
-            cache_file=cfg.CACHE_FILE,
-        ),
-        postprocessing=AttributionPostprocessingConfig(
-            cluster_name=cfg.CLUSTER_NAME,
-            slack_bot_token=(cfg.SLACK_BOT_TOKEN or "").strip() or None,
-            slack_channel=cfg.SLACK_CHANNEL,
-        ),
-        progressive=AttributionProgressiveConfig(mode=cfg.PROGRESSIVE_ANALYSIS),
-    )
-
-
 class AttributionHttpAdapter:
     """
     HTTP adapter facade over the selected attribution implementation.
 
     ``AttributionHttpAdapter`` owns Settings conversion and keeps the public service
-    method names stable for FastAPI routes. ``lib`` bypasses the legacy
-    controller and cache; ``mcp`` delegates to the existing controller.
+    method names stable for FastAPI routes.
     """
 
     def __init__(self, cfg: Settings):
@@ -172,40 +129,33 @@ class AttributionHttpAdapter:
             cfg: Application settings (ALLOWED_ROOT must be validated via setup())
         """
         self.cfg = cfg
-        if cfg.ANALYSIS_BACKEND == "lib":
-            restart_config = restart_agent_config_from_settings(cfg)
-            self._backend: AttributionServiceBackend = RestartAgentServiceBackend(
-                allowed_root=cfg.ALLOWED_ROOT,
-                runtime=build_restart_agent_runtime(restart_config),
-                config=restart_config,
-                convergence=LogConvergencePolicy(
-                    quiet_seconds=cfg.RESTART_AGENT_LOG_QUIET_SECONDS,
-                    max_wait_seconds=cfg.RESTART_AGENT_LOG_MAX_WAIT_SECONDS,
-                    poll_seconds=cfg.RESTART_AGENT_LOG_POLL_SECONDS,
+        restart_config = restart_agent_config_from_settings(cfg)
+        self._backend: AttributionServiceBackend = RestartAgentServiceBackend(
+            allowed_root=cfg.ALLOWED_ROOT,
+            runtime=build_restart_agent_runtime(restart_config),
+            config=restart_config,
+            convergence=LogConvergencePolicy(
+                quiet_seconds=cfg.RESTART_AGENT_LOG_QUIET_SECONDS,
+                max_wait_seconds=cfg.RESTART_AGENT_LOG_MAX_WAIT_SECONDS,
+                poll_seconds=cfg.RESTART_AGENT_LOG_POLL_SECONDS,
+            ),
+            progressive=ProgressiveAnalysisPolicy(
+                enabled=(
+                    cfg.RESTART_AGENT_PROGRESSIVE_ENABLED and cfg.PROGRESSIVE_ANALYSIS != "off"
                 ),
-                progressive=ProgressiveAnalysisPolicy(
-                    enabled=(
-                        cfg.RESTART_AGENT_PROGRESSIVE_ENABLED and cfg.PROGRESSIVE_ANALYSIS != "off"
-                    ),
-                    pre_end_poll_seconds=cfg.RESTART_AGENT_PRE_END_POLL_SECONDS,
-                    active_idle_seconds=cfg.RESTART_AGENT_ACTIVE_IDLE_SECONDS,
-                    max_active_states=cfg.RESTART_AGENT_MAX_ACTIVE_STATES,
-                    max_completed_results=cfg.RESTART_AGENT_MAX_COMPLETED_RESULTS,
+                pre_end_poll_seconds=cfg.RESTART_AGENT_PRE_END_POLL_SECONDS,
+                active_idle_seconds=cfg.RESTART_AGENT_ACTIVE_IDLE_SECONDS,
+                max_active_states=cfg.RESTART_AGENT_MAX_ACTIVE_STATES,
+                max_completed_results=cfg.RESTART_AGENT_MAX_COMPLETED_RESULTS,
+            ),
+            accumulator_factory=partial(
+                ProgressiveL0Accumulator,
+                reader=ChunkedLogReader(
+                    chunk_bytes=restart_config.l0_source.chunk_size_bytes,
+                    read_mode=restart_config.l0_source.read_mode,
                 ),
-                accumulator_factory=partial(
-                    ProgressiveL0Accumulator,
-                    reader=ChunkedLogReader(
-                        chunk_bytes=restart_config.l0_source.chunk_size_bytes,
-                        read_mode=restart_config.l0_source.read_mode,
-                    ),
-                ),
-            )
-        else:
-            if cfg.RESTART_AGENT_CONFIG:
-                raise ValueError("RESTART_AGENT_CONFIG requires ANALYSIS_BACKEND=lib")
-            from nvidia_resiliency_ext.attribution.controller import AttributionController
-
-            self._backend = AttributionController(_controller_config_from_settings(cfg))
+            ),
+        )
         logger.info("Initialized AttributionHttpAdapter backend=%s", cfg.ANALYSIS_BACKEND)
 
     def shutdown(self) -> None:
@@ -214,24 +164,24 @@ class AttributionHttpAdapter:
         logger.info("AttributionHttpAdapter shutdown complete")
 
     async def shutdown_async(self) -> None:
-        """Shutdown the adapter including MCP client cleanup."""
+        """Shutdown the adapter and stop backend-owned async resources."""
         await self._backend.shutdown_async()
         logger.info("AttributionHttpAdapter shutdown complete")
 
     async def start(self, loop: asyncio.AbstractEventLoop | None = None) -> dict[str, Any]:
-        """Start controller-owned runtime dependencies."""
+        """Start backend-owned runtime dependencies."""
         return await self._backend.start(loop)
 
     async def save_cache(self, cache_file: str | None = None) -> bool:
-        """Save controller cache to file for persistence across restarts."""
+        """Save backend cache to file when the backend supports persistence."""
         return await self._backend.save_cache(cache_file)
 
     async def load_cache(self, cache_file: str | None = None) -> int:
-        """Load controller cache from file."""
+        """Load backend cache from file when the backend supports persistence."""
         return await self._backend.load_cache(cache_file)
 
     async def check_mcp_health(self, timeout_seconds: float = 5.0) -> tuple[str, str]:
-        """Check MCP backend health."""
+        """Return MCP health compatibility status."""
         return await self._backend.check_mcp_health(timeout_seconds)
 
     def validate_path(
@@ -272,7 +222,7 @@ class AttributionHttpAdapter:
         wl_restart: int | None = None,
         wait: bool = True,
     ) -> LogAnalysisCycleResult | LogAnalysisSplitlogResult | LogAnalyzerError:
-        """Analyze a log file using the configured attribution backend."""
+        """Analyze a log file using the direct Restart Agent backend."""
         return await self._backend.analyze_log(
             log_path,
             file=file,
@@ -287,7 +237,7 @@ class AttributionHttpAdapter:
         return self._backend.read_file_preview(log_path, max_bytes=max_bytes)
 
     async def get_stats(self) -> dict[str, Any]:
-        """Get controller, cache, posting/dataflow, and Slack statistics."""
+        """Get direct Restart Agent backend statistics."""
         return await self._backend.get_stats()
 
     async def get_cache(self) -> CacheResult:

--- a/src/nvidia_resiliency_ext/skills/nvrx-attr/SKILL.md
+++ b/src/nvidia_resiliency_ext/skills/nvrx-attr/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Orchestration layer over nvidia_resiliency_ext attribution modules. Provides
   log-analysis, fr-analysis, and a Megatron-LM-oriented fault-injection feedback
   loop for benchmarking attribution quality on SLURM workloads.
-compatibility: Requires Python 3.10+, nvidia-resiliency-ext installed, logsage, langchain-openai, and LLM_API_KEY (env var, LLM_API_KEY_FILE, or ~/.llm_api_key). The fault-injection loop has only been validated with Megatron-LM workloads.
+compatibility: Requires Python 3.10+, nvidia-resiliency-ext[attribution] installed, and LLM_API_KEY (env var, LLM_API_KEY_FILE, or ~/.llm_api_key). The fault-injection loop has only been validated with Megatron-LM workloads.
 metadata:
   author: nvidia
 ---
@@ -46,9 +46,7 @@ full coalescing stack.
 ## Common prerequisites
 
 - `LLM_API_KEY` environment variable, `LLM_API_KEY_FILE`, or `~/.llm_api_key`
-- `langchain-openai` installed
-- `logsage` package installed (required by `log_analysis`)
-- Package installed: `pip install nvidia-resiliency-ext` or `pip install -e .` from repo root
+- Package installed: `pip install 'nvidia-resiliency-ext[attribution]'` or `pip install -e '.[attribution]'` from repo root
 - The fault-injection loop has only been validated with Megatron-LM training scripts
 
 ## Fault-Loop Local Setup

--- a/src/nvidia_resiliency_ext/skills/nvrx-attr/fault-injection-loop/SKILL.md
+++ b/src/nvidia_resiliency_ext/skills/nvrx-attr/fault-injection-loop/SKILL.md
@@ -8,7 +8,7 @@ description: >
   After all jobs complete, runs /log-analysis and /fr-analysis on every experiment,
   scores attribution vs. ground truth, aggregates gaps, and iterates on attribution
   modules to close them.
-compatibility: Requires SLURM cluster access, sbatch, LLM_API_KEY, langchain-openai, logsage, and nvidia-resiliency-ext installed. This workflow has only been validated with Megatron-LM workloads.
+compatibility: Requires SLURM cluster access, sbatch, LLM_API_KEY, and nvidia-resiliency-ext[attribution] installed. This workflow has only been validated with Megatron-LM workloads.
 metadata:
   author: nvidia
   sub-skills: [log-analysis, fr-analysis]

--- a/src/nvidia_resiliency_ext/skills/nvrx-attr/log-analysis/SKILL.md
+++ b/src/nvidia_resiliency_ext/skills/nvrx-attr/log-analysis/SKILL.md
@@ -5,7 +5,7 @@ description: >
   NVRxLogAnalyzer. Use when you have a SLURM training job log and need to determine why the
   job failed and whether it should be restarted. Performs per-cycle chunking, fast-path pattern
   matching, and LLM-based classification.
-compatibility: Requires LLM_API_KEY, langchain-openai, and logsage packages installed. nvidia-resiliency-ext must be installed.
+compatibility: Requires LLM_API_KEY and nvidia-resiliency-ext[attribution] installed.
 metadata:
   entry-point: NVRxLogAnalyzer
   script: scripts/nvrx_logsage.py
@@ -113,4 +113,4 @@ is emitted separately as `recommendation.action` / `recommendation.source`. The 
 ## Prerequisites
 
 - `LLM_API_KEY` set (env var, `LLM_API_KEY_FILE`, or `~/.llm_api_key`)
-- `langchain-openai` and `logsage` packages installed
+- Package installed: `pip install 'nvidia-resiliency-ext[attribution]'` or `pip install -e '.[attribution]'` from repo root

--- a/tests/attribution/unit/test_attrsvc_settings.py
+++ b/tests/attribution/unit/test_attrsvc_settings.py
@@ -63,6 +63,13 @@ def test_attrsvc_analysis_backend_uses_current_env_name_only(tmp_path, monkeypat
     assert cfg.ANALYSIS_BACKEND == "lib"
 
 
+def test_attrsvc_analysis_backend_rejects_mcp(tmp_path, monkeypatch):
+    monkeypatch.setenv("NVRX_ATTRSVC_ANALYSIS_BACKEND", "mcp")
+
+    with pytest.raises(ValueError, match="only supports 'lib'"):
+        Settings(ALLOWED_ROOT=str(tmp_path), _env_file=None)
+
+
 def test_attrsvc_progressive_analysis_defaults_to_all_explicit(tmp_path, monkeypatch):
     monkeypatch.delenv("NVRX_ATTRSVC_PROGRESSIVE_ANALYSIS", raising=False)
 

--- a/tests/attribution/unit/test_mcp_server_command.py
+++ b/tests/attribution/unit/test_mcp_server_command.py
@@ -3,7 +3,6 @@
 
 import sys
 import unittest
-from unittest.mock import patch
 
 PY310_PLUS = sys.version_info >= (3, 10)
 
@@ -13,21 +12,19 @@ if PY310_PLUS:
 
 @unittest.skipUnless(PY310_PLUS, "attribution tests require Python 3.10+")
 class TestGetServerCommand(unittest.TestCase):
-    def test_prefers_nvrx_mcp_analysis_on_path(self):
-        with patch(
-            "nvidia_resiliency_ext.attribution.mcp_integration.mcp_client.shutil.which"
-        ) as w:
-            w.return_value = "/opt/conda/bin/nvrx-mcp-analysis"
-            cmd = get_server_command()
-        self.assertEqual(cmd, ["/opt/conda/bin/nvrx-mcp-analysis", "--log-level", "INFO"])
+    def test_uses_packaged_server_launcher(self):
+        cmd = get_server_command()
+
+        self.assertEqual(cmd[0], sys.executable)
+        self.assertTrue(cmd[1].endswith("server_launcher.py"))
+        self.assertEqual(cmd[2:], ["--log-level", "INFO"])
 
     def test_log_level_override(self):
-        with patch(
-            "nvidia_resiliency_ext.attribution.mcp_integration.mcp_client.shutil.which"
-        ) as w:
-            w.return_value = "/opt/conda/bin/nvrx-mcp-analysis"
-            cmd = get_server_command(log_level="debug")
-        self.assertEqual(cmd, ["/opt/conda/bin/nvrx-mcp-analysis", "--log-level", "DEBUG"])
+        cmd = get_server_command(log_level="debug")
+
+        self.assertEqual(cmd[0], sys.executable)
+        self.assertTrue(cmd[1].endswith("server_launcher.py"))
+        self.assertEqual(cmd[2:], ["--log-level", "DEBUG"])
 
 
 if __name__ == "__main__":

--- a/tests/fault_tolerance/unit/test_attribution_manager.py
+++ b/tests/fault_tolerance/unit/test_attribution_manager.py
@@ -195,7 +195,7 @@ def test_attribution_config_maps_launcher_args(tmp_path):
             ft_attribution_llm_api_key_file=str(api_key_file),
             ft_attribution_llm_base_url="https://llm.example/v1",
             ft_attribution_llm_model="model-a",
-            ft_attribution_analysis_backend="mcp",
+            ft_attribution_analysis_backend="lib",
             ft_attribution_log_level="DEBUG",
             ft_attribution_export_url=(
                 "https://dataflow.example.test/dataflow2/example-index/posting"
@@ -211,7 +211,7 @@ def test_attribution_config_maps_launcher_args(tmp_path):
     assert env["NVRX_ATTRSVC_ALLOWED_ROOT"] == str(applog_dir)
     assert env["NVRX_ATTRSVC_LLM_BASE_URL"] == "https://llm.example/v1"
     assert env["NVRX_ATTRSVC_LLM_MODEL"] == "model-a"
-    assert env["NVRX_ATTRSVC_ANALYSIS_BACKEND"] == "mcp"
+    assert env["NVRX_ATTRSVC_ANALYSIS_BACKEND"] == "lib"
     assert env["NVRX_ATTRSVC_LOG_LEVEL"] == "DEBUG"
     assert (
         env["NVRX_ATTRSVC_EXPORT_URL"]
@@ -230,6 +230,18 @@ def test_attribution_config_accepts_lib_analysis_backend(tmp_path):
     )
 
     assert cfg.analysis_backend == "lib"
+
+
+def test_attribution_config_rejects_mcp_analysis_backend(tmp_path):
+    with pytest.raises(ValueError, match="only supports 'lib'"):
+        AttributionConfig.from_args(
+            _args(
+                ft_attribution_endpoint="localhost",
+                ft_attribution_analysis_backend="mcp",
+            ),
+            str(tmp_path / "train.log"),
+            FaultToleranceConfig(),
+        )
 
 
 def test_managed_attrsvc_inherits_log_convergence_overrides(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Attribution currently pulls in a large dependency stack by default, including LogSage, LangChain, MCP, and Slack-related packages. That makes the default NVRx install heavier than necessary for users who only need the regular FT / Restart Agent / attrsvc path.

This PR moves the optional attribution dependency stack behind the `nvidia-resiliency-ext[attribution]` extra. The functionality remains available for users who need those attribution workflows, while the default install stays smaller and easier for regular NVRx users.

## What changed

- Keep `nvrx-attrsvc` and the direct Restart Agent backend in the default install.
- Move optional attribution dependencies to `[attribution]`:
  - `logsage`
  - `langchain-core`
  - `langchain-openai`
  - `mcp`
  - `setproctitle`
  - Slack SDK packages
- Remove MCP as a launcher-managed / attrsvc-selectable backend.
- Keep lower-level MCP code available for explicit use after installing `[attribution]`.
- Update docs, service scripts, and tests for the new install contract.