### PR TITLE
Make LogSage imports lazy and add [logsage] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ grpcio-tools = "^1.76.0"
 protobuf = ">=4.22.0"
 
 [tool.poetry.extras]
+# Full attribution stack: LogSage log analysis + MCP server + Slack posting.
 attribution = [
     "langchain-core",
     "langchain-openai",
@@ -73,6 +74,12 @@ attribution = [
     "setproctitle",
     "slack-bolt",
     "slack-sdk",
+]
+# LogSage-only alias for users who want the log analyzer but not MCP / Slack.
+logsage = [
+    "langchain-core",
+    "langchain-openai",
+    "logsage",
 ]
 
 [tool.poetry.scripts]

--- a/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr.py
+++ b/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr.py
@@ -13,7 +13,10 @@ from nvidia_resiliency_ext.attribution.base import (
     merged_attribution_config,
     normalize_attribution_args,
 )
-from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
+
+# ``NVRxLogAnalyzer`` requires LogSage / LangChain (installed via the ``[attribution]`` extra);
+# it is imported lazily inside :func:`main` so that ``CombinedLogFR`` (the merge class) is
+# importable under the default install.
 from nvidia_resiliency_ext.attribution.logging_utils import bounded_log_value
 from nvidia_resiliency_ext.attribution.orchestration.config import (
     DEFAULT_LLM_BASE_URL,
@@ -161,6 +164,9 @@ def main():
     fr_paths = args_dict.get("fr_path")
     if isinstance(fr_paths, list) and fr_paths:
         args_dict["fr_path"] = fr_paths[0]
+
+    # Lazy import: keeps LogSage / LangChain out of the default install path.
+    from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
 
     log_analyzer = NVRxLogAnalyzer(args_dict)
     log_result = log_analyzer.run_sync(args_dict)

--- a/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py
+++ b/src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from nvidia_resiliency_ext.attribution.base import AttributionState
 from nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr import CombinedLogFR
 from nvidia_resiliency_ext.attribution.combined_log_fr.llm_merge import unpack_run_result
-from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
+
+# ``NVRxLogAnalyzer`` pulls in LogSage / LangChain (see the ``[attribution]`` extra); imported
+# lazily inside :meth:`CombinedLogFRMCPOrchestrator._run_from_paths` so this module can be
+# imported under the default install (e.g. for typing / registration paths that never run it).
 from nvidia_resiliency_ext.attribution.orchestration.config import (
     MODULE_LOG_ANALYZER,
     MODULE_LOG_FR_ANALYZER,
@@ -25,6 +28,9 @@ from nvidia_resiliency_ext.attribution.trace_analyzer.fr_attribution import Coll
 from nvidia_resiliency_ext.attribution.trace_analyzer.fr_support import (
     fr_path_resolvable_for_collective_analyzer,
 )
+
+if TYPE_CHECKING:
+    from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -223,6 +229,9 @@ class CombinedLogFRMCPOrchestrator:
         }
 
         async def _run_log_analyzer() -> Any:
+            # Lazy import: keeps LogSage / LangChain out of the default install path.
+            from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
+
             async with self._log_analyzer_lock:
                 if self._log_analyzer is None:
                     self._log_analyzer = NVRxLogAnalyzer(log_kw)

--- a/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
+++ b/src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py
@@ -40,7 +40,8 @@ from nvidia_resiliency_ext.attribution.orchestration.types import (
 
 _ATTRIBUTION_EXTRA_MESSAGE = (
     "LogSage attribution dependencies are not installed. "
-    "Install with: pip install 'nvidia-resiliency-ext[attribution]'"
+    "Install with: pip install 'nvidia-resiliency-ext[logsage]' "
+    "(or 'nvidia-resiliency-ext[attribution]' for the full stack)"
 )
 
 try:

--- a/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
+++ b/src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py
@@ -9,7 +9,10 @@ from typing import Any
 from nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr_mcp import (
     CombinedLogFRMCPOrchestrator,
 )
-from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
+
+# ``NVRxLogAnalyzer`` requires LogSage / LangChain (installed via the ``[attribution]`` extra);
+# it is imported lazily inside :func:`register_all_modules` — the only caller in this module —
+# so the module itself can be imported under the default install.
 from nvidia_resiliency_ext.attribution.mcp_integration.registry import global_registry
 from nvidia_resiliency_ext.attribution.orchestration.config import (
     DEFAULT_LLM_BASE_URL,
@@ -225,6 +228,9 @@ def _progressive_start_output_schema() -> dict[str, Any]:
 
 def register_all_modules():
     """Register all NVRX attribution modules with the global registry."""
+
+    # Lazy import: keeps LogSage / LangChain out of the default install path.
+    from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
 
     # Register Log Analyzer (LogSage)
     global_registry.register(

--- a/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
+++ b/src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py
@@ -19,7 +19,10 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from nvidia_resiliency_ext.attribution.coalescing import LogAnalysisCoalesced
 
 # svc is a connector layer; cross-package imports from attribution.* are intentional.
-from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
+# ``NVRxLogAnalyzer`` pulls in LogSage / LangChain (see ``[attribution]`` extra); we import it
+# lazily inside :meth:`LogSageRunner._get_lib_log_analyzer` so that this module can be imported
+# under the default install (e.g. by :mod:`~nvidia_resiliency_ext.attribution.analyzer.engine`
+# and :class:`~nvidia_resiliency_ext.attribution.controller.AttributionController`).
 from nvidia_resiliency_ext.attribution.mcp_integration import create_mcp_client
 from nvidia_resiliency_ext.attribution.path_utils import path_is_under_allowed_root
 from nvidia_resiliency_ext.attribution.postprocessing import post_analysis_items
@@ -210,6 +213,11 @@ class LogSageRunner:
             if self._lib_log_analyzer_init_error is not None:
                 raise self._lib_log_analyzer_init_error
             try:
+                # Lazy import: keeps LogSage / LangChain out of the default install path.
+                from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import (
+                    NVRxLogAnalyzer,
+                )
+
                 self._lib_log_analyzer = NVRxLogAnalyzer(dict(run_kwargs))
             except Exception as e:
                 self._lib_log_analyzer_init_error = e

--- a/tests/attribution/unit/test_combined_log_fr.py
+++ b/tests/attribution/unit/test_combined_log_fr.py
@@ -180,7 +180,12 @@ def test_log_fr_mcp_path_collects_without_merge_by_default(monkeypatch):
         def __init__(self, _kwargs):
             raise AssertionError("merge LLM should not be constructed unless merge_llm=True")
 
-    monkeypatch.setattr(module, "NVRxLogAnalyzer", FakeLogAnalyzer)
+    # ``NVRxLogAnalyzer`` is imported lazily inside ``_run_from_paths``; patch the source
+    # module so the lazy ``from ... import NVRxLogAnalyzer`` picks up the fake.
+    nvrx_logsage_mod = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage"
+    )
+    monkeypatch.setattr(nvrx_logsage_mod, "NVRxLogAnalyzer", FakeLogAnalyzer, raising=False)
     monkeypatch.setattr(module, "CollectiveAnalyzer", FakeFRAnalyzer)
     monkeypatch.setattr(module, "CombinedLogFR", FakeCombinedLogFR)
     monkeypatch.setattr(module, "fr_path_resolvable_for_collective_analyzer", lambda _path: True)
@@ -241,7 +246,12 @@ def test_log_fr_mcp_path_passes_cycle_counter_to_logsage(monkeypatch):
         def __init__(self, _kwargs):
             raise AssertionError("merge LLM should not be constructed unless merge_llm=True")
 
-    monkeypatch.setattr(module, "NVRxLogAnalyzer", FakeLogAnalyzer)
+    # ``NVRxLogAnalyzer`` is imported lazily inside ``_run_from_paths``; patch the source
+    # module so the lazy ``from ... import NVRxLogAnalyzer`` picks up the fake.
+    nvrx_logsage_mod = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage"
+    )
+    monkeypatch.setattr(nvrx_logsage_mod, "NVRxLogAnalyzer", FakeLogAnalyzer, raising=False)
     monkeypatch.setattr(module, "CollectiveAnalyzer", FakeFRAnalyzer)
     monkeypatch.setattr(module, "CombinedLogFR", FakeCombinedLogFR)
     monkeypatch.setattr(module, "fr_path_resolvable_for_collective_analyzer", lambda _path: True)
@@ -311,7 +321,12 @@ def test_log_fr_mcp_path_reuses_logsage_analyzer_across_cycles(monkeypatch):
         def __init__(self, _kwargs):
             raise AssertionError("merge LLM should not be constructed unless merge_llm=True")
 
-    monkeypatch.setattr(module, "NVRxLogAnalyzer", FakeLogAnalyzer)
+    # ``NVRxLogAnalyzer`` is imported lazily inside ``_run_from_paths``; patch the source
+    # module so the lazy ``from ... import NVRxLogAnalyzer`` picks up the fake.
+    nvrx_logsage_mod = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage"
+    )
+    monkeypatch.setattr(nvrx_logsage_mod, "NVRxLogAnalyzer", FakeLogAnalyzer, raising=False)
     monkeypatch.setattr(module, "CollectiveAnalyzer", FakeFRAnalyzer)
     monkeypatch.setattr(module, "CombinedLogFR", FakeCombinedLogFR)
     monkeypatch.setattr(module, "fr_path_resolvable_for_collective_analyzer", lambda _path: True)
@@ -395,7 +410,12 @@ def test_log_fr_mcp_path_state_ignores_fr_and_merge_stop_when_merge_enabled(monk
                 AttributionState.STOP,
             )
 
-    monkeypatch.setattr(module, "NVRxLogAnalyzer", FakeLogAnalyzer)
+    # ``NVRxLogAnalyzer`` is imported lazily inside ``_run_from_paths``; patch the source
+    # module so the lazy ``from ... import NVRxLogAnalyzer`` picks up the fake.
+    nvrx_logsage_mod = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage"
+    )
+    monkeypatch.setattr(nvrx_logsage_mod, "NVRxLogAnalyzer", FakeLogAnalyzer, raising=False)
     monkeypatch.setattr(module, "CollectiveAnalyzer", FakeFRAnalyzer)
     monkeypatch.setattr(module, "CombinedLogFR", FakeCombinedLogFR)
     monkeypatch.setattr(module, "fr_path_resolvable_for_collective_analyzer", lambda _path: True)
@@ -466,7 +486,12 @@ def test_log_fr_mcp_path_merge_unwraps_logsage_result_for_llm(monkeypatch):
             captured["run_log_input"] = kwargs["input_data"][0]
             return ("merged", AttributionState.CONTINUE)
 
-    monkeypatch.setattr(module, "NVRxLogAnalyzer", FakeLogAnalyzer)
+    # ``NVRxLogAnalyzer`` is imported lazily inside ``_run_from_paths``; patch the source
+    # module so the lazy ``from ... import NVRxLogAnalyzer`` picks up the fake.
+    nvrx_logsage_mod = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage"
+    )
+    monkeypatch.setattr(nvrx_logsage_mod, "NVRxLogAnalyzer", FakeLogAnalyzer, raising=False)
     monkeypatch.setattr(module, "CollectiveAnalyzer", FakeFRAnalyzer)
     monkeypatch.setattr(module, "CombinedLogFR", FakeCombinedLogFR)
     monkeypatch.setattr(module, "fr_path_resolvable_for_collective_analyzer", lambda _path: True)
@@ -526,7 +551,12 @@ def test_log_fr_mcp_skips_merge_when_fr_data_is_missing(monkeypatch):
         def __init__(self, _kwargs):
             raise AssertionError("merge LLM should not be constructed without FR data")
 
-    monkeypatch.setattr(module, "NVRxLogAnalyzer", FakeLogAnalyzer)
+    # ``NVRxLogAnalyzer`` is imported lazily inside ``_run_from_paths``; patch the source
+    # module so the lazy ``from ... import NVRxLogAnalyzer`` picks up the fake.
+    nvrx_logsage_mod = importlib.import_module(
+        "nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage"
+    )
+    monkeypatch.setattr(nvrx_logsage_mod, "NVRxLogAnalyzer", FakeLogAnalyzer, raising=False)
     monkeypatch.setattr(module, "CollectiveAnalyzer", FakeFRAnalyzer)
     monkeypatch.setattr(module, "CombinedLogFR", FakeCombinedLogFR)
     monkeypatch.setattr(module, "fr_path_resolvable_for_collective_analyzer", lambda _path: True)


### PR DESCRIPTION
## Motivation

PR #404 moved the LogSage / LangChain / MCP / Slack dependency stack behind the `nvidia-resiliency-ext[attribution]` optional extra so the default `pip install .` no longer pulls it in. That's the right call — LogSage is chunky and no longer part of the mainline NVRx path.

However the packaging change was only half the job. Several modules still eagerly imported `NVRxLogAnalyzer` at the top of the file, so anything downstream of `Analyzer` / `AttributionController` (both exposed as lazy exports on `nvidia_resiliency_ext.attribution`) blew up on `ModuleNotFoundError: langchain_core` under the default install:

```
>>> from nvidia_resiliency_ext.attribution import AttributionController
ModuleNotFoundError: LogSage attribution dependencies are not installed.
    Install with: pip install 'nvidia-resiliency-ext[attribution]'
```

The default install must let users touch the base API without LangChain being installed.

## What changed

**Lazy imports** — four files that imported `NVRxLogAnalyzer` at module top now import it at call sites:

- `src/nvidia_resiliency_ext/attribution/orchestration/log_analyzer.py` — moved the import into `LogSageRunner._get_lib_log_analyzer`.
- `src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr.py` — moved the import into the `main()` CLI entrypoint. The `CombinedLogFR` merge class does not use it.
- `src/nvidia_resiliency_ext/attribution/combined_log_fr/combined_log_fr_mcp.py` — moved the import into `_run_from_paths._run_log_analyzer`; used `TYPE_CHECKING` for the surviving annotation.
- `src/nvidia_resiliency_ext/attribution/mcp_integration/module_definitions.py` — moved the import into `register_all_modules()`.

**pyproject.toml** — added a narrower `[logsage]` extra that installs only `langchain-core`, `langchain-openai`, and `logsage`. The existing `[attribution]` extra (which also brings in MCP, Slack, setproctitle) is preserved as the full-stack umbrella.

**Error message** — updated the guard in `nvrx_logsage.py` to point at both extras.

**Tests** — six sites in `tests/attribution/unit/test_combined_log_fr.py` monkeypatched `NVRxLogAnalyzer` as a module attribute on `combined_log_fr_mcp`. They now patch it on the source (`log_analyzer.nvrx_logsage`) so the lazy `from ... import NVRxLogAnalyzer` inside the async runner picks up the fake.

**Logsage source stays in-tree** — no code deleted. The `nvrx_logsage.py` module still lives at `src/nvidia_resiliency_ext/attribution/log_analyzer/nvrx_logsage.py` and continues to raise a friendly error when the extras are not installed.

## How to install

- Default (no LogSage): `pip install .`
- LogSage only: `pip install '.[logsage]'`
- Full attribution stack (LogSage + MCP + Slack): `pip install '.[attribution]'`

## Verification (fresh venv)

```
$ virtualenv /tmp/venv && cd repo
$ STRAGGLER_DET_SKIP_CUPTI_EXT_BUILD=1 /tmp/venv/bin/pip install .
Successfully installed ... (no langchain / logsage / mcp / slack)

$ /tmp/venv/bin/pip list | grep -iE 'langchain|langgraph|openai|logsage|mcp|slack|setproctitle'
(empty)

$ /tmp/venv/bin/python -c "
from nvidia_resiliency_ext.attribution import Analyzer, AttributionController
import nvidia_resiliency_ext.attribution.controller
import nvidia_resiliency_ext.attribution.analyzer
import nvidia_resiliency_ext.attribution.combined_log_fr.combined_log_fr_mcp
import nvidia_resiliency_ext.attribution.mcp_integration.module_definitions
print('all imports OK')
"
all imports OK

$ STRAGGLER_DET_SKIP_CUPTI_EXT_BUILD=1 /tmp/venv/bin/pip install '.[logsage]'
Successfully installed langchain-* langchain-core-* langchain-openai-* logsage-* openai-*

$ /tmp/venv/bin/python -c "
from nvidia_resiliency_ext.attribution.log_analyzer.nvrx_logsage import NVRxLogAnalyzer
print('logsage import OK')
"
logsage import OK

$ /tmp/venv/bin/python -m pytest tests/attribution/unit -q
485 passed, 15 skipped
```

One unrelated pre-existing flake in `test_restart_agent_progressive.py::test_unchanged_poll_is_metadata_only_and_same_size_rewrite_resets` reproduces on unmodified `main` and is out of scope for this PR.

## Test plan
- [ ] CI green on default install
- [ ] CI green with `[attribution]` extra installed
- [ ] Manual smoke: `nvrx-attrsvc` with LogSage runtime (needs `[attribution]`)