### PR TITLE
Document the storage requirement for direct-write per-cycle logs

### DIFF
--- a/docs/source/fault_tolerance/usage_guide.rst
+++ b/docs/source/fault_tolerance/usage_guide.rst
@@ -404,6 +404,28 @@ with optional gRPC log funneling (``--ft-enable-log-server``), worker and launch
 merged through pipes and streamed to one or more aggregators on the rendezvous host before a single
 writer appends to shared storage (for example Lustre).
 
+Two write paths are possible:
+
+* **With log funneling** (``--ft-enable-log-server``, enabled automatically when
+  ``--ft-nvrx-logfile`` is set): every node streams to an aggregator on the rendezvous host and
+  a *single* process writes the shared file. No cross-client write guarantees are needed, so
+  this works on any shared filesystem and is the recommended deployment for multi-node jobs.
+* **Without log funneling** (direct write): every node opens the same
+  ``<prefix>_cycleN.log`` and appends to it with ``O_APPEND``. This is a multi-writer
+  deployment and is not recommended on any filesystem. On Lustre the appends are atomic, but
+  all nodes serialise on the same extent lock, so it does not scale. On NFS- and VAST-style
+  storage the append is not atomic across clients at all, so concurrent appends can interleave
+  or be lost and nothing reports an error.
+
+.. important::
+
+   **Use log funneling for multi-node jobs.** The recommended configuration is to pass
+   ``--ft-nvrx-logfile`` alongside ``--ft-per-cycle-applog-prefix``; that enables
+   ``--ft-enable-log-server`` automatically. Setting ``--ft-per-cycle-applog-prefix`` on its own
+   leaves the log server off and selects multi-writer direct append, which is not a supported
+   multi-node deployment. If you use neither option, worker and launcher output go to
+   stdout/stderr and are captured by ``srun --output`` / ``--error`` as usual.
+
 .. important::
 
    **Best-effort semantics.** Per-cycle gRPC log aggregation is best-effort. Logs around failure

--- a/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
+++ b/src/nvidia_resiliency_ext/fault_tolerance/cli_args.py
@@ -217,9 +217,14 @@ def add_log_funnel_args(
         help="Prefix for per-cycle application log files (must be absolute path, e.g. /lustre/logs/job_12345.log). "
         "Creates training worker logs per cycle: /lustre/logs/job_12345_cycle0.log, job_12345_cycle1.log, etc. "
         "All ranks/nodes capture logs with automatic rank prefixes (like 'srun -l'). "
-        "Without --ft-enable-log-server: Each node writes directly to Lustre with O_APPEND (safe concurrent writes). "
-        "With --ft-enable-log-server (recommended): All nodes stream logs to gRPC server on rank 0, which becomes the single Lustre writer. "
-        "gRPC mode eliminates Lustre lock contention and scales to 1000+ nodes. "
+        "Recommended: also pass --ft-nvrx-logfile, which enables --ft-enable-log-server "
+        "automatically; all nodes then stream logs to a gRPC server on the rendezvous host, "
+        "which becomes the single writer. That eliminates lock contention and scales to 1000+ nodes. "
+        "Without --ft-enable-log-server every node appends to the same shared file with O_APPEND. "
+        "Multi-writer direct append is not a recommended deployment on any filesystem: on Lustre "
+        "the writers serialise on the same extent lock and it does not scale, and on NFS/VAST-style "
+        "storage the append is not atomic across clients, so lines can interleave or be lost with "
+        "no error reported. "
         "Note: NVRx launcher logs go to stdout/stderr by default unless --ft-nvrx-logfile is specified.",
     )
     _add_argument(
@@ -253,7 +258,10 @@ def add_log_funnel_args(
         "(3) Root server writes to Lustre (single writer). "
         "With --ft-log-aggregator-count=N>1, N leaf processes plus one root use ports P..P+N (see --ft-log-server-port). "
         "Use --ft-log-aggregator-count=1 for a single server on P only. "
-        "Benefits: No Lustre lock contention, scales to 1500+ nodes. "
+        "Benefits: no lock contention, scales to 1500+ nodes, and a single writer means shared "
+        "storage does not need atomic cross-client O_APPEND. This is the recommended deployment "
+        "for multi-node jobs; the direct-write alternative does not scale on Lustre and can "
+        "silently interleave or lose lines on NFS/VAST-style storage. "
         f"Requires: grpcio. Default: {enable_default_help}.",
     )
     _add_argument(


### PR DESCRIPTION
## Problem

The `--ft-per-cycle-applog-prefix` help said, unconditionally:

> Without `--ft-enable-log-server`: Each node writes directly to Lustre with O_APPEND (safe concurrent writes).

Every node opens the same `<prefix>_cycleN.log` and appends to it (`per_cycle_logs.py`, `open(path, 'a')`), so that path is a **multi-writer** deployment — and it isn't recommended on any filesystem:

- **Lustre** — appends are atomic, but all nodes serialise on the same extent lock, so it doesn't scale. This is exactly why the gRPC funnel exists ("single writer eliminates O_APPEND contention").
- **NFS / VAST-style** — the append isn't atomic across clients at all, so concurrent appends can interleave or be lost with nothing reporting an error.

`--ft-enable-log-server` defaults to off for `ft_launcher` (`enable_default=None`), so setting only `--ft-per-cycle-applog-prefix` selects that path. A user following the help text lands in an unsupported multi-node configuration by default, and on NFS/VAST the result is silent log loss.

## Change

Docs and CLI help only — no behaviour change.

- `--ft-per-cycle-applog-prefix` help: leads with the recommended pairing (`--ft-nvrx-logfile`, which enables the log server automatically), then states plainly that multi-writer direct append is not recommended on any filesystem, with the distinct Lustre and NFS/VAST reasons.
- `--ft-enable-log-server` help: notes a single writer removes the need for atomic cross-client `O_APPEND` and is the recommended deployment for multi-node jobs.
- `usage_guide.rst`: adds a "Two write paths" comparison and an `.. important::` block stating the recommended configuration, that applog-prefix-alone is not a supported multi-node deployment, and that with neither option output goes to stdout/stderr via `srun --output` / `--error`.

## Verification

- rST parses cleanly (docutils, full section).
- `black` / `isort` / `ruff` clean; arg-parsing tests pass.
- Rendered `ft_launcher --help` reviewed for both flags.

## Note for reviewers

Per CONTRIBUTING this needs a tracked issue and the `#<Issue Number> - <Title>` commit prefix — please supply the issue number and I'll amend.

Nothing in code prevents the unsupported configuration: `_validate_args` enforces `--ft-nvrx-logfile` ⇒ `--ft-per-cycle-applog-prefix`, but not the reverse, so applog-prefix-alone still silently selects multi-writer direct append. Options for a follow-up, deliberately left out of a docs-only PR: warn when the applog prefix is set without the log server, or auto-enable it the way `--ft-nvrx-logfile` already does (`launcher.py:2911-2916`) — the tri-state default (`None` vs explicit `False`) makes that straightforward while still honouring an explicit opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
