### PR TITLE
Avoid Bandit false positive in restart prompt

### DIFF
--- a/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
+++ b/src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py
@@ -45,9 +45,9 @@ Evidence method:
   teardown events in related_failures only after a primary has been identified. If the
   log contains only downstream or teardown evidence, use insufficient_evidence rather
   than promoting that evidence to primary. Preserve up to three visible failure surfaces
-  in observed_failures. Select exactly one only when it is the unique terminal surface
-  after excluding retry-pending, recovered, progressed-after, and diagnostic-only
-  observations; independent tied surfaces leave selected_observed_failure_id null.
+  in observed_failures. Set selected_observed_failure_id only when exactly one is the
+  unique terminal surface after excluding retry-pending, recovered, progressed-after,
+  and diagnostic-only observations; leave it null for independent tied surfaces.
 - Repeated rendering or multi-rank fanout within one causal episode is one event, not
   evidence of cross-attempt persistence.
 - A reporting component, call stack, resource name, or diagnostic suggestion does not


### PR DESCRIPTION
## Summary
- replace SQL-like prompt wording that triggers Bandit B608
- state the `selected_observed_failure_id` contract directly
- avoid adding a `# nosec` suppression

## Validation
- `uvx bandit==1.8.6 -q src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py`
- `.venv/bin/python -m ruff check src/nvidia_resiliency_ext/attribution/restart_agent/l1/prompts.py`
- `.venv/bin/python -m pytest tests/attribution/unit` (735 passed)