### PR TITLE
Confine gRPC log server writes to allowed roots

### DIFF
--- a/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/control_plane.py
@@ -161,7 +161,24 @@ def _start_control_services(
         applog_prefix = args.ft_per_cycle_applog_prefix
         log_funnel_ports = None
         grpc_log_prefix = None
-        if args.ft_enable_log_server:
+        # The funnel writes to paths its clients choose, so it can only run confined to the
+        # directories those logs live in. --ft-log-server-log-prefix names where the funnel's
+        # own diagnostics go and cannot define that boundary. Co-located control gets this
+        # structurally (the launcher only funnels inside `if base_log_file:`); mirror it here
+        # rather than failing startup, since log funneling is on by default for nvrx-control.
+        log_funnel_enabled = bool(args.ft_enable_log_server) and bool(
+            args.ft_per_cycle_applog_prefix or args.ft_nvrx_logfile
+        )
+        if args.ft_enable_log_server and not log_funnel_enabled:
+            logger.warning(
+                "Log funneling is enabled but neither --ft-per-cycle-applog-prefix nor "
+                "--ft-nvrx-logfile is set, so there is no client log destination to confine "
+                "the funnel to; not starting the gRPC log server(s). Launchers that are "
+                "themselves configured to funnel will block waiting for this host's funnel "
+                "port -- they do not fall back to direct writes. Pass the same applog prefix "
+                "here, or disable --ft-enable-log-server on those launchers."
+            )
+        if log_funnel_enabled:
             grpc_log_prefix = _resolve_grpc_log_server_log_prefix(args)
             assert grpc_log_prefix is not None
             log_funnel_ports = LogFunnelPorts.from_launcher_args(args)
@@ -182,7 +199,7 @@ def _start_control_services(
                 )
                 services.attribution_service.start_poller()
 
-        if args.ft_enable_log_server:
+        if log_funnel_enabled:
             assert log_funnel_ports is not None
             assert grpc_log_prefix is not None
             services.grpc_processes = _start_grpc_log_servers(

--- a/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/launcher.py
@@ -3255,6 +3255,48 @@ def _grpc_log_path(log_prefix: str, suffix: str) -> str:
     return log_prefix + suffix
 
 
+def _resolve_grpc_log_allowed_roots(args: Any) -> List[str]:
+    """
+    Directories the gRPC log servers are allowed to write into.
+
+    The servers bind an unauthenticated port and write to a path chosen by each client, so
+    they are given exactly the directories that gRPC clients actually target: the per-cycle
+    application log prefix and the launcher log. Per-cycle files (``<prefix>_cycleN.log``)
+    stay in the prefix's directory, so the dirname covers every cycle.
+
+    ``--ft-log-server-log-prefix`` is deliberately excluded: the servers' own ``_root.log`` /
+    ``_leaf_N.log`` are written by the launcher redirecting each subprocess's stdout/stderr
+    (see ``_open_log``), never through a ``LogChunk``, so allowing that directory would widen
+    the boundary for no reason.
+
+    Each directory is created before being resolved. ``realpath`` of a path that does not
+    exist yet returns the path unchanged, so a directory that only later appears as (or
+    under) a symlink would resolve differently at write time and the job's own logs would
+    be rejected. Creating it first pins the resolution; the log server would create it on
+    the first chunk regardless.
+
+    Returns:
+        Deduplicated resolved directories; empty only if no log paths are configured.
+    """
+    candidates = [
+        getattr(args, 'ft_per_cycle_applog_prefix', None),
+        getattr(args, 'ft_nvrx_logfile', None),
+    ]
+    roots: List[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        expanded = os.path.abspath(os.path.expanduser(candidate))
+        dirname = os.path.dirname(expanded) or os.sep
+        # Best effort: if creation fails the server will report the real error on first write.
+        with contextlib.suppress(OSError):
+            os.makedirs(dirname, exist_ok=True)
+        root = os.path.realpath(dirname)
+        if root not in roots:
+            roots.append(root)
+    return roots
+
+
 _LOG_FUNNEL_NODES_PER_LEAF = 1536  # max nodes per single log server (≈6K GPU at 4 GPUs/node)
 
 
@@ -3378,6 +3420,21 @@ def _start_grpc_log_servers(
 
     procs: List[subprocess.Popen] = []
     try:
+        # Clients pick the destination path for every log chunk, and these servers listen
+        # on all interfaces without auth, so confine writes to the configured log
+        # directories. Raising here is caught below and reported as a startup failure, so
+        # the launcher falls back to direct file writing rather than running unconfined.
+        allowed_roots = _resolve_grpc_log_allowed_roots(args)
+        if not allowed_roots:
+            raise ValueError(
+                "cannot determine allowed log write roots for the gRPC log server(s); "
+                "expected --ft-per-cycle-applog-prefix (or --ft-nvrx-logfile) to be set"
+            )
+        allowed_root_args: List[str] = []
+        for root in allowed_roots:
+            allowed_root_args += ['--allowed-root', root]
+        logger.info(f"gRPC log server(s) confined to allowed roots: {allowed_roots}")
+
         if not funnel_ports.uses_two_level:
             grpc_server_log = _grpc_log_path(log_prefix, '_root.log')
             max_workers = min(4096, max(100, max_nodes + 10))
@@ -3397,6 +3454,7 @@ def _start_grpc_log_servers(
                         str(max_workers),
                         '--graceful-shutdown-timeout',
                         str(graceful_shutdown_timeout),
+                        *allowed_root_args,
                     ],
                     stdout=fd,
                     stderr=subprocess.STDOUT,
@@ -3440,6 +3498,7 @@ def _start_grpc_log_servers(
                     str(root_workers),
                     '--graceful-shutdown-timeout',
                     str(root_graceful_shutdown_timeout),
+                    *allowed_root_args,
                 ],
                 stdout=root_fd,
                 stderr=subprocess.STDOUT,
@@ -3475,6 +3534,7 @@ def _start_grpc_log_servers(
                     str(max_queue),
                     '--graceful-shutdown-timeout',
                     str(graceful_shutdown_timeout),
+                    *allowed_root_args,
                 ]
                 lp = subprocess.Popen(  # nosec B603
                     leaf_cmd,

--- a/src/nvidia_resiliency_ext/shared_utils/grpc_log_leaf_server.py
+++ b/src/nvidia_resiliency_ext/shared_utils/grpc_log_leaf_server.py
@@ -37,9 +37,14 @@ import threading
 import time
 import urllib.parse
 from concurrent import futures
-from typing import Any, Iterator, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Union
 
 import grpc
+
+from nvidia_resiliency_ext.shared_utils.os_utils import (
+    normalize_allowed_roots,
+    resolve_under_allowed_roots,
+)
 
 try:
     from nvidia_resiliency_ext.shared_utils.proto import (
@@ -60,6 +65,17 @@ _DEFAULT_GRPC_BIND_HOST = "0.0.0.0"  # nosec B104
 
 # Sentinel placed on queue after graceful drain to end upstream StreamLogs
 _STOP = object()
+
+# Per-RPC memo of validated file paths, keeping the confinement check off the per-chunk hot
+# path without any shared-state locking.
+#
+# Sizing: a stream's *concurrent* working set is 2 paths — the fixed launcher log and the
+# current per-cycle application log (per_cycle_logs passes the same launcher log to every
+# update_pipes, and rotates only ``<prefix>_cycleN.log``). A long-lived stream accumulates one
+# more distinct path per restart cycle, so the cap must not be read as a cycle budget: entries
+# are evicted FIFO, and old cycle logs go permanently cold the moment a new cycle starts.
+# 32 leaves wide headroom over a working set of 2 while hard-bounding per-stream memory.
+_LEAF_VALIDATED_PATH_CACHE_MAX = 32
 
 # Slice timeout for Queue.put / Condition.wait so StreamLogs handlers can poll
 # ``reject_new_streams`` and exit during shutdown (no uninterruptible block).
@@ -88,11 +104,18 @@ _GRPC_OPTS = [
 ]
 
 
-def _copy_chunk(chunk: log_aggregation_pb2.LogChunk) -> log_aggregation_pb2.LogChunk:
+def _copy_chunk(
+    chunk: log_aggregation_pb2.LogChunk, file_path: Optional[str] = None
+) -> log_aggregation_pb2.LogChunk:
+    """Copy ``chunk``, optionally substituting an already-validated ``file_path``.
+
+    Forwarding the resolved path means the root does not have to re-resolve a string that
+    could resolve differently later.
+    """
     return log_aggregation_pb2.LogChunk(
         node_id=chunk.node_id,
         data=chunk.data,
-        file_path=chunk.file_path,
+        file_path=chunk.file_path if file_path is None else file_path,
     )
 
 
@@ -265,12 +288,62 @@ class LeafLogServicer(log_aggregation_pb2_grpc.LogAggregationServiceServicer):
         chunk_queue: _LeafChunkQueue,
         reject_new_streams: threading.Event,
         upstream_ready: threading.Event,
+        *,
+        allowed_roots: Sequence[str],
     ):
+        """
+        Args:
+            chunk_queue: Bounded queue drained by the upstream forwarder.
+            reject_new_streams: Set during shutdown to stop accepting work.
+            upstream_ready: Set while the leaf->root StreamLogs RPC is active.
+            allowed_roots: Non-empty directories that client-supplied ``file_path`` values
+                must resolve under. Rejecting here keeps out-of-root chunks from consuming
+                queue capacity and from reaching the root at all. Required with no default:
+                every chunk names its own destination, so there is no safe unconfined mode.
+
+        Raises:
+            ValueError: If ``allowed_roots`` is empty.
+        """
+        resolved_roots = normalize_allowed_roots(allowed_roots)
+        if not resolved_roots:
+            raise ValueError(
+                "allowed_roots must contain at least one directory: clients name their own "
+                "destination on every chunk, so an unconfined leaf would let any peer make "
+                "the root append to any file it can write"
+            )
         self._chunkq = chunk_queue
         self._reject = reject_new_streams
         self._upstream_ready = upstream_ready
+        self._allowed_roots: List[str] = resolved_roots
         self.connected_clients = 0
         self.clients_lock = threading.Lock()
+        logger.info(f"Leaf log write confinement enabled, allowed roots: {self._allowed_roots}")
+
+    def _resolve_target_path(self, file_path: str, memo: Dict[str, str]) -> str:
+        """
+        Validate a client-supplied path, memoizing per RPC so it costs syscalls only once.
+
+        Args:
+            file_path: ``LogChunk.file_path`` as sent by the peer (untrusted).
+            memo: Per-RPC cache of already-validated paths; only successes are cached.
+
+        Returns:
+            The fully resolved path to forward upstream.
+
+        Raises:
+            ValueError: If the path escapes every allowed root.
+        """
+        cached = memo.get(file_path)
+        if cached is not None:
+            return cached
+        resolved = resolve_under_allowed_roots(file_path, self._allowed_roots)
+        if len(memo) >= _LEAF_VALIDATED_PATH_CACHE_MAX:
+            # Evict oldest first (dicts preserve insertion order). Refusing to insert once
+            # full would be backwards here: the newest path is the hot one (the current
+            # cycle log), so it would be the one permanently re-resolved on every chunk.
+            del memo[next(iter(memo))]
+        memo[file_path] = resolved
+        return resolved
 
     def StreamLogs(self, request_iterator, context):
         if self._reject.is_set():
@@ -283,6 +356,7 @@ class LeafLogServicer(log_aggregation_pb2_grpc.LogAggregationServiceServicer):
         source_node_id = None
         total = 0
         nchunks = 0
+        validated_paths: Dict[str, str] = {}
         try:
             for chunk in request_iterator:
                 if self._reject.is_set():
@@ -292,7 +366,25 @@ class LeafLogServicer(log_aggregation_pb2_grpc.LogAggregationServiceServicer):
                     logger.info(
                         f"Compute node StreamLogs opened peer={peer} source_node_id={source_node_id}"
                     )
-                copied = _copy_chunk(chunk)
+                if not chunk.file_path:
+                    msg = f"peer={peer} node_id={chunk.node_id!r} sent chunk without file_path"
+                    logger.error(f"Protocol error in leaf StreamLogs: {msg}")
+                    context.abort(grpc.StatusCode.INVALID_ARGUMENT, msg)
+                    return log_aggregation_pb2.StreamResponse(
+                        status="INVALID_ARGUMENT", bytes_received=total
+                    )
+                try:
+                    target_path = self._resolve_target_path(chunk.file_path, validated_paths)
+                except ValueError as e:
+                    logger.error(
+                        f"Rejected log chunk in leaf StreamLogs peer={peer} "
+                        f"source_node_id={source_node_id}: {e}"
+                    )
+                    context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(e))
+                    return log_aggregation_pb2.StreamResponse(
+                        status="INVALID_ARGUMENT", bytes_received=total
+                    )
+                copied = _copy_chunk(chunk, file_path=target_path)
                 if not self._chunkq.put_chunk(
                     copied,
                     self._reject,
@@ -330,7 +422,31 @@ def serve(
     max_workers: int,
     max_queue_chunks: int,
     graceful_shutdown_timeout: float,
+    allowed_roots: Sequence[str],
 ) -> None:
+    """
+    Run a leaf aggregator that forwards downstream chunks to the root server.
+
+    Args:
+        host: Bind host for the downstream port.
+        port: Bind port for the downstream port.
+        upstream: Root server ``host:port``.
+        max_workers: gRPC worker threads (one per downstream stream).
+        max_queue_chunks: Bounded queue capacity for backpressure.
+        graceful_shutdown_timeout: Seconds to wait for downstream clients on shutdown.
+        allowed_roots: Non-empty list of directories that client-supplied ``file_path``
+            values must resolve under. Required because this entry point binds an
+            unauthenticated network port.
+
+    Raises:
+        ValueError: If ``allowed_roots`` is empty.
+    """
+    resolved_roots = normalize_allowed_roots(allowed_roots)
+    if not resolved_roots:
+        raise ValueError(
+            "allowed_roots must contain at least one directory: this leaf binds an "
+            "unauthenticated port and must not forward client-chosen write destinations"
+        )
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s [%(levelname)s] [%(process)5s] %(filename)s:%(lineno)d %(message)s',
@@ -357,7 +473,9 @@ def serve(
         forwarder.join(timeout=10.0)
         sys.exit(1)
 
-    servicer = LeafLogServicer(chunk_queue, reject_new, forwarder.upstream_ready)
+    servicer = LeafLogServicer(
+        chunk_queue, reject_new, forwarder.upstream_ready, allowed_roots=resolved_roots
+    )
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=max_workers),
         options=_GRPC_OPTS,
@@ -479,6 +597,17 @@ def main() -> None:
         'chunks are often smaller.',
     )
     p.add_argument('--graceful-shutdown-timeout', type=float, default=60.0)
+    p.add_argument(
+        '--allowed-root',
+        type=str,
+        action='append',
+        required=True,
+        dest='allowed_roots',
+        metavar='DIR',
+        help='Directory that client-supplied log file paths must resolve under. Repeatable. '
+        'Required: this leaf binds an unauthenticated port, so without confinement any peer '
+        'that can reach it could make the root append to any file it can write.',
+    )
     args = p.parse_args()
     serve(
         host=args.host,
@@ -487,6 +616,7 @@ def main() -> None:
         max_workers=args.max_workers,
         max_queue_chunks=args.max_queue_chunks,
         graceful_shutdown_timeout=args.graceful_shutdown_timeout,
+        allowed_roots=args.allowed_roots,
     )
 
 

--- a/src/nvidia_resiliency_ext/shared_utils/grpc_log_server.py
+++ b/src/nvidia_resiliency_ext/shared_utils/grpc_log_server.py
@@ -59,7 +59,11 @@ Manually for testing:
     python -m nvidia_resiliency_ext.shared_utils.grpc_log_server \\
         --host 0.0.0.0 \\
         --port 50051 \\
-        --output-file /lustre/logs/training.log
+        --allowed-root /lustre/logs
+
+**Security note:** the listening port is unauthenticated, and each ``LogChunk`` carries a
+client-chosen ``file_path``. ``--allowed-root`` (repeatable, required) confines those writes;
+paths resolving outside every root are rejected with ``INVALID_ARGUMENT``.
 """
 
 import argparse
@@ -74,9 +78,14 @@ import time
 import urllib.parse
 from concurrent import futures
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import grpc
+
+from nvidia_resiliency_ext.shared_utils.os_utils import (
+    normalize_allowed_roots,
+    resolve_under_allowed_roots,
+)
 
 # Import generated protobuf code
 # Note: Proto files are in shared_utils/proto/ and compiled during build (build.py)
@@ -141,6 +150,8 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
         graceful_shutdown_timeout: float = 60.0,
         flush_interval: float = 1.0,
         completion_idle_timeout: float = _DEFAULT_COMPLETION_IDLE_TIMEOUT_SECONDS,
+        *,
+        allowed_roots: Sequence[str],
     ):
         """
         Initialize log aggregation server.
@@ -157,9 +168,26 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
             completion_idle_timeout: Seconds a per-cycle application log must receive no new
                                      chunks after its latest flush before a heuristic completion
                                      line is emitted.
+            allowed_roots: Non-empty directories that client-supplied ``LogChunk.file_path``
+                           values must resolve under. Chunks targeting anything else are
+                           rejected with ``INVALID_ARGUMENT``. Required with no default:
+                           every chunk names its own destination, so there is no safe
+                           unconfined mode.
+
+        Raises:
+            ValueError: If ``completion_idle_timeout`` is negative or ``allowed_roots`` is empty.
         """
         if completion_idle_timeout < 0:
             raise ValueError("completion_idle_timeout must be non-negative")
+        # Resolved once here so the per-path check is a comparison of resolved strings.
+        resolved_roots = normalize_allowed_roots(allowed_roots)
+        if not resolved_roots:
+            raise ValueError(
+                "allowed_roots must contain at least one directory: clients name their own "
+                "destination on every chunk, so an unconfined servicer would let any peer "
+                "append to any file writable by this process"
+            )
+        self.allowed_roots: List[str] = resolved_roots
         self.max_buffer_size = max_buffer_size
         self.graceful_shutdown_timeout = graceful_shutdown_timeout
         self.completion_idle_timeout = completion_idle_timeout
@@ -183,12 +211,29 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
         # Logging
         self.logger = logging.getLogger("LogAggregationServer")
         self.logger.setLevel(logging.INFO)
+        self.logger.info(f"Log write confinement enabled, allowed roots: {self.allowed_roots}")
 
         # Background flush thread (flushes buffer periodically)
         self.flush_interval = flush_interval
         self.shutdown_event = threading.Event()
         self.flush_thread = threading.Thread(target=self._periodic_flush, daemon=True)
         self.flush_thread.start()
+
+    def _resolve_target_path(self, file_path: str) -> str:
+        """
+        Resolve a client-supplied target path, enforcing allowed-root confinement.
+
+        Args:
+            file_path: ``LogChunk.file_path`` as sent by the peer (untrusted).
+
+        Returns:
+            The fully resolved path to actually open.
+
+        Raises:
+            ValueError: If the path escapes every allowed root. ``StreamLogs`` maps this to
+                ``INVALID_ARGUMENT`` and ends the stream.
+        """
+        return resolve_under_allowed_roots(file_path, self.allowed_roots)
 
     def _get_or_create_file_state(self, file_path: str) -> Dict[str, Any]:
         """
@@ -205,9 +250,17 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
 
         with self.files_lock:
             if file_path not in self.files:
-                # Create new file state
-                os.makedirs(os.path.dirname(os.path.abspath(file_path)) or ".", exist_ok=True)
-                file_handle = open(file_path, 'ab', buffering=self.max_buffer_size)
+                # Confinement check runs only on the first chunk for a given path (this
+                # branch also does the makedirs/open), so steady-state chunk handling stays
+                # a single dict lookup with no extra syscalls.
+                target_path = self._resolve_target_path(file_path)
+                # Create new file state. ``target_path`` is fully resolved, so neither the
+                # makedirs nor the open can be redirected outside an allowed root by a
+                # symlink swapped in after the check.
+                os.makedirs(os.path.dirname(target_path) or ".", exist_ok=True)
+                file_handle = open(target_path, 'ab', buffering=self.max_buffer_size)
+                # Cycle bookkeeping is lexical and in-memory only (log_family is just a dict
+                # key for completion tracking), so it stays on the client-supplied path.
                 cycle_info = _cycle_log_info(file_path)
                 if cycle_info is None:
                     log_family = None
@@ -673,6 +726,7 @@ class LogAggregationServicer(log_aggregation_pb2_grpc.LogAggregationServiceServi
 def serve(
     host: str,
     port: int,
+    allowed_roots: Sequence[str],
     max_workers: int = 100,
     graceful_shutdown_timeout: float = 60.0,
     completion_idle_timeout: float = _DEFAULT_COMPLETION_IDLE_TIMEOUT_SECONDS,
@@ -686,9 +740,16 @@ def serve(
     Args:
         host: Host to bind to (e.g., '0.0.0.0' for all interfaces)
         port: Port to listen on
+        allowed_roots: Non-empty list of directories that client-supplied ``file_path``
+            values must resolve under. This entry point binds a network port without
+            authentication, so without confinement any peer that can reach the port could
+            append to any file writable by this process.
         max_workers: Maximum number of worker threads for gRPC
         graceful_shutdown_timeout: Maximum seconds to wait for clients during shutdown
         completion_idle_timeout: Idle seconds before heuristic per-cycle completion is logged
+
+    Raises:
+        ValueError: If ``allowed_roots`` is empty.
     """
     # Set up logging (using aegis-style format)
     logging.basicConfig(
@@ -700,6 +761,7 @@ def serve(
     servicer = LogAggregationServicer(
         graceful_shutdown_timeout=graceful_shutdown_timeout,
         completion_idle_timeout=completion_idle_timeout,
+        allowed_roots=allowed_roots,
     )
 
     # Create gRPC server
@@ -808,6 +870,17 @@ def main():
         'for up to this timeout or until all clients disconnect, whichever comes first.',
     )
     parser.add_argument(
+        '--allowed-root',
+        type=str,
+        action='append',
+        required=True,
+        dest='allowed_roots',
+        metavar='DIR',
+        help='Directory that client-supplied log file paths must resolve under. Repeatable. '
+        'Required: this server binds an unauthenticated port, so without confinement any '
+        'peer that can reach it could append to any file writable by this process.',
+    )
+    parser.add_argument(
         '--completion-idle-timeout',
         type=float,
         default=_DEFAULT_COMPLETION_IDLE_TIMEOUT_SECONDS,
@@ -820,6 +893,7 @@ def main():
     serve(
         host=args.host,
         port=args.port,
+        allowed_roots=args.allowed_roots,
         max_workers=args.max_workers,
         graceful_shutdown_timeout=args.graceful_shutdown_timeout,
         completion_idle_timeout=args.completion_idle_timeout,

--- a/src/nvidia_resiliency_ext/shared_utils/os_utils.py
+++ b/src/nvidia_resiliency_ext/shared_utils/os_utils.py
@@ -23,6 +23,7 @@ safe file operations.
 
 import os
 import stat
+from typing import Iterable, List, Optional, Sequence
 
 
 def validate_directory(dir_path: str) -> None:
@@ -92,3 +93,76 @@ def validate_filepath(file_path: str) -> None:
         except OSError as e:
             raise OSError(f"Cannot access file {file_path}: {e}")
     # If file doesn't exist, that's fine - it will be created
+
+
+def normalize_allowed_roots(allowed_roots: Optional[Iterable[str]]) -> List[str]:
+    """
+    Resolve a set of allowed-root directories to absolute, symlink-free paths.
+
+    Roots are resolved once at startup so that per-path confinement checks are a cheap
+    lexical comparison against already-resolved strings.
+
+    Args:
+        allowed_roots: Iterable of directory paths (may be relative or contain ``~``).
+
+    Returns:
+        Deduplicated list of resolved absolute roots, preserving input order. Empty
+        entries are skipped; an empty/None input yields an empty list.
+    """
+    normalized: List[str] = []
+    for root in allowed_roots or ():
+        if not root:
+            continue
+        real = os.path.realpath(os.path.abspath(os.path.expanduser(root)))
+        if real not in normalized:
+            normalized.append(real)
+    return normalized
+
+
+def resolve_under_allowed_roots(file_path: str, allowed_roots: Sequence[str]) -> str:
+    """
+    Resolve an untrusted file path and require that it stay under an allowed root.
+
+    Fully resolves ``file_path`` (``..`` segments and symlinks on every component) and
+    requires the result to live under one of ``allowed_roots``. Callers should operate on
+    the returned path rather than the original: the returned path contains no symlinks,
+    so opening it cannot be redirected outside the root between check and use.
+
+    Args:
+        file_path: Untrusted path, e.g. supplied by a network peer.
+        allowed_roots: Non-empty roots, already passed through
+            :func:`normalize_allowed_roots`.
+
+    Returns:
+        The resolved absolute path, guaranteed to be under one of ``allowed_roots``.
+
+    Raises:
+        ValueError: If ``file_path`` is empty, cannot be resolved, or resolves outside
+            every allowed root.
+    """
+    if not file_path:
+        raise ValueError("file_path cannot be empty")
+    if not allowed_roots:
+        raise ValueError("no allowed roots configured; refusing to resolve untrusted file_path")
+    if "\x00" in file_path:
+        raise ValueError("file_path contains a NUL byte")
+
+    try:
+        real = os.path.realpath(os.path.abspath(file_path))
+    except (OSError, ValueError) as e:
+        raise ValueError(f"cannot resolve file_path {file_path!r}: {e}") from e
+
+    for root in allowed_roots:
+        try:
+            # commonpath compares whole path components, so /lustre/logs does not
+            # match /lustre/logs_evil the way a plain string prefix check would.
+            if os.path.commonpath([real, root]) == root:
+                return real
+        except ValueError:
+            # Different drives / mixed absolute-relative: treat as not under this root.
+            continue
+
+    raise ValueError(
+        f"file_path {file_path!r} (resolved to {real!r}) is outside the allowed "
+        f"root(s) {list(allowed_roots)!r}"
+    )

--- a/tests/fault_tolerance/unit/test_control_plane.py
+++ b/tests/fault_tolerance/unit/test_control_plane.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -263,6 +264,37 @@ def test_nvrx_control_does_not_start_attribution_without_endpoint(tmp_path):
         control_plane.run(args)
 
     manager_cls.assert_not_called()
+
+
+def test_control_skips_log_funnel_without_confinable_destination(tmp_path, caplog):
+    """--ft-log-server-log-prefix alone is accepted by validation, but names where the
+    funnel's own diagnostics go, not where clients write, so it cannot define the
+    confinement boundary. Skip the funnel (as the launcher does when no applog prefix is
+    set) instead of failing nvrx-control startup."""
+    args = control_plane.parse_args(
+        [
+            "--nnodes",
+            "2",
+            "--rdzv-endpoint",
+            "127.0.0.1:29500",
+            "--ft-log-server-log-prefix",
+            str(tmp_path / "ctrl" / "grpc"),
+        ]
+    )
+    ft_cfg = control_plane.FaultToleranceConfig.from_args(args)
+    control_plane._validate_args(args, ft_cfg)
+
+    with (
+        patch.object(control_plane, "_create_tcp_store"),
+        patch.object(control_plane, "_start_grpc_log_servers") as start_servers,
+        patch.object(control_plane, "stop_grpc_log_servers"),
+        patch.object(control_plane, "_run_control_rendezvous_loop"),
+        caplog.at_level(logging.WARNING),
+    ):
+        control_plane.run(args)
+
+    start_servers.assert_not_called()
+    assert any("no client log destination" in r.getMessage() for r in caplog.records)
 
 
 def test_control_parser_rejects_log_server_without_diagnostic_prefix():

--- a/tests/fault_tolerance/unit/test_launcher.py
+++ b/tests/fault_tolerance/unit/test_launcher.py
@@ -35,6 +35,7 @@ from nvidia_resiliency_ext.fault_tolerance.utils import (
     RDZV_SHUTDOWN_REASON_ATTRIBUTION_STOP,
     RDZV_SHUTDOWN_REASON_NO_PROGRESS,
 )
+from nvidia_resiliency_ext.shared_utils.os_utils import resolve_under_allowed_roots
 
 WORLD_SIZE = 4
 DEFAULT_TIMEOUT = 90
@@ -1149,10 +1150,15 @@ def test_start_grpc_log_servers_uses_prefix_for_root_and_leaf_logs(tmp_path):
         def wait(self):
             pass
 
+    applog_dir = tmp_path / "applogs"
+    applog_dir.mkdir()
     args = SimpleNamespace(
         nnodes="2",
         ft_log_server_graceful_shutdown_timeout=60.0,
         ft_log_leaf_max_queue_chunks=-1,
+        ft_per_cycle_applog_prefix=str(applog_dir / "train.log"),
+        ft_nvrx_logfile=None,
+        ft_log_server_log_prefix=None,
     )
     log_dir = tmp_path / "missing" / "logs"
     log_prefix = str(log_dir / "grpc_diag")
@@ -1166,6 +1172,39 @@ def test_start_grpc_log_servers_uses_prefix_for_root_and_leaf_logs(tmp_path):
     assert (log_dir / "grpc_diag_root.log").is_file()
     assert (log_dir / "grpc_diag_leaf_0.log").is_file()
     assert (log_dir / "grpc_diag_leaf_1.log").is_file()
+
+    # Every spawned server must be confined to the configured log directory: these bind
+    # unauthenticated ports and write to a path chosen by the client on each chunk.
+    for proc in procs:
+        cmd = proc.args[0]
+        roots = [cmd[i + 1] for i, a in enumerate(cmd) if a == "--allowed-root"]
+        assert roots == [os.path.realpath(str(applog_dir))], cmd
+
+
+def test_start_grpc_log_servers_requires_resolvable_allowed_roots(tmp_path):
+    """Refuse to start unconfined rather than accept client-chosen write destinations."""
+    from types import SimpleNamespace
+
+    from nvidia_resiliency_ext.fault_tolerance import launcher
+
+    class FakePopen:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("no server should be spawned without allowed roots")
+
+    args = SimpleNamespace(
+        nnodes="2",
+        ft_log_server_graceful_shutdown_timeout=60.0,
+        ft_log_leaf_max_queue_chunks=-1,
+        ft_per_cycle_applog_prefix=None,
+        ft_nvrx_logfile=None,
+        ft_log_server_log_prefix=None,
+    )
+    ports = launcher.LogFunnelPorts(base_port=50051, first_level_count=1)
+
+    with patch.object(launcher.subprocess, "Popen", FakePopen):
+        # Failure is reported by returning no processes; the caller then disables gRPC
+        # log aggregation and falls back to direct file writing.
+        assert launcher._start_grpc_log_servers(args, str(tmp_path / "grpc_diag"), ports) == []
 
 
 def test_managed_attribution_listen_port_rejects_log_funnel_overlap():
@@ -1676,3 +1715,98 @@ def test_launch_agent_signal_exception_with_rank_failure_re_raises():
     record_event.assert_called_once_with(agent.get_event_failed.return_value)
     rdzv_handler.shutdown.assert_not_called()
     rdzv_handler.shutdown_due_to_failure.assert_not_called()
+
+
+class TestLauncherAllowedRoots:
+    """The launcher must derive roots covering every path its clients legitimately write."""
+
+    def _args(self, **kwargs):
+        from argparse import Namespace
+
+        base = dict(
+            ft_per_cycle_applog_prefix=None,
+            ft_nvrx_logfile=None,
+            ft_log_server_log_prefix=None,
+        )
+        base.update(kwargs)
+        return Namespace(**base)
+
+    def test_roots_are_dirnames_of_configured_log_paths(self, tmp_path):
+        from nvidia_resiliency_ext.fault_tolerance.launcher import _resolve_grpc_log_allowed_roots
+
+        applog = tmp_path / "app" / "train.log"
+        nvrx = tmp_path / "launcher" / "nvrx.log"
+        applog.parent.mkdir()
+        nvrx.parent.mkdir()
+        roots = _resolve_grpc_log_allowed_roots(
+            self._args(
+                ft_per_cycle_applog_prefix=str(applog),
+                ft_nvrx_logfile=str(nvrx),
+            )
+        )
+        assert roots == [
+            os.path.realpath(str(applog.parent)),
+            os.path.realpath(str(nvrx.parent)),
+        ]
+
+    def test_root_covers_every_per_cycle_log(self, tmp_path):
+        """Per-cycle files are <prefix>_cycleN.log in the prefix dir, so one root suffices."""
+        from nvidia_resiliency_ext.fault_tolerance.launcher import _resolve_grpc_log_allowed_roots
+
+        applog = tmp_path / "app" / "train.log"
+        applog.parent.mkdir()
+        (roots,) = _resolve_grpc_log_allowed_roots(
+            self._args(ft_per_cycle_applog_prefix=str(applog))
+        )
+        for cycle in (0, 1, 42):
+            cycle_log = str(applog).replace(".log", f"_cycle{cycle}.log")
+            assert resolve_under_allowed_roots(cycle_log, [roots]) == cycle_log
+
+    def test_duplicate_directories_collapse(self, tmp_path):
+        from nvidia_resiliency_ext.fault_tolerance.launcher import _resolve_grpc_log_allowed_roots
+
+        roots = _resolve_grpc_log_allowed_roots(
+            self._args(
+                ft_per_cycle_applog_prefix=str(tmp_path / "train.log"),
+                ft_nvrx_logfile=str(tmp_path / "nvrx.log"),
+            )
+        )
+        assert roots == [os.path.realpath(str(tmp_path))]
+
+    def test_roots_are_pinned_against_later_symlink_creation(self, tmp_path):
+        """realpath of a non-existent dir returns it unchanged, so a dir that only later
+        appears as a symlink would resolve elsewhere at write time and the job's own logs
+        would be rejected. Roots must be created before being resolved."""
+        from nvidia_resiliency_ext.fault_tolerance.launcher import _resolve_grpc_log_allowed_roots
+
+        logdir = tmp_path / "logs"
+        assert not logdir.exists()
+        (roots,) = _resolve_grpc_log_allowed_roots(
+            self._args(ft_per_cycle_applog_prefix=str(logdir / "train.log"))
+        )
+        assert logdir.is_dir(), "root directory must exist so its resolution is stable"
+        # The job's own log path still validates.
+        cycle_log = str(logdir / "train_cycle0.log")
+        assert resolve_under_allowed_roots(cycle_log, [roots]) == cycle_log
+
+    def test_server_own_log_dir_is_not_an_allowed_root(self, tmp_path):
+        """`_root.log`/`_leaf_N.log` are written by the launcher redirecting each
+        subprocess's stdout/stderr, never through a LogChunk, so that directory must not
+        be exposed to gRPC clients."""
+        from nvidia_resiliency_ext.fault_tolerance.launcher import _resolve_grpc_log_allowed_roots
+
+        applog_dir = tmp_path / "applogs"
+        srv_dir = tmp_path / "serverlogs"
+        roots = _resolve_grpc_log_allowed_roots(
+            self._args(
+                ft_per_cycle_applog_prefix=str(applog_dir / "train.log"),
+                ft_log_server_log_prefix=str(srv_dir / "grpc"),
+            )
+        )
+        assert roots == [os.path.realpath(str(applog_dir))]
+        assert os.path.realpath(str(srv_dir)) not in roots
+
+    def test_no_configured_paths_yields_no_roots(self):
+        from nvidia_resiliency_ext.fault_tolerance.launcher import _resolve_grpc_log_allowed_roots
+
+        assert _resolve_grpc_log_allowed_roots(self._args()) == []

--- a/tests/fault_tolerance/unit/test_launcher_grpc_integration.py
+++ b/tests/fault_tolerance/unit/test_launcher_grpc_integration.py
@@ -71,7 +71,7 @@ def _get_util_script_path():
 # ==============================================================================
 
 
-def test_grpc_server_can_start_and_shutdown():
+def test_grpc_server_can_start_and_shutdown(tmp_dir):
     """Test that gRPC server can be started and shut down cleanly."""
 
     # Try to start the gRPC server directly
@@ -86,6 +86,8 @@ def test_grpc_server_can_start_and_shutdown():
             '50052',  # Use different port to avoid conflicts
             '--max-workers',
             '10',
+            '--allowed-root',
+            tmp_dir,
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -108,7 +110,7 @@ def test_grpc_server_can_start_and_shutdown():
         pytest.fail("gRPC server did not shut down within 5 seconds")
 
 
-def test_grpc_server_health_check():
+def test_grpc_server_health_check(tmp_dir):
     """Test that gRPC server responds to health check requests."""
 
     port = 50053  # Use unique port
@@ -123,6 +125,8 @@ def test_grpc_server_health_check():
             str(port),
             '--max-workers',
             '10',
+            '--allowed-root',
+            tmp_dir,
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -208,6 +212,8 @@ def test_grpc_client_can_connect_and_stream_logs(tmp_dir):
             str(port),
             '--max-workers',
             '10',
+            '--allowed-root',
+            tmp_dir,
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tests/shared_utils/test_grpc_log_leaf_server.py
+++ b/tests/shared_utils/test_grpc_log_leaf_server.py
@@ -3,6 +3,10 @@
 
 """Unit and integration tests for grpc_log_leaf_server.py and two-level log aggregation."""
 
+import os
+import subprocess
+import sys
+import tempfile
 import threading
 import time
 from concurrent import futures
@@ -19,6 +23,10 @@ from nvidia_resiliency_ext.shared_utils.grpc_log_leaf_server import (
 )
 from nvidia_resiliency_ext.shared_utils.grpc_log_server import LogAggregationServicer
 from nvidia_resiliency_ext.shared_utils.proto import log_aggregation_pb2, log_aggregation_pb2_grpc
+
+# These tests exercise queueing/forwarding behaviour, not path confinement (see
+# test_grpc_log_server_confinement.py). Every path they write to lives under the temp dir.
+_TEST_ROOTS = ["/tmp", tempfile.gettempdir()]
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -53,7 +61,9 @@ def _start_leaf_stack(upstream_addr: str, host: str = "127.0.0.1"):
         reconnect_sleep=0.1,
     )
     forwarder.start()
-    servicer = LeafLogServicer(chunk_q, reject_ev, forwarder.upstream_ready)
+    servicer = LeafLogServicer(
+        chunk_q, reject_ev, forwarder.upstream_ready, allowed_roots=_TEST_ROOTS
+    )
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     log_aggregation_pb2_grpc.add_LogAggregationServiceServicer_to_server(servicer, server)
     leaf_port = server.add_insecure_port(f"{host}:0")
@@ -141,7 +151,12 @@ class TestLeafLogServicer:
             upstream_ready.set()
         if rejected:
             reject.set()
-        return LeafLogServicer(chunk_q, reject, upstream_ready), chunk_q, reject, upstream_ready
+        return (
+            LeafLogServicer(chunk_q, reject, upstream_ready, allowed_roots=_TEST_ROOTS),
+            chunk_q,
+            reject,
+            upstream_ready,
+        )
 
     # --- HealthCheck ---------------------------------------------------------
 
@@ -221,7 +236,7 @@ class TestTwoLevelLogAggregation:
 
     def test_chunks_reach_root_file(self, tmp_path):
         log_file = str(tmp_path / "output.log")
-        root_svc = LogAggregationServicer(flush_interval=0.1)
+        root_svc = LogAggregationServicer(flush_interval=0.1, allowed_roots=_TEST_ROOTS)
         root_server, root_port = _start_root_server(root_svc)
 
         server, leaf_port, forwarder, _, chunk_q, stop_ev, _ = _start_leaf_stack(
@@ -256,7 +271,9 @@ class TestTwoLevelLogAggregation:
             reconnect_sleep=0.1,
         )
         forwarder.start()
-        svc = LeafLogServicer(chunk_q, threading.Event(), forwarder.upstream_ready)
+        svc = LeafLogServicer(
+            chunk_q, threading.Event(), forwarder.upstream_ready, allowed_roots=_TEST_ROOTS
+        )
 
         resp = svc.HealthCheck(log_aggregation_pb2.HealthRequest(), MagicMock())
         assert resp.healthy is False
@@ -266,7 +283,7 @@ class TestTwoLevelLogAggregation:
 
     def test_leaf_health_becomes_healthy_after_root_starts(self):
         """Leaf HealthCheck flips to healthy once upstream root is reachable."""
-        root_svc = LogAggregationServicer(flush_interval=0.1)
+        root_svc = LogAggregationServicer(flush_interval=0.1, allowed_roots=_TEST_ROOTS)
         root_server, root_port = _start_root_server(root_svc)
 
         server, leaf_port, forwarder, svc, chunk_q, stop_ev, _ = _start_leaf_stack(
@@ -285,7 +302,7 @@ class TestTwoLevelLogAggregation:
     def test_multiple_clients_via_leaf(self, tmp_path):
         """Three concurrent clients → leaf → root; all logs reach file."""
         log_file = str(tmp_path / "multi.log")
-        root_svc = LogAggregationServicer(flush_interval=0.1)
+        root_svc = LogAggregationServicer(flush_interval=0.1, allowed_roots=_TEST_ROOTS)
         root_server, root_port = _start_root_server(root_svc)
 
         server, leaf_port, forwarder, _, chunk_q, stop_ev, _ = _start_leaf_stack(
@@ -320,7 +337,7 @@ class TestTwoLevelLogAggregation:
     def test_leaf_drains_queue_on_shutdown(self, tmp_path):
         """Chunks buffered in leaf queue before shutdown all reach root file."""
         log_file = str(tmp_path / "drain.log")
-        root_svc = LogAggregationServicer(flush_interval=0.1)
+        root_svc = LogAggregationServicer(flush_interval=0.1, allowed_roots=_TEST_ROOTS)
         root_server, root_port = _start_root_server(root_svc)
 
         server, leaf_port, forwarder, _, chunk_q, stop_ev, _ = _start_leaf_stack(
@@ -355,7 +372,7 @@ class TestTwoLevelLogAggregation:
     def test_large_volume_via_leaf(self, tmp_path):
         """500 chunks streamed through leaf all reach root file."""
         log_file = str(tmp_path / "large.log")
-        root_svc = LogAggregationServicer(flush_interval=0.1)
+        root_svc = LogAggregationServicer(flush_interval=0.1, allowed_roots=_TEST_ROOTS)
         root_server, root_port = _start_root_server(root_svc)
 
         server, leaf_port, forwarder, _, chunk_q, stop_ev, _ = _start_leaf_stack(
@@ -377,3 +394,171 @@ class TestTwoLevelLogAggregation:
             _stop_leaf_stack(server, forwarder, chunk_q, stop_ev)
             root_server.stop(grace=1.0)
             root_server.wait_for_termination(timeout=5.0)
+
+
+def leaf_mod_cache_max():
+    import nvidia_resiliency_ext.shared_utils.grpc_log_leaf_server as leaf_mod
+
+    return leaf_mod._LEAF_VALIDATED_PATH_CACHE_MAX
+
+
+@pytest.fixture
+def log_root(tmp_path):
+    root = tmp_path / "logs"
+    root.mkdir()
+    # realpath: on some platforms the pytest tmp dir itself sits behind a symlink.
+    return os.path.realpath(str(root))
+
+
+@pytest.fixture
+def outside_dir(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    return os.path.realpath(str(outside))
+
+
+class TestLeafServerConfinement:
+    """The leaf must reject out-of-root chunks before they consume queue capacity."""
+
+    def _servicer(self, allowed_roots, max_chunks=64):
+        # Nothing drains the queue in these tests, so it must hold every chunk sent:
+        # put_chunk blocks for backpressure once full.
+        chunk_q = _LeafChunkQueue(max_chunks=max_chunks)
+        upstream_ready = threading.Event()
+        upstream_ready.set()
+        servicer = LeafLogServicer(
+            chunk_q, threading.Event(), upstream_ready, allowed_roots=allowed_roots
+        )
+        return servicer, chunk_q
+
+    @pytest.mark.parametrize("roots", [None, [], [""]])
+    def test_leaf_servicer_refuses_to_construct_unconfined(self, roots):
+        with pytest.raises(ValueError, match="at least one directory"):
+            self._servicer(roots)
+
+    def test_leaf_servicer_requires_allowed_roots_explicitly(self):
+        with pytest.raises(TypeError, match="allowed_roots"):
+            LeafLogServicer(_LeafChunkQueue(max_chunks=4), threading.Event(), threading.Event())
+
+    def test_forwards_chunk_inside_root(self, log_root):
+        servicer, chunk_q = self._servicer([log_root])
+        target = os.path.join(log_root, "train.log")
+        resp = servicer.StreamLogs(iter([_chunk(b"hi\n", target)]), MagicMock())
+        assert resp.status == "OK"
+        assert chunk_q.qsize() == 1
+        assert chunk_q.get_upstream(timeout=1.0).file_path == target
+
+    def test_rejects_chunk_outside_root_without_enqueueing(self, log_root, outside_dir):
+        servicer, chunk_q = self._servicer([log_root])
+        context = MagicMock()
+        context.abort.side_effect = grpc.RpcError("aborted")
+        with pytest.raises(grpc.RpcError):
+            servicer.StreamLogs(
+                iter([_chunk(b"payload\n", os.path.join(outside_dir, "owned.txt"))]), context
+            )
+        context.abort.assert_called_once()
+        assert context.abort.call_args[0][0] == grpc.StatusCode.INVALID_ARGUMENT
+        assert chunk_q.qsize() == 0
+
+    def test_rejects_empty_file_path(self, log_root):
+        servicer, chunk_q = self._servicer([log_root])
+        context = MagicMock()
+        context.abort.side_effect = grpc.RpcError("aborted")
+        with pytest.raises(grpc.RpcError):
+            servicer.StreamLogs(iter([_chunk(b"payload\n", "")]), context)
+        assert context.abort.call_args[0][0] == grpc.StatusCode.INVALID_ARGUMENT
+        assert chunk_q.qsize() == 0
+
+    def test_forwards_resolved_path(self, log_root):
+        """Leaf hands the root an already-resolved path, not the raw client string."""
+        servicer, chunk_q = self._servicer([log_root])
+        raw = os.path.join(log_root, "sub", "..", "train.log")
+        resp = servicer.StreamLogs(iter([_chunk(b"hi\n", raw)]), MagicMock())
+        assert resp.status == "OK"
+        assert chunk_q.get_upstream(timeout=1.0).file_path == os.path.join(log_root, "train.log")
+
+    def test_cache_survives_many_restart_cycles(self, log_root, monkeypatch):
+        """A long-lived stream rotates <prefix>_cycleN.log once per restart cycle.
+
+        Far more cycles than the cache holds must not degrade the hot path: the current
+        cycle log is the newest entry, so a "stop inserting when full" policy would leave
+        it permanently uncached and re-resolve it on every chunk.
+        """
+        import nvidia_resiliency_ext.shared_utils.grpc_log_leaf_server as leaf_mod
+
+        launcher_log = os.path.join(log_root, "nvrx.log")
+        cycles = leaf_mod._LEAF_VALIDATED_PATH_CACHE_MAX * 8
+        chunks_per_cycle = 20
+        servicer, chunk_q = self._servicer([log_root], max_chunks=cycles * chunks_per_cycle * 2 + 1)
+
+        calls = []
+        original = leaf_mod.resolve_under_allowed_roots
+        monkeypatch.setattr(
+            leaf_mod,
+            "resolve_under_allowed_roots",
+            lambda path, roots: (calls.append(path), original(path, roots))[1],
+        )
+
+        def stream():
+            for cycle in range(cycles):
+                cycle_log = os.path.join(log_root, f"train_cycle{cycle}.log")
+                for _ in range(chunks_per_cycle):
+                    yield _chunk(b"step\n", cycle_log)
+                    yield _chunk(b"agent\n", launcher_log)
+
+        total_chunks = cycles * chunks_per_cycle * 2
+        resp = servicer.StreamLogs(stream(), MagicMock())
+        assert resp.status == "OK"
+        assert chunk_q.qsize() == total_chunks
+
+        # Resolves must scale with the number of distinct paths, not the number of chunks:
+        # one per cycle log, plus occasional re-resolves of the launcher log as FIFO ages
+        # it out. Under a "stop inserting once full" policy this would be O(total_chunks).
+        distinct_paths = cycles + 1
+        assert len(calls) < 2 * distinct_paths
+        assert len(calls) < total_chunks / 10
+
+    def test_cache_is_bounded(self, log_root):
+        """Per-stream memory stays bounded no matter how many paths a peer cycles through."""
+        servicer, _ = self._servicer([log_root])
+        memo = {}
+        for i in range(leaf_mod_cache_max() * 4):
+            servicer._resolve_target_path(os.path.join(log_root, f"f{i}.log"), memo)
+        assert len(memo) == leaf_mod_cache_max()
+
+    def test_validation_is_memoized_per_stream(self, log_root, monkeypatch):
+        servicer, chunk_q = self._servicer([log_root])
+        import nvidia_resiliency_ext.shared_utils.grpc_log_leaf_server as leaf_mod
+
+        calls = []
+        original = leaf_mod.resolve_under_allowed_roots
+
+        def counting(path, roots):
+            calls.append(path)
+            return original(path, roots)
+
+        monkeypatch.setattr(leaf_mod, "resolve_under_allowed_roots", counting)
+        target = os.path.join(log_root, "train.log")
+        servicer.StreamLogs(iter([_chunk(b"a\n", target) for _ in range(50)]), MagicMock())
+        assert len(calls) == 1
+        assert chunk_q.qsize() == 50
+
+
+class TestLeafCliRequiresAllowedRoots:
+    def test_cli_requires_allowed_root(self):
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "nvidia_resiliency_ext.shared_utils.grpc_log_leaf_server",
+                "--port",
+                "0",
+                "--upstream",
+                "127.0.0.1:1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert proc.returncode != 0
+        assert "--allowed-root" in proc.stderr

--- a/tests/shared_utils/test_grpc_log_server.py
+++ b/tests/shared_utils/test_grpc_log_server.py
@@ -5,6 +5,8 @@
 
 import logging
 import os
+import subprocess
+import sys
 import tempfile
 import time
 from unittest.mock import MagicMock
@@ -12,8 +14,12 @@ from unittest.mock import MagicMock
 import grpc
 import pytest
 
-from nvidia_resiliency_ext.shared_utils.grpc_log_server import LogAggregationServicer
+from nvidia_resiliency_ext.shared_utils.grpc_log_server import LogAggregationServicer, serve
 from nvidia_resiliency_ext.shared_utils.proto import log_aggregation_pb2
+
+# These tests exercise buffering/flush behaviour, not path confinement (see
+# test_grpc_log_server_confinement.py). Every path they write to lives under the temp dir.
+_TEST_ROOTS = ["/tmp", tempfile.gettempdir()]
 
 
 class TestLogAggregationServicer:
@@ -28,7 +34,7 @@ class TestLogAggregationServicer:
     @pytest.fixture
     def servicer(self):
         """Create a LogAggregationServicer instance."""
-        return LogAggregationServicer(max_buffer_size=1024 * 1024)  # 1MB
+        return LogAggregationServicer(max_buffer_size=1024 * 1024, allowed_roots=_TEST_ROOTS)  # 1MB
 
     def test_multi_file_support(self, servicer, temp_log_dir):
         """Test that server writes to different files based on file_path."""
@@ -76,7 +82,8 @@ class TestLogAggregationServicer:
 
         # Create servicer with small buffer for testing
         servicer_small_buffer = LogAggregationServicer(
-            max_buffer_size=100  # Small buffer (periodic flush will handle flushing)
+            allowed_roots=_TEST_ROOTS,
+            max_buffer_size=100,  # Small buffer (periodic flush will handle flushing)
         )
 
         # Create chunks that exceed buffer size
@@ -275,7 +282,7 @@ class TestLogAggregationServicer:
         # Use nested directory that doesn't exist
         nested_file = os.path.join(temp_log_dir, "subdir", "nested", "file.log")
 
-        servicer = LogAggregationServicer()
+        servicer = LogAggregationServicer(allowed_roots=_TEST_ROOTS)
 
         chunks = [
             log_aggregation_pb2.LogChunk(
@@ -301,7 +308,9 @@ class TestPeriodicFlush:
         log_file = tmp_path / "periodic.log"
 
         # Create servicer with short flush interval
-        servicer = LogAggregationServicer(max_buffer_size=1024 * 1024)  # Large buffer
+        servicer = LogAggregationServicer(
+            max_buffer_size=1024 * 1024, allowed_roots=_TEST_ROOTS
+        )  # Large buffer
 
         # Manually set flush interval to 0.5s for testing
         servicer.flush_interval = 0.5
@@ -376,7 +385,9 @@ class TestHeuristicCycleLogCompletion:
 
     def test_current_cycle_log_does_not_complete_on_idle_only(self, tmp_path, caplog):
         log_file = tmp_path / "train_cycle3.log"
-        servicer = LogAggregationServicer(flush_interval=1000.0, completion_idle_timeout=1.0)
+        servicer = LogAggregationServicer(
+            flush_interval=1000.0, completion_idle_timeout=1.0, allowed_roots=_TEST_ROOTS
+        )
         try:
             with caplog.at_level(logging.INFO, logger="LogAggregationServer"):
                 self._stream_chunk(servicer, log_file)
@@ -388,7 +399,9 @@ class TestHeuristicCycleLogCompletion:
 
     def test_shutdown_completion_includes_latest_cycle_without_idle_wait(self, tmp_path, caplog):
         log_file = tmp_path / "train_cycle3.log"
-        servicer = LogAggregationServicer(flush_interval=1000.0, completion_idle_timeout=1000.0)
+        servicer = LogAggregationServicer(
+            flush_interval=1000.0, completion_idle_timeout=1000.0, allowed_roots=_TEST_ROOTS
+        )
 
         with caplog.at_level(logging.INFO, logger="LogAggregationServer"):
             self._stream_chunk(servicer, log_file)
@@ -404,7 +417,9 @@ class TestHeuristicCycleLogCompletion:
     ):
         log_file = tmp_path / "train_cycle3.log"
         next_log_file = tmp_path / "train_cycle4.log"
-        servicer = LogAggregationServicer(flush_interval=1000.0, completion_idle_timeout=1.0)
+        servicer = LogAggregationServicer(
+            flush_interval=1000.0, completion_idle_timeout=1.0, allowed_roots=_TEST_ROOTS
+        )
         try:
             with caplog.at_level(logging.INFO, logger="LogAggregationServer"):
                 self._stream_chunk(servicer, log_file)
@@ -425,7 +440,9 @@ class TestHeuristicCycleLogCompletion:
 
     def test_non_cycle_log_is_ignored_by_completion_scan(self, tmp_path, caplog):
         log_file = tmp_path / "train.log"
-        servicer = LogAggregationServicer(flush_interval=1000.0, completion_idle_timeout=1.0)
+        servicer = LogAggregationServicer(
+            flush_interval=1000.0, completion_idle_timeout=1.0, allowed_roots=_TEST_ROOTS
+        )
         try:
             with caplog.at_level(logging.INFO, logger="LogAggregationServer"):
                 servicer.StreamLogs(
@@ -451,7 +468,9 @@ class TestHeuristicCycleLogCompletion:
     def test_late_cycle_chunk_warns_and_allows_updated_completion(self, tmp_path, caplog):
         log_file = tmp_path / "train_cycle7.log"
         next_log_file = tmp_path / "train_cycle8.log"
-        servicer = LogAggregationServicer(flush_interval=1000.0, completion_idle_timeout=1.0)
+        servicer = LogAggregationServicer(
+            flush_interval=1000.0, completion_idle_timeout=1.0, allowed_roots=_TEST_ROOTS
+        )
         try:
             with caplog.at_level(logging.INFO, logger="LogAggregationServer"):
                 self._stream_chunk(servicer, log_file, data=b"first chunk\n")
@@ -478,7 +497,9 @@ class TestGracefulShutdown:
         log_file = tmp_path / "graceful.log"
 
         # Create servicer with short timeout and fast flush for testing
-        servicer = LogAggregationServicer(graceful_shutdown_timeout=2.0, flush_interval=0.1)
+        servicer = LogAggregationServicer(
+            graceful_shutdown_timeout=2.0, flush_interval=0.1, allowed_roots=_TEST_ROOTS
+        )
 
         # Simulate client connection by manually incrementing counter
         with servicer.clients_lock:
@@ -518,7 +539,9 @@ class TestGracefulShutdown:
         """Test that graceful shutdown respects timeout when clients don't disconnect."""
 
         # Create servicer with very short timeout and fast flush for testing
-        servicer = LogAggregationServicer(graceful_shutdown_timeout=1.0, flush_interval=0.1)
+        servicer = LogAggregationServicer(
+            graceful_shutdown_timeout=1.0, flush_interval=0.1, allowed_roots=_TEST_ROOTS
+        )
 
         # Simulate client that doesn't disconnect
         with servicer.clients_lock:
@@ -535,7 +558,9 @@ class TestGracefulShutdown:
     def test_graceful_shutdown_with_no_clients(self, tmp_path):
         """Test that graceful shutdown exits immediately when no clients connected."""
 
-        servicer = LogAggregationServicer(graceful_shutdown_timeout=10.0)  # Long timeout
+        servicer = LogAggregationServicer(
+            graceful_shutdown_timeout=10.0, allowed_roots=_TEST_ROOTS
+        )  # Long timeout
 
         # No clients connected (default state)
         assert servicer.connected_clients == 0
@@ -552,7 +577,7 @@ class TestGracefulShutdown:
         """Test that graceful shutdown properly flushes all buffered data."""
         log_file = tmp_path / "graceful_flush.log"
 
-        servicer = LogAggregationServicer(graceful_shutdown_timeout=1.0)
+        servicer = LogAggregationServicer(graceful_shutdown_timeout=1.0, allowed_roots=_TEST_ROOTS)
 
         # Write data
         chunks = [
@@ -572,3 +597,144 @@ class TestGracefulShutdown:
         with open(log_file, 'r') as f:
             content = f.read()
         assert "Data before graceful shutdown\n" in content
+
+
+def _chunk(file_path, data=b"payload\n", node_id="evil"):
+    return log_aggregation_pb2.LogChunk(node_id=node_id, data=data, file_path=file_path)
+
+
+@pytest.fixture
+def log_root(tmp_path):
+    root = tmp_path / "logs"
+    root.mkdir()
+    # realpath: on some platforms the pytest tmp dir itself sits behind a symlink.
+    return os.path.realpath(str(root))
+
+
+@pytest.fixture
+def outside_dir(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    return os.path.realpath(str(outside))
+
+
+class TestRootServerConfinement:
+    """The root server must refuse chunks aimed outside its allowed roots."""
+
+    def test_write_inside_root_is_accepted(self, log_root):
+        servicer = LogAggregationServicer(flush_interval=1000.0, allowed_roots=[log_root])
+        target = os.path.join(log_root, "sub", "train.log")
+        try:
+            resp = servicer.StreamLogs(iter([_chunk(target, b"hello\n")]), MagicMock())
+            assert resp.status == "OK"
+        finally:
+            servicer.shutdown()
+        with open(target, "rb") as f:
+            assert f.read() == b"hello\n"
+
+    @pytest.mark.parametrize("relative_escape", [False, True])
+    def test_write_outside_root_is_rejected(self, log_root, outside_dir, relative_escape):
+        servicer = LogAggregationServicer(flush_interval=1000.0, allowed_roots=[log_root])
+        if relative_escape:
+            target = os.path.join(log_root, "..", "outside", "pwned", "owned.txt")
+        else:
+            target = os.path.join(outside_dir, "pwned", "owned.txt")
+
+        context = MagicMock()
+        context.abort.side_effect = grpc.RpcError("aborted")
+        try:
+            with pytest.raises(grpc.RpcError):
+                servicer.StreamLogs(iter([_chunk(target)]), MagicMock(wraps=context))
+        finally:
+            servicer.shutdown()
+
+        context.abort.assert_called_once()
+        assert context.abort.call_args[0][0] == grpc.StatusCode.INVALID_ARGUMENT
+        # Neither the file nor the directory the server would have had to create exists.
+        assert not os.path.exists(target)
+        assert not os.path.exists(os.path.dirname(target))
+
+    def test_rejected_path_is_not_tracked_or_opened(self, log_root, outside_dir):
+        servicer = LogAggregationServicer(flush_interval=1000.0, allowed_roots=[log_root])
+        target = os.path.join(outside_dir, "owned.txt")
+        context = MagicMock()
+        context.abort.side_effect = grpc.RpcError("aborted")
+        try:
+            with pytest.raises(grpc.RpcError):
+                servicer.StreamLogs(iter([_chunk(target)]), context)
+            assert servicer.files == {}
+        finally:
+            servicer.shutdown()
+
+    def test_symlink_inside_root_cannot_redirect_write(self, log_root, outside_dir):
+        """A symlink planted in the log dir must not become an append target."""
+        victim = os.path.join(outside_dir, "authorized_keys")
+        with open(victim, "wb") as f:
+            f.write(b"original\n")
+        link = os.path.join(log_root, "train.log")
+        os.symlink(victim, link)
+
+        servicer = LogAggregationServicer(flush_interval=1000.0, allowed_roots=[log_root])
+        context = MagicMock()
+        context.abort.side_effect = grpc.RpcError("aborted")
+        try:
+            with pytest.raises(grpc.RpcError):
+                servicer.StreamLogs(iter([_chunk(link, b"ssh-rsa AAAA...\n")]), context)
+        finally:
+            servicer.shutdown()
+
+        with open(victim, "rb") as f:
+            assert f.read() == b"original\n"
+
+    def test_confinement_check_runs_once_per_path(self, log_root, monkeypatch):
+        """Steady-state chunks must not re-run the resolve (per-chunk syscall cost)."""
+        servicer = LogAggregationServicer(flush_interval=1000.0, allowed_roots=[log_root])
+        calls = []
+        original = servicer._resolve_target_path
+
+        def counting(file_path):
+            calls.append(file_path)
+            return original(file_path)
+
+        monkeypatch.setattr(servicer, "_resolve_target_path", counting)
+        target = os.path.join(log_root, "train.log")
+        try:
+            servicer.StreamLogs(iter([_chunk(target, b"a\n") for _ in range(50)]), MagicMock())
+        finally:
+            servicer.shutdown()
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize("roots", [None, [], [""]])
+    def test_servicer_refuses_to_construct_unconfined(self, roots):
+        """There is no unconfined mode: every chunk names its own destination."""
+        with pytest.raises(ValueError, match="at least one directory"):
+            LogAggregationServicer(flush_interval=1000.0, allowed_roots=roots)
+
+    def test_servicer_requires_allowed_roots_explicitly(self):
+        """allowed_roots is keyword-only with no default, so it cannot be forgotten."""
+        with pytest.raises(TypeError, match="allowed_roots"):
+            LogAggregationServicer(flush_interval=1000.0)
+
+
+class TestServeRequiresAllowedRoots:
+    """The network-facing entry point must fail closed."""
+
+    def test_serve_rejects_empty_allowed_roots(self):
+        with pytest.raises(ValueError, match="at least one directory"):
+            serve(host="127.0.0.1", port=0, allowed_roots=[])
+
+    def test_cli_requires_allowed_root(self):
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "nvidia_resiliency_ext.shared_utils.grpc_log_server",
+                "--port",
+                "0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert proc.returncode != 0
+        assert "--allowed-root" in proc.stderr

--- a/tests/shared_utils/test_os_utils.py
+++ b/tests/shared_utils/test_os_utils.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for shared_utils/os_utils.py path helpers."""
+
+import os
+
+import pytest
+
+from nvidia_resiliency_ext.shared_utils.os_utils import (
+    normalize_allowed_roots,
+    resolve_under_allowed_roots,
+)
+
+
+@pytest.fixture
+def log_root(tmp_path):
+    root = tmp_path / "logs"
+    root.mkdir()
+    # realpath: on some platforms the pytest tmp dir itself sits behind a symlink.
+    return os.path.realpath(str(root))
+
+
+@pytest.fixture
+def outside_dir(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    return os.path.realpath(str(outside))
+
+
+class TestResolveUnderAllowedRoots:
+    """Unit tests for the shared confinement helper."""
+
+    def test_accepts_path_inside_root(self, log_root):
+        target = os.path.join(log_root, "train.log")
+        assert resolve_under_allowed_roots(target, [log_root]) == target
+
+    def test_accepts_not_yet_existing_nested_path(self, log_root):
+        target = os.path.join(log_root, "nested", "deeper", "train.log")
+        assert resolve_under_allowed_roots(target, [log_root]) == target
+
+    def test_rejects_absolute_path_outside_root(self, log_root, outside_dir):
+        with pytest.raises(ValueError, match="outside the allowed"):
+            resolve_under_allowed_roots(os.path.join(outside_dir, "owned.txt"), [log_root])
+
+    def test_rejects_dotdot_traversal(self, log_root, outside_dir):
+        escape = os.path.join(log_root, "..", "outside", "owned.txt")
+        with pytest.raises(ValueError, match="outside the allowed"):
+            resolve_under_allowed_roots(escape, [log_root])
+
+    def test_rejects_symlink_escape(self, log_root, outside_dir):
+        os.symlink(outside_dir, os.path.join(log_root, "link"))
+        with pytest.raises(ValueError, match="outside the allowed"):
+            resolve_under_allowed_roots(os.path.join(log_root, "link", "owned.txt"), [log_root])
+
+    def test_rejects_symlinked_file_pointing_outside(self, log_root, outside_dir):
+        victim = os.path.join(outside_dir, "authorized_keys")
+        open(victim, "w").close()
+        link = os.path.join(log_root, "train.log")
+        os.symlink(victim, link)
+        with pytest.raises(ValueError, match="outside the allowed"):
+            resolve_under_allowed_roots(link, [log_root])
+
+    def test_rejects_sibling_root_prefix(self, tmp_path):
+        """commonpath compares components: /a/logs must not match /a/logs_evil."""
+        root = os.path.realpath(str(tmp_path / "logs"))
+        os.makedirs(root)
+        evil = os.path.realpath(str(tmp_path / "logs_evil"))
+        os.makedirs(evil)
+        with pytest.raises(ValueError, match="outside the allowed"):
+            resolve_under_allowed_roots(os.path.join(evil, "x.log"), [root])
+
+    def test_rejects_empty_path_and_missing_roots(self, log_root):
+        with pytest.raises(ValueError):
+            resolve_under_allowed_roots("", [log_root])
+        with pytest.raises(ValueError, match="no allowed roots"):
+            resolve_under_allowed_roots(os.path.join(log_root, "a.log"), [])
+
+    def test_rejects_nul_byte(self, log_root):
+        with pytest.raises(ValueError, match="NUL"):
+            resolve_under_allowed_roots(os.path.join(log_root, "a\x00.log"), [log_root])
+
+    def test_multiple_roots_accepts_either(self, log_root, outside_dir):
+        roots = [log_root, outside_dir]
+        assert resolve_under_allowed_roots(os.path.join(outside_dir, "b.log"), roots)
+        assert resolve_under_allowed_roots(os.path.join(log_root, "a.log"), roots)
+
+    def test_normalize_dedupes_and_absolutizes(self, log_root):
+        assert normalize_allowed_roots([log_root, log_root, "", None]) == [log_root]
+        assert normalize_allowed_roots(None) == []


### PR DESCRIPTION
## Problem

`LogAggregationServicer.StreamLogs` passed the client-supplied `LogChunk.file_path`
straight to `os.makedirs` + `open(path, 'ab')` with no confinement — no allowed root, no
rejection of absolute paths or `..`, no symlink check. `ft_launcher` auto-spawns this
server bound to `0.0.0.0` via `add_insecure_port`, so any peer that could reach the funnel
port could create directories and append attacker-controlled bytes to any file writable by
the training process. The leaf server forwarded the same client-controlled path to the root.

## Fix

- `resolve_under_allowed_roots()` in `shared_utils/os_utils.py` — `realpath` + `commonpath`
  confinement. Returns the resolved path, and that is what gets opened, so a symlink planted
  between check and open cannot redirect the write.
- `allowed_roots` is **keyword-only with no default** on both servicers, so there is no
  unconfined mode to fall into. Rejected chunks abort the stream with `INVALID_ARGUMENT`.
- Both CLIs take a repeatable, required `--allowed-root`. The launcher derives the roots and
  passes them to the root and every leaf; if they cannot be resolved it fails closed, falling
  back to direct file writing rather than running unconfined.

## Scope decisions

Roots are `--ft-per-cycle-applog-prefix` and `--ft-nvrx-logfile` only — the two destinations
clients actually target over gRPC. Deliberately excluded:

- `--ft-log-server-log-prefix` — `_root.log` / `_leaf_N.log` are written by the launcher
  redirecting each subprocess's stdout/stderr, never through a `LogChunk`.
- `--ft-cycle-info-dir` — `CycleInfoWriter` writes its JSON and symlink directly.

Including either would widen the boundary for no functional gain.

Root directories are created before being resolved: `realpath()` of a missing directory
returns it unchanged, so a directory that only later appeared as a symlink would resolve
elsewhere at write time and the job's **own** logs would be rejected.

## Performance

No steady-state cost. The root validates inside the branch that already does the
`makedirs`/`open`, so it runs once per distinct path — chunk handling stays a single dict
lookup. The leaf memoizes per RPC and evicts FIFO, because the newest path (the current
cycle log) is the hot one.

## Testing

- New `tests/shared_utils/test_os_utils.py`; confinement coverage added to the existing
  `test_grpc_log_server.py`, `test_grpc_log_leaf_server.py`, and `test_launcher.py` so the
  layout keeps mirroring modules.
- The reported reproducer plus variants (`..` traversal, symlinked dir, symlinked file,
  `~/.ssh/authorized_keys`, `/etc/cron.d`, sibling-prefix root, relative path, NUL byte,
  empty path) verified blocked against both servers; legitimate writes unaffected.
- No regressions against the pre-change baseline; `black` / `isort` / `ruff` clean.

## Note for reviewers

Per CONTRIBUTING this needs a tracked issue and the `#<Issue Number> - <Title>` commit
prefix — please supply the issue number and I will amend. Two pre-existing items are
**not** addressed here and may deserve their own issues: the log client has no backoff on
`grpc.RpcError`, and in two-level mode the root binds `0.0.0.0` although only same-host
leaves connect to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
