### PR TITLE
Bump MCP dependency floor for CVE-2026-59950

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pydantic-settings = ">=2.0.0"
 slowapi = ">=0.1.9"
 slack-bolt = { version = ">=1.23.0", optional = true }
 slack-sdk = { version = ">=3.35.0", optional = true }
-mcp = { version = ">=1.15.0,<2.0.0", optional = true }
+mcp = { version = ">=1.28.1,<2.0.0", optional = true }
 setproctitle = { version = ">=1.3.0", optional = true }
 grpcio = "^1.76.0"
 grpcio-tools = "^1.76.0"

--- a/src/nvidia_resiliency_ext/attribution/legacy_logsage/requirements.txt
+++ b/src/nvidia_resiliency_ext/attribution/legacy_logsage/requirements.txt
@@ -1,6 +1,6 @@
 # Source-checkout-only dependencies for legacy LogSage MCP tools.
 # Keep the MCP range aligned with the attribution extra in pyproject.toml.
-mcp>=1.15.0,<2.0.0
+mcp>=1.28.1,<2.0.0
 langchain-core
 langchain-openai
 logsage


### PR DESCRIPTION
## Summary
- Raise the optional MCP SDK dependency floor from `>=1.15.0` to `>=1.28.1` for the attribution extra.
- Keep the legacy LogSage MCP requirements aligned with the same floor.

## Problem
Nspect flagged `mcp` via CVE-2026-59950. MCP Python SDK versions before `1.28.1` allowed the deprecated websocket server transport to accept WebSocket handshakes without SDK-level Host/Origin validation.

NVRx Attribution uses the stdio MCP transport, not the deprecated websocket transport, so the direct runtime exposure is low. The packaging metadata still allowed vulnerable MCP versions to be installed, though, which is enough for dependency scanners to keep flagging the checkout.

## Fix
Constrain both NVRx packaging paths that declare MCP to `mcp>=1.28.1,<2.0.0`, so attribution installs resolve to a patched MCP SDK while preserving the existing major-version ceiling.

## Validation
- Local temp install of `mcp>=1.28.1,<2.0.0` resolved `mcp-1.29.1`.
- Local: `PYTHONPATH=src python -m pytest -q tests/attribution/unit/test_mcp_server_command.py tests/attribution/unit/test_mcp_server_cache.py tests/attribution/unit/test_mcp_module_definitions.py tests/attribution/unit/test_attrsvc_settings.py` -> `29 passed`.
- Local: `PYTHONPATH=src python -m pytest -q tests/fault_tolerance/unit/test_attribution_manager.py` -> `48 passed`.
- Dev `10.86.160.9`: isolated `pip --target` resolved `mcp-1.29.1`; MCP stdio smoke listed `fr_analyzer,get_result,restart_agent,status` and returned `status=running`.
- Dev `10.86.160.9`: focused MCP/settings subset -> `29 passed`.
