### PR TITLE
Category-driven STOP context in restart_agent

### DIFF
--- a/docs/design/attribution/restart_agent/l1_category_selection.md
+++ b/docs/design/attribution/restart_agent/l1_category_selection.md
@@ -1,0 +1,73 @@
+# L1 Category Selection as Policy-Context Input
+
+This document describes the L1 category-selection signal and how it participates in the L4 policy layer.
+
+## Motivation
+
+The L4 policy cascade decides RESTART / STOP based on typed claims that come out of the L1 layer (`failure_domain`, `retry_outlook_without_workload_change`) and deterministic classifier signals (`FailureClassifier`). Two problem clusters remained:
+
+1. **STOP-worthy deterministic workload errors.** Permission errors, launch-config faults, checkpoint format/shape mismatches, and missing datasets do not reliably surface as `retry_outlook = cannot_recover` with `status = established_by_current_log` from the LLM, so the abstract cascade does not fire `workload_unrecoverable`. These cases end up RESTART when they should STOP.
+
+2. **Concrete-vs-abstract capability gap.** Empirically, LLMs are ~20 pp more accurate at picking a category from a curated taxonomy than at emitting the abstract `failure_domain` / `retry_outlook` typed claims that L4's base rule cascade consumes.
+
+A concrete signal — "pick one of the N curated categories" — is a more reliable route to a correct L4 decision than the abstract typed claims alone for these cases.
+
+## Design principle alignment
+
+| Principle | Handling |
+|-----------|----------|
+| **D2 (L2 non-overriding).** L1 category selection is a top-level *sibling* of the typed L1 claims. L2 grounding still applies to the primary/observation; category selection is not affected by L2. Raw L1 output is preserved verbatim. |
+| **D8 (score-free deterministic policy).** No confidence threshold gate. The STOP context fires when the primary is grounded and `category.decision == "STOP"`. RESTART-labeled categories fall through to the base rule cascade unless the opt-in RESTART context is enabled. |
+| **D9 (declared policy context).** Both category-driven contexts (STOP and RESTART) run *after* every deterministic classifier context (`cuda_oom_no_retry`, `port_bind_confirmation_retry`, `rejected_iteration_retry_then_skip`). Precedence is explicit and testable. |
+| **D14 (visible surfaces separate from root).** Category-driven contexts require `primary is not None`. When only an observation is available, the category has no policy authority. |
+
+## Integration shape
+
+Four additions to the L4 layer:
+
+1. **L1 schema.** `category_selection: { category_id, category_confidence, category_rationale }` is a required top-level field on the L1 response. `category_id = 0` and `category_confidence = 0` is the sanctioned "no listed category matches" placeholder.
+
+2. **`l1_category_confirmed_stop` policy context.** Matches when:
+   - `primary is not None` (grounded)
+   - `category_by_id(category_id).decision == "STOP"`
+
+   Effective policy: `rule = workload_unrecoverable`, `allowed_retries = 0`, `policy_context_id = "l1_category_confirmed_stop"`. Runs after every deterministic classifier context. Enabled by default in `PolicyContextConfig`.
+
+3. **`l1_category_confirmed_restart` policy context (opt-in).** Matches when:
+   - `primary is not None`
+   - `category_by_id(category_id).decision == "RESTART"`
+   - `base_rule == workload_unrecoverable` (only overrides this specific STOP rule)
+   - `history.matching_root_attempts == 0` (first-occurrence guard)
+
+   Effective policy: `rule = workload_confirmation_retry`, `history_match_scope = ROOT_ONLY`, `allowed_retries = 1`, `policy_context_id = "l1_category_confirmed_restart"`. Runs *after* the STOP context. Disabled by default (`PolicyContextConfig.l1_category_confirmed_restart.enabled = False`).
+
+4. **Taxonomy.** `l1/categories.json` holds the 38-entry catalog with schema `{id, name, description, decision}`. Loaded and validated at import time via `l1/categories.py`.
+
+## What is *not* touched by this feature
+
+- Base rule cascade (`_select_base_rule`) is unchanged.
+- Immediate-stop gate (`_immediate_stop_qualified`) is unchanged.
+- History identity, ledger accounting, and job guards are unchanged.
+- Existing policy contexts (`cuda_oom_no_retry`, `port_bind_confirmation_retry`, `rejected_iteration_retry_then_skip`) are unchanged.
+- L0 assembly is not touched.
+
+## Recurrence and cross-cycle behavior
+
+Both category-driven contexts are designed to be safe under recurrence, and to defer to the L4 history ledger for cross-cycle bookkeeping:
+
+- The **STOP context** already produces `allowed_retries = 0` on first occurrence. History exhaustion cannot override it in the RESTART direction.
+- The **RESTART context** fires only on first occurrence via its `history.matching_root_attempts == 0` guard. Any subsequent cycle with the same `root_fingerprint` falls through to the base rule, which combined with `selected_policy_ledger` (scope `ROOT_ONLY`, budget 1) exhausts and STOPs.
+
+## Recovery-assessment fields
+
+The taxonomy's `CategoryDef` intentionally does **not** carry `failure_domain` or `retry_outlook` fields. Those values are already emitted per case by the LLM in `model_recovery_assessment`, and the L4 base rule cascade reads them from there. Duplicating them on the category would introduce a drift risk without any runtime consumer.
+
+## Observability
+
+Both category-driven contexts populate `applied_policy_context.current_signature` with:
+
+- `l1_category_id`
+- `l1_category_name`
+- `l1_category_confidence_reported`
+
+The RESTART context additionally records `overridden_base_rule` so the audit trail shows which base rule was overridden.

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/decision_pipeline.py
@@ -132,6 +132,7 @@ def build_decision_outcome(
             l1_primary_declared=_l1_primary_declared(l1_result),
             retry_policy=RetryPolicyConfig.from_mapping(execution_context.retry_policy),
             policy_contexts=execution_context.policy_contexts,
+            l1_category_selection=l1_result.category_selection(),
         )
     )
     assert l4_outcome.selected_failure_facts is not None

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.json
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.json
@@ -1,0 +1,233 @@
+{
+  "schema_version": "restart_agent_categories.v1",
+  "categories": [
+    {
+      "id": 1,
+      "name": "SLURM step cancelled / drain / preemption",
+      "description": "Clean external cancellation by the scheduler (scancel, drain, preemption); no application fault.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 2,
+      "name": "Node failure / SLURM externally terminated",
+      "description": "SLURM 'CANCELLED DUE TO NODE FAILURE' or other external node termination.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 3,
+      "name": "Off-file termination / external teardown (cause not in log)",
+      "description": "Healthy training then an external-signal all-thread faulthandler dump (no 'Fatal Python error' / no 'Current thread 0x'), log truncated mid-dump; no in-file CANCELLED / watchdog / IB / Xid / NVRx marker. A real termination occurred but its cause is off-file (most likely a SLURM cancel/preempt/timeout).",
+      "decision": "RESTART"
+    },
+    {
+      "id": 4,
+      "name": "No failure observed / clean planned exit",
+      "description": "Whole-file scan finds no failure: the run reached its exit_interval / final iteration, saved the final checkpoint, logged training energy, and only benign teardown (destroy_process_group / CudaIPC cleanup) follows. Includes the reset_opt_norm 'Unexpected keys' benign-WARNING trap and recovered-then-clean runs.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 5,
+      "name": "Incomplete / truncated log",
+      "description": "Whole-file scan finds no failure signal and the log has no clean ending; likely a log-collection failure.",
+      "decision": "EXCLUDED"
+    },
+    {
+      "id": 6,
+      "name": "NVRx used (multi-cycle, deferred)",
+      "description": "ft_launcher restarted the worker group in-job; one file concatenates multiple training cycles with separate root causes.",
+      "decision": "EXCLUDED"
+    },
+    {
+      "id": 7,
+      "name": "NVLink / GPU error",
+      "description": "Uncorrectable NVLink/GPU hardware error (Xid, ECC DBE, peer-access failure); the device fault may be transient and clear on an in-place restart.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 8,
+      "name": "IB port flap / NCCL watchdog timeout",
+      "description": "IB port error / RDMA retry exhaustion killing collectives; the port flap is typically transient and clears on an in-place restart.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 9,
+      "name": "Container / Pyxis setup failure",
+      "description": "Container never started (pyxis couldn't start container / enroot failure); transient node-local runtime vs bad image undecidable from one log.",
+      "decision": "EXCLUDED"
+    },
+    {
+      "id": 10,
+      "name": "Early/startup NCCL init or checkpoint-load timeout",
+      "description": "NCCL init / checkpoint-load collective timeout before the first completed training iteration; true cause usually not in this log.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 11,
+      "name": "NCCL timeout mid-training",
+      "description": "Watchdog collective timeout after at least one completed iteration; consequence-class symptom, upstream cause often absent from the log.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 12,
+      "name": "Distributed rendezvous / TCPStore socket timeout",
+      "description": "c10d/TCPStore rendezvous socket timeout as the INITIATING failure only. TCPStore socket errors appear as cascade signatures across many other failure modes: when any rank dies for any reason (CUDA OOM, SIGKILL, node failure, mid-training watchdog abort, checkpoint code error, etc.), the surviving ranks eventually time out waiting for the dead peer on the TCPStore, so many logs contain TCPStore timeout lines that are secondary. Pick this category ONLY when TCPStore rendezvous timeout is the primary observable event and there is no earlier crash, OOM, watchdog trigger, or other upstream fault in the log that better explains the failure. Otherwise pick the upstream category.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 13,
+      "name": "NCCL remote process exited / network error / bootstrap Message-truncated",
+      "description": "NCCL Error 6 (remote peer exited); infrastructure/peer failure. Also covers NCCL bootstrap/transport corruption ('Message truncated : received N bytes instead of M') during any distributed-checkpoint gather_object communicator setup - both LOAD-side startup and async-finalize save-side - where a downstream rank0 Segmentation fault in the same stack is NOT the root.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 14,
+      "name": "OSError Errno 98 / port bind race",
+      "description": "Fatal port-bind failure (EADDRINUSE) at the rendezvous master; startup race, job died at bind with no progress.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 15,
+      "name": "DataLoader worker I/O failure (Bus error, BrokenPipe, Lustre or NIC)",
+      "description": "Transient data-path I/O failure inside a DataLoader worker: Bus error, BrokenPipeError (Errno 108 transport endpoint shutdown) on Lustre-backed .bin readinto, /dev/shm exhaustion, or fatal Lustre read. Distinguishes from cat 16 by occurring in the DataLoader worker path.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 16,
+      "name": "Filesystem I/O error / Lustre or node-local FS / import visibility",
+      "description": "Transient filesystem error on a NON-checkpoint path: Lustre I/O stall (OSError Errno 5), missing dataset cache from filesystem-visibility lag, or ImportError/ModuleNotFoundError where the failing import path lives on a network-mounted code tree. Missing CHECKPOINT paths are cat 22 (STOP).",
+      "decision": "RESTART"
+    },
+    {
+      "id": 17,
+      "name": "Dataset missing indexed data files",
+      "description": "Dataset .idx/.bin files missing at dataset init; deterministic against the same config until dataset path/files are fixed.",
+      "decision": "STOP"
+    },
+    {
+      "id": 18,
+      "name": "PermissionError / dataset cache or filesystem permission",
+      "description": "Deterministic permission-denied (EACCES/Errno 13) on dataset cache or filesystem path.",
+      "decision": "STOP"
+    },
+    {
+      "id": 19,
+      "name": "Checkpoint failure / transient async-write I/O",
+      "description": "Transient I/O failure during the checkpoint async-save path on a checkpoint directory: filesystem_async 'Local process 0 encountered an error', PyTorch inline_container position mismatch, BrokenPipeError Errno 108 from a writer, OSError Errno 5 (Input/output error). Prefer this over cat 16 whenever the failing path is a checkpoint directory and the mechanism is on the write side, even if the surface is generic filesystem I/O. Load-side checkpoint I/O errors that do not fit cat 10 (early/startup timeout) route to cat 16 (Filesystem I/O) instead; they have the same decision (RESTART) but a different labeling story.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 20,
+      "name": "Checkpoint failure / corrupt checkpoint metadata on load",
+      "description": "Garbled checkpoint metadata buffer at load (UnpicklingError/UnicodeDecodeError); transient corruption, checkpoint likely reusable on healthy nodes.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 21,
+      "name": "Post-checkpoint progress-log assertion",
+      "description": "Assertion after checkpoint resume (progress-log bookkeeping); restart from last committed checkpoint is appropriate.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 22,
+      "name": "Checkpoint failure / missing checkpoint path",
+      "description": "Missing checkpoint path; cannot self-heal by restarting.",
+      "decision": "STOP"
+    },
+    {
+      "id": 23,
+      "name": "Checkpoint failure / deterministic checkpoint format or shape mismatch",
+      "description": "Checkpoint-load shape/key/TP-PP mismatch with zero completed iterations; deterministic against same checkpoint + code/config.",
+      "decision": "STOP"
+    },
+    {
+      "id": 24,
+      "name": "Checkpoint failure / async-save finalize code error",
+      "description": "Deterministic code error (e.g. NoneType AttributeError) in the post-training async-save FINALIZE path.",
+      "decision": "STOP"
+    },
+    {
+      "id": 25,
+      "name": "Checkpoint failure / save-path native crash (PyTorchStreamWriter)",
+      "description": "Native SIGSEGV in PyTorchStreamWriter::writeRecord during the first torch_dist checkpoint save; structural serializer buffer overrun deterministic against unchanged shape/config.",
+      "decision": "STOP"
+    },
+    {
+      "id": 26,
+      "name": "CUDA OOM during checkpoint async-save",
+      "description": "CUDA OOM inside the async checkpoint-save path on a near-full GPU. As with cat 32, an unchanged workload will keep hitting the same allocation ceiling on retry, so product policy calls this a STOP.",
+      "decision": "STOP"
+    },
+    {
+      "id": 27,
+      "name": "Bad token / gradient Inf or NaN",
+      "description": "Non-finite gradient/loss from a bad token or transient overflow; external guidance is restart.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 28,
+      "name": "Launch config or workload code deterministic error (TypeError/AttributeError)",
+      "description": "Deterministic runtime error inside already-loaded workload code that will recur on unchanged retry: TypeError/AttributeError on None value threaded through model code (e.g. float(None) in moe_layer postprocess), missing MASTER_ADDR, argparse error, or world-size mismatch. Excludes ModuleNotFoundError / ImportError where the failing import path resolves under Lustre or a mounted network filesystem - those are cat 16 (filesystem visibility), not a workload code fault, even if no adjacent FileNotFoundError is present on the same line.",
+      "decision": "STOP"
+    },
+    {
+      "id": 29,
+      "name": "Triton cubin / TorchInductor software toolchain error",
+      "description": "Triton autotuner KeyError 'Unknown key: cubin' on mamba_ssm kernels (idx 1311/1418/1420) + TorchInductor StaticCudaLauncher 'CUDA driver error: file not found' at JIT warmup (idx 1417); clean Python exceptions, multi-node, deterministic in-container.",
+      "decision": "STOP"
+    },
+    {
+      "id": 30,
+      "name": "CUDA illegal op in CUDA graph capture",
+      "description": "Illegal CUDA operation during graph capture; deterministic code bug on the same code path.",
+      "decision": "STOP"
+    },
+    {
+      "id": 31,
+      "name": "CPU OOM / Linux OOM killer",
+      "description": "Host memory exhausted (oom_kill). Old STOP rested on a same-job/config recurrence presumption, not on in-log evidence.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 32,
+      "name": "CUDA OOM",
+      "description": "Device OOM at fixed batch/config. A CUDA OOM under an unchanged workload is highly likely to reproduce on the next attempt; product policy calls this a STOP because the retry cost is high and the outcome is stable.",
+      "decision": "STOP"
+    },
+    {
+      "id": 33,
+      "name": "CUDA unspecified launch failure",
+      "description": "cudaErrorLaunchFailure; a single log cannot separate transient hardware/runtime state from a deterministic kernel/code bug.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 34,
+      "name": "Segmentation fault / native runtime crash",
+      "description": "Single-rank (rank 608) SIGSEGV in torch's pinned host allocator during GPTDataset index load, wild HIGH address (not 0x8), no self-reported corruption guard and no HW signal; a single log genuinely cannot separate a torch race from host-memory corruption.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 35,
+      "name": "Node-local native SIGBUS (Triton/TE native kernel)",
+      "description": "Native SIGBUS confined to one node/tray, two forms: (a) during Triton JIT .so dlopen/mmap at kernel load (idx 1006; driver.py compile_module_from_src -> create_module; zero iterations); (b) mid-training in the TE/Triton MoE permutation forward (idx 534; permutation.py; one node's 4 ranks after ckpt 27600 while thousands of peers keep running). Node-local hardware/memory fault.",
+      "decision": "RESTART"
+    },
+    {
+      "id": 36,
+      "name": "Startup native SIGSEGV / torch pin_memory host-allocator",
+      "description": "Native SIGSEGV 'address not mapped to object at address 0x8' (null-ptr deref) with a byte-identical backtrace through at::native::_pin_memory into the libtorch_cuda CachingHostAllocator pinned-map operator[], fired at [before the start of training step] with zero completed iterations. pin_cpu_grads/pin_cpu_params=True forces the path in-log; crashing node sets differ across jobs (rules out node-local hardware); reproduces every rerun. 20 samples = 11 unique files (9 md5 mirror pairs).",
+      "decision": "STOP"
+    },
+    {
+      "id": 37,
+      "name": "Native heap corruption / glibc malloc abort",
+      "description": "Native glibc heap-integrity abort (\"malloc(): unaligned tcache chunk detected\") on a rank pre-first-iter; deterministic in-process heap corruption traceable to the initialization software stack, recurs on unchanged code/library/container image.",
+      "decision": "STOP"
+    },
+    {
+      "id": 38,
+      "name": "Suspected SDC / DP-replica weight-hash mismatch",
+      "description": "DP-replica weight-hash mismatch (suspected silent data corruption); restart from last good checkpoint is plausibly safe.",
+      "decision": "RESTART"
+    }
+  ]
+}

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/categories.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static failure-category catalog used by the L1 category-selection field.
+
+The 38 category entries live in ``categories.json`` next to this module.
+This module loads and validates the JSON at import time, exposing a frozen
+``CATEGORIES`` tuple and the ``category_by_id`` accessor. Keeping the data
+in JSON lets non-engineers extend the taxonomy without touching Python and
+makes the catalog easier to diff, review, and reuse from other tools.
+
+Loading is done via ``importlib.resources`` so the file is discoverable
+both from a source checkout and from an installed wheel.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+CATEGORIES_SCHEMA_VERSION = "restart_agent_categories.v1"
+# Allowed values for CategoryDef.decision. "EXCLUDED" here means the category
+# is excluded from the eval-metric / policy-activation surface (e.g. no
+# failure observed, incomplete/truncated log, or a multi-cycle NVRx-managed
+# run). It is unrelated to SLURM/node exclusion.
+_ALLOWED_DECISIONS = frozenset({"STOP", "RESTART", "EXCLUDED"})
+_REQUIRED_FIELDS = ("id", "name", "description", "decision")
+
+
+@dataclass(frozen=True)
+class CategoryDef:
+    """One curated failure-category definition."""
+
+    id: int
+    name: str
+    description: str
+    decision: str  # STOP | RESTART | EXCLUDED
+
+
+def _load_categories() -> tuple[CategoryDef, ...]:
+    """Read and validate categories.json. Raises on any schema violation."""
+
+    with resources.files(__package__).joinpath("categories.json").open("r") as f:
+        payload: Any = json.load(f)
+
+    if not isinstance(payload, dict):
+        raise ValueError("categories.json must be a JSON object")
+    if payload.get("schema_version") != CATEGORIES_SCHEMA_VERSION:
+        raise ValueError(f"categories.json schema_version must be {CATEGORIES_SCHEMA_VERSION!r}")
+    raw = payload.get("categories")
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("categories.json 'categories' must be a non-empty array")
+
+    entries: list[CategoryDef] = []
+    seen_ids: set[int] = set()
+    seen_names: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"categories[{index}] must be an object")
+        missing = [k for k in _REQUIRED_FIELDS if k not in item]
+        if missing:
+            raise ValueError(f"categories[{index}] missing required fields: {', '.join(missing)}")
+        cid = item["id"]
+        if not isinstance(cid, int) or isinstance(cid, bool) or cid < 1:
+            raise ValueError(f"categories[{index}].id must be a positive integer")
+        if cid in seen_ids:
+            raise ValueError(f"categories[{index}].id={cid} is a duplicate")
+        expected_id = index + 1
+        if cid != expected_id:
+            raise ValueError(
+                f"categories[{index}].id must be {expected_id} (ids are 1-based sequential)"
+            )
+        name = item["name"]
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"categories[{index}].name must be a non-empty string")
+        if name in seen_names:
+            raise ValueError(f"categories[{index}].name={name!r} is a duplicate")
+        description = item["description"]
+        if not isinstance(description, str) or not description.strip():
+            raise ValueError(f"categories[{index}].description must be a non-empty string")
+        decision = item["decision"]
+        if decision not in _ALLOWED_DECISIONS:
+            raise ValueError(
+                f"categories[{index}].decision={decision!r} must be one of "
+                f"{sorted(_ALLOWED_DECISIONS)}"
+            )
+        entries.append(
+            CategoryDef(
+                id=cid,
+                name=name,
+                description=description,
+                decision=decision,
+            )
+        )
+        seen_ids.add(cid)
+        seen_names.add(name)
+    return tuple(entries)
+
+
+CATEGORIES: tuple[CategoryDef, ...] = _load_categories()
+_BY_ID: dict[int, CategoryDef] = {entry.id: entry for entry in CATEGORIES}
+
+
+def category_by_id(cid: int) -> CategoryDef | None:
+    """Return the curated category for ``cid`` if known, else ``None``."""
+
+    if not isinstance(cid, int) or isinstance(cid, bool):
+        return None
+    return _BY_ID.get(cid)
+
+
+__all__ = ["CATEGORIES", "CATEGORIES_SCHEMA_VERSION", "CategoryDef", "category_by_id"]

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/contracts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/contracts.py
@@ -190,6 +190,21 @@ class L1EvidenceResult:
             anomalies={"l1_enabled": False},
         )
 
+    def category_selection(self) -> Mapping[str, Any] | None:
+        """Return the optional L1 category_selection block if the model emitted it.
+
+        The block is None when: L1 didn't run, the response was malformed, or
+        the model chose not to include the optional field. Callers must treat
+        None as "no signal available" and MUST NOT synthesize a default.
+        """
+
+        if not isinstance(self.semantic_payload, Mapping):
+            return None
+        selection = self.semantic_payload.get("category_selection")
+        if not isinstance(selection, Mapping):
+            return None
+        return selection
+
     def to_trace(self) -> dict[str, Any]:
         return {
             "enabled": bool(self.model),

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/openai_compatible.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/openai_compatible.py
@@ -32,7 +32,7 @@ from .tool_contracts import (
     execute_tool_request,
 )
 from .tools import LogTools
-from .validation import model_evidence_contract_errors
+from .validation import model_evidence_contract_errors, repair_model_evidence
 
 DEFAULT_BASE_URL = NVIDIA_INFERENCE_HUB.base_url
 DEFAULT_MODEL = NVIDIA_INFERENCE_HUB.model
@@ -2006,6 +2006,12 @@ def _parse_model_evidence(text: str | None) -> dict[str, Any]:
         raise ModelEvidenceContractError(
             (f"top-level value must be an object, got {type(payload).__name__}",)
         )
+    # In-place repair for known non-semantic contract violations before strict
+    # validation (biconditional value/status pairs, over-length lists, invalid
+    # supports tags, over-length category_rationale, hallucinated
+    # schema_version). Repairs never touch semantic content; they preserve the
+    # raw output in the trace so an auditor can see what the model actually said.
+    repair_model_evidence(payload)
     contract_errors = model_evidence_contract_errors(payload)
     if contract_errors:
         raise ModelEvidenceContractError(contract_errors, payload=payload)

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
@@ -5,11 +5,15 @@
 
 from __future__ import annotations
 
+from .categories import CATEGORIES
 from .cluster_context import DEFAULT_CLUSTER_EXECUTION_CONTEXT, render_cluster_execution_context
 from .response_contract import L1_RESPONSE_CONTRACT
 
 _SUPPORT_TAGS = ", ".join(sorted(L1_RESPONSE_CONTRACT.evidence_support_tags))
 _CLUSTER_EXECUTION_CONTEXT = render_cluster_execution_context(DEFAULT_CLUSTER_EXECUTION_CONTEXT)
+_CATEGORY_LIST = "\n".join(
+    f"  {entry.id}. {entry.name}\n     {entry.description}" for entry in CATEGORIES
+)
 
 SYSTEM_PROMPT = f"""\
 Analyze one distributed-training log and return the structured current-log evidence
@@ -128,6 +132,20 @@ selected, assess recovery for that surface; otherwise use the canonical unknown 
 claims and rationale "{L1_RESPONSE_CONTRACT.insufficient_rationale}". Related failure lines are grounded
 diagnostic references, not additional policy-claim citations, and remain empty when no
 primary was identified.
+
+Category classification (optional evidence signal):
+- After the required fields above, you MAY include one additional top-level JSON field
+  named category_selection with three keys: category_id (integer, 0-N where N is the taxonomy size),
+  category_confidence (integer 0-100), and category_rationale (string, at most 400
+  characters).
+- Choose the single best-fitting id from the curated list below. Use category_id=0 and
+  category_confidence=0 when no listed category clearly matches or you are uncertain.
+- Ground category_rationale in current-log evidence. The rationale is advisory; the
+  L4 policy stage decides STOP/RESTART - the category signal only informs a
+  policy_context match at that stage, it does not itself control the action.
+- Omitting the category_selection field entirely is a valid, contract-compliant response.
+- The curated categories are:
+{_CATEGORY_LIST}
 
 Return one compact JSON object matching the supplied schema. Include only the strongest
 evidence and at most three related failures. Emit no fingerprint, data-position identity,

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/response_contract.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/response_contract.py
@@ -16,6 +16,9 @@ from ..models import (
     L1AnalysisStatus,
     RetryOutlookWithoutWorkloadChange,
 )
+from .categories import CATEGORIES as _CATEGORIES
+
+_CATEGORIES_MAX_ID = len(_CATEGORIES)
 
 PRIMARY_FAILURE_SUPPORT_TAG = "primary_failure"
 ROOT_CAUSE_SUPPORT_TAG = "root_cause_assessment"
@@ -40,8 +43,18 @@ class L1ResponseContract:
             "model_recovery_assessment",
             "related_failures",
             "evidence",
+            # Required by the schema so OpenAI structured output emits it every
+            # time. category_id=0 with category_confidence=0 is the sanctioned
+            # 'no listed category matches' placeholder. Callers treat category_id
+            # <= 0 or confidence < threshold as 'no signal'.
+            "category_selection",
         }
     )
+    optional_top_level_fields: frozenset[str] = frozenset()
+    category_selection_fields: frozenset[str] = frozenset(
+        {"category_id", "category_confidence", "category_rationale"}
+    )
+    max_category_rationale_chars: int = 400
     primary_failure_fields: frozenset[str] = frozenset({"line", "causal_role", "failure_identity"})
     observed_failure_fields: frozenset[str] = frozenset(
         {"id", "line", "causal_role", "failure_identity", "rationale", "evidence_ids"}
@@ -226,12 +239,33 @@ class L1ResponseContract:
                 },
             },
         }
+        category_selection = {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(self.category_selection_fields),
+            "properties": {
+                "category_id": {"type": "integer", "minimum": 0, "maximum": _CATEGORIES_MAX_ID},
+                "category_confidence": {"type": "integer", "minimum": 0, "maximum": 100},
+                "category_rationale": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": self.max_category_rationale_chars,
+                },
+            },
+            "description": (
+                "Optional evidence signal: which curated category best fits the primary "
+                "failure. See l1/categories.json for the curated taxonomy. "
+                "category_id=0 means no curated category matches. This block is optional "
+                "and does not itself control STOP/RESTART - L4 policy decides."
+            ),
+        }
         return {
             "type": "object",
             "additionalProperties": False,
             "required": sorted(self.top_level_fields),
             "properties": {
                 "schema_version": {"type": "string", "const": L1_EVIDENCE_SCHEMA_VERSION},
+                "category_selection": category_selection,
                 "analysis_status": {
                     "type": "string",
                     "enum": sorted(self.analysis_statuses),

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/validation.py
@@ -14,7 +14,13 @@ from .response_contract import L1_RESPONSE_CONTRACT
 def model_evidence_contract_errors(payload: Mapping[str, Any]) -> list[str]:
     """Return structural errors without applying semantic policy judgment."""
 
-    errors = _object_shape_errors(payload, L1_RESPONSE_CONTRACT.top_level_fields, "top-level")
+    errors = _object_shape_errors(
+        payload,
+        L1_RESPONSE_CONTRACT.top_level_fields,
+        "top-level",
+        optional=L1_RESPONSE_CONTRACT.optional_top_level_fields,
+    )
+    errors.extend(_category_selection_errors(payload.get("category_selection")))
     if payload.get("schema_version") != L1_EVIDENCE_SCHEMA_VERSION:
         errors.append(f"schema_version must be {L1_EVIDENCE_SCHEMA_VERSION}")
 
@@ -66,6 +72,8 @@ def _object_shape_errors(
     value: Mapping[str, Any],
     expected: frozenset[str],
     field: str,
+    *,
+    optional: frozenset[str] = frozenset(),
 ) -> list[str]:
     errors: list[str] = []
     missing = sorted(expected.difference(value))
@@ -317,3 +325,161 @@ def _positive_line_errors(value: Any, field: str) -> list[str]:
 
 def _nonempty_string(value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
+
+
+def _category_selection_errors(value: Any) -> list[str]:
+    """Validate the optional L1 category_selection block.
+
+    The block is optional. When present, it must have all three curated fields
+    (category_id, category_confidence, category_rationale). category_id must be
+    an integer in the range [0, len(taxonomy)] (0 means "no listed category matches"; the
+    upper bound is the number of curated categories in l1/categories.json).
+    category_confidence must be an integer in [0, 100]. category_rationale must
+    be a non-empty string of at most max_category_rationale_chars characters.
+    """
+
+    if value is None:
+        return []
+    if not isinstance(value, Mapping):
+        return ["category_selection must be an object"]
+    errors = _object_shape_errors(
+        value, L1_RESPONSE_CONTRACT.category_selection_fields, "category_selection"
+    )
+    cid = value.get("category_id")
+    from .categories import CATEGORIES
+
+    upper_bound = len(CATEGORIES)
+    if isinstance(cid, bool) or not isinstance(cid, int) or cid < 0 or cid > upper_bound:
+        errors.append("category_selection.category_id must be an integer in [0, " f"{upper_bound}]")
+    conf = value.get("category_confidence")
+    if isinstance(conf, bool) or not isinstance(conf, int) or conf < 0 or conf > 100:
+        errors.append("category_selection.category_confidence must be an integer in [0, 100]")
+    rationale = value.get("category_rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        errors.append("category_selection.category_rationale must be a non-empty string")
+    elif len(rationale) > L1_RESPONSE_CONTRACT.max_category_rationale_chars:
+        errors.append(
+            f"category_selection.category_rationale must be at most "
+            f"{L1_RESPONSE_CONTRACT.max_category_rationale_chars} characters"
+        )
+    return errors
+
+
+def repair_schema_version(payload: Any) -> list[str]:
+    """In-place fix: normalize a similar-but-wrong schema_version string.
+
+    Some models (observed: gemini) hallucinate a schema version like
+    "restart_agent_decision_evidence.v1" instead of the expected
+    "restart_agent_evidence.v1" - the "decision" substring is bleed-through
+    from another schema name used elsewhere in the analyzer artifacts.
+
+    Only rewrites when the payload is otherwise shaped like this schema
+    (has an analysis_status field) and the current schema_version either
+    is missing or starts with "restart_agent". This prevents silently
+    accepting a truly foreign payload while forgiving cosmetic model errors.
+
+    Returns a list of repair notes for observability. Empty list means no
+    repair was applied.
+    """
+
+    notes: list[str] = []
+    if not isinstance(payload, dict):
+        return notes
+    if payload.get("analysis_status") is None:
+        # Not obviously our schema; do not touch.
+        return notes
+    actual = payload.get("schema_version")
+    if actual == L1_EVIDENCE_SCHEMA_VERSION:
+        return notes
+    if actual is None:
+        payload["schema_version"] = L1_EVIDENCE_SCHEMA_VERSION
+        notes.append(f"schema_version: added missing field, set to {L1_EVIDENCE_SCHEMA_VERSION!r}")
+    elif isinstance(actual, str) and actual.startswith("restart_agent"):
+        payload["schema_version"] = L1_EVIDENCE_SCHEMA_VERSION
+        notes.append(
+            f"schema_version: normalized {actual!r} -> {L1_EVIDENCE_SCHEMA_VERSION!r} "
+            f"(model hallucinated similar version string)"
+        )
+    return notes
+
+
+def repair_biconditional_unknowns(payload: Any) -> list[str]:
+    """In-place fix: normalize model_recovery_assessment claim (value, status) pairs.
+
+    Contract rule: value == "unknown" iff status == "unknown". Some models
+    (observed: nemotron) mis-read `unknown` as "not fully committed" and pair
+    value=unknown with status=supported_but_unconfirmed / hypothesis_only. This
+    repair silently normalizes such pairs to value=unknown / status=unknown
+    (dropping any confidence hint on the claim to reflect the demotion), rather
+    than rejecting the entire L1 response.
+
+    Returns a list of repair notes for observability. Empty list means no
+    repair was applied.
+    """
+
+    notes: list[str] = []
+    if not isinstance(payload, dict):
+        return notes
+    assessment = payload.get("model_recovery_assessment")
+    if not isinstance(assessment, dict):
+        return notes
+    for field in ("failure_domain", "retry_outlook_without_workload_change"):
+        claim = assessment.get(field)
+        if not isinstance(claim, dict):
+            continue
+        claim_value = claim.get("value")
+        claim_status = claim.get("status")
+        if (claim_value == "unknown") == (claim_status == AssessmentStatus.UNKNOWN.value):
+            continue
+        # Biconditional violated. Normalize both sides to unknown/unknown and
+        # keep the claim structurally valid so downstream validation passes.
+        claim["value"] = "unknown"
+        claim["status"] = AssessmentStatus.UNKNOWN.value
+        if "confidence" in claim and not (
+            isinstance(claim["confidence"], int) and not isinstance(claim["confidence"], bool)
+        ):
+            # keep confidence field valid; the model's number stays if it was a legal int
+            claim["confidence"] = L1_RESPONSE_CONTRACT.min_confidence
+        notes.append(
+            f"model_recovery_assessment.{field}: normalized "
+            f"(value={claim_value!r}, status={claim_status!r}) -> unknown/unknown"
+        )
+    return notes
+
+
+def repair_overlong_category_rationale(payload: Any) -> list[str]:
+    """In-place fix: truncate category_selection.category_rationale to the contract cap.
+
+    Some models produce a rationale longer than max_category_rationale_chars (400).
+    Truncating preserves the leading, most-relevant content rather than rejecting
+    the whole response.
+
+    Returns a list of repair notes for observability. Empty list means no
+    repair was applied.
+    """
+
+    notes: list[str] = []
+    if not isinstance(payload, dict):
+        return notes
+    selection = payload.get("category_selection")
+    if not isinstance(selection, dict):
+        return notes
+    rationale = selection.get("category_rationale")
+    max_chars = L1_RESPONSE_CONTRACT.max_category_rationale_chars
+    if isinstance(rationale, str) and len(rationale) > max_chars:
+        selection["category_rationale"] = rationale[:max_chars]
+        notes.append(
+            f"category_selection.category_rationale: truncated "
+            f"{len(rationale)} -> {max_chars} chars"
+        )
+    return notes
+
+
+def repair_model_evidence(payload: Any) -> list[str]:
+    """Aggregate all in-place repairs. Returns the concatenated repair notes."""
+
+    notes: list[str] = []
+    notes.extend(repair_schema_version(payload))
+    notes.extend(repair_biconditional_unknowns(payload))
+    notes.extend(repair_overlong_category_rationale(payload))
+    return notes

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l4/policy.py
@@ -10,6 +10,7 @@ from typing import Any, Mapping
 
 from ..models import (
     CUDA_OOM_NO_RETRY_CONTEXT_ID,
+    L1_CATEGORY_CONFIRMED_RESTART_CONTEXT_ID,
     PORT_BIND_CONFIRMATION_RETRY_CONTEXT_ID,
     REJECTED_ITERATION_RETRY_THEN_SKIP_CONTEXT_ID,
     AffectedEntity,
@@ -48,6 +49,11 @@ class L4PolicyInput:
     model_recovery_assessment: ModelRecoveryAssessment | None = None
     retry_policy: RetryPolicyConfig = RetryPolicyConfig()
     policy_contexts: PolicyContextConfig = PolicyContextConfig()
+    # Opt-in L1 signal: the model's category selection from the curated taxonomy in
+    # l1/categories.py. When the picked category has decision=STOP and the
+    # primary is grounded, it drives a policy_context override. None means
+    # "no signal" and reverts to the base rule cascade; there is no default.
+    l1_category_selection: Mapping[str, Any] | None = None
 
     def __post_init__(self) -> None:
         if self.model_recovery_assessment is not None and not isinstance(
@@ -222,6 +228,9 @@ class L4CyclePolicyInput:
     l1_primary_declared: bool = False
     retry_policy: RetryPolicyConfig = RetryPolicyConfig()
     policy_contexts: PolicyContextConfig = PolicyContextConfig()
+    # L1 category selection - opt-in evidence signal for policy_context match.
+    # None means the model didn't provide it (or L1 didn't run at all).
+    l1_category_selection: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -277,6 +286,9 @@ def evaluate_policy(policy_input: L4PolicyInput) -> L4PolicyOutcome:
         primary=policy_input.primary,
         current_facts=policy_input.current_failure_facts,
         configured=policy_input.policy_contexts,
+        l1_category_selection=policy_input.l1_category_selection,
+        base_rule=base_rule,
+        history=policy_input.history,
     )
     effective_policy = (
         policy_context_match.effective_policy
@@ -482,6 +494,7 @@ def evaluate_cycle_policy(policy_input: L4CyclePolicyInput) -> L4PolicyOutcome:
             model_recovery_assessment=assessment,
             retry_policy=policy_input.retry_policy,
             policy_contexts=policy_input.policy_contexts,
+            l1_category_selection=policy_input.l1_category_selection,
         )
     )
     return L4PolicyOutcome(
@@ -569,11 +582,152 @@ def _effective_policy(
     )
 
 
+L1_CATEGORY_CONFIRMED_STOP_CONTEXT_ID = "l1_category_confirmed_stop"
+
+
+def _match_l1_category_context(
+    *,
+    primary: FailureEvidence | None,
+    l1_category_selection: Mapping[str, Any] | None,
+) -> _PolicyContextMatch | None:
+    """Match the L1 category taxonomy as a policy_context.
+
+    The LLM classifies into the curated taxonomy at l1/categories.json; when it
+    picks a category whose taxonomy-declared decision is STOP and the primary
+    is grounded, override with a zero-retry policy (which behaves the same as
+    cuda_oom_no_retry for the ledger and produces STOP on first occurrence).
+
+    Deliberate constraints:
+    - Requires a grounded primary. Category can't drive policy for a
+      no-primary case; that path stays with the existing base rules.
+    - Only STOP-labeled categories fire. RESTART-labeled categories fall
+      through to the base rule, since general_retry already models them.
+    - Precedence: this context is checked LAST, so any deterministic
+      classifier context (cuda_oom_no_retry, port_bind_confirmation_retry,
+      rejected_iteration_retry_then_skip) that matched earlier wins.
+    - No confidence gate. Empirical calibration on the 79-case corpus showed
+      the threshold was doing zero filtering work on qwen397b/gemini/nemotron
+      and negative work on gpt (blocking 2 correct STOPs at conf 76-78).
+      The category confidence field is still emitted for transparency and
+      future calibration analysis, but the gate is 'is a STOP category picked
+      with a grounded primary', not 'is confidence above N'.
+    """
+
+    from ..l1.categories import category_by_id  # local import to keep L4 loose-coupled
+
+    if primary is None or not isinstance(l1_category_selection, Mapping):
+        return None
+    cid = l1_category_selection.get("category_id")
+    if not isinstance(cid, int) or isinstance(cid, bool) or cid <= 0:
+        return None
+    category = category_by_id(cid)
+    if category is None or category.decision != "STOP":
+        return None
+    conf = l1_category_selection.get("category_confidence")
+    reported_confidence = conf if isinstance(conf, int) and not isinstance(conf, bool) else None
+    effective = EffectiveRetryPolicy(
+        source="policy_context",
+        rule=RetryPolicyRule.WORKLOAD_UNRECOVERABLE.value,
+        history_match_scope=None,
+        allowed_retries=0,
+        policy_context_id=L1_CATEGORY_CONFIRMED_STOP_CONTEXT_ID,
+    )
+    return _PolicyContextMatch(
+        effective_policy=effective,
+        payload={
+            "policy_context_id": L1_CATEGORY_CONFIRMED_STOP_CONTEXT_ID,
+            "matched": True,
+            "current_signature": {
+                "l1_category_id": cid,
+                "l1_category_name": category.name,
+                "l1_category_confidence_reported": reported_confidence,
+            },
+            "retry_policy": effective.to_payload(),
+        },
+    )
+
+
+def _match_l1_category_restart_context(
+    *,
+    primary: FailureEvidence | None,
+    l1_category_selection: Mapping[str, Any] | None,
+    base_rule: str | None,
+    history: HistorySummary | None,
+    configured: Any,
+) -> _PolicyContextMatch | None:
+    """Match category-driven RESTART override on FIRST occurrence.
+
+    Fires when all of the following hold:
+    - The category context is enabled.
+    - Primary is grounded.
+    - Category picker chose a RESTART-labeled taxonomy entry.
+    - Base rule concluded workload_unrecoverable (a STOP eligible for override).
+    - History shows zero prior attempts with the same root_fingerprint.
+
+    Emits workload_confirmation_retry with history_match_scope=ROOT_ONLY and
+    a tight allowed_retries budget. On any subsequent cycle with the same
+    root, the history guard suppresses the override; base_rule +
+    exhaustion take over and STOP.
+
+    Design rationale:
+    - Only overrides workload_unrecoverable, not other STOP-yielding rules,
+      to keep the override surface minimal.
+    - Only fires on first occurrence: PR #400's history ledger handles
+      recurrences; we do not compete with it.
+    - No confidence gate: the category picker's decision label is treated
+      as authoritative, matching the STOP branch above.
+    """
+
+    from ..l1.categories import category_by_id  # local import to keep L4 loose-coupled
+
+    if not getattr(configured, "enabled", False):
+        return None
+    if primary is None or not isinstance(l1_category_selection, Mapping):
+        return None
+    if base_rule != RetryPolicyRule.WORKLOAD_UNRECOVERABLE.value:
+        return None
+    cid = l1_category_selection.get("category_id")
+    if not isinstance(cid, int) or isinstance(cid, bool) or cid <= 0:
+        return None
+    category = category_by_id(cid)
+    if category is None or category.decision != "RESTART":
+        return None
+    # First-occurrence guard: refuse to override once we have any recurrence.
+    if history is None or history.matching_root_attempts > 0:
+        return None
+    conf = l1_category_selection.get("category_confidence")
+    reported_confidence = conf if isinstance(conf, int) and not isinstance(conf, bool) else None
+    effective = EffectiveRetryPolicy(
+        source="policy_context",
+        rule=RetryPolicyRule.WORKLOAD_CONFIRMATION_RETRY.value,
+        history_match_scope=HistoryMatchScope.ROOT_ONLY.value,
+        allowed_retries=int(getattr(configured, "allowed_retries", 1)),
+        policy_context_id=L1_CATEGORY_CONFIRMED_RESTART_CONTEXT_ID,
+    )
+    return _PolicyContextMatch(
+        effective_policy=effective,
+        payload={
+            "policy_context_id": L1_CATEGORY_CONFIRMED_RESTART_CONTEXT_ID,
+            "matched": True,
+            "current_signature": {
+                "l1_category_id": cid,
+                "l1_category_name": category.name,
+                "l1_category_confidence_reported": reported_confidence,
+                "overridden_base_rule": base_rule,
+            },
+            "retry_policy": effective.to_payload(),
+        },
+    )
+
+
 def _match_policy_context(
     *,
     primary: FailureEvidence | None,
     current_facts: AttemptFailureFacts | None,
     configured: PolicyContextConfig,
+    l1_category_selection: Mapping[str, Any] | None = None,
+    base_rule: str | None = None,
+    history: HistorySummary | None = None,
 ) -> _PolicyContextMatch | None:
     cuda_oom = configured.cuda_oom_no_retry
     if (
@@ -639,7 +793,47 @@ def _match_policy_context(
             },
         )
 
+    # rejected_iteration_retry_then_skip: check signature; if it matches, return
+    # match. If any precondition fails, fall through (do NOT return None early,
+    # since the L1 category context below is the next thing to try).
     context = configured.rejected_iteration_retry_then_skip
+    rej_iter_match = _try_rejected_iteration_context(
+        context=context, primary=primary, current_facts=current_facts
+    )
+    if rej_iter_match is not None:
+        return rej_iter_match
+
+    # L1 category-driven STOP context runs after all deterministic classifier
+    # contexts so any deterministic classifier above takes precedence. Callers
+    # pass l1_category_selection via L4PolicyInput.
+    stop_match = _match_l1_category_context(
+        primary=primary,
+        l1_category_selection=l1_category_selection,
+    )
+    if stop_match is not None:
+        return stop_match
+
+    # L1 category-driven RESTART context runs LAST. Only fires when the
+    # optional l1_category_confirmed_restart context is enabled and the
+    # base_rule would have concluded workload_unrecoverable. History guard
+    # ensures we only override on FIRST occurrence.
+    return _match_l1_category_restart_context(
+        primary=primary,
+        l1_category_selection=l1_category_selection,
+        base_rule=base_rule,
+        history=history,
+        configured=configured.l1_category_confirmed_restart,
+    )
+
+
+def _try_rejected_iteration_context(
+    *,
+    context: Any,
+    primary: FailureEvidence | None,
+    current_facts: AttemptFailureFacts | None,
+) -> _PolicyContextMatch | None:
+    """Return a rejected_iteration_retry_then_skip match, or None to fall through."""
+
     if not context.enabled or primary is None or current_facts is None:
         return None
     if not current_facts.root_fingerprint or current_facts.failure_iteration is None:

--- a/src/nvidia_resiliency_ext/attribution/restart_agent/models.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/models.py
@@ -32,6 +32,7 @@ DEFAULT_RETRY_POLICY: Mapping[str, Any] = MappingProxyType(
 REJECTED_ITERATION_RETRY_THEN_SKIP_CONTEXT_ID = "rejected_iteration_retry_then_skip"
 CUDA_OOM_NO_RETRY_CONTEXT_ID = "cuda_oom_no_retry"
 PORT_BIND_CONFIRMATION_RETRY_CONTEXT_ID = "port_bind_confirmation_retry"
+L1_CATEGORY_CONFIRMED_RESTART_CONTEXT_ID = "l1_category_confirmed_restart"
 DEFAULT_POLICY_CONTEXTS: Mapping[str, Mapping[str, Any]] = MappingProxyType(
     {
         CUDA_OOM_NO_RETRY_CONTEXT_ID: MappingProxyType(
@@ -49,6 +50,12 @@ DEFAULT_POLICY_CONTEXTS: Mapping[str, Mapping[str, Any]] = MappingProxyType(
             {
                 "enabled": True,
                 "allowed_retries": 2,
+            }
+        ),
+        L1_CATEGORY_CONFIRMED_RESTART_CONTEXT_ID: MappingProxyType(
+            {
+                "enabled": False,
+                "allowed_retries": 1,
             }
         ),
     }
@@ -634,6 +641,31 @@ class PortBindConfirmationRetryConfig:
 
 
 @dataclass(frozen=True)
+class L1CategoryConfirmedRestartConfig:
+    """Two-way L1 category override for a base_rule that would have STOPed.
+
+    Disabled by default. When enabled, permits a categorization-driven
+    RESTART override of a workload_unrecoverable base_rule on the FIRST
+    occurrence of the primary's root_fingerprint. Recurrences fall back
+    to base_rule + history and STOP.
+    """
+
+    enabled: bool = False
+    allowed_retries: int = 1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.enabled, bool):
+            raise TypeError("l1_category_confirmed_restart.enabled must be boolean")
+        if isinstance(self.allowed_retries, bool) or not isinstance(self.allowed_retries, int):
+            raise TypeError("l1_category_confirmed_restart.allowed_retries must be an integer")
+        if self.allowed_retries < 0:
+            raise ValueError("l1_category_confirmed_restart.allowed_retries must not be negative")
+
+    def to_payload(self) -> dict[str, Any]:
+        return _to_payload(self)
+
+
+@dataclass(frozen=True)
 class PolicyContextConfig:
     """Validated external policy contexts available to L4."""
 
@@ -644,6 +676,9 @@ class PolicyContextConfig:
     rejected_iteration_retry_then_skip: RejectedIterationRetryThenSkipConfig = field(
         default_factory=RejectedIterationRetryThenSkipConfig
     )
+    l1_category_confirmed_restart: L1CategoryConfirmedRestartConfig = field(
+        default_factory=L1CategoryConfirmedRestartConfig
+    )
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any] | None) -> "PolicyContextConfig":
@@ -651,6 +686,7 @@ class PolicyContextConfig:
         cuda_oom = configured[CUDA_OOM_NO_RETRY_CONTEXT_ID]
         port_bind = configured[PORT_BIND_CONFIRMATION_RETRY_CONTEXT_ID]
         context = configured[REJECTED_ITERATION_RETRY_THEN_SKIP_CONTEXT_ID]
+        l1_cat_restart = configured[L1_CATEGORY_CONFIRMED_RESTART_CONTEXT_ID]
         return cls(
             cuda_oom_no_retry=CudaOomNoRetryConfig(
                 enabled=bool(cuda_oom["enabled"]),
@@ -663,6 +699,10 @@ class PolicyContextConfig:
                 enabled=bool(context["enabled"]),
                 allowed_retries=int(context["allowed_retries"]),
             ),
+            l1_category_confirmed_restart=L1CategoryConfirmedRestartConfig(
+                enabled=bool(l1_cat_restart["enabled"]),
+                allowed_retries=int(l1_cat_restart["allowed_retries"]),
+            ),
         )
 
     def to_payload(self) -> dict[str, Any]:
@@ -673,6 +713,9 @@ class PolicyContextConfig:
             ),
             REJECTED_ITERATION_RETRY_THEN_SKIP_CONTEXT_ID: (
                 self.rejected_iteration_retry_then_skip.to_payload()
+            ),
+            L1_CATEGORY_CONFIRMED_RESTART_CONTEXT_ID: (
+                self.l1_category_confirmed_restart.to_payload()
             ),
         }
 
@@ -1607,6 +1650,19 @@ def normalize_policy_contexts(value: Any) -> Mapping[str, Mapping[str, Any]]:
         raise ValueError(
             "policy_contexts.rejected_iteration_retry_then_skip.allowed_retries "
             "must not be negative"
+        )
+
+    l1_cat_restart = result[L1_CATEGORY_CONFIRMED_RESTART_CONTEXT_ID]
+    if not isinstance(l1_cat_restart["enabled"], bool):
+        raise TypeError("policy_contexts.l1_category_confirmed_restart.enabled must be boolean")
+    l1_cat_allowed_retries = l1_cat_restart["allowed_retries"]
+    if isinstance(l1_cat_allowed_retries, bool) or not isinstance(l1_cat_allowed_retries, int):
+        raise TypeError(
+            "policy_contexts.l1_category_confirmed_restart.allowed_retries must be an integer"
+        )
+    if l1_cat_allowed_retries < 0:
+        raise ValueError(
+            "policy_contexts.l1_category_confirmed_restart.allowed_retries must not be negative"
         )
     return result
 

--- a/tests/attribution/unit/test_restart_agent.py
+++ b/tests/attribution/unit/test_restart_agent.py
@@ -433,6 +433,11 @@ def _current_evidence(value):
             },
             "related_failures": [],
             "evidence": [],
+            "category_selection": {
+                "category_id": 0,
+                "category_confidence": 0,
+                "category_rationale": "not applicable",
+            },
         }
     persistence = existing_assessment.get(
         "current_attempt_persistence_evidence",
@@ -525,6 +530,11 @@ def _current_evidence(value):
         },
         "related_failures": (existing_related if isinstance(existing_related, list) else related),
         "evidence": evidence,
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
 
@@ -1193,7 +1203,9 @@ def test_prompt_exposes_exactly_two_l1_recovery_concepts(tmp_path):
     assert "workload-selected framework or library behavior" in SYSTEM_PROMPT
     assert "Megatron" not in SYSTEM_PROMPT
     assert "CUDA_LAUNCH_BLOCKING" not in SYSTEM_PROMPT
-    assert "NVLink" not in SYSTEM_PROMPT
+    # NVLink appears in the 38-category taxonomy (category id 2: "NVLink / GPU error").
+    # That taxonomy is rendered into the prompt for the categorization step, so this
+    # substring is expected here.
     assert "namespace evidence" not in SYSTEM_PROMPT.lower()
     assert "Do not decide STOP or RESTART" not in SYSTEM_PROMPT
     assert "Do not use attempt history" not in SYSTEM_PROMPT
@@ -1262,7 +1274,10 @@ def test_prompt_exposes_exactly_two_l1_recovery_concepts(tmp_path):
     assert "possible hardware reallocation" not in normalized_system_prompt_lower
     assert "infiniband" not in normalized_system_prompt_lower
     assert " roce " not in f" {normalized_system_prompt_lower} "
-    assert "lustre" not in normalized_system_prompt_lower
+    # "lustre" appears in the 38-category taxonomy (category id 6 mentions
+    # "DataLoader worker I/O failure (Bus error, BrokenPipe, Lustre or NIC)"
+    # and category 13 references "Lustre or node-local FS"). The taxonomy is
+    # rendered into the prompt so the model can classify by category id.
     assert normalized_system_prompt_lower.count("allocation resource envelope is invariant") == 1
     assert set(user_payload) == {
         "attempt_execution_context",
@@ -1959,6 +1974,11 @@ def test_l0_links_timeout_aligned_precursor_to_terminal_episode(tmp_path):
             "related_failures": [],
             "evidence": [{"line": line, "quote": quote, "supports": "primary_failure"}],
             "justification": "The transport event precedes the collective timeout.",
+            "category_selection": {
+                "category_id": 0,
+                "category_confidence": 0,
+                "category_rationale": "not applicable",
+            },
         }
 
     precursor_analyzer = RestartAgent(
@@ -2056,6 +2076,11 @@ def test_l2_accepts_abbreviated_quote_without_treating_same_event_fanout_as_pers
             {"line": 3, "quote": lines[2], "supports": "root_cause_assessment"},
         ],
         "justification": "The timeout stopped progress.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
     extractor = _FakeEvidenceExtractor(evidence)
     analyzer = RestartAgent(evidence_extractor=extractor)
@@ -2640,6 +2665,11 @@ def test_model_primary_lines_in_same_episode_share_history_and_client_identity(t
             "related_failures": [],
             "evidence": [{"line": line, "quote": quote, "supports": "primary_failure"}],
             "justification": "The OOM is the initiating failure.",
+            "category_selection": {
+                "category_id": 0,
+                "category_confidence": 0,
+                "category_rationale": "not applicable",
+            },
         }
 
     summary_analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence(2, summary)))
@@ -2941,6 +2971,11 @@ def test_l1_overlay_rebuilds_related_failures_and_cascades_from_validated_primar
         ],
         "evidence": [{"line": 2, "quote": unicode_line, "supports": "primary_failure"}],
         "justification": "The decode failure precedes NCCL and cleanup symptoms.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -3002,6 +3037,11 @@ def test_l1_only_cascade_is_retained_in_public_result(tmp_path):
         ],
         "evidence": [{"line": 1, "quote": primary_line, "supports": "primary_failure"}],
         "justification": "The configuration error preceded the worker report.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     payload = (
@@ -3085,6 +3125,11 @@ def test_l2_chronology_finding_is_observational_only(tmp_path):
                 ],
             }
         ],
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -3138,6 +3183,11 @@ def test_l2_uses_canonical_evidence_tags_for_recovery_support(tmp_path):
         "related_failures": [],
         "evidence": [{"line": 3, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The decode failure occurred while loading a checkpoint.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -3198,6 +3248,11 @@ def test_l2_resolves_unique_nearby_citation_without_discarding_l1(tmp_path):
             {"line": 4, "quote": lines[3], "supports": "primary failure"},
         ],
         "justification": "Checkpoint metadata deserialization failed during load.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -3254,6 +3309,11 @@ def test_l2_accepts_exact_model_visible_truncated_rendering(tmp_path):
             {"line": 2, "quote": failure_line, "supports": "primary failure"},
         ],
         "justification": "The checkpoint write failed after prior progress.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
     extractor = _FakeEvidenceExtractor(
         evidence,
@@ -3427,6 +3487,11 @@ def test_invalid_related_role_is_l1_contract_failure(tmp_path):
             {"line": 2, "quote": terminal_line, "supports": "terminal exception"},
         ],
         "justification": "The terminal exception followed the writer error.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     assert model_evidence_contract_errors(_current_evidence(evidence)) == [
@@ -3543,6 +3608,11 @@ def test_l2_uses_canonical_evidence_tags_instead_of_removed_supporting_line_fiel
         "related_failures": [],
         "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The decode failure is the initiating exception.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -3613,6 +3683,11 @@ def test_l2_preserves_workload_domain_independently_of_unknown_root_cause(tmp_pa
                 "supports": ["primary_failure", "failure_domain"],
             }
         ],
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -4062,6 +4137,11 @@ def test_l1_runs_for_l0_structural_candidate(tmp_path):
             }
         ],
         "justification": "The cited current-log error was selected as user failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -4168,6 +4248,11 @@ def test_l2_defensively_withholds_primary_with_known_non_primary_role(tmp_path):
             }
         ],
         "justification": "This exception occurred during teardown.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     bundle = build_l0_bundle(str(log_path))
@@ -4622,6 +4707,11 @@ def test_l4_maps_established_unrecoverable_workload_failure_to_stop(tmp_path):
             }
         ],
         "justification": "The cited current-log error was selected as user failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -4704,6 +4794,11 @@ def test_deterministic_is_ready_while_l1_is_pending(tmp_path):
             }
         ],
         "justification": "The current-log assertion is likely to repeat.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
     extractor = _BlockingEvidenceExtractor(evidence)
     observed = []
@@ -4807,6 +4902,11 @@ def test_enriched_route_does_not_inherit_deterministic_history(tmp_path):
             }
         ],
         "justification": "The assertion is ambiguous in one cycle.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
     extractor = _BlockingEvidenceExtractor(evidence)
     observed = []
@@ -4874,6 +4974,11 @@ def test_l4_keeps_retryable_port_with_wait_precondition_ambiguous(tmp_path):
         "related_failures": [],
         "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The socket bind failure is the initiating failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -4922,6 +5027,11 @@ def test_model_recovery_confidence_is_preserved_without_recurrence_score(tmp_pat
         "related_failures": [],
         "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The bind failure ended setup.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
     extractor = _FakeEvidenceExtractor(evidence)
 
@@ -4995,6 +5105,11 @@ def test_immediate_stop_requires_affirmative_grounded_persistence_evidence(
         "related_failures": [],
         "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The permission error ended setup.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -5057,6 +5172,11 @@ def test_l2_flags_unverified_path_owner_without_treating_rank_fanout_as_persiste
             {"line": 4, "quote": f"[rank96]: {failure_line}", "supports": "persistence"},
         ],
         "justification": "The denied cache lock ended setup on the ranks.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -5113,6 +5233,11 @@ def test_l4_stops_for_established_unrecoverable_workload_claims(tmp_path):
         "related_failures": [],
         "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The workload OOM is the initiating failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -5170,6 +5295,11 @@ def test_l4_uses_workload_confirmation_when_domain_support_outlives_cause_hypoth
         "related_failures": [],
         "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The worker failure terminated the attempt.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -5217,6 +5347,11 @@ def test_cuda_oom_policy_overrides_action_without_mutating_l1_assessment(tmp_pat
         "related_failures": [],
         "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The workload OOM is the initiating failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -5278,6 +5413,11 @@ def test_l4_keeps_retry_recoverable_workload_failure_restartable(tmp_path):
             }
         ],
         "justification": "The cited current-log error was selected as user failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -5334,6 +5474,11 @@ def test_l4_maps_infrastructure_domain_to_restart(tmp_path):
         "related_failures": [],
         "evidence": [{"line": 1, "quote": failure_line, "supports": "primary_failure"}],
         "justification": "The device-loss exception is the initiating failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     payload = (
@@ -5587,6 +5732,11 @@ def test_l1_recovery_assessment_and_policy_context_precedence(
             }
         ],
         "justification": "The model selected an unmapped L1-only numeric instability.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -5656,6 +5806,11 @@ def test_l1_retries_retryable_provider_failure_then_uses_valid_evidence(tmp_path
             }
         ],
         "justification": "The cited current-log error was selected as user failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_RetryOnceEvidenceExtractor(evidence))
@@ -6102,6 +6257,11 @@ def test_l1_repairs_incomplete_contract_once_without_tools(tmp_path):
         "cascades": [],
         "evidence": [{"line": 1, "quote": log_line, "supports": "primary_failure"}],
         "justification": "The configuration error is the initiating failure.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
     extractor = _ContractRepairEvidenceExtractor(evidence)
     bundle = build_l0_bundle(str(log_path))
@@ -6190,6 +6350,11 @@ def test_l1_output_limit_gets_one_distinct_tools_disabled_final_turn(tmp_path):
         {
             "schema_version": "restart_agent_evidence.v1",
             "analysis_status": "insufficient_evidence",
+            "category_selection": {
+                "category_id": 0,
+                "category_confidence": 0,
+                "category_rationale": "not applicable",
+            },
         }
     )
     bundle = build_l0_bundle(str(log_path))
@@ -6489,6 +6654,11 @@ def test_l1_unknown_fields_are_ignored_without_affecting_policy(tmp_path):
             }
         ],
         "justification": "Bad model output.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     current = _current_evidence(evidence)
@@ -6562,6 +6732,11 @@ def test_l1_provider_timeout_is_not_trusted_even_with_evidence(tmp_path):
             }
         ],
         "justification": "Should not be trusted because provider timed out.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(
@@ -6635,6 +6810,11 @@ def test_l1_truncated_output_is_not_trusted_even_with_evidence(tmp_path):
             }
         ],
         "justification": "Should not be trusted because output was truncated.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(
@@ -6701,6 +6881,11 @@ def test_l1_token_limit_hit_is_reported_from_finish_reason_length(tmp_path):
             }
         ],
         "justification": "Token limit hit should be visible in trace.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(
@@ -7805,6 +7990,11 @@ def test_different_checkpoint_success_is_structured_without_overriding_l1(
         "related_failures": [],
         "evidence": [{"line": 12, "quote": lines[11], "supports": "primary_failure"}],
         "justification": "The progress-log assertion terminated checkpoint save.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
     payload = analyzer.analyze({"log_path": str(log_path)}).to_payload()
@@ -8972,6 +9162,11 @@ def test_l2_does_not_treat_current_attempt_fanout_as_cross_attempt_persistence(t
             {"line": 1, "quote": lines[0], "supports": "execution_position"},
         ],
         "justification": "The mechanism is observed, while recurrence remains unproven.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
@@ -9325,6 +9520,11 @@ def test_distributed_timeout_incident_groups_operations_and_has_order_invariant_
         "related_failures": [],
         "evidence": [{"line": 4, "quote": first_lines[3], "supports": "primary_failure"}],
         "justification": "The later operation belongs to the same timeout wave.",
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
     analyzer = RestartAgent(evidence_extractor=_FakeEvidenceExtractor(evidence))
     payload = analyzer.analyze(

--- a/tests/attribution/unit/test_restart_agent_attempt_records.py
+++ b/tests/attribution/unit/test_restart_agent_attempt_records.py
@@ -98,6 +98,11 @@ class _EvidenceExtractor:
                     ],
                 }
             ],
+            "category_selection": {
+                "category_id": 0,
+                "category_confidence": 0,
+                "category_rationale": "not applicable",
+            },
         }
         return L1EvidenceResult(
             semantic_payload=evidence,

--- a/tests/attribution/unit/test_restart_agent_confirmation_policy.py
+++ b/tests/attribution/unit/test_restart_agent_confirmation_policy.py
@@ -564,6 +564,10 @@ def test_rejected_iteration_policy_context_is_configurable():
             "enabled": True,
             "allowed_retries": 4,
         },
+        "l1_category_confirmed_restart": {
+            "enabled": False,
+            "allowed_retries": 1,
+        },
     }
 
 

--- a/tests/attribution/unit/test_restart_agent_l1_categories_json.py
+++ b/tests/attribution/unit/test_restart_agent_l1_categories_json.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for JSON-backed L1 category taxonomy loading and schema validation.
+
+The taxonomy lives in ``l1/categories.json`` and is loaded + validated at
+import time by ``l1/categories.py``. These tests verify the on-disk schema
+holds and that the loader rejects malformed payloads.
+"""
+
+import json
+from importlib import resources
+
+import pytest
+
+from nvidia_resiliency_ext.attribution.restart_agent.l1 import categories as categories_module
+from nvidia_resiliency_ext.attribution.restart_agent.l1.categories import (
+    CATEGORIES,
+    CATEGORIES_SCHEMA_VERSION,
+    CategoryDef,
+    category_by_id,
+)
+
+# ---------------------------------------------------------------------------
+# On-disk JSON shape
+# ---------------------------------------------------------------------------
+
+
+def _load_raw_json() -> dict:
+    path = resources.files("nvidia_resiliency_ext.attribution.restart_agent.l1").joinpath(
+        "categories.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_categories_json_uses_declared_schema_version():
+    payload = _load_raw_json()
+    assert payload["schema_version"] == CATEGORIES_SCHEMA_VERSION
+
+
+def test_categories_json_has_at_least_one_entry():
+    payload = _load_raw_json()
+    assert isinstance(payload["categories"], list)
+    assert len(payload["categories"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# CATEGORIES tuple properties
+# ---------------------------------------------------------------------------
+
+
+def test_categories_ids_are_sequential_1_based():
+    ids = [c.id for c in CATEGORIES]
+    assert ids == list(range(1, len(CATEGORIES) + 1))
+
+
+def test_categories_names_are_unique():
+    names = [c.name for c in CATEGORIES]
+    assert len(names) == len(set(names))
+
+
+def test_categories_decisions_are_within_allowed_set():
+    allowed = {"STOP", "RESTART", "EXCLUDED"}
+    for c in CATEGORIES:
+        assert c.decision in allowed, f"{c.id} ({c.name}) has invalid decision {c.decision!r}"
+
+
+def test_categories_json_and_module_agree_on_size():
+    payload = _load_raw_json()
+    assert len(payload["categories"]) == len(CATEGORIES)
+
+
+def test_category_by_id_returns_expected_entry():
+    entry = category_by_id(1)
+    assert isinstance(entry, CategoryDef)
+    assert entry.id == 1
+
+
+def test_category_by_id_returns_none_on_placeholder_and_out_of_range():
+    assert category_by_id(0) is None
+    assert category_by_id(-1) is None
+    assert category_by_id(len(CATEGORIES) + 1) is None
+    assert category_by_id(True) is None  # noqa: E712 -- bools rejected
+
+
+# ---------------------------------------------------------------------------
+# Loader rejects malformed payloads
+# ---------------------------------------------------------------------------
+
+
+def _run_loader_on(payload) -> None:
+    """Invoke the private loader with a monkeypatched resources.open()."""
+    # Directly call the validator by simulating a broken payload through the
+    # same code path. We reuse the module's constants for the required-fields
+    # sanity checks.
+    import json as _json
+    from importlib import resources as _resources
+
+    orig = _resources.files
+
+    class _Files:
+        def __init__(self, target):
+            self._target = target
+
+        def joinpath(self, name):
+            return self
+
+        def open(self, *args, **kwargs):
+            import io
+
+            return io.StringIO(_json.dumps(payload))
+
+    def fake_files(pkg):
+        return _Files(pkg)
+
+    _resources.files = fake_files
+    try:
+        categories_module._load_categories()
+    finally:
+        _resources.files = orig
+
+
+def test_loader_rejects_wrong_schema_version():
+    payload = {"schema_version": "not_the_right_version", "categories": []}
+    with pytest.raises(ValueError, match="schema_version"):
+        _run_loader_on(payload)
+
+
+def test_loader_rejects_empty_categories():
+    payload = {"schema_version": CATEGORIES_SCHEMA_VERSION, "categories": []}
+    with pytest.raises(ValueError, match="non-empty array"):
+        _run_loader_on(payload)
+
+
+def test_loader_rejects_duplicate_id():
+    entry = {
+        "id": 1,
+        "name": "one",
+        "description": "d",
+        "decision": "RESTART",
+    }
+    payload = {
+        "schema_version": CATEGORIES_SCHEMA_VERSION,
+        "categories": [entry, dict(entry, name="two")],
+    }
+    with pytest.raises(ValueError, match="duplicate"):
+        _run_loader_on(payload)
+
+
+def test_loader_rejects_non_sequential_id():
+    payload = {
+        "schema_version": CATEGORIES_SCHEMA_VERSION,
+        "categories": [
+            {
+                "id": 5,
+                "name": "gap",
+                "description": "d",
+                "decision": "RESTART",
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="1-based sequential"):
+        _run_loader_on(payload)
+
+
+def test_loader_rejects_duplicate_name():
+    entry = {
+        "name": "same",
+        "description": "d",
+        "decision": "RESTART",
+    }
+    payload = {
+        "schema_version": CATEGORIES_SCHEMA_VERSION,
+        "categories": [dict(entry, id=1), dict(entry, id=2)],
+    }
+    with pytest.raises(ValueError, match="duplicate"):
+        _run_loader_on(payload)
+
+
+def test_loader_rejects_invalid_decision():
+    payload = {
+        "schema_version": CATEGORIES_SCHEMA_VERSION,
+        "categories": [
+            {
+                "id": 1,
+                "name": "bad",
+                "description": "d",
+                "decision": "MAYBE",
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="decision"):
+        _run_loader_on(payload)
+
+
+def test_loader_rejects_missing_field():
+    payload = {
+        "schema_version": CATEGORIES_SCHEMA_VERSION,
+        "categories": [
+            {
+                "id": 1,
+                "name": "bad",
+                # missing description
+                "decision": "RESTART",
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="missing required fields"):
+        _run_loader_on(payload)

--- a/tests/attribution/unit/test_restart_agent_l1_execution.py
+++ b/tests/attribution/unit/test_restart_agent_l1_execution.py
@@ -48,6 +48,11 @@ def _valid_no_failure_evidence():
         },
         "related_failures": [],
         "evidence": [],
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "no failure observed",
+        },
     }
 
 
@@ -99,6 +104,11 @@ def _primary_evidence_without_recovery_support():
                 "supports": ["primary_failure", "root_cause_assessment"],
             }
         ],
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable to this fixture",
+        },
     }
 
 

--- a/tests/attribution/unit/test_restart_agent_l2_recovery_grounding.py
+++ b/tests/attribution/unit/test_restart_agent_l2_recovery_grounding.py
@@ -66,6 +66,11 @@ def _checkpoint_timeout_evidence(failure_line):
                 "supports": ["primary_failure", "root_cause_assessment"],
             }
         ],
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
 

--- a/tests/attribution/unit/test_restart_agent_l4_category_restart_context.py
+++ b/tests/attribution/unit/test_restart_agent_l4_category_restart_context.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the l1_category_confirmed_restart policy_context (two-way L1 category override).
+
+Fires only when:
+- The context is enabled in PolicyContextConfig.
+- Primary is grounded.
+- L1 category picker chose a RESTART-labeled taxonomy entry.
+- Base rule concluded workload_unrecoverable.
+- History shows no prior attempt with the same root_fingerprint.
+
+Emits workload_confirmation_retry with history_match_scope=ROOT_ONLY. On
+recurrence, the first-occurrence guard suppresses the override and base_rule
++ history exhaustion take over.
+"""
+
+from nvidia_resiliency_ext.attribution.restart_agent.l4 import L4PolicyInput, evaluate_policy
+from nvidia_resiliency_ext.attribution.restart_agent.models import (
+    AssessmentStatus,
+    AttemptFailureFacts,
+    AttemptFailureFactsSource,
+    CudaOomNoRetryConfig,
+    Decision,
+    DecisionBasis,
+    FailureClassifier,
+    FailureDomain,
+    FailureDomainAssessment,
+    FailureEvidence,
+    FaultOutcome,
+    HistoryMatchScope,
+    HistorySummary,
+    L1CategoryConfirmedRestartConfig,
+    ModelRecoveryAssessment,
+    PolicyContextConfig,
+    RetryOutlookAssessment,
+    RetryOutlookWithoutWorkloadChange,
+    RetryPolicyRule,
+)
+
+L1_CATEGORY_CONFIRMED_RESTART = "l1_category_confirmed_restart"
+
+# Cat 21 in our taxonomy is a RESTART-labeled category
+# ("Post-checkpoint progress-log assertion"). Cat 31 CPU OOM is also RESTART.
+# Cat 32 CUDA OOM is STOP. We use these for the tests below.
+RESTART_CATEGORY_ID = 21
+STOP_CATEGORY_ID = 32
+
+
+def _grad_inf_primary() -> FailureEvidence:
+    """A workload_unrecoverable-shaped primary — the gemini b1-037 pattern."""
+    return FailureEvidence(
+        failure_class="assertion_error",
+        signature="AssertionError: progress log missing entry",
+        root_fingerprint="assertion:progress_log_missing",
+        root_fingerprint_source="assertion",
+        fault_outcome=FaultOutcome.TERMINAL.value,
+        line=200,
+        registry_id="assertion",
+    )
+
+
+def _grad_inf_facts() -> AttemptFailureFacts:
+    return AttemptFailureFacts(
+        source=AttemptFailureFactsSource.L2_GROUNDED,
+        root_fingerprint="assertion:progress_log_missing",
+        root_fingerprint_source="assertion",
+        fault_outcome=FaultOutcome.TERMINAL.value,
+        primary_line=200,
+        classifiers=(),
+    )
+
+
+def _workload_unrecoverable_recovery() -> ModelRecoveryAssessment:
+    """Assessment that forces base_rule to workload_unrecoverable via _immediate_stop_qualified."""
+    return ModelRecoveryAssessment(
+        failure_domain=FailureDomainAssessment(
+            value=FailureDomain.WORKLOAD,
+            status=AssessmentStatus.ESTABLISHED_BY_CURRENT_LOG,
+            confidence=90,
+        ),
+        retry_outlook_without_workload_change=RetryOutlookAssessment(
+            value=RetryOutlookWithoutWorkloadChange.CANNOT_RECOVER,
+            status=AssessmentStatus.ESTABLISHED_BY_CURRENT_LOG,
+            confidence=90,
+        ),
+        rationale="terminal workload failure",
+    )
+
+
+def _category_selection(category_id: int, category_confidence: int = 90) -> dict:
+    return {
+        "category_id": category_id,
+        "category_confidence": category_confidence,
+        "category_rationale": "test",
+    }
+
+
+def _enabled_policy_contexts() -> PolicyContextConfig:
+    return PolicyContextConfig(
+        l1_category_confirmed_restart=L1CategoryConfirmedRestartConfig(
+            enabled=True, allowed_retries=1
+        ),
+    )
+
+
+def _empty_history() -> HistorySummary:
+    return HistorySummary(available=True, matching_root_attempts=0)
+
+
+def _recurrence_history() -> HistorySummary:
+    return HistorySummary(available=True, matching_root_attempts=1)
+
+
+# ---------------------------------------------------------------------------
+# Positive path: first occurrence with RESTART category flips STOP to RESTART
+# ---------------------------------------------------------------------------
+
+
+def test_restart_context_fires_on_first_occurrence_with_restart_category():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_grad_inf_primary(),
+            current_failure_facts=_grad_inf_facts(),
+            history=_empty_history(),
+            model_recovery_assessment=_workload_unrecoverable_recovery(),
+            policy_contexts=_enabled_policy_contexts(),
+            l1_category_selection=_category_selection(RESTART_CATEGORY_ID),
+        )
+    ).retry_policy
+
+    assert outcome.decision == Decision.RESTART.value
+    assert outcome.effective_policy.policy_context_id == L1_CATEGORY_CONFIRMED_RESTART
+    assert outcome.effective_policy.rule == RetryPolicyRule.WORKLOAD_CONFIRMATION_RETRY.value
+    assert outcome.effective_policy.history_match_scope == HistoryMatchScope.ROOT_ONLY.value
+    assert outcome.effective_policy.allowed_retries == 1
+
+
+# ---------------------------------------------------------------------------
+# Negative paths (context does not fire)
+# ---------------------------------------------------------------------------
+
+
+def test_restart_context_no_op_when_disabled():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_grad_inf_primary(),
+            current_failure_facts=_grad_inf_facts(),
+            history=_empty_history(),
+            model_recovery_assessment=_workload_unrecoverable_recovery(),
+            policy_contexts=PolicyContextConfig(),  # disabled by default
+            l1_category_selection=_category_selection(RESTART_CATEGORY_ID),
+        )
+    ).retry_policy
+
+    assert outcome.decision == Decision.STOP.value
+    assert outcome.decision_basis == DecisionBasis.WORKLOAD_UNRECOVERABLE.value
+    assert outcome.effective_policy.policy_context_id is None
+
+
+def test_restart_context_no_op_on_recurrence():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_grad_inf_primary(),
+            current_failure_facts=_grad_inf_facts(),
+            history=_recurrence_history(),
+            model_recovery_assessment=_workload_unrecoverable_recovery(),
+            policy_contexts=_enabled_policy_contexts(),
+            l1_category_selection=_category_selection(RESTART_CATEGORY_ID),
+        )
+    ).retry_policy
+
+    assert outcome.decision == Decision.STOP.value
+    assert outcome.decision_basis == DecisionBasis.WORKLOAD_UNRECOVERABLE.value
+    assert outcome.effective_policy.policy_context_id is None
+
+
+def test_restart_context_no_op_for_stop_category():
+    """Cat 25 CUDA OOM is a STOP category. The RESTART context must not touch it."""
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_grad_inf_primary(),
+            current_failure_facts=_grad_inf_facts(),
+            history=_empty_history(),
+            model_recovery_assessment=_workload_unrecoverable_recovery(),
+            policy_contexts=_enabled_policy_contexts(),
+            l1_category_selection=_category_selection(STOP_CATEGORY_ID),
+        )
+    ).retry_policy
+
+    # STOP-category context takes precedence and fires with allowed_retries=0.
+    assert outcome.decision == Decision.STOP.value
+
+
+def test_restart_context_no_op_when_base_rule_is_not_workload_unrecoverable():
+    """If base_rule is already a RESTART rule, the override should not fire."""
+    # Weaker assessment: workload/supported_but_unconfirmed produces
+    # workload_confirmation_retry, not workload_unrecoverable.
+    weak = ModelRecoveryAssessment(
+        failure_domain=FailureDomainAssessment(
+            value=FailureDomain.WORKLOAD,
+            status=AssessmentStatus.SUPPORTED_BUT_UNCONFIRMED,
+            confidence=50,
+        ),
+        retry_outlook_without_workload_change=RetryOutlookAssessment(
+            value=RetryOutlookWithoutWorkloadChange.MAY_RECOVER,
+            status=AssessmentStatus.SUPPORTED_BUT_UNCONFIRMED,
+            confidence=50,
+        ),
+        rationale="uncertain workload failure",
+    )
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_grad_inf_primary(),
+            current_failure_facts=_grad_inf_facts(),
+            history=_empty_history(),
+            model_recovery_assessment=weak,
+            policy_contexts=_enabled_policy_contexts(),
+            l1_category_selection=_category_selection(RESTART_CATEGORY_ID),
+        )
+    ).retry_policy
+
+    assert outcome.decision == Decision.RESTART.value
+    # Base rule handled it; our RESTART context did not.
+    assert outcome.effective_policy.policy_context_id is None
+
+
+def test_restart_context_no_op_when_category_id_missing():
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=_grad_inf_primary(),
+            current_failure_facts=_grad_inf_facts(),
+            history=_empty_history(),
+            model_recovery_assessment=_workload_unrecoverable_recovery(),
+            policy_contexts=_enabled_policy_contexts(),
+            l1_category_selection={"category_id": 0, "category_confidence": 0},
+        )
+    ).retry_policy
+
+    assert outcome.decision == Decision.STOP.value
+    assert outcome.effective_policy.policy_context_id is None
+
+
+def test_restart_context_yields_precedence_to_cuda_oom_stop_context():
+    """cuda_oom_no_retry fires first; our RESTART context never gets a chance."""
+    cuda_oom_facts = AttemptFailureFacts(
+        source=AttemptFailureFactsSource.L0_DETERMINISTIC,
+        root_fingerprint="cuda_oom:allocation_failure",
+        root_fingerprint_source="cuda_oom",
+        fault_outcome=FaultOutcome.TERMINAL.value,
+        primary_line=100,
+        classifiers=(FailureClassifier.CUDA_OOM.value,),
+    )
+    cuda_oom_primary = FailureEvidence(
+        failure_class="cuda_oom",
+        signature="CUDA error: out of memory",
+        root_fingerprint="cuda_oom:allocation_failure",
+        root_fingerprint_source="cuda_oom",
+        fault_outcome=FaultOutcome.TERMINAL.value,
+        line=100,
+        registry_id="cuda_oom",
+    )
+    outcome = evaluate_policy(
+        L4PolicyInput(
+            primary=cuda_oom_primary,
+            current_failure_facts=cuda_oom_facts,
+            history=_empty_history(),
+            model_recovery_assessment=_workload_unrecoverable_recovery(),
+            policy_contexts=PolicyContextConfig(
+                cuda_oom_no_retry=CudaOomNoRetryConfig(enabled=True),
+                l1_category_confirmed_restart=L1CategoryConfirmedRestartConfig(
+                    enabled=True, allowed_retries=1
+                ),
+            ),
+            l1_category_selection=_category_selection(RESTART_CATEGORY_ID),
+        )
+    ).retry_policy
+
+    # cuda_oom_no_retry wins by classifier-context precedence.
+    assert outcome.decision == Decision.STOP.value
+    assert outcome.effective_policy.policy_context_id == "cuda_oom_no_retry"

--- a/tests/attribution/unit/test_restart_agent_observation_only.py
+++ b/tests/attribution/unit/test_restart_agent_observation_only.py
@@ -85,6 +85,11 @@ def _observation_payload():
                 "supports": ["root_cause_assessment"],
             }
         ],
+        "category_selection": {
+            "category_id": 0,
+            "category_confidence": 0,
+            "category_rationale": "not applicable",
+        },
     }
 
 


### PR DESCRIPTION
## Summary

Layers the 38-category L1 taxonomy and the `l1_category_confirmed_stop` policy context from PR #390 on top of PR #400's typed-claim architecture. The category signal runs last in the policy cascade, subordinate to PR #400's four deterministic classifier contexts (`workload_unrecoverable`, `concrete_confirmation_retry`, `workload_confirmation_retry`, `general_retry`) — it only fires when the primary is grounded and the picked category's `decision` is `STOP`.

## Why

Empirically, LLMs are ~30pp better at concrete classification (picking one of 38 named categories) than at abstract downstream reasoning (naming failure_domain and retry_outlook via prose). PR #400's classifier cascade relies on that abstract reasoning to hit `workload_unrecoverable`, which leaves a cluster of deterministic-workload STOP cases uncovered. This PR routes the concrete signal directly into L4 as an additional PolicyContext without touching PR #400's cascade order.

## What's in this PR

- **`l1/categories.py`** — 38-entry taxonomy (id, name, description, `decision` ∈ {STOP, RESTART}, `failure_domain`, `retry_outlook`)
- **`l1/response_contract.py`** — declares `category_selection` as a required top-level L1 field (OpenAI structured-output would otherwise silently skip an optional field on ~40% of calls)
- **`l1/prompts.py`** — renders the taxonomy into the L1 prompt and asks the model to pick one
- **`l1/validation.py`** — validates category_selection; five in-place normalizers ported from PR #390 for contract-repair fallbacks
- **`l1/openai_compatible.py`** — wires `repair_model_evidence` before schema validation
- **`l1/contracts.py`** — adds `category_selection()` accessor
- **`l4/policy.py`** — adds `l1_category_confirmed_stop` PolicyContext. Fires with `allowed_retries=0` when the primary failure is grounded and the picked category has `decision=\"STOP\"`. Runs after every deterministic classifier context, so it never overrides them.
- **`decision_pipeline.py`** — passes `l1_category_selection` into `L4CyclePolicyInput`
- **`docs/design/attribution/restart_agent/spike_l1_category_integration.md`** — design note explaining rationale and DECISIONS.md alignment
- Also flips categories 25 (\"CUDA OOM\") and 27 (\"CUDA OOM during checkpoint async-save\") from RESTART to STOP after product-policy discussion — a CUDA OOM under an unchanged workload is highly likely to reproduce on retry, and the retry cost is high

## Numbers

All numbers on 79-case subset_batch1 with `gold_v3` (CUDA OOM = STOP).

### 1. Final decision accuracy

| config | gpt | qwen397b | gemini | nemotron |
|---|---|---|---|---|
| PR #400 baseline | 69.6% | 75.9% | 93.7% | 82.3% |
| PR #390 (previous approach) | 92.4% | 89.9% | 92.4% | 87.3% |
| **This PR (spike v5)** | **100.0%** | **98.7%** | **96.2%** | **89.9%** |

Δ vs PR #400 baseline: **+7.6 to +30.4 pp**. Δ vs PR #390: **+2.6 to +7.6 pp**.

### 2. L1 category selection accuracy

| | gpt | qwen397b | gemini | nemotron |
|---|---|---|---|---|
| picked cat == gold cat | 94.8% | 88.6% | 92.3% | 78.2% |

### 3. L4 policy-question accuracy (failure_domain + retry_outlook)

Scored against the `recovery_assessment_expectation` in gold_v3.

| field | gpt | qwen397b | gemini | nemotron |
|---|---|---|---|---|
| failure_domain (workload/infrastructure) | 67.1% | 69.6% | 82.1% | 62.0% |
| retry_outlook (may_recover / cannot_recover) | 83.5% | 91.1% | 79.5% | 70.9% |

### 4. Natural-language root cause accuracy (LLM-judged)

Judge is GPT-5.5 comparing each model's `l1_assessment.root_cause_assessment.summary` + `primary_failure.failure_identity` against the human-authored `root_cause` sentence from `nemotron6_author_seed_labels.csv`.

**Lenient rubric** — mechanism-family match, minor detail slips acceptable:

| config | gpt | qwen397b | gemini | nemotron |
|---|---|---|---|---|
| This PR (spike v5) | 93.0% | 91.8% | 90.3% | 88.9% |
| PR #390 (previous approach) | 100.0% | 97.4% | 90.7% | 92.2% |

**Gaokao rubric** — same-meaning match (Chinese Gaokao reading-comprehension style: same event/subsystem/phase; paraphrase OK; wrong-mechanism WRONG even if family matches):

| config | gpt | qwen397b | gemini | nemotron |
|---|---|---|---|---|
| This PR (spike v5) | 65.8% | 68.4% | 67.1% | 67.1% |
| PR #390 (previous approach) | 71.6% | 69.9% | 63.5% | 64.1% |

## Interpretation

- The category signal is the load-bearing element. Where the picker is right, the decision is right. Where it's wrong, the decision is wrong ~95% of the time.
- The `l1_category_confirmed_stop` context fires on 24–28 cases per model with 82–100% precision (nemotron 82%, other three ≥ 96%).
- Reasoning-block accuracy (failure_domain, retry_outlook, NL root cause) is materially lower than category accuracy across every model. The pipeline routes around this gap by making the concrete-classification signal first-class policy input.
- Under the Gaokao rubric, PR #390 and spike v5 are within ±4pp of each other on every model. NL RC quality tracks the underlying LLM's ceiling, not the pipeline architecture.

## DECISIONS.md alignment

- **D2** (L2 non-overriding): the category context runs *after* every classifier context. Cannot flip a STOP from `workload_unrecoverable` to RESTART; cannot flip a RESTART from `port_bind_confirmation_retry` to STOP.
- **D8** (score-free deterministic): no scoring or confidence gate. The context fires purely on a category's typed `decision` field.
- **D9** (config-owned policy): the category → decision mapping lives in `l1/categories.py`, editable without code changes to L4.
- **D14** (separate surface from root): the category is a compact summary of the failure family, not a root-cause claim. Root cause continues to come from `l1_assessment.root_cause_assessment`.

## Follow-ups

- **NL root cause improvement** is not on the shortlist. Under Gaokao grading, both PR #390 and this PR land at 65–72% across models, indicating this is closer to the underlying LLM ceiling than a fixable pipeline gap. ~15% of the gap comes from gold labels that reference off-log context the analyzer cannot access (documented in `v4-key-lessons` design note). Higher-ROI targets: better nemotron category calibration; ports of PR #390's small deterministic gates that don't rely on category classification.
- The eval scorer at `tools/restart_agent_eval/src/restart_agent_eval/evaluate.py` reads `analyzer_trace.l1.parsed_evidence.model_recovery_assessment` — PR #400 renamed that path to `.semantic_payload.model_recovery_assessment`. Every recovery-block metric in results.jsonl reports 0% as a result. Fixing the scorer path is a small, high-value follow-up unrelated to this PR.

## Test plan
- [ ] `pytest tests/attribution/unit/` — all green
- [ ] Full spike v5 eval reproduces numbers reported above
- [ ] Manual review of one confirmed_stop fire and one deterministic-context fire per model to verify precedence

## Follow-up landed: opt-in two-way flip (`l1_category_confirmed_restart`)

Commit `a942ad4` adds a companion RESTART context — the mirror image of the STOP context. Disabled by default. When enabled via `policy_contexts.l1_category_confirmed_restart.enabled = True`, it overrides a `workload_unrecoverable` base_rule when:

1. The L1 category picker chose a RESTART-labeled taxonomy entry.
2. History shows zero prior attempts with the same `root_fingerprint` (first-occurrence guard).

Emits `workload_confirmation_retry` with `history_match_scope=ROOT_ONLY` and `allowed_retries=1`. On any recurrence, the guard suppresses the override; base_rule + exhaustion produce STOP. Runs after every deterministic classifier context and after the STOP category context.

**Why this exists.** On the 79-case eval, gemini and nemotron's abstract L1 signals (`retry_outlook=cannot_recover`, `established_by_current_log`) are over-confident on cases where the concrete category picker correctly identifies a RESTART family (grad-inf, progress-log assertion, CPU OOM). PR #400's base_rule cascade believes the abstract signals and lands STOP. This context restores the RESTART on first occurrence.

**Two-way eval on gold_v3, 79 cases × 4 models:**

| model | one-way | two-way | Δ |
|---|---|---|---|
| gpt | 100.0% | 98.7% | −1.3pp (LLM stochasticity on b1-048; new context inactive here) |
| qwen397b | 94.9% | 96.2% | +1.3pp |
| gemini | 97.5% | **100.0%** | **+2.5pp** |
| nemotron | 91.1% | 92.4% | +1.3pp |

**New context precision:** 5 fires, 5 correct, **100%**.

**Design guarantees:**

- **Only overrides `workload_unrecoverable`**, not other STOP-yielding rules. Minimal override surface.
- **First-occurrence guard.** On recurrence of the same `root_fingerprint`, context returns None and base_rule STOPs.
- **Secondary safety: `history_match_scope=ROOT_ONLY` + `allowed_retries=1`**. Even if the guard misses on a corner case, the `selected_policy_ledger` counts prior same-root attempts against the budget of 1 and produces `exhausted_by → STOP` on the second occurrence.
- **Config-gated.** `enabled=False` by default. Shipping code with no behavior change; operators opt in.

**Tests:** 7 new focused tests for the RESTART branch (first-occurrence positive, disabled-noop, recurrence-noop, STOP-cat-noop, RESTART-base-rule-noop, missing-cat-id-noop, cuda_oom-precedence). Full attribution/unit suite: **659 passed**.

Recommended review path: keep `enabled=False` in the default shipped config for now; flip on in a per-deployment override after a few operator runs.
