### PR TITLE
[WIP] #405 - Optimize CPU-SHM snapshot copies

### DIFF
--- a/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
+++ b/src/nvidia_resiliency_ext/checkpointing/async_ckpt/filesystem_async.py
@@ -154,6 +154,13 @@ def _compute_tensor_data_ptrs(items: List[WriteItem], tensors: List[Any]) -> Tup
     return tuple(ptrs)
 
 
+def _synchronize_current_cuda_stream() -> None:
+    """Wait for work queued on the current CUDA stream without synchronizing the device."""
+    event = torch.cuda.Event()
+    event.record(torch.cuda.current_stream())
+    event.synchronize()
+
+
 @_disable_gc()
 def get_write_results_queue(mp_mode: str = 'spawn') -> mp.Queue:
     """Get or create a multiprocessing queue for write results.
@@ -371,10 +378,10 @@ class FileSystemWriterAsync(FileSystemWriter):
                         # pages (shm tensors are not pinned so copy_ is not a pinned DMA).
                         pending_cuda_copies += int(source_t.device.type == "cuda")
                         if pending_cuda_copies == 8:
-                            torch.cuda.synchronize()
+                            _synchronize_current_cuda_stream()
                             pending_cuda_copies = 0
                     if pending_cuda_copies:
-                        torch.cuda.synchronize()
+                        _synchronize_current_cuda_stream()
                     logger.debug(
                         f"Copied {len(shm_tensors)} tensors into reused shm allocations "
                         f"(key={key})"
@@ -385,21 +392,18 @@ class FileSystemWriterAsync(FileSystemWriter):
                     shm_tensors = []
                     total_bytes = 0
                     pending_cuda_copies = 0
-                    for tensor in cacheable_data:
-                        contiguous_tensor = tensor.contiguous()
-                        shm_t = torch.empty(
-                            contiguous_tensor.shape, dtype=contiguous_tensor.dtype
-                        ).share_memory_()
-                        shm_t.copy_(contiguous_tensor, non_blocking=True)
+                    for source_t in cacheable_data:
+                        shm_t = torch.empty(source_t.shape, dtype=source_t.dtype).share_memory_()
+                        shm_t.copy_(source_t, non_blocking=True)
                         shm_tensors.append(shm_t)
                         total_bytes += shm_t.nbytes
                         # Periodically sync to avoid exhausting CUDA's pageable staging pages
-                        pending_cuda_copies += int(contiguous_tensor.device.type == "cuda")
+                        pending_cuda_copies += int(source_t.device.type == "cuda")
                         if pending_cuda_copies == 8:
-                            torch.cuda.synchronize()
+                            _synchronize_current_cuda_stream()
                             pending_cuda_copies = 0
                     if pending_cuda_copies:
-                        torch.cuda.synchronize()
+                        _synchronize_current_cuda_stream()
                     if self.use_cached_data_structure:
                         FileSystemWriterAsync._shm_tensor_cache[key] = (
                             cacheable_items,

--- a/tests/checkpointing/unit/test_preload_snapshot.py
+++ b/tests/checkpointing/unit/test_preload_snapshot.py
@@ -17,11 +17,15 @@
 
 from unittest.mock import Mock
 
+import pytest
 import torch
 from torch.distributed.checkpoint.metadata import MetadataIndex
 from torch.distributed.checkpoint.planner import SavePlan, WriteItem, WriteItemType
 
-from nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async import FileSystemWriterAsync
+from nvidia_resiliency_ext.checkpointing.async_ckpt.filesystem_async import (
+    FileSystemWriterAsync,
+    _synchronize_current_cuda_stream,
+)
 
 
 def _tensor_write_items(count):
@@ -70,7 +74,9 @@ class TestFileSystemWriterPrepareSnapshot:
     def test_cpu_shm_snapshots_and_reuses_cpu_tensor_storage(self, tmp_path, monkeypatch):
         """CPU tensors use the reusable snapshot cache in CPU shared-memory mode."""
         cuda_synchronize = Mock()
+        cuda_event = Mock()
         monkeypatch.setattr(torch.cuda, "synchronize", cuda_synchronize)
+        monkeypatch.setattr(torch.cuda, "Event", cuda_event)
         drain = Mock()
         FileSystemWriterAsync.cleanup_tensor_caches()
         FileSystemWriterAsync.register_shm_drain_callback(drain)
@@ -108,6 +114,60 @@ class TestFileSystemWriterPrepareSnapshot:
             assert torch.equal(reused_snapshot, torch.tensor(2.0))
             drain.assert_called_once_with()
             cuda_synchronize.assert_not_called()
+            cuda_event.assert_not_called()
         finally:
             FileSystemWriterAsync.register_shm_drain_callback(None)
             FileSystemWriterAsync.cleanup_tensor_caches()
+
+    def test_cuda_copy_wait_uses_current_stream_event(self, monkeypatch):
+        """The copy barrier must not synchronize unrelated CUDA streams."""
+        cuda_synchronize = Mock()
+        current_stream = Mock()
+        event = Mock()
+        monkeypatch.setattr(torch.cuda, "synchronize", cuda_synchronize)
+        monkeypatch.setattr(torch.cuda, "current_stream", Mock(return_value=current_stream))
+        monkeypatch.setattr(torch.cuda, "Event", Mock(return_value=event))
+
+        _synchronize_current_cuda_stream()
+
+        event.record.assert_called_once_with(current_stream)
+        event.synchronize.assert_called_once_with()
+        cuda_synchronize.assert_not_called()
+
+    @staticmethod
+    def _tensor_layout(layout, device):
+        base = torch.arange(64, dtype=torch.float32, device=device).reshape(8, 8)
+        if layout == "contiguous":
+            return base
+        if layout == "transpose":
+            return base.t()
+        if layout == "strided_offset":
+            return base[1:7:2, 1:8:2]
+        raise ValueError(f"Unknown layout: {layout}")
+
+    @torch.no_grad()
+    @pytest.mark.parametrize("layout", ["contiguous", "transpose", "strided_offset"])
+    @pytest.mark.parametrize(
+        "device",
+        [
+            "cpu",
+            pytest.param(
+                "cuda",
+                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required"),
+            ),
+        ],
+    )
+    def test_cpu_shm_direct_copy_supports_tensor_layouts(self, layout, device, tmp_path):
+        source = self._tensor_layout(layout, device)
+
+        writer = self._prepare_writer(
+            tmp_path,
+            [source],
+            use_cpu_shm_for_gpu_tensors=True,
+        )
+
+        _, snapshots = writer.cached_tensor_data
+        (snapshot,) = snapshots
+        assert snapshot.is_contiguous()
+        assert snapshot.untyped_storage().is_shared()
+        assert torch.equal(snapshot, source.cpu())


### PR DESCRIPTION
## Summary

- copy CPU and CUDA sources directly into contiguous shared-memory snapshots instead of explicitly materializing `source.contiguous()` first;
- replace device-wide synchronization in both the initial-allocation and cache-reuse paths with an event recorded on the current CUDA stream;
- preserve the existing wait-after-eight-copies staging-page backpressure and the SHM cache drain/ownership protocol;
- cover CPU-only behavior, event scoping, and contiguous/transpose/strided-offset inputs on CPU and CUDA.

Refs #405.

## Dependency

This is a stacked WIP PR on top of #376 and therefore targets its upstream branch, `nvbug6439229`. Once #376 lands, this branch can be rebased and the PR base changed to `main`.

#376 is required because it routes CPU-resident tensors through the same owned CPU-SHM snapshot path. This PR does not change its snapshot isolation or reuse/drain semantics.

## Synchronization semantics

The event remains a host-side completion barrier for the copies that produce the snapshot, but it no longer waits for unrelated work on other CUDA streams. The periodic wait after eight CUDA sources is retained as backpressure for pageable/shared-memory staging pages.

## H200 benchmark

Environment: one NVIDIA H200 NVL, PyTorch `2.11.0+cu130`, 141 GiB `/dev/shm`; square FP32 transpose source; contiguous SHM destination. Copy-only numbers are medians of nine iterations after warmup.

### Reused SHM destination

| Source | Size | Current | This PR | Change |
|---|---:|---:|---:|---:|
| CPU | 64 MiB | 28.301 ms | 11.883 ms | -58.01% |
| CPU | 256 MiB | 99.407 ms | 47.185 ms | -52.53% |
| CPU | 1 GiB | 394.121 ms | 189.257 ms | -51.98% |
| CUDA | 64 MiB | 2.436 ms | 2.441 ms | +0.21% |
| CUDA | 256 MiB | 9.589 ms | 9.591 ms | +0.02% |
| CUDA | 1 GiB | 38.173 ms | 38.186 ms | +0.04% |

For fresh SHM allocation plus copy, the CPU-source path improved by 28-38% from 64 MiB through 1 GiB. The CUDA-source path remained within 0-3% in that three-iteration allocation-heavy microbenchmark.

PyTorch profiler shows that PyTorch 2.11 currently materializes a full-size contiguous CUDA temporary internally for a strided CUDA-to-CPU `copy_`, so CUDA peak temporary allocation remains unchanged. This PR removes the forced materialization from NVRx without regressing CUDA copy latency; the clear direct-copy benefit on this stack is for CPU-resident non-contiguous sources.

### Unrelated-stream interference

With `torch.cuda._sleep(2_000_000_000)` queued on an unrelated stream while copying a 64 MiB snapshot:

| Barrier | Host wait |
|---|---:|
| `torch.cuda.synchronize()` | 1124.072 ms |
| current-stream event | 2.564 ms |

The event wait returned while the unrelated stream was still running, and the SHM snapshot contents were correct.

## Validation

- `black --check .` (380 files unchanged)
- `isort --check-only .`
- `ruff check .`
- `tests/checkpointing/unit/test_preload_snapshot.py`: 10 passed
- `tests/checkpointing/unit/test_async_writer.py`: 19 passed on one H200/NCCL rank
- torn-checkpoint mode matrix `(cached structure on/off) × (CPU SHM on/off)`: 4 passed
