### PR TITLE
Merge origin/main into stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pydantic-settings = ">=2.0.0"
 slowapi = ">=0.1.9"
 slack-bolt = { version = ">=1.23.0", optional = true }
 slack-sdk = { version = ">=3.35.0", optional = true }
-mcp = { version = ">=1.15.0,<2.0.0", optional = true }
+mcp = { version = ">=1.28.1,<2.0.0", optional = true }
 setproctitle = { version = ">=1.3.0", optional = true }
 grpcio = "^1.76.0"
 grpcio-tools = "^1.76.0"

--- a/src/nvidia_resiliency_ext/attribution/legacy_logsage/requirements.txt
+++ b/src/nvidia_resiliency_ext/attribution/legacy_logsage/requirements.txt
@@ -1,6 +1,6 @@
 # Source-checkout-only dependencies for legacy LogSage MCP tools.
 # Keep the MCP range aligned with the attribution extra in pyproject.toml.
-mcp>=1.15.0,<2.0.0
+mcp>=1.28.1,<2.0.0
 langchain-core
 langchain-openai
 logsage


### PR DESCRIPTION
Merge origin/main into release/v0.7. Brings in:
- Bump MCP dependency floor (#412)

Clean merge, no conflicts.